### PR TITLE
Corrected space derivative typos

### DIFF
--- a/docs/source/theory/windEnergy.rst
+++ b/docs/source/theory/windEnergy.rst
@@ -88,7 +88,7 @@ as shown below
    :label: abl_pottemp
 
    \frac{\partial}{\partial t} \left(\bar{\rho}\, \widetilde{\theta}\right) +
-   \frac{\partial}{\partial t} \left(\bar{\rho}\, \widetilde{u}_j \widetilde{\theta} \right) = - \frac{\partial}{\partial x_j} \hat{q}_j
+   \frac{\partial}{\partial x_j} \left(\bar{\rho}\, \widetilde{u}_j \widetilde{\theta} \right) = - \frac{\partial}{\partial x_j} \hat{q}_j
 
 where, :math:`\hat{q}_j` represents the temperature transport due to molecular and SFS
 turbulence effects. Due to the high Reynolds number associated with ABL flows,
@@ -118,7 +118,7 @@ equation. The enthalpy equation solved in wind energy problems is shown below
    :label: abl_enth
 
    \frac{\partial}{\partial t} \left(\bar{\rho}\, \widetilde{T}\right) +
-   \frac{\partial}{\partial t} \left(\bar{\rho}\, \widetilde{u}_j \widetilde{T} \right) = - \frac{\partial}{\partial x_j} q_j
+   \frac{\partial}{\partial x_j} \left(\bar{\rho}\, \widetilde{u}_j \widetilde{T} \right) = - \frac{\partial}{\partial x_j} q_j
 
 It is noted here that the terms :math:`\hat{q}_j` (Eq. :eq:`abl_pottemp`) and
 :math:`q_j` (Eq. :eq:`abl_enth`) are not equivalent and must be scaled


### PR DESCRIPTION
d/dx_j derivatives were mistakenly typed as d/dt derivatives