### PR TITLE
Make ScratchViews use ElemDataRequestsNGP instead of ElemDataRequests.

### DIFF
--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -60,9 +60,12 @@ public:
 
       int rhsSize = meElemInfo.nodalGatherSize_*numDof_, lhsSize = rhsSize*rhsSize, scratchIdsSize = rhsSize;
 
+      ElemDataRequestsNGP faceDataNGP(faceDataNeeded_);
+      ElemDataRequestsNGP elemDataNGP(elemDataNeeded_);
+
       const int bytes_per_team = 0;
       const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(lhsSize, rhsSize, scratchIdsSize,
-                                                                       nDim, faceDataNeeded_, elemDataNeeded_, meElemInfo);
+                                                                       nDim, faceDataNGP, elemDataNGP, meElemInfo);
 
       const bool interleaveMeViews = false;
 
@@ -80,7 +83,7 @@ public:
                        "AssembleFaceElemSolverAlgorithm expected nodesPerEntity_ = "
                        <<nodesPerFace_<<", but b.topology().num_nodes() = "<<b.topology().num_nodes());
 
-        SharedMemData_FaceElem smdata(team, bulk, faceDataNeeded_, elemDataNeeded_, meElemInfo, rhsSize);
+        SharedMemData_FaceElem smdata(team, bulk, faceDataNGP, elemDataNGP, meElemInfo, rhsSize);
 
         const size_t bucketLen   = b.size();
         const size_t simdBucketLen = sierra::nalu::get_num_simd_groups(bucketLen);
@@ -106,8 +109,8 @@ public:
               smdata.connectedNodes[simdFaceIndex] = bulk.begin_nodes(elems[0]);
               smdata.elemFaceOrdinal = thisElemFaceOrdinal;
               elemFaceOrdinal = thisElemFaceOrdinal;
-              sierra::nalu::fill_pre_req_data(faceDataNeeded_, bulk, face, *smdata.faceViews[simdFaceIndex], interleaveMeViews);
-              sierra::nalu::fill_pre_req_data(elemDataNeeded_, bulk, elems[0], *smdata.elemViews[simdFaceIndex], interleaveMeViews);
+              sierra::nalu::fill_pre_req_data(faceDataNGP, bulk, face, *smdata.faceViews[simdFaceIndex], interleaveMeViews);
+              sierra::nalu::fill_pre_req_data(elemDataNGP, bulk, elems[0], *smdata.elemViews[simdFaceIndex], interleaveMeViews);
               ++simdFaceIndex;
             }
             smdata.numSimdFaces = simdFaceIndex;
@@ -115,8 +118,8 @@ public:
   
             copy_and_interleave(smdata.faceViews, smdata.numSimdFaces, smdata.simdFaceViews, interleaveMeViews);
             copy_and_interleave(smdata.elemViews, smdata.numSimdFaces, smdata.simdElemViews, interleaveMeViews);
-            fill_master_element_views(faceDataNeeded_, bulk, smdata.simdFaceViews, smdata.elemFaceOrdinal);
-            fill_master_element_views(elemDataNeeded_, bulk, smdata.simdElemViews, smdata.elemFaceOrdinal);
+            fill_master_element_views(faceDataNGP, bulk, smdata.simdFaceViews, smdata.elemFaceOrdinal);
+            fill_master_element_views(elemDataNGP, bulk, smdata.simdElemViews, smdata.elemFaceOrdinal);
   
             lamdbaFunc(smdata);
           } while(numFacesProcessed < simdGroupLen);

--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -54,6 +54,9 @@ struct FieldInfo {
   FieldInfo(const stk::mesh::FieldBase* fld, unsigned tensorDim1, unsigned tensorDim2)
   : field(fld), scalarsDim1(tensorDim1), scalarsDim2(tensorDim2)
   {}
+  FieldInfo()
+  : field(nullptr), scalarsDim1(0), scalarsDim2(0)
+  {}
 
   const stk::mesh::FieldBase* field;
   unsigned scalarsDim1;

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -11,7 +11,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 
-#include <ElemDataRequests.h>
+#include <ElemDataRequestsNGP.h>
 #include <KokkosInterface.h>
 #include <SimdInterface.h>
 
@@ -23,7 +23,7 @@ namespace nalu{
 struct SharedMemData {
     SharedMemData(const sierra::nalu::TeamHandleType& team,
          const stk::mesh::BulkData& bulk,
-         const ElemDataRequests& dataNeededByKernels,
+         const ElemDataRequestsNGP& dataNeededByKernels,
          unsigned nodesPerEntity,
          unsigned rhsSize)
      : simdPrereqData(team, bulk, nodesPerEntity, dataNeededByKernels)
@@ -56,8 +56,8 @@ struct SharedMemData {
 struct SharedMemData_FaceElem {
     SharedMemData_FaceElem(const sierra::nalu::TeamHandleType& team,
          const stk::mesh::BulkData& bulk,
-         const ElemDataRequests& faceDataNeeded,
-         const ElemDataRequests& elemDataNeeded,
+         const ElemDataRequestsNGP& faceDataNeeded,
+         const ElemDataRequestsNGP& elemDataNeeded,
          const ScratchMeInfo& meElemInfo,
          unsigned rhsSize)
      : simdFaceViews(team, bulk, meElemInfo.nodesPerFace_, faceDataNeeded),

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -64,7 +64,7 @@
 #include <kernel/KernelBuilderLog.h>
 
 // kernels
-#include <AssembleElemSolverAlgorithm.h>
+#include <AssembleFaceElemSolverAlgorithm.h>
 #include <kernel/ScalarMassElemKernel.h>
 #include <kernel/ScalarAdvDiffElemKernel.h>
 #include <kernel/ScalarUpwAdvDiffElemKernel.h>

--- a/unit_tests/UnitTestElemDataRequests.C
+++ b/unit_tests/UnitTestElemDataRequests.C
@@ -16,7 +16,6 @@
 void do_the_test(const sierra::nalu::ElemDataRequests& dataReq)
 {
   sierra::nalu::ElemDataRequestsNGP ngpDataReq(dataReq);
-  ngpDataReq.copy_to_device();
 
   unsigned numCorrectTests = 0;
   auto team_exec = sierra::nalu::get_device_team_policy(1, 0, 0);


### PR DESCRIPTION
This brings ScratchViews a step closer to being constructable on GPU.

Note: ElemDataRequestsNGP still holds MasterElement pointers that come
from the host, that will need to be addressed.