### PR TITLE
Kokkos::View::dimension is being replaced with Kokkos::View::extent

### DIFF
--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -42,7 +42,7 @@ void interleave_2D(SharedMemView<DTYPE**>& dview, const SharedMemView<double**>&
 template<typename DTYPE>
 void interleave_1D(SharedMemView<DTYPE*>& dview, const SharedMemView<double*>& sview, int simdIndex)
 {
-  int dim = dview.dimension(0);
+  int dim = dview.extent(0);
 
   DTYPE* data = dview.data();
   double* src = sview.data();
@@ -54,7 +54,7 @@ void interleave_1D(SharedMemView<DTYPE*>& dview, const SharedMemView<double*>& s
 template<typename DTYPE>
 void interleave_1D(SharedMemView<DTYPE*>& dview, const double* sviews[], int simdElems)
 {
-    int dim = dview.dimension(0);
+    int dim = dview.extent(0);
     DoubleType* dptr = dview.data();
     for(int i=0; i<dim; ++i) {
         DoubleType& d = dptr[i];
@@ -67,7 +67,7 @@ void interleave_1D(SharedMemView<DTYPE*>& dview, const double* sviews[], int sim
 template<typename DTYPE>
 void interleave_2D(SharedMemView<DTYPE**>& dview, const double* sviews[], int simdElems)
 {
-    int len = dview.dimension(0)*dview.dimension(1);
+    int len = dview.extent(0)*dview.extent(1);
     DoubleType* d = dview.data();
     for(int idx=0; idx<len; ++idx) {
         DoubleType& dv = d[idx];
@@ -80,7 +80,7 @@ void interleave_2D(SharedMemView<DTYPE**>& dview, const double* sviews[], int si
 template<typename DTYPE>
 void interleave_3D(SharedMemView<DTYPE***>& dview, const double* sviews[], int simdElems)
 {
-    int len = dview.dimension(0)*dview.dimension(1)*dview.dimension(2);
+    int len = dview.extent(0)*dview.extent(1)*dview.extent(2);
     DoubleType* d = dview.data();
     for(int idx=0; idx<len; ++idx) {
         DoubleType& dv = d[idx];
@@ -188,7 +188,7 @@ void copy_and_interleave(std::unique_ptr<ScratchViews<double>>* data,
 inline
 void extract_vector_lane(const SharedMemView<DoubleType*>& simdrhs, int simdIndex, SharedMemView<double*>& rhs)
 {
-  int dim = simdrhs.dimension(0);
+  int dim = simdrhs.extent(0);
   const DoubleType* sr = simdrhs.data();
   double* r = rhs.data();
   for(int i=0; i<dim; ++i) {
@@ -199,7 +199,7 @@ void extract_vector_lane(const SharedMemView<DoubleType*>& simdrhs, int simdInde
 inline
 void extract_vector_lane(const SharedMemView<DoubleType**>& simdlhs, int simdIndex, SharedMemView<double**>& lhs)
 {
-  int len = simdlhs.dimension(0)*simdlhs.dimension(1);
+  int len = simdlhs.extent(0)*simdlhs.extent(1);
   const DoubleType* sl = simdlhs.data();
   double* l = lhs.data();
   for(int i=0; i<len; ++i) {

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -361,7 +361,7 @@ void fill_pre_req_data(
       }
       else {
         SharedMemView<double*>& shmemView = prereqData.get_scratch_view_1D(*fieldInfo.field);
-        unsigned len = shmemView.dimension(0);
+        unsigned len = shmemView.extent(0);
         double* fieldDataPtr = static_cast<double*>(stk::mesh::field_data(*fieldInfo.field, elem));
         for(unsigned i=0; i<len; ++i) {
           shmemView(i) = fieldDataPtr[i];

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1253,8 +1253,8 @@ TpetraLinearSystem::finalizeLinearSystem()
 
   sort_connections(connections_);
 
-  size_t numSharedNotOwned = sharedNotOwnedRowsMap_->getMyGlobalIndices().dimension(0);
-  size_t numLocallyOwned = ownedRowsMap_->getMyGlobalIndices().dimension(0);
+  size_t numSharedNotOwned = sharedNotOwnedRowsMap_->getMyGlobalIndices().extent(0);
+  size_t numLocallyOwned = ownedRowsMap_->getMyGlobalIndices().extent(0);
   LinSys::RowLengths sharedNotOwnedRowLengths("rowLengths", numSharedNotOwned);
   LinSys::RowLengths locallyOwnedRowLengths("rowLengths", numLocallyOwned);
   Kokkos::View<size_t*,HostSpace> ownedRowLengths = locallyOwnedRowLengths.view<HostSpace>();

--- a/src/master_element/Quad42DCVFEM.C
+++ b/src/master_element/Quad42DCVFEM.C
@@ -39,7 +39,7 @@ namespace nalu{
 void quad_derivative(const std::vector<double> &par_coord, 
                      SharedMemView<DoubleType***>& deriv) {
   const double half = 0.5;
-  const size_t npts = deriv.dimension(0);
+  const size_t npts = deriv.extent(0);
 
   for(size_t j=0; j<npts; ++j) {
     const DoubleType s1 = par_coord[2*j+0];

--- a/src/master_element/Tet4CVFEM.C
+++ b/src/master_element/Tet4CVFEM.C
@@ -35,7 +35,7 @@ namespace nalu{
 template <typename DerivType>
 void tet_deriv(DerivType& deriv)
 {
-  for(size_t j=0; j<deriv.dimension(0); ++j) {
+  for(size_t j=0; j<deriv.extent(0); ++j) {
     deriv(j,0,0) = -1.0;
     deriv(j,0,1) = -1.0;
     deriv(j,0,2) = -1.0;

--- a/src/master_element/Tri32DCVFEM.C
+++ b/src/master_element/Tri32DCVFEM.C
@@ -36,7 +36,7 @@ namespace nalu{
 
 //-------- tri_derivative -----------------------------------------------------
 void tri_derivative (SharedMemView<DoubleType***>& deriv) {
-  const int npts = deriv.dimension(0); 
+  const int npts = deriv.extent(0); 
   for (int j=0; j<npts; ++j) {
     deriv(j,0,0) = -1.0;
     deriv(j,1,0) =  1.0;
@@ -53,8 +53,8 @@ void tri_gradient_operator(
   SharedMemView<DoubleType***>& gradop,
   SharedMemView<DoubleType***>& deriv) {
       
-  const int nint = deriv.dimension(0);
-  const int npe  = deriv.dimension(1);
+  const int nint = deriv.extent(0);
+  const int npe  = deriv.extent(1);
  
   DoubleType dx_ds1, dx_ds2;
   DoubleType dy_ds1, dy_ds2;

--- a/unit_tests/UnitTestKokkosME.C
+++ b/unit_tests/UnitTestKokkosME.C
@@ -12,7 +12,7 @@
 void check_that_values_match(const sierra::nalu::SharedMemView<DoubleType*>& values,
                              const double* oldValues)
 {
-  for(size_t i=0; i<values.dimension(0); ++i) {
+  for(size_t i=0; i<values.extent(0); ++i) {
       EXPECT_NEAR(stk::simd::get_data(values(i),0), oldValues[i], tol)<<"i:"<<i;
   }
 }
@@ -21,8 +21,8 @@ void check_that_values_match(const sierra::nalu::SharedMemView<DoubleType**>& va
                              const double* oldValues)
 {
   int counter = 0;
-  for(size_t i=0; i<values.dimension(0); ++i) {
-    for(size_t j=0; j<values.dimension(1); ++j) {
+  for(size_t i=0; i<values.extent(0); ++i) {
+    for(size_t j=0; j<values.extent(1); ++j) {
       EXPECT_NEAR(stk::simd::get_data(values(i,j),0), oldValues[counter++], tol)<<"i:"<<i<<", j:"<<j;
     }
   }
@@ -32,9 +32,9 @@ void check_that_values_match(const sierra::nalu::SharedMemView<DoubleType***>& v
                              const double* oldValues)
 {
   int counter = 0;
-  for(size_t i=0; i<values.dimension(0); ++i) {
-    for(size_t j=0; j<values.dimension(1); ++j) {
-      for(size_t k=0; k<values.dimension(2); ++k) {
+  for(size_t i=0; i<values.extent(0); ++i) {
+    for(size_t j=0; j<values.extent(1); ++j) {
+      for(size_t k=0; k<values.extent(2); ++k) {
         EXPECT_NEAR(stk::simd::get_data(values(i,j,k),0), oldValues[counter++], tol)<<"i:"<<i<<", j:"<<j<<", k:"<<k;
       }
     }
@@ -56,7 +56,7 @@ void compare_old_scv_volume( const sierra::nalu::SharedMemView<DoubleType**>& v_
                             const sierra::nalu::SharedMemView<DoubleType*>& scv_volume,
                             sierra::nalu::MasterElement* meSCV)
 {
-  int len = scv_volume.dimension(0);
+  int len = scv_volume.extent(0);
   std::vector<double> coords;
   copy_DoubleType0_to_double(v_coords, coords);
   std::vector<double> volume(len, 0.0);
@@ -70,7 +70,7 @@ void compare_old_scs_areav( const sierra::nalu::SharedMemView<DoubleType**>& v_c
                             const sierra::nalu::SharedMemView<DoubleType**>& scs_areav,
                             sierra::nalu::MasterElement* meSCS)
 {
-  int len = scs_areav.dimension(0)*scs_areav.dimension(1);
+  int len = scs_areav.extent(0)*scs_areav.extent(1);
   std::vector<double> coords;
   copy_DoubleType0_to_double(v_coords, coords);
   std::vector<double> areav(len, 0.0);
@@ -85,7 +85,7 @@ void compare_old_scs_grad_op( const sierra::nalu::SharedMemView<DoubleType**>& v
                             const sierra::nalu::SharedMemView<DoubleType***>& scs_deriv,
                             sierra::nalu::MasterElement* meSCS)
 {
-  int len = scs_dndx.dimension(0)*scs_dndx.dimension(1)*scs_dndx.dimension(2);
+  int len = scs_dndx.extent(0)*scs_dndx.extent(1)*scs_dndx.extent(2);
   std::vector<double> coords;
   copy_DoubleType0_to_double(v_coords, coords);
   std::vector<double> grad_op(len, 0.0);
@@ -103,7 +103,7 @@ void compare_old_scs_shifted_grad_op( const sierra::nalu::SharedMemView<DoubleTy
                             const sierra::nalu::SharedMemView<DoubleType***>& scs_deriv,
                             sierra::nalu::MasterElement* meSCS)
 {
-  int len = scs_dndx.dimension(0)*scs_dndx.dimension(1)*scs_dndx.dimension(2);
+  int len = scs_dndx.extent(0)*scs_dndx.extent(1)*scs_dndx.extent(2);
   std::vector<double> coords;
   copy_DoubleType0_to_double(v_coords, coords);
   std::vector<double> grad_op(len, 0.0);
@@ -121,7 +121,7 @@ void compare_old_scs_gij(const sierra::nalu::SharedMemView<DoubleType**>& v_coor
                          const sierra::nalu::SharedMemView<DoubleType***>& v_deriv,
                          sierra::nalu::MasterElement* meSCS)
 {
-  int len = v_gijUpper.dimension(0)*v_gijUpper.dimension(1)*v_gijUpper.dimension(2);
+  int len = v_gijUpper.extent(0)*v_gijUpper.extent(1)*v_gijUpper.extent(2);
   std::vector<double> coords;
   copy_DoubleType0_to_double(v_coords, coords);
   std::vector<double> gijUpper(len, 0.0);

--- a/unit_tests/UnitTestKokkosMEBC.C
+++ b/unit_tests/UnitTestKokkosMEBC.C
@@ -14,9 +14,9 @@ namespace {
     const double* oldValues)
   {
     int counter = 0;
-    for(size_t i=0; i<values.dimension(0); ++i) {
-      for(size_t j=0; j<values.dimension(1); ++j) {
-        for(size_t k=0; k<values.dimension(2); ++k) {
+    for(size_t i=0; i<values.extent(0); ++i) {
+      for(size_t j=0; j<values.extent(1); ++j) {
+        for(size_t k=0; k<values.extent(2); ++k) {
           EXPECT_NEAR(stk::simd::get_data(values(i,j,k),0), oldValues[counter++], tol)<<"i:"<<i<<", j:"<<j<<", k:"<<k;
         }
       }
@@ -42,7 +42,7 @@ void compare_old_face_grad_op(
   const sierra::nalu::SharedMemView<DoubleType***>& scs_fc_dndx,
   sierra::nalu::MasterElement* meSCS)
 {
-  int len = scs_fc_dndx.dimension(0)*scs_fc_dndx.dimension(1)*scs_fc_dndx.dimension(2);
+  int len = scs_fc_dndx.extent(0)*scs_fc_dndx.extent(1)*scs_fc_dndx.extent(2);
   std::vector<double> coords;
   copy_DoubleType0_to_double(v_coords, coords);
   std::vector<double> grad_op(len, 0.0);

--- a/unit_tests/UnitTestLinearSystem.h
+++ b/unit_tests/UnitTestLinearSystem.h
@@ -48,13 +48,13 @@ public:
       )
   {
     if (numSumIntoCalls_ == 0) {
-      rhs_ = Kokkos::View<double*>("rhs_",rhs.dimension(0));
-      for(size_t i=0; i<rhs.dimension(0); ++i) {
+      rhs_ = Kokkos::View<double*>("rhs_",rhs.extent(0));
+      for(size_t i=0; i<rhs.extent(0); ++i) {
         rhs_(i) = rhs(i);
       }
-      lhs_ = Kokkos::View<double**>("lhs_",lhs.dimension(0), lhs.dimension(1));
-      for(size_t i=0; i<lhs.dimension(0); ++i) {
-        for(size_t j=0; j<lhs.dimension(1); ++j) {
+      lhs_ = Kokkos::View<double**>("lhs_",lhs.extent(0), lhs.extent(1));
+      for(size_t i=0; i<lhs.extent(0); ++i) {
+        for(size_t j=0; j<lhs.extent(1); ++j) {
           lhs_(i,j) = lhs(i,j);
         }
       }

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -75,17 +75,17 @@ public:
     SharedMemView<double*>& elemVectorView = elemData.get_scratch_view_1D(*elemVectorField);
     SharedMemView<double**>& elemTensorView = elemData.get_scratch_view_2D(*elemTensorField);
 
-    EXPECT_EQ(nodesPerElem, nodalScalarView.dimension(0));
-    EXPECT_EQ(nodesPerElem, nodalVectorView.dimension(0));
-    EXPECT_EQ(4u,           nodalVectorView.dimension(1));
-    EXPECT_EQ(nodesPerElem, nodalTensorView.dimension(0));
-    EXPECT_EQ(3u,           nodalTensorView.dimension(1));
-    EXPECT_EQ(3u,           nodalTensorView.dimension(2));
+    EXPECT_EQ(nodesPerElem, nodalScalarView.extent(0));
+    EXPECT_EQ(nodesPerElem, nodalVectorView.extent(0));
+    EXPECT_EQ(4u,           nodalVectorView.extent(1));
+    EXPECT_EQ(nodesPerElem, nodalTensorView.extent(0));
+    EXPECT_EQ(3u,           nodalTensorView.extent(1));
+    EXPECT_EQ(3u,           nodalTensorView.extent(2));
 
-    EXPECT_EQ(1u, elemScalarView.dimension(0));
-    EXPECT_EQ(8u, elemVectorView.dimension(0));
-    EXPECT_EQ(2u, elemTensorView.dimension(0));
-    EXPECT_EQ(2u, elemTensorView.dimension(1));
+    EXPECT_EQ(1u, elemScalarView.extent(0));
+    EXPECT_EQ(8u, elemVectorView.extent(0));
+    EXPECT_EQ(2u, elemTensorView.extent(0));
+    EXPECT_EQ(2u, elemTensorView.extent(1));
   }
 
 private:

--- a/unit_tests/kernels/UnitTestContinuityAdvElem.C
+++ b/unit_tests/kernels/UnitTestContinuityAdvElem.C
@@ -91,9 +91,9 @@ TEST_F(ContinuityKernelHex8Mesh, advection_default)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(0), 8u);
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(1), 8u);
-  EXPECT_EQ(helperObjs.linsys->rhs_.dimension(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
 
   namespace gold_values = hex8_golds::advection_default;
 
@@ -137,9 +137,9 @@ TEST_F(ContinuityKernelHex8Mesh, advection_reduced_sens_cvfem_poisson)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(0), 8u);
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(1), 8u);
-  EXPECT_EQ(helperObjs.linsys->rhs_.dimension(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
 
   namespace gold_values = hex8_golds::advection_reduced_sensitivities;
 
@@ -183,9 +183,9 @@ TEST_F(ContinuityKernelHex8Mesh, advection_reduced_shift_cvfem_poisson)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(0), 8u);
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(1), 8u);
-  EXPECT_EQ(helperObjs.linsys->rhs_.dimension(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
 
   namespace gold_values = hex8_golds::advection_reduced_sensitivities;
 

--- a/unit_tests/kernels/UnitTestContinuityMassElem.C
+++ b/unit_tests/kernels/UnitTestContinuityMassElem.C
@@ -45,9 +45,9 @@ TEST_F(ContinuityKernelHex8Mesh, density_time_derivative)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(0), 8u);
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(1), 8u);
-  EXPECT_EQ(helperObjs.linsys->rhs_.dimension(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,-12.5);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_,0.0);
@@ -87,9 +87,9 @@ TEST_F(ContinuityKernelHex8Mesh, density_time_derivative_lumped)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(0), 8u);
-  EXPECT_EQ(helperObjs.linsys->lhs_.dimension(1), 8u);
-  EXPECT_EQ(helperObjs.linsys->rhs_.dimension(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,-12.5);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_,0.0);


### PR DESCRIPTION
Kokkos is deprecating 'dimension', so this commit replaces nalu's
usage of 'dimension' with 'extent'.