### PR TITLE
Fix neutral ABL regression test and examples

### DIFF
--- a/examples/abl_neutral/abl_simulation.yaml
+++ b/examples/abl_neutral/abl_simulation.yaml
@@ -140,9 +140,9 @@ realms:
     periodic_user_data:
       search_tolerance: 0.0001
 
-  - symmetry_boundary_condition: bc_upper
+  - abltop_boundary_condition: bc_upper
     target_name: upper
-    symmetry_user_data:
+    abltop_user_data:
       normal_temperature_gradient: 0.003
 
   - wall_boundary_condition: bc_lower

--- a/examples/abl_neutral/template_input_files/ablNeutralEdge.yaml
+++ b/examples/abl_neutral/template_input_files/ablNeutralEdge.yaml
@@ -140,9 +140,9 @@ realms:
       periodic_user_data:
         search_tolerance: 0.0001
 
-    - symmetry_boundary_condition: bc_upper
+    - abltop_boundary_condition: bc_upper
       target_name: upper
-      symmetry_user_data:
+      abltop_user_data:
         normal_temperature_gradient: -0.003
 
     - wall_boundary_condition: bc_lower

--- a/examples/nalu_input_fileX
+++ b/examples/nalu_input_fileX
@@ -495,7 +495,7 @@ class mapping_object_class():
         for var in self.yaml_input['realms'][0]['boundary_conditions']:
 
             # Top boundary condition
-            if 'symmetry_boundary_condition' in var.keys():
+            if 'abltop_boundary_condition' in var.keys():
 
                 # If the gradient is specified, use that value, if not, compute
                 #     it from the initial condition
@@ -505,7 +505,7 @@ class mapping_object_class():
                                 self.yaml_setup['temperature_heights'][-1]
                                 - self.yaml_setup['temperature_heights'][-2])
                 # Assign the initial condition
-                var['symmetry_user_data']['normal_temperature_gradient'] = \
+                var['abltop_user_data']['normal_temperature_gradient'] = \
                     TGradUpper
 
 
@@ -721,9 +721,9 @@ class mapping_object_class():
         # Loop through all the boundary conditions and modify accordingly
         for var in self.yaml_input['realms'][0]['boundary_conditions']:
             # Top boundary condition
-            if 'symmetry_boundary_condition' in var.keys():
+            if 'abltop_boundary_condition' in var.keys():
                 # Read the upper wall temperature gradient
-                var['symmetry_user_data']['normal_temperature_gradient'] = Tg
+                var['abltop_user_data']['normal_temperature_gradient'] = Tg
 
 
     def set_boundary_layer_statistics(self):

--- a/examples/wind_farm/case_1_precursor_simulation.yaml
+++ b/examples/wind_farm/case_1_precursor_simulation.yaml
@@ -140,9 +140,9 @@ realms:
     periodic_user_data:
       search_tolerance: 0.0001
 
-  - symmetry_boundary_condition: bc_upper
+  - abltop_boundary_condition: bc_upper
     target_name: upper
-    symmetry_user_data:
+    abltop_user_data:
       normal_temperature_gradient: 0.003
 
   - wall_boundary_condition: bc_lower

--- a/examples/wind_farm/case_2_abl_precursor_boundary_data.yaml
+++ b/examples/wind_farm/case_2_abl_precursor_boundary_data.yaml
@@ -140,9 +140,9 @@ realms:
     periodic_user_data:
       search_tolerance: 0.0001
 
-  - symmetry_boundary_condition: bc_upper
+  - abltop_boundary_condition: bc_upper
     target_name: upper
-    symmetry_user_data:
+    abltop_user_data:
       normal_temperature_gradient: -0.003
 
   - wall_boundary_condition: bc_lower

--- a/examples/wind_farm/case_3_wind_farm.yaml
+++ b/examples/wind_farm/case_3_wind_farm.yaml
@@ -166,9 +166,9 @@ realms:
       - 0.0
       temperature: 300.0
       external_data: yes
-  - symmetry_boundary_condition: bc_upper
+  - abltop_boundary_condition: bc_upper
     target_name: upper
-    symmetry_user_data:
+    abltop_user_data:
       normal_temperature_gradient: -0.003
 
   - wall_boundary_condition: bc_lower

--- a/examples/wind_farm/setup_abl_precursor_boundary_data.yaml
+++ b/examples/wind_farm/setup_abl_precursor_boundary_data.yaml
@@ -140,9 +140,9 @@ realms:
     periodic_user_data:
       search_tolerance: 0.0001
 
-  - symmetry_boundary_condition: bc_upper
+  - abltop_boundary_condition: bc_upper
     target_name: upper
-    symmetry_user_data:
+    abltop_user_data:
       normal_temperature_gradient: -0.003
 
   - wall_boundary_condition: bc_lower

--- a/examples/wind_farm/template_input_files/abl_precursor.yaml
+++ b/examples/wind_farm/template_input_files/abl_precursor.yaml
@@ -140,9 +140,9 @@ realms:
       periodic_user_data:
         search_tolerance: 0.0001
 
-    - symmetry_boundary_condition: bc_upper
+    - abltop_boundary_condition: bc_upper
       target_name: upper
-      symmetry_user_data:
+      abltop_user_data:
         normal_temperature_gradient: -0.003
 
     - wall_boundary_condition: bc_lower

--- a/examples/wind_farm/template_input_files/abl_precursor_boundary_data.yaml
+++ b/examples/wind_farm/template_input_files/abl_precursor_boundary_data.yaml
@@ -140,9 +140,9 @@ realms:
       periodic_user_data:
         search_tolerance: 0.0001
 
-    - symmetry_boundary_condition: bc_upper
+    - abltop_boundary_condition: bc_upper
       target_name: upper
-      symmetry_user_data:
+      abltop_user_data:
         normal_temperature_gradient: -0.003
 
     - wall_boundary_condition: bc_lower

--- a/examples/wind_farm/template_input_files/wind_farm.yaml
+++ b/examples/wind_farm/template_input_files/wind_farm.yaml
@@ -150,9 +150,9 @@ realms:
       periodic_user_data:
         search_tolerance: 0.0001
 
-    - symmetry_boundary_condition: bc_upper
+    - abltop_boundary_condition: bc_upper
       target_name: upper
-      symmetry_user_data:
+      abltop_user_data:
         normal_temperature_gradient: -0.003
 
     - wall_boundary_condition: bc_lower

--- a/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.i
+++ b/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.i
@@ -124,7 +124,7 @@ realms:
     # Boundary conditions are periodic on the north, south, east, and west
     # sides.  The lower boundary condition is a wall that uses an atmospheric
     # rough wall shear stress model.  The upper boundary is a stress free
-    # rigid lid applied through symmetry, but the temperature is set to hold
+    # rigid lid,  the temperature is set to hold
     # a specified boundary normal gradient that matches the stable layer
     # immediately below.
     boundary_conditions:
@@ -139,10 +139,12 @@ realms:
       periodic_user_data:
         search_tolerance: 0.0001 
 
-    - symmetry_boundary_condition: bc_upper
+    - abltop_boundary_condition: bc_upper
       target_name: upper
-      symmetry_user_data:
+      abltop_user_data:
+        potential_flow_bc: false
         normal_temperature_gradient: -0.003
+
 
     - wall_boundary_condition: bc_lower
       target_name: lower

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -925,8 +925,6 @@ EnthalpyEquationSystem::register_symmetry_bc(
   ScalarFieldType &enthalpyNp1 = enthalpy_->field_of_state(stk::mesh::StateNP1);
   VectorFieldType &dhdxNone = dhdx_->field_of_state(stk::mesh::StateNone);
 
-  stk::mesh::MetaData &meta_data = realm_.meta_data();
-
   // extract user data
   SymmetryUserData userData = symmetryBCData.userData_;
   std::string temperatureName = "temperature";

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -1168,6 +1168,10 @@ namespace YAML
   bool convert<sierra::nalu::SymmetryUserData>::decode(const Node& node,
     sierra::nalu::SymmetryUserData& symmetryData)
   {
+    // Normal temperature gradient for ABL top BC is now implemented in
+    // abltop_boundary_condition. Throw error to inform user of the change
+    if (node["normal_temperature_gradient"])
+      throw std::runtime_error("SymmetryBoundaryConditionData: Normal temperature gradient for ABL top boundary must use abltop_boundary_condition");
     return true;
   }
 


### PR DESCRIPTION
Pull request #34 introduced a change in the specification of temperature
gradient for ABL top boundary. This commit propagates the necessary
changes to ablNeutralEdge regression test and the ABL examples.

Fix unused warning in EnthalpyEquationSystem.C

Fixes #52