### PR TITLE
Fix Nalu timers

### DIFF
--- a/nalu.C
+++ b/nalu.C
@@ -223,9 +223,9 @@ int main( int argc, char ** argv )
 
   //output timings consistent w/ rest of Sierra
   stk::diag::Timer & sierra_timer = sierra::nalu::Simulation::rootTimer();
-  const double elapsed_time = sierra_timer.getMetric<stk::diag::CPUTime>().getAccumulatedLap(false);
+  const double elapsed_time = sierra_timer.getMetric<stk::diag::WallTime>().getAccumulatedLap(false);
   stk::diag::Timer & mesh_output_timer = sierra::nalu::Simulation::outputTimer();
-  double mesh_output_time = mesh_output_timer.getMetric<stk::diag::CPUTime>().getAccumulatedLap(false);
+  double mesh_output_time = mesh_output_timer.getMetric<stk::diag::WallTime>().getAccumulatedLap(false);
   double time_without_output = elapsed_time-mesh_output_time;
 
   stk::parallel_print_time_without_output_and_hwm(naluEnv.parallel_comm(), time_without_output, naluEnv.naluOutputP0());

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -3976,10 +3976,6 @@ Realm::dump_simulation_time()
                   << " \tmin: " << g_min_time[4] << " \tmax: " << g_max_time[4] << std::endl;
   NaluEnv::self().naluOutputP0() << " io populate fd   --  " << " \tavg: " << g_total_time[5]/double(nprocs)
                   << " \tmin: " << g_min_time[5] << " \tmax: " << g_max_time[5] << std::endl;
-  NaluEnv::self().naluOutputP0() << "Timing for connectivity/finalize lysys: " << std::endl;
-  NaluEnv::self().naluOutputP0() << "         eqs init --  " << " \tavg: " << g_total_time[2]/double(nprocs)
-                  << " \tmin: " << g_min_time[2] << " \tmax: " << g_max_time[2] << std::endl;
-
   NaluEnv::self().naluOutputP0() << "Timing for property evaluation:         " << std::endl;
   NaluEnv::self().naluOutputP0() << "            props --  " << " \tavg: " << g_total_time[3]/double(nprocs)
                   << " \tmin: " << g_min_time[3] << " \tmax: " << g_max_time[3] << std::endl;


### PR DESCRIPTION
- Fix timerMisc for LowMach and Momentum EQS that were counting certain
  execution regions twice. timerMisc_ was accumulating time when
  computing projected_nodal_gradient which in turn was either
  incrementing timerMisc_ or accumulating time in PNGEQS. Current fix is
  to keep calls to compute_projected_nodal_gradient out of timed blocks.

- Low Mach timerMisc_ accumulates time with project_nodal_velocity which
  calls ContinuityEQS projected_nodal_gradient where there is additional
  time accumulation in continuityEQS->timerMisc_.

- "No output time" was reporting CPU Time instead of WallClock time.
  This commit changes that to WallClock time so that it is consistent
  with what is being reported for STKPERF: Total time

- "Timing for connectivity" summary was removed because this is already
  reported as "init" for each equation system

With these changes the sum of all the timers in the timing table should
be less than the total time reported for "main()" as well as "STKPERF:
Total Time" in the summary.