### PR TITLE
Add compile guards in EigenDecomposition for non-SIMD architectures

### DIFF
--- a/include/EigenDecomposition.h
+++ b/include/EigenDecomposition.h
@@ -24,6 +24,7 @@ namespace EigenDecomposition
   void matrix_matrix_multiply(const double (&D)[2][2], const double (&Q)[2][2], double (&A)[2][2]);
   void matrix_matrix_multiply(const double (&D)[3][3], const double (&Q)[3][3], double (&A)[3][3]);
 
+#ifndef STK_HAVE_NO_SIMD
   // Simd solvers
   void sym_diagonalize(const DoubleType (&A)[2][2], DoubleType (&Q)[2][2], DoubleType (&D)[2][2]);
   void sym_diagonalize(const DoubleType (&A)[3][3], DoubleType (&Q)[3][3], DoubleType (&D)[3][3]);
@@ -31,6 +32,7 @@ namespace EigenDecomposition
   void reconstruct_matrix_from_decomposition(const DoubleType (&D)[3][3], const DoubleType (&Q)[3][3], DoubleType (&A)[3][3]);
   void matrix_matrix_multiply(const DoubleType (&D)[2][2], const DoubleType (&Q)[2][2], DoubleType (&A)[2][2]);
   void matrix_matrix_multiply(const DoubleType (&D)[3][3], const DoubleType (&Q)[3][3], DoubleType (&A)[3][3]);
+#endif
 
 }
 

--- a/src/EigenDecomposition.C
+++ b/src/EigenDecomposition.C
@@ -251,6 +251,7 @@ EigenDecomposition::matrix_matrix_multiply(
   }
 }
 
+#ifndef STK_HAVE_NO_SIMD
 //--------------------------------------------------------------------------
 //------------- SIMD solvers -----------------------------------------------
 //--------------------------------------------------------------------------
@@ -510,7 +511,7 @@ EigenDecomposition::matrix_matrix_multiply(
     }
   }
 }
-
+#endif // STK_HAVE_NO_SIMD
 
 } // namespace nalu
 } // namespace Sierra


### PR DESCRIPTION
On non-SIMD architectures, stk::simd::DoubleType is the same as double.
This causes compilation errors because of redefinition of functions. 