### PR TITLE
TIOGA Overset interface updates

### DIFF
--- a/include/overset/TiogaBlock.h
+++ b/include/overset/TiogaBlock.h
@@ -150,6 +150,11 @@ private:
    */
   void process_elements();
 
+  /** Reset iblank data with moving mesh applications
+   *
+   */
+  void reset_iblank_data();
+
   /** Print summary of mesh blocks
    */
   void print_summary();

--- a/include/overset/TiogaBlock.h
+++ b/include/overset/TiogaBlock.h
@@ -18,7 +18,7 @@ class tioga;
 namespace tioga_nalu {
 
 typedef stk::mesh::Field<double, stk::mesh::Cartesian> VectorFieldType;
-typedef stk::mesh::Field<double> ScalarFieldType;
+typedef stk::mesh::Field<int> ScalarIntFieldType;
 
 /**
  * Interface to convert STK Mesh Part(s) to TIOGA blocks.

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -148,6 +148,9 @@ private:
   //! ghosted to another MPI rank to ensure that owned and shared nodes are
   //! consistent.
   std::vector<stk::mesh::EntityId> donorIDs_;
+
+  //! User option to determine whether inactive part is generated with TIOGA
+  bool populateInactivePart_{true};
 };
 
 

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -149,6 +149,9 @@ private:
   //! consistent.
   std::vector<stk::mesh::EntityId> donorIDs_;
 
+  //! Set the symmetry direction for TIOGA, default is z-direction (3)
+  int symmetryDir_{3};
+
   //! User option to determine whether inactive part is generated with TIOGA
   bool populateInactivePart_{true};
 };

--- a/src/overset/TiogaBlock.C
+++ b/src/overset/TiogaBlock.C
@@ -438,10 +438,22 @@ void TiogaBlock::process_elements()
   }
 }
 
+void TiogaBlock::reset_iblank_data()
+{
+  for (size_t i=0; i < iblank_.size(); i++)
+    iblank_[i] = 1;
+
+  for (size_t i=0; i < iblank_cell_.size(); i++)
+    iblank_cell_[i] = 1;
+}
+
 void TiogaBlock::register_block(tioga& tg)
 {
   // Do nothing if this mesh block isn't present in this MPI Rank
   if (num_nodes_ < 1) return;
+
+  // Reset iblanks before tioga connectivity
+  reset_iblank_data();
 
   // Register the mesh block information to TIOGA
   tg.registerGridData(

--- a/src/overset/TiogaBlock.C
+++ b/src/overset/TiogaBlock.C
@@ -76,10 +76,10 @@ void TiogaBlock::setup(stk::mesh::PartVector& bcPartVec)
   if (ovsetNames_.size() > 0)
     names_to_parts(ovsetNames_, ovsetParts_);
 
-  ScalarFieldType& ibf = meta_.declare_field<ScalarFieldType>(
+  ScalarIntFieldType& ibf = meta_.declare_field<ScalarIntFieldType>(
     stk::topology::NODE_RANK, "iblank");
 
-  ScalarFieldType& ibcell = meta_.declare_field<ScalarFieldType>(
+  ScalarIntFieldType& ibcell = meta_.declare_field<ScalarIntFieldType>(
     stk::topology::ELEM_RANK, "iblank_cell");
 
   for (auto p: blkParts_) {
@@ -168,8 +168,8 @@ TiogaBlock::update_connectivity()
 void
 TiogaBlock::update_iblanks()
 {
-  ScalarFieldType* ibf =
-    meta_.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "iblank");
+  ScalarIntFieldType* ibf =
+    meta_.get_field<ScalarIntFieldType>(stk::topology::NODE_RANK, "iblank");
 
   stk::mesh::Selector mesh_selector = stk::mesh::selectUnion(blkParts_);
   const stk::mesh::BucketVector& mbkts =
@@ -177,7 +177,7 @@ TiogaBlock::update_iblanks()
 
   int ip = 0;
   for (auto b : mbkts) {
-    double* ib = stk::mesh::field_data(*ibf, *b);
+    int* ib = stk::mesh::field_data(*ibf, *b);
     for (size_t in = 0; in < b->size(); in++) {
       ib[in] = iblank_[ip++];
     }
@@ -186,7 +186,7 @@ TiogaBlock::update_iblanks()
 
 void TiogaBlock::update_iblank_cell()
 {
-  ScalarFieldType* ibf = meta_.get_field<ScalarFieldType>(
+  ScalarIntFieldType* ibf = meta_.get_field<ScalarIntFieldType>(
     stk::topology::ELEM_RANK, "iblank_cell");
 
   stk::mesh::Selector mesh_selector = meta_.locally_owned_part() &
@@ -196,7 +196,7 @@ void TiogaBlock::update_iblank_cell()
 
   int ip = 0;
   for (auto b: mbkts) {
-    double* ib = stk::mesh::field_data(*ibf, *b);
+    int* ib = stk::mesh::field_data(*ibf, *b);
     for(size_t in=0; in < b->size(); in++) {
       ib[in] = iblank_cell_[ip++];
     }

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -64,6 +64,9 @@ TiogaSTKIface::load(const YAML::Node& node)
 
   if (node["tioga_populate_inactive_part"])
     populateInactivePart_ = node["tioga_populate_inactive_part"].as<bool>();
+
+  if (node["tioga_symmetry_direction"])
+    symmetryDir_ = node["tioga_symmetry_direction"].as<int>();
 }
 
 void TiogaSTKIface::setup(stk::mesh::PartVector& bcPartVec)
@@ -85,6 +88,8 @@ void TiogaSTKIface::initialize()
   tg_->setCommunicator(bulk_.parallel(),
                        bulk_.parallel_rank(),
                        bulk_.parallel_size());
+
+  tg_->setSymmetry(symmetryDir_);
 
   sierra::nalu::NaluEnv::self().naluOutputP0()
     << "TIOGA: Initializing overset mesh blocks: " << std::endl;

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -61,6 +61,9 @@ TiogaSTKIface::load(const YAML::Node& node)
 
   sierra::nalu::NaluEnv::self().naluOutputP0()
       << "TIOGA: Using coordinates field: " << coords_name << std::endl;
+
+  if (node["tioga_populate_inactive_part"])
+    populateInactivePart_ = node["tioga_populate_inactive_part"].as<bool>();
 }
 
 void TiogaSTKIface::setup(stk::mesh::PartVector& bcPartVec)
@@ -150,7 +153,7 @@ void TiogaSTKIface::execute()
   // step.
   update_ghosting();
 
-  populate_inactive_part();
+  if (populateInactivePart_) populate_inactive_part();
 
   // Update overset fringe connectivity information for Constraint based algorithm
   populate_overset_info();

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -139,7 +139,7 @@ void TiogaSTKIface::execute()
   }
 
   // Synchronize IBLANK data for shared nodes
-  ScalarFieldType* ibf = meta_.get_field<ScalarFieldType>(
+  ScalarIntFieldType* ibf = meta_.get_field<ScalarIntFieldType>(
           stk::topology::NODE_RANK, "iblank");
   std::vector<const stk::mesh::FieldBase*> pvec{ibf};
   stk::mesh::copy_owned_to_shared(bulk_, pvec);
@@ -277,7 +277,7 @@ void TiogaSTKIface::update_fringe_info()
 
   VectorFieldType *coords = meta_.get_field<VectorFieldType>
     (stk::topology::NODE_RANK, realm.get_coordinates_name());
-  ScalarFieldType* ibf = meta_.get_field<ScalarFieldType>(
+  ScalarIntFieldType* ibf = meta_.get_field<ScalarIntFieldType>(
           stk::topology::NODE_RANK, "iblank");
   int nbadnodes = 0;
 
@@ -299,9 +299,9 @@ void TiogaSTKIface::update_fringe_info()
     stk::mesh::Entity elem = bulk_.get_entity(stk::topology::ELEM_RANK, donorID);
 
     if (!bulk_.bucket(node).owned()) {
-        double ibval = *stk::mesh::field_data(*ibf, node);
+        int ibval = *stk::mesh::field_data(*ibf, node);
 
-        if (ibval > -1.0) {
+        if (ibval > -1) {
             nbadnodes++;
             std::cerr << mtag << "\t" << nodeID << "\t" << donorID 
                 << "\t" << ibval << std::endl;
@@ -384,7 +384,7 @@ void TiogaSTKIface::update_fringe_info()
 void
 TiogaSTKIface::get_receptor_info()
 {
-  ScalarFieldType* ibf = meta_.get_field<ScalarFieldType>(
+  ScalarIntFieldType* ibf = meta_.get_field<ScalarIntFieldType>(
     stk::topology::NODE_RANK, "iblank");
 
   std::vector<unsigned long> nodesToReset;
@@ -413,9 +413,9 @@ TiogaSTKIface::get_receptor_info()
     if (!bulk_.bucket(node).owned()) {
       // We have a shared node that is marked as fringe. Ensure that the owning
       // proc also has this marked as fringe.
-      double ibval = *stk::mesh::field_data(*ibf, node);
+      int ibval = *stk::mesh::field_data(*ibf, node);
 
-      if (ibval > -1.0) {
+      if (ibval > -1) {
         // Disagreement between owner and shared status of iblank. Communicate
         // to owner and other shared procs that it must be a fringe.
         std::vector<int> sprocs;


### PR DESCRIPTION
This pull request adds the following changes to the TIOGA nalu-wind interface: 

- Resets `iblank` and `iblank_cell` values for moving mesh applications before recomputing the overset connectivity
- Fixes the datatype of the STK field data for iblank and iblank_cell from `double` to `int` 