### PR TITLE
Created ElemDataRequestsNGP class.

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -96,6 +96,7 @@ add_sources(GlobalHeaderList
    EffectiveSSTDiffFluxCoeffAlgorithm.h
    EigenDecomposition.h
    ElemDataRequests.h
+   ElemDataRequestsNGP.h
    EnthalpyABLSrcNodeSuppAlg.h
    EnthalpyEffectiveDiffFluxCoeffAlgorithm.h
    EnthalpyEquationSystem.h

--- a/include/ElemDataRequestsNGP.h
+++ b/include/ElemDataRequestsNGP.h
@@ -1,0 +1,163 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef ElemDataRequestsNGP_h
+#define ElemDataRequestsNGP_h
+
+#include <KokkosInterface.h>
+#include <Kokkos_Core.hpp>
+#include <ElemDataRequests.h>
+
+namespace sierra{
+namespace nalu{
+
+//Temporary placeholder to allow storing field pointers in
+//kokkos views (see FieldView typedef below).
+//This won't be necessary when we get stk's ngp::Field because
+//those are stored by value (intended to be copied rather than
+//referenced through pointers).
+struct FieldPtr {
+  const stk::mesh::FieldBase* ptr;
+
+  operator const stk::mesh::FieldBase*() const { return ptr; }
+};
+
+class ElemDataRequestsNGP
+{
+public:
+  typedef Kokkos::View<COORDS_TYPES*, Kokkos::LayoutRight, MemSpace> CoordsTypesView;
+  typedef Kokkos::View<ELEM_DATA_NEEDED*, Kokkos::LayoutRight, MemSpace> DataEnumView;
+  typedef Kokkos::View<FieldPtr*, Kokkos::LayoutRight, MemSpace> FieldView;
+
+  ElemDataRequestsNGP(const ElemDataRequests& dataReq)
+    : dataEnums(),
+      hostDataEnums(),
+      coordsFields_(),
+      hostCoordsFields_(),
+      coordsFieldsTypes_(),
+      hostCoordsFieldsTypes_(),
+      fields(),
+      hostFields(),
+      meFC_(nullptr), meSCS_(nullptr), meSCV_(nullptr), meFEM_(nullptr)
+  {
+    fill_host_data_enums(dataReq, CURRENT_COORDINATES);
+    fill_host_data_enums(dataReq, MODEL_COORDINATES);
+
+    fill_host_fields(dataReq);
+
+    fill_host_coords_fields(dataReq);
+  }
+
+  ~ElemDataRequestsNGP() {}
+
+  void copy_to_device()
+  {
+    if (hostDataEnums[CURRENT_COORDINATES].size() > 0) {
+      Kokkos::deep_copy(dataEnums[CURRENT_COORDINATES], hostDataEnums[CURRENT_COORDINATES]);
+    }
+    if (hostDataEnums[MODEL_COORDINATES].size() > 0) {
+      Kokkos::deep_copy(dataEnums[MODEL_COORDINATES], hostDataEnums[MODEL_COORDINATES]);
+    }
+    Kokkos::deep_copy(coordsFields_, hostCoordsFields_);
+    Kokkos::deep_copy(coordsFieldsTypes_, hostCoordsFieldsTypes_);
+    Kokkos::deep_copy(fields, hostFields);
+  }
+
+  void add_cvfem_face_me(MasterElement *meFC)
+  { meFC_ = meFC; }
+
+  void add_cvfem_volume_me(MasterElement *meSCV)
+  { meSCV_ = meSCV; }
+
+  void add_cvfem_surface_me(MasterElement *meSCS)
+  { meSCS_ = meSCS; }
+
+  void add_fem_volume_me(MasterElement *meFEM)
+  { meFEM_ = meFEM; }
+
+  KOKKOS_FUNCTION
+  const DataEnumView& get_data_enums(const COORDS_TYPES cType) const
+  { return dataEnums[cType]; }
+
+  KOKKOS_FUNCTION
+  const FieldView& get_coordinates_fields() const
+  { return coordsFields_; }
+
+  KOKKOS_FUNCTION
+  const CoordsTypesView& get_coordinates_types() const
+  { return coordsFieldsTypes_; }
+
+  KOKKOS_FUNCTION
+  const FieldView& get_fields() const { return fields; }  
+
+  MasterElement *get_cvfem_face_me() const {return meFC_;}
+  MasterElement *get_cvfem_volume_me() const {return meSCV_;}
+  MasterElement *get_cvfem_surface_me() const {return meSCS_;}
+  MasterElement *get_fem_volume_me() const {return meFEM_;}
+
+private:
+  void fill_host_data_enums(const ElemDataRequests& dataReq, COORDS_TYPES ctype)
+  {
+    if (dataReq.get_data_enums(ctype).size() > 0) {
+      dataEnums[ctype] = DataEnumView("DataEnumsCurrentCoords", dataReq.get_data_enums(ctype).size());
+      hostDataEnums[ctype] = Kokkos::create_mirror_view(dataEnums[ctype]);
+      unsigned i=0;
+      for(ELEM_DATA_NEEDED d : dataReq.get_data_enums(ctype)) {
+        hostDataEnums[ctype](i++) = d;
+      }
+    }
+  }
+
+  void fill_host_fields(const ElemDataRequests& dataReq)
+  {
+    fields = FieldView("Fields", dataReq.get_fields().size());
+    hostFields = Kokkos::create_mirror_view(fields);
+    unsigned i = 0;
+    for(const FieldInfo& finfo : dataReq.get_fields()) {
+      hostFields(i++) = {finfo.field};
+    }
+  }
+ 
+  void fill_host_coords_fields(const ElemDataRequests& dataReq)
+  {
+    coordsFields_ = FieldView("CoordsFields", dataReq.get_coordinates_map().size());
+    coordsFieldsTypes_ = CoordsTypesView("CoordsFieldsTypes", dataReq.get_coordinates_map().size());
+
+    hostCoordsFields_ = Kokkos::create_mirror_view(coordsFields_);
+    hostCoordsFieldsTypes_ = Kokkos::create_mirror_view(coordsFieldsTypes_);
+
+    unsigned i = 0;
+    for(auto iter : dataReq.get_coordinates_map()) {
+      hostCoordsFields_(i) = {iter.second};
+      hostCoordsFieldsTypes_(i) = iter.first;
+      ++i;
+    }
+  }
+
+  DataEnumView dataEnums[MAX_COORDS_TYPES];
+  DataEnumView::HostMirror hostDataEnums[MAX_COORDS_TYPES];
+
+  FieldView coordsFields_;
+  FieldView::HostMirror hostCoordsFields_;
+  CoordsTypesView coordsFieldsTypes_;
+  CoordsTypesView::HostMirror hostCoordsFieldsTypes_;
+
+  FieldView fields;
+  FieldView::HostMirror hostFields;
+
+  MasterElement *meFC_;
+  MasterElement *meSCS_;
+  MasterElement *meSCV_;
+  MasterElement *meFEM_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif
+

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -31,6 +31,14 @@
 namespace sierra {
 namespace nalu {
 
+#ifdef KOKKOS_HAVE_CUDA
+   typedef Kokkos::CudaSpace    MemSpace;
+#elif defined(KOKKOS_HAVE_OPENMP)
+   typedef Kokkos::OpenMP       MemSpace;
+#else
+   typedef Kokkos::HostSpace    MemSpace;
+#endif
+
 using HostSpace = Kokkos::DefaultHostExecutionSpace;
 using DeviceSpace = Kokkos::DefaultExecutionSpace;
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_sources(GlobalUnitSourceList
    UnitTestABLWallFunction.C
    UnitTestBasicKokkos.C
    UnitTestCreateOnDevice.C
+   UnitTestElemDataRequests.C
    UnitTestElemSuppAlg.C
    UnitTestElementDescription.C
    UnitTestFieldUtils.C

--- a/unit_tests/UnitTestElemDataRequests.C
+++ b/unit_tests/UnitTestElemDataRequests.C
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#include <stk_util/environment/WallTime.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include <SimdInterface.h>
+#include <ElemDataRequests.h>
+#include <ElemDataRequestsNGP.h>
+#include <SharedMemData.h>
+#include <ScratchViews.h>
+
+TEST_F(Hex8MeshWithNSOFields, ElemDataRequestsNGP)
+{
+  fill_mesh_and_initialize_test_fields("generated:2x2x2");
+  stk::topology elemTopo = stk::topology::HEX_8;
+
+  sierra::nalu::ElemDataRequests dataReq;
+  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
+  dataReq.add_cvfem_volume_me(meSCV);
+
+  dataReq.add_gathered_nodal_field(*velocity, 3);
+  dataReq.add_gathered_nodal_field(*pressure, 1);
+
+  dataReq.add_coordinates_field(*bulk.mesh_meta_data().coordinate_field(), 3, sierra::nalu::CURRENT_COORDINATES);
+  dataReq.add_coordinates_field(*bulk.mesh_meta_data().coordinate_field(), 3, sierra::nalu::MODEL_COORDINATES);
+
+  EXPECT_EQ(3u, dataReq.get_fields().size());
+
+  sierra::nalu::ElemDataRequestsNGP ngpDataReq(dataReq);
+  ngpDataReq.copy_to_device();
+
+  unsigned numCorrectTests = 0;
+  auto team_exec = sierra::nalu::get_device_team_policy(1, 0, 0);
+  Kokkos::parallel_reduce(team_exec, KOKKOS_LAMBDA(const sierra::nalu::TeamHandleType& team, unsigned& localNumTests)
+  {
+    if (ngpDataReq.get_fields().size() == 3) {
+      ++localNumTests;
+    }
+
+    if (ngpDataReq.get_coordinates_fields().size() == 2) {
+      ++localNumTests;
+    }
+
+    if (ngpDataReq.get_coordinates_types().size() == 2) {
+      ++localNumTests;
+    }
+
+    if (ngpDataReq.get_coordinates_types()(0) == sierra::nalu::CURRENT_COORDINATES) {
+      ++localNumTests;
+    }
+
+    if (ngpDataReq.get_coordinates_types()(1) == sierra::nalu::MODEL_COORDINATES) {
+      ++localNumTests;
+    }
+  }, numCorrectTests);
+
+  EXPECT_EQ(5u, numCorrectTests);
+}
+


### PR DESCRIPTION
The purpose of this class is to copy the contents of
ElemDataRequests to a GPU device for use by ScratchViews etc.

Data-enums and fields are stored in kokkos views instead of
std sets and maps.

Unit test in UnitTestElemDataRequests.C shows how this class
could be used to copy the contents of a regular ElemDataRequests
class to a gpu device for access within a parallel_for loop.

This class is not yet used by ScratchViews and SharedMemData, but
will be soon as they are next up for GPU overhaul.

Still need to address the master-element pointers, which need
to be allocated on device in order to be used on device...