### PR TITLE
Cleanup get shmem view

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -64,18 +64,6 @@ inline DeviceTeamPolicy get_device_team_policy(const size_t sz, const size_t byt
   return policy.set_scratch_size(0, Kokkos::PerTeam(bytes_per_team), Kokkos::PerThread(bytes_per_thread));
 }
 
-inline
-SharedMemView<int*> get_int_shmem_view_1D(const TeamHandleType& team, size_t len)
-{
-  return Kokkos::subview(SharedMemView<int**>(team.team_shmem(), team.team_size(), len), team.team_rank(), Kokkos::ALL());
-}
-
-inline
-SharedMemView<stk::mesh::Entity*> get_entity_shmem_view_1D(const TeamHandleType& team, size_t len)
-{
-  return Kokkos::subview(SharedMemView<stk::mesh::Entity**>(team.team_shmem(), team.team_size(), len), team.team_rank(), Kokkos::ALL());
-}
-
 template<typename T>
 SharedMemView<T*> get_shmem_view_1D(const TeamHandleType& team, size_t len)
 {

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -36,8 +36,8 @@ struct SharedMemData {
         rhs = get_shmem_view_1D<double>(team, rhsSize);
         lhs = get_shmem_view_2D<double>(team, rhsSize, rhsSize);
 
-        scratchIds = get_int_shmem_view_1D(team, rhsSize);
-        sortPermutation = get_int_shmem_view_1D(team, rhsSize);
+        scratchIds = get_shmem_view_1D<int>(team, rhsSize);
+        sortPermutation = get_shmem_view_1D<int>(team, rhsSize);
     }
 
     const stk::mesh::Entity* elemNodes[simdLen];
@@ -72,8 +72,8 @@ struct SharedMemData_FaceElem {
         rhs = get_shmem_view_1D<double>(team, rhsSize);
         lhs = get_shmem_view_2D<double>(team, rhsSize, rhsSize);
 
-        scratchIds = get_int_shmem_view_1D(team, rhsSize);
-        sortPermutation = get_int_shmem_view_1D(team, rhsSize);
+        scratchIds = get_shmem_view_1D<int>(team, rhsSize);
+        sortPermutation = get_shmem_view_1D<int>(team, rhsSize);
     }
 
     const stk::mesh::Entity* connectedNodes[simdLen];

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -23,6 +23,7 @@ add_sources(GlobalUnitSourceList
    UnitTestPecletFunction.C
    UnitTestQuadElementPromotion.C
    UnitTestRealm.C
+   UnitTestShmemAlignment.C
    UnitTestSideIsInElement.C
    UnitTestSideNodeOrdinals.C
    UnitTestSidePCoords.C

--- a/unit_tests/UnitTestShmemAlignment.C
+++ b/unit_tests/UnitTestShmemAlignment.C
@@ -11,16 +11,25 @@ TEST(Shmem, align)
   unsigned bytes_per_thread = 2048;
 
   auto team_exec = sierra::nalu::get_device_team_policy(N, bytes_per_team, bytes_per_thread);
-  Kokkos::parallel_for(team_exec, KOKKOS_LAMBDA(const sierra::nalu::TeamHandleType& team)
+  unsigned numCorrectlyAlignedViews = 0;
+  Kokkos::parallel_reduce(team_exec, KOKKOS_LAMBDA(const sierra::nalu::TeamHandleType& team, unsigned& localResult)
   {
     sierra::nalu::SharedMemView<double*> view1 = sierra::nalu::get_shmem_view_1D<double>(team, numScalars);
-    std::cerr<<"view1.data(): "<<view1.data()<<", alignof(view1.data()): "<<alignof(view1.data())<<std::endl;
+    if (alignof(view1.data()) == 8) {
+        ++localResult;
+    }
 
     sierra::nalu::SharedMemView<double*> view2 = sierra::nalu::get_shmem_view_1D<double>(team, numScalars);
-    std::cerr<<"view2-view1: "<<ptrdiff_t(view2.data()-view1.data())*sizeof(double)<<", view2.data(): "<<view2.data()<<", alignof(view2.data()): "<<alignof(view2.data())<<std::endl;
+    if (alignof(view1.data()) == 8) {
+        ++localResult;
+    }
 
     sierra::nalu::SharedMemView<double*> view3 = sierra::nalu::get_shmem_view_1D<double>(team, numScalars);
-    std::cerr<<"view3-view2: "<<ptrdiff_t(view3.data()-view2.data())*sizeof(double)<<", view3.data(): "<<view3.data()<<", alignof(view3.data()): "<<alignof(view3.data())<<std::endl;
-  });
+    if (alignof(view1.data()) == 8) {
+        ++localResult;
+    }
+  }, numCorrectlyAlignedViews);
+
+  EXPECT_EQ(3u, numCorrectlyAlignedViews);
 }
 

--- a/unit_tests/UnitTestShmemAlignment.C
+++ b/unit_tests/UnitTestShmemAlignment.C
@@ -1,0 +1,26 @@
+#include <gtest/gtest.h>
+
+#include <KokkosInterface.h>
+
+TEST(Shmem, align)
+{
+  unsigned N = 1;
+  unsigned numScalars = 3;
+
+  unsigned bytes_per_team = 0;
+  unsigned bytes_per_thread = 2048;
+
+  auto team_exec = sierra::nalu::get_device_team_policy(N, bytes_per_team, bytes_per_thread);
+  Kokkos::parallel_for(team_exec, KOKKOS_LAMBDA(const sierra::nalu::TeamHandleType& team)
+  {
+    sierra::nalu::SharedMemView<double*> view1 = sierra::nalu::get_shmem_view_1D<double>(team, numScalars);
+    std::cerr<<"view1.data(): "<<view1.data()<<", alignof(view1.data()): "<<alignof(view1.data())<<std::endl;
+
+    sierra::nalu::SharedMemView<double*> view2 = sierra::nalu::get_shmem_view_1D<double>(team, numScalars);
+    std::cerr<<"view2-view1: "<<ptrdiff_t(view2.data()-view1.data())*sizeof(double)<<", view2.data(): "<<view2.data()<<", alignof(view2.data()): "<<alignof(view2.data())<<std::endl;
+
+    sierra::nalu::SharedMemView<double*> view3 = sierra::nalu::get_shmem_view_1D<double>(team, numScalars);
+    std::cerr<<"view3-view2: "<<ptrdiff_t(view3.data()-view2.data())*sizeof(double)<<", view3.data(): "<<view3.data()<<", alignof(view3.data()): "<<alignof(view3.data())<<std::endl;
+  });
+}
+


### PR DESCRIPTION
Removed a couple of un-needed overloads of the get_shmem_view function.

Also added a unit-test for alignment of shared-mem-views. The unit-test currently has a gold value of 8, that will change to KOKKOS_MEMORY_ALIGNMENT after kokkos has been fixed.

