### PR TITLE
Fix 'partially overridden' warnings

### DIFF
--- a/include/AuxFunction.h
+++ b/include/AuxFunction.h
@@ -57,7 +57,7 @@ public:
   }
   virtual void setup(const double time) {}
 
-private:
+protected:
 
   // Derived classes must at_least implement this method
   virtual void do_evaluate(
@@ -82,7 +82,6 @@ private:
     do_evaluate(coords, time, spatialDimension, numPoints, fieldPtr, fieldSize, 0, fieldSize);
   }
 
-protected:
   const unsigned beginPos_;
   const unsigned endPos_;
 };

--- a/include/ConstantAuxFunction.h
+++ b/include/ConstantAuxFunction.h
@@ -19,6 +19,7 @@ namespace nalu{
 class ConstantAuxFunction : public AuxFunction
 {
 public:
+  using AuxFunction::do_evaluate;
 
   ConstantAuxFunction(
     const unsigned beginPos,

--- a/include/kernel/ContinuityAdvElemKernel.h
+++ b/include/kernel/ContinuityAdvElemKernel.h
@@ -44,6 +44,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/ContinuityInflowElemKernel.h
+++ b/include/kernel/ContinuityInflowElemKernel.h
@@ -44,6 +44,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType **>&lhs,
     SharedMemView<DoubleType *>&rhs,

--- a/include/kernel/ContinuityMassElemKernel.h
+++ b/include/kernel/ContinuityMassElemKernel.h
@@ -45,6 +45,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/ContinuityOpenElemKernel.h
+++ b/include/kernel/ContinuityOpenElemKernel.h
@@ -44,6 +44,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**> &lhs,
     SharedMemView<DoubleType*> &rhs,

--- a/include/kernel/MomentumActuatorSrcElemKernel.h
+++ b/include/kernel/MomentumActuatorSrcElemKernel.h
@@ -40,6 +40,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/MomentumAdvDiffElemKernel.h
+++ b/include/kernel/MomentumAdvDiffElemKernel.h
@@ -41,6 +41,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
+++ b/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
@@ -39,6 +39,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/MomentumBuoyancySrcElemKernel.h
+++ b/include/kernel/MomentumBuoyancySrcElemKernel.h
@@ -39,6 +39,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/MomentumCoriolisSrcElemKernel.h
+++ b/include/kernel/MomentumCoriolisSrcElemKernel.h
@@ -35,6 +35,7 @@ public:
 
   virtual ~MomentumCoriolisSrcElemKernel();
 
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/MomentumHybridTurbElemKernel.h
+++ b/include/kernel/MomentumHybridTurbElemKernel.h
@@ -38,6 +38,7 @@ public:
 
   virtual ~MomentumHybridTurbElemKernel() {}
 
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/MomentumMassElemKernel.h
+++ b/include/kernel/MomentumMassElemKernel.h
@@ -45,6 +45,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/MomentumOpenAdvDiffElemKernel.h
+++ b/include/kernel/MomentumOpenAdvDiffElemKernel.h
@@ -51,6 +51,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**> &lhs,
     SharedMemView<DoubleType*> &rhs,

--- a/include/kernel/MomentumSymmetryElemKernel.h
+++ b/include/kernel/MomentumSymmetryElemKernel.h
@@ -42,6 +42,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**> &lhs,
     SharedMemView<DoubleType*> &rhs,

--- a/include/kernel/MomentumUpwAdvDiffElemKernel.h
+++ b/include/kernel/MomentumUpwAdvDiffElemKernel.h
@@ -47,6 +47,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/MomentumWallFunctionElemKernel.h
+++ b/include/kernel/MomentumWallFunctionElemKernel.h
@@ -39,6 +39,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/ScalarAdvDiffElemKernel.h
+++ b/include/kernel/ScalarAdvDiffElemKernel.h
@@ -41,6 +41,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/ScalarDiffElemKernel.h
+++ b/include/kernel/ScalarDiffElemKernel.h
@@ -41,6 +41,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/ScalarDiffFemKernel.h
+++ b/include/kernel/ScalarDiffFemKernel.h
@@ -43,6 +43,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/ScalarFluxPenaltyElemKernel.h
+++ b/include/kernel/ScalarFluxPenaltyElemKernel.h
@@ -43,6 +43,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**> &lhs,
     SharedMemView<DoubleType*> &rhs,

--- a/include/kernel/ScalarMassElemKernel.h
+++ b/include/kernel/ScalarMassElemKernel.h
@@ -46,6 +46,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/ScalarOpenAdvElemKernel.h
+++ b/include/kernel/ScalarOpenAdvElemKernel.h
@@ -52,6 +52,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**> &lhs,
     SharedMemView<DoubleType*> &rhs,

--- a/include/kernel/ScalarUpwAdvDiffElemKernel.h
+++ b/include/kernel/ScalarUpwAdvDiffElemKernel.h
@@ -47,6 +47,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
+++ b/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
@@ -37,6 +37,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h
@@ -39,6 +39,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/TurbKineticEnergyKsgsSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergyKsgsSrcElemKernel.h
@@ -39,6 +39,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
@@ -37,6 +37,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
@@ -37,6 +37,7 @@ public:
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
+  using Kernel::execute;
   virtual void execute(
     SharedMemView<DoubleType**>&,
     SharedMemView<DoubleType*>&,

--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -32,6 +32,8 @@ class HexahedralP2Element : public MasterElement
 {
 public:
   using AlgTraits = AlgTraitsHex27;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   HexahedralP2Element();
   virtual ~HexahedralP2Element() {}
@@ -203,6 +205,9 @@ public:
 
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shifted_grad_op;
 
   void shape_fcn(SharedMemView<DoubleType**> &shpfc) final;
   void shifted_shape_fcn(SharedMemView<DoubleType**> &shpfc) final;
@@ -269,6 +274,7 @@ public:
 
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
+  using MasterElement::determinant;
 
   void shape_fcn(SharedMemView<DoubleType**> &shpfc);
   void shifted_shape_fcn(SharedMemView<DoubleType**> &shpfc);
@@ -471,6 +477,8 @@ class Quad93DSCS : public HexahedralP2Element
 public:
   Quad93DSCS();
   virtual ~Quad93DSCS() {}
+
+  using MasterElement::determinant;
 
   const int * ipNodeMap(int ordinal = 0);
 

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -25,6 +25,9 @@ public:
 
   const int * ipNodeMap(int ordinal = 0);
 
+  using MasterElement::determinant;
+  using MasterElement::shifted_grad_op;
+
   // NGP-ready methods first
   void determinant(
     SharedMemView<DoubleType**>& coords,
@@ -76,6 +79,8 @@ public:
   virtual ~HexSCS();
 
   const int * ipNodeMap(int ordinal = 0);
+
+  using MasterElement::determinant;
 
   // NGP-ready methods first
   void shape_fcn(

--- a/include/master_element/Hex8FEM.h
+++ b/include/master_element/Hex8FEM.h
@@ -22,6 +22,11 @@ public:
   Hex8FEM();
   virtual ~Hex8FEM();
 
+  using MasterElement::grad_op;
+  using MasterElement::shifted_grad_op;
+  using MasterElement::face_grad_op;
+  using MasterElement::gij;
+
   void grad_op(
     const int nelem,
     const double *coords,

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -515,6 +515,9 @@ class Edge32DSCS : public QuadrilateralP2Element
 public:
   Edge32DSCS();
   virtual ~Edge32DSCS() {}
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   const int * ipNodeMap(int ordinal = 0);
 

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -177,15 +177,15 @@ public:
 
   virtual const int * adjacentNodes() {
     throw std::runtime_error("adjacentNodes not implemented");
-    return NULL;}
+    }
 
   virtual const int * scsIpEdgeOrd() {
     throw std::runtime_error("scsIpEdgeOrd not implemented");
-    return NULL;}
+    }
 
   virtual const int * ipNodeMap(int ordinal = 0) {
       throw std::runtime_error("ipNodeMap not implemented");
-      return NULL;}
+     }
 
   virtual void shape_fcn(
     double *shpfc) {
@@ -202,14 +202,14 @@ public:
   virtual int opposingFace(
     const int ordinal, const int node) {
     throw std::runtime_error("opposingFace not implemented"); 
-    return 0; }
+    }
 
   virtual double isInElement(
     const double *elemNodalCoord,
     const double *pointCoord,
     double *isoParCoord) {
     throw std::runtime_error("isInElement not implemented"); 
-    return 1.0e6; }
+    }
 
   virtual void interpolatePoint(
     const int &nComp,
@@ -280,6 +280,8 @@ class QuadrilateralP2Element : public MasterElement
 {
 public:
   using Traits = AlgTraitsQuad9_2D;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   QuadrilateralP2Element();
   virtual ~QuadrilateralP2Element() {}
@@ -377,6 +379,10 @@ public:
   Tri2DSCV();
   virtual ~Tri2DSCV();
 
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
+
   const int * ipNodeMap(int ordinal = 0);
 
   void determinant(
@@ -404,6 +410,10 @@ public:
 
   Tri3DSCS();
   virtual ~Tri3DSCS();
+
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   const int * ipNodeMap(int ordinal = 0);
 
@@ -455,6 +465,9 @@ class Edge2DSCS : public MasterElement
 public:
   Edge2DSCS();
   virtual ~Edge2DSCS();
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   const int * ipNodeMap(int ordinal = 0);
 

--- a/include/master_element/MasterElementHO.h
+++ b/include/master_element/MasterElementHO.h
@@ -35,6 +35,10 @@ class TensorProductQuadratureRule;
 class HigherOrderHexSCV final: public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shape_fcn;
+
   HigherOrderHexSCV(
     ElementDescription elem,
     LagrangeBasis basis,
@@ -92,6 +96,12 @@ private:
 class HigherOrderHexSCS final: public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shape_fcn;
+  using MasterElement::gij;
+  using MasterElement::face_grad_op;
+
   HigherOrderHexSCS(
     ElementDescription elem,
     LagrangeBasis basis,
@@ -185,6 +195,9 @@ private:
 class HigherOrderQuad3DSCS final: public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+
   HigherOrderQuad3DSCS(
     ElementDescription elem,
     LagrangeBasis basis,
@@ -237,6 +250,10 @@ private:
 class HigherOrderQuad2DSCV final: public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::grad_op;
+
   HigherOrderQuad2DSCV(
     ElementDescription elem,
     LagrangeBasis basis,
@@ -291,6 +308,12 @@ private:
 class HigherOrderQuad2DSCS final: public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::grad_op;
+  using MasterElement::face_grad_op;
+  using MasterElement::gij;
+
   HigherOrderQuad2DSCS(
     ElementDescription elem,
     LagrangeBasis basis,

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -39,7 +39,11 @@ class PyrSCV : public MasterElement
 {
 public:
   using AlgTraits = AlgTraitsPyr5;
-
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shifted_grad_op;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   PyrSCV();
   virtual ~PyrSCV();
@@ -88,6 +92,9 @@ class PyrSCS : public MasterElement
 {
 public:
   using AlgTraits = AlgTraitsPyr5;
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   PyrSCS();
   virtual ~PyrSCS();

--- a/include/master_element/Quad42DCVFEM.h
+++ b/include/master_element/Quad42DCVFEM.h
@@ -31,6 +31,12 @@ class Quad42DSCV : public MasterElement
 {
 public:
   using Traits = AlgTraitsQuad4_2D;
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shifted_grad_op;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
+
   Quad42DSCV();
   virtual ~Quad42DSCV();
 
@@ -73,6 +79,10 @@ class Quad42DSCS : public MasterElement
 {
 public:
   using Traits = AlgTraitsQuad4_2D;
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
+
   Quad42DSCS();
   virtual ~Quad42DSCS();
 

--- a/include/master_element/Quad43DCVFEM.h
+++ b/include/master_element/Quad43DCVFEM.h
@@ -18,6 +18,7 @@ namespace nalu{
 class Quad3DSCS : public MasterElement
 {
 public:
+  using MasterElement::determinant;
 
   Quad3DSCS();
   virtual ~Quad3DSCS();

--- a/include/master_element/Quad92DCVFEM.h
+++ b/include/master_element/Quad92DCVFEM.h
@@ -31,6 +31,10 @@ namespace nalu{
 class Quad92DSCV : public QuadrilateralP2Element
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shifted_grad_op;
+
   Quad92DSCV();
   virtual ~Quad92DSCV() {}
 
@@ -74,6 +78,8 @@ private:
 class Quad92DSCS : public QuadrilateralP2Element
 {
 public:
+  using MasterElement::determinant;
+
   Quad92DSCS();
   virtual ~Quad92DSCS() {}
 

--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -18,6 +18,11 @@ namespace nalu{
 class TetSCV : public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shifted_grad_op;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   TetSCV();
   virtual ~TetSCV();
@@ -60,6 +65,9 @@ public:
 class TetSCS : public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   TetSCS();
   virtual ~TetSCS();

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -30,6 +30,12 @@ namespace nalu{
 class Tri32DSCV : public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shifted_grad_op;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
+
   Tri32DSCV();
   virtual ~Tri32DSCV();
 
@@ -72,6 +78,10 @@ public:
 class Tri32DSCS : public MasterElement
 {
 public:
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
+
   Tri32DSCS();
   virtual ~Tri32DSCS();
 

--- a/include/master_element/Wed6CVFEM.h
+++ b/include/master_element/Wed6CVFEM.h
@@ -20,6 +20,12 @@ public:
   WedSCV();
   virtual ~WedSCV();
 
+  using MasterElement::determinant;
+  using MasterElement::grad_op;
+  using MasterElement::shifted_grad_op;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
+
   const int * ipNodeMap(int ordinal = 0);
 
   void determinant(
@@ -60,6 +66,10 @@ class WedSCS : public MasterElement
 public:
   WedSCS();
   virtual ~WedSCS();
+
+  using MasterElement::determinant;
+  using MasterElement::shape_fcn;
+  using MasterElement::shifted_shape_fcn;
 
   const int * ipNodeMap(int ordinal = 0);
 

--- a/include/user_functions/BoundaryLayerPerturbationAuxFunction.h
+++ b/include/user_functions/BoundaryLayerPerturbationAuxFunction.h
@@ -32,6 +32,7 @@ public:
 
   virtual ~BoundaryLayerPerturbationAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/BoussinesqNonIsoTemperatureAuxFunction.h
+++ b/include/user_functions/BoussinesqNonIsoTemperatureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~BoussinesqNonIsoTemperatureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/BoussinesqNonIsoVelocityAuxFunction.h
+++ b/include/user_functions/BoussinesqNonIsoVelocityAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~BoussinesqNonIsoVelocityAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/CappingInversionTemperatureAuxFunction.h
+++ b/include/user_functions/CappingInversionTemperatureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~CappingInversionTemperatureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/ConvectingTaylorVortexPressureAuxFunction.h
+++ b/include/user_functions/ConvectingTaylorVortexPressureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~ConvectingTaylorVortexPressureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,
@@ -52,6 +53,7 @@ public:
 
   virtual ~ConvectingTaylorVortexPressureGradAuxFunction() {}
 
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/ConvectingTaylorVortexVelocityAuxFunction.h
+++ b/include/user_functions/ConvectingTaylorVortexVelocityAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~ConvectingTaylorVortexVelocityAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/FlowPastCylinderTempAuxFunction.h
+++ b/include/user_functions/FlowPastCylinderTempAuxFunction.h
@@ -17,11 +17,11 @@ namespace nalu{
 class FlowPastCylinderTempAuxFunction : public AuxFunction
 {
 public:
-
   FlowPastCylinderTempAuxFunction();
 
   virtual ~FlowPastCylinderTempAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/KovasznayPressureAuxFunction.h
+++ b/include/user_functions/KovasznayPressureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~KovasznayPressureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,
@@ -47,6 +48,7 @@ public:
 
   virtual ~KovasznayPressureGradientAuxFunction() {}
 
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/KovasznayVelocityAuxFunction.h
+++ b/include/user_functions/KovasznayVelocityAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~KovasznayVelocityAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/LinearRampMeshDisplacementAuxFunction.h
+++ b/include/user_functions/LinearRampMeshDisplacementAuxFunction.h
@@ -26,6 +26,7 @@ public:
 
   virtual ~LinearRampMeshDisplacementAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/OneTwoTenVelocityAuxFunction.h
+++ b/include/user_functions/OneTwoTenVelocityAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~OneTwoTenVelocityAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/RayleighTaylorMixFracAuxFunction.h
+++ b/include/user_functions/RayleighTaylorMixFracAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~RayleighTaylorMixFracAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/SinMeshDisplacementAuxFunction.h
+++ b/include/user_functions/SinMeshDisplacementAuxFunction.h
@@ -26,6 +26,7 @@ public:
 
   virtual ~SinMeshDisplacementAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/SinProfileChannelFlowVelocityAuxFunction.h
+++ b/include/user_functions/SinProfileChannelFlowVelocityAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~SinProfileChannelFlowVelocityAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/SteadyTaylorVortexGradPressureAuxFunction.h
+++ b/include/user_functions/SteadyTaylorVortexGradPressureAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~SteadyTaylorVortexGradPressureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/SteadyTaylorVortexPressureAuxFunction.h
+++ b/include/user_functions/SteadyTaylorVortexPressureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~SteadyTaylorVortexPressureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/SteadyTaylorVortexVelocityAuxFunction.h
+++ b/include/user_functions/SteadyTaylorVortexVelocityAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~SteadyTaylorVortexVelocityAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/SteadyThermal3dContactAuxFunction.h
+++ b/include/user_functions/SteadyThermal3dContactAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~SteadyThermal3dContactAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/SteadyThermal3dContactDtDxAuxFunction.h
+++ b/include/user_functions/SteadyThermal3dContactDtDxAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~SteadyThermal3dContactDtDxAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/SteadyThermalContactAuxFunction.h
+++ b/include/user_functions/SteadyThermalContactAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~SteadyThermalContactAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/TaylorGreenPressureAuxFunction.h
+++ b/include/user_functions/TaylorGreenPressureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~TaylorGreenPressureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/TaylorGreenVelocityAuxFunction.h
+++ b/include/user_functions/TaylorGreenVelocityAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~TaylorGreenVelocityAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/TornadoAuxFunction.h
+++ b/include/user_functions/TornadoAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~TornadoAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/VariableDensityMixFracAuxFunction.h
+++ b/include/user_functions/VariableDensityMixFracAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~VariableDensityMixFracAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/VariableDensityNonIsoTemperatureAuxFunction.h
+++ b/include/user_functions/VariableDensityNonIsoTemperatureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~VariableDensityNonIsoTemperatureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/VariableDensityPressureAuxFunction.h
+++ b/include/user_functions/VariableDensityPressureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~VariableDensityPressureAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/VariableDensityVelocityAuxFunction.h
+++ b/include/user_functions/VariableDensityVelocityAuxFunction.h
@@ -25,6 +25,7 @@ public:
 
   virtual ~VariableDensityVelocityAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/WindEnergyAuxFunction.h
+++ b/include/user_functions/WindEnergyAuxFunction.h
@@ -31,6 +31,7 @@ public:
 
   virtual ~WindEnergyAuxFunction();
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/WindEnergyTaylorVortexAuxFunction.h
+++ b/include/user_functions/WindEnergyTaylorVortexAuxFunction.h
@@ -26,6 +26,7 @@ public:
 
   virtual ~WindEnergyTaylorVortexAuxFunction() {}
   
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,

--- a/include/user_functions/WindEnergyTaylorVortexPressureAuxFunction.h
+++ b/include/user_functions/WindEnergyTaylorVortexPressureAuxFunction.h
@@ -23,6 +23,7 @@ public:
 
   virtual ~WindEnergyTaylorVortexPressureAuxFunction() {}
 
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,
@@ -53,6 +54,7 @@ public:
 
   virtual ~WindEnergyTaylorVortexPressureGradAuxFunction() {}
 
+  using AuxFunction::do_evaluate;
   virtual void do_evaluate(
     const double * coords,
     const double time,


### PR DESCRIPTION
This commit addresses the following warnings issued when compiling on GCC 7.2.0 and Cuda 9.x on ORNL SummitDev and SNL ascicgpu machines.

```
nalu-wind/include/master_element/MasterElement.h(180): warning: statement is unreachable

nalu-wind/include/master_element/MasterElement.h(374): warning: overloaded
virtual function "sierra::nalu::MasterElement::determinant" is only partially
overridden in class "sierra::nalu::Tri2DSCV"

nalu-wind/include/user_functions/FlowPastCylinderTempAuxFunction.h(17): warning:
overloaded virtual function "sierra::nalu::AuxFunction::do_evaluate" is only
partially overridden in class "sierra::nalu::FlowPastCylinderTempAuxFunction"

nalu-wind/include/kernel/ScalarMassElemKernel.h(30): warning: overloaded virtual function "sierra::nalu::Kernel::execute" is only partially overridden in class "sierra::nalu::ScalarMassElemKernel<sierra::nalu::AlgTraitsHex8>"
          detected during:
            instantiation of class "sierra::nalu::ScalarMassElemKernel<AlgTraits> [with AlgTraits=sierra::nalu::AlgTraitsHex8]"
```