### PR TITLE
Adding register_overset_bc function to ProjectedNodalGradientEquation class

### DIFF
--- a/include/ProjectedNodalGradientEquationSystem.h
+++ b/include/ProjectedNodalGradientEquationSystem.h
@@ -80,6 +80,8 @@ public:
     stk::mesh::Part *part,
     const stk::topology &theTopo);
 
+  void register_overset_bc();
+
   // internal solve and update from EquationSystems
   void solve_and_update();
 

--- a/src/ProjectedNodalGradientEquationSystem.C
+++ b/src/ProjectedNodalGradientEquationSystem.C
@@ -307,6 +307,25 @@ ProjectedNodalGradientEquationSystem::register_non_conformal_bc(
 }
 
 //--------------------------------------------------------------------------
+//-------- register_overset_bc ---------------------------------------------
+//--------------------------------------------------------------------------
+void
+ProjectedNodalGradientEquationSystem::register_overset_bc()
+{
+  create_constraint_algorithm(dqdx_);
+
+  int nDim = realm_.meta_data().spatial_dimension();
+
+  // Perform fringe updates before all equation system solves
+  UpdateOversetFringeAlgorithmDriver* theAlg = new UpdateOversetFringeAlgorithmDriver(realm_);
+
+  equationSystems_.preIterAlgDriver_.push_back(theAlg);
+
+  theAlg->fields_.push_back(
+    std::unique_ptr<OversetFieldData>(new OversetFieldData(dqdx_,1,nDim)));
+}
+
+//--------------------------------------------------------------------------
 //-------- initialize ------------------------------------------------------
 //--------------------------------------------------------------------------
 void


### PR DESCRIPTION
When using TIOGA with consistent_mass_matrix_png option in the input file, the pressure solution
blows up if the projected nodal gradients are not accounted for in the overset BC.

Fixed the above by adding register_overset_bc function to ProjectedNodalGradientEquation class.