### PR TITLE
Fix memory errors in nightly test for ABL Top BC implementation.

### DIFF
--- a/include/AssembleMomentumEdgeABLTopBC.h
+++ b/include/AssembleMomentumEdgeABLTopBC.h
@@ -64,7 +64,7 @@ public:
     stk::mesh::Part *part,
     EquationSystem *eqSystem, std::vector<int>& grid_dims_,
     std::vector<int>& horiz_bcs_, double z_sample_);
-  virtual ~AssembleMomentumEdgeABLTopBC() {}
+  virtual ~AssembleMomentumEdgeABLTopBC();
   virtual void initialize_connectivity();
 
   /** Main function to compute and set the boundary values.

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -2156,7 +2156,7 @@ MomentumEquationSystem::register_abltop_bc(
     //       faceElemSolverAlg->elemDataNeeded_);
     // }
     throw std::runtime_error("MomentumEqSys: Consolidated algorithm not "
-                             "supported at this time for ABL Top BC.")
+                             "supported at this time for ABL Top BC.");
   }
 #else
   throw std::runtime_error(


### PR DESCRIPTION
- Deallocate fftw plans within destructor
- Use std::runtime_error instead of printf+exit for signaling error