### PR TITLE
Add wind-utils to nalu-wind repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,6 @@
 	path = reg_tests/mesh
 	url = https://github.com/Exawind/meshes.git
         ignore = dirty
+[submodule "wind-utils"]
+	path = wind-utils
+	url = git@github.com:exawind/wind-utils.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 option(ENABLE_TESTS "Enable regression testing." OFF)
 option(ENABLE_DOCUMENTATION "Build documentation." OFF)
 option(ENABLE_SPHINX_API_DOCS "Link Doxygen API docs to Sphinx" OFF)
+option(ENABLE_WIND_UTILS "Build wind utils along with Nalu-Wind" OFF)
 option(ENABLE_OPENFAST
        "Use OPENFAST tpl to get actuator line positions and forces" OFF)
 option(ENABLE_PARAVIEW_CATALYST
@@ -279,4 +280,17 @@ if(ENABLE_TESTS)
    enable_testing()
    include(CTest)
    add_subdirectory(reg_tests)
+endif()
+
+if (ENABLE_WIND_UTILS)
+  if (EXISTS ${CMAKE_SOURCE_DIR}/wind-utils/CMakeLists.txt)
+    add_subdirectory(wind-utils)
+  else()
+    message(WARNING
+      "ENABLE_WIND_UTILS is ON, but wind-utils submodule has not been initialized.\
+       You should execute 'git submodule init && git submodule update' \
+       or use '-DENABLE_WIND_UTILS=OFF' to turn off this warning. \
+       DISABLING wind-utils compilation.
+      ")
+  endif()
 endif()


### PR DESCRIPTION
Include wind-utils as a submodule within nalu-wind and add necessary
links in CMakeLists.txt to allow compilation of wind-utils from within
nalu-wind repo for users.

Introduce a new variable ENABLE_WIND_UTILS (default: OFF) to allow user
to activate building wind-utils from within nalu-wind.