### PR TITLE
Added total-num-fields to ElemDataRequestsNGP.

### DIFF
--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -52,7 +52,7 @@ public:
     const int lhsSize = rhsSize_*rhsSize_;
     const int scratchIdsSize = rhsSize_;
 
-   ElemDataRequestsNGP dataNeededNGP(dataNeededByKernels_);
+   ElemDataRequestsNGP dataNeededNGP(dataNeededByKernels_, meta_data.get_fields().size());
 
    const int bytes_per_team = 0;
    const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(lhsSize, rhsSize_, scratchIdsSize,

--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -45,6 +45,7 @@ public:
   void run_face_elem_algorithm(stk::mesh::BulkData& bulk, LambdaFunction lamdbaFunc)
   {
       int nDim = bulk.mesh_meta_data().spatial_dimension();
+      int totalNumFields = bulk.mesh_meta_data().get_fields().size();
 
       sierra::nalu::MasterElement* meFC = faceDataNeeded_.get_cvfem_face_me();
       sierra::nalu::MasterElement* meSCS = faceDataNeeded_.get_cvfem_surface_me();
@@ -60,8 +61,8 @@ public:
 
       int rhsSize = meElemInfo.nodalGatherSize_*numDof_, lhsSize = rhsSize*rhsSize, scratchIdsSize = rhsSize;
 
-      ElemDataRequestsNGP faceDataNGP(faceDataNeeded_);
-      ElemDataRequestsNGP elemDataNGP(elemDataNeeded_);
+      ElemDataRequestsNGP faceDataNGP(faceDataNeeded_, totalNumFields);
+      ElemDataRequestsNGP elemDataNGP(elemDataNeeded_, totalNumFields);
 
       const int bytes_per_team = 0;
       const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(lhsSize, rhsSize, scratchIdsSize,

--- a/include/ElemDataRequestsNGP.h
+++ b/include/ElemDataRequestsNGP.h
@@ -35,8 +35,9 @@ public:
   typedef Kokkos::View<FieldPtr*, Kokkos::LayoutRight, MemSpace> FieldView;
   typedef Kokkos::View<FieldInfo*, Kokkos::LayoutRight, MemSpace> FieldInfoView;
 
-  ElemDataRequestsNGP(const ElemDataRequests& dataReq)
-    : dataEnums(),
+  ElemDataRequestsNGP(const ElemDataRequests& dataReq, unsigned totalFields)
+    : totalNumFields(totalFields),
+      dataEnums(),
       hostDataEnums(),
       coordsFields_(),
       hostCoordsFields_(),
@@ -93,6 +94,8 @@ public:
   MasterElement *get_cvfem_surface_me() const {return meSCS_;}
   MasterElement *get_fem_volume_me() const {return meFEM_;}
 
+  unsigned get_total_num_fields() const { return totalNumFields; }
+
 private:
   void copy_to_device()
   {
@@ -145,6 +148,7 @@ private:
     }
   }
 
+  unsigned totalNumFields;
   DataEnumView dataEnums[MAX_COORDS_TYPES];
   DataEnumView::HostMirror hostDataEnums[MAX_COORDS_TYPES];
 

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -103,14 +103,14 @@ SharedMemView<T***,TeamShmemType> get_shmem_view_3D(const TEAMHANDLETYPE& team, 
 
 template<typename T, typename TEAMHANDLETYPE, typename TeamShmemType=HostShmem>
 KOKKOS_FUNCTION
-SharedMemView<T***,TeamShmemType> get_shmem_view_4D(const TEAMHANDLETYPE& team, size_t len1, size_t len2, size_t len3, size_t len4)
+SharedMemView<T****,TeamShmemType> get_shmem_view_4D(const TEAMHANDLETYPE& team, size_t len1, size_t len2, size_t len3, size_t len4)
 {
   return Kokkos::subview(SharedMemView<T*****,TeamShmemType>(team.team_scratch(1), team.team_size(), len1, len2, len3, len4), team.team_rank(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
 }
 
 template<typename T, typename TEAMHANDLETYPE, typename TeamShmemType=HostShmem>
 KOKKOS_FUNCTION
-SharedMemView<T***,TeamShmemType> get_shmem_view_5D(const TEAMHANDLETYPE& team, size_t len1, size_t len2, size_t len3, size_t len4, size_t len5)
+SharedMemView<T*****,TeamShmemType> get_shmem_view_5D(const TEAMHANDLETYPE& team, size_t len1, size_t len2, size_t len3, size_t len4, size_t len5)
 {
   return Kokkos::subview(SharedMemView<T******,TeamShmemType>(team.team_scratch(1), team.team_size(), len1, len2, len3, len4, len5), team.team_rank(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
 }

--- a/unit_tests/UnitTestElemDataRequests.C
+++ b/unit_tests/UnitTestElemDataRequests.C
@@ -16,7 +16,8 @@
 
 void do_the_test_ngp(const sierra::nalu::ElemDataRequests& dataReq)
 {
-  sierra::nalu::ElemDataRequestsNGP ngpDataReq(dataReq);
+  unsigned totalNumFields_guess = 10;
+  sierra::nalu::ElemDataRequestsNGP ngpDataReq(dataReq, totalNumFields_guess);
 
   unsigned numCorrectTests = 0;
   int threadsPerTeam = 1;

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -125,7 +125,7 @@ public:
   
       const stk::mesh::BucketVector& elemBuckets = bulkData_.get_buckets(stk::topology::ELEM_RANK, meta.locally_owned_part());
   
-      sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeededByKernels_);
+      sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeededByKernels_, meta.get_fields().size());
       const int bytes_per_team = 0;
       const int bytes_per_thread = get_num_bytes_pre_req_data(dataNeededNGP, meta.spatial_dimension());
       auto team_exec = sierra::nalu::get_host_team_policy(elemBuckets.size(), bytes_per_team, bytes_per_thread);

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -116,7 +116,7 @@ public:
       //a topology would be available.
       dataNeededByKernels_.add_cvfem_surface_me(sierra::nalu::MasterElementRepo::get_surface_master_element(stk::topology::HEX_8));
 
-      sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeededByKernels_);
+      sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeededByKernels_, meta.get_fields().size());
       const int bytes_per_team = 0;
       const int bytes_per_thread = get_num_bytes_pre_req_data(dataNeededNGP, meta.spatial_dimension());
       auto team_exec = sierra::nalu::get_host_team_policy(elemBuckets.size(), bytes_per_team, bytes_per_thread);

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -582,7 +582,7 @@ void calc_mass_flow_rate_scs(
     meta.locally_owned_part() | meta.globally_shared_part();
   const auto& buckets = bulk.get_buckets(stk::topology::ELEM_RANK, selector);
 
-  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded);
+  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data(
@@ -664,7 +664,7 @@ void calc_projected_nodal_gradient_interior(
   const stk::mesh::Selector selector = meta.locally_owned_part() | meta.globally_shared_part();
   const auto& buckets = bulk.get_buckets(stk::topology::ELEM_RANK, selector);
 
-  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded);
+  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data(dataNeededNGP, meta.spatial_dimension()) ;
@@ -743,7 +743,7 @@ void calc_projected_nodal_gradient_interior(
   const stk::mesh::Selector selector = meta.locally_owned_part() | meta.globally_shared_part();
   const auto& buckets = bulk.get_buckets(stk::topology::ELEM_RANK, selector);
 
-  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded);
+  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data(dataNeededNGP, meta.spatial_dimension()) ;
@@ -825,7 +825,7 @@ void calc_projected_nodal_gradient_boundary(
   const stk::mesh::Selector selector = meta.locally_owned_part() | meta.globally_shared_part();
   const auto& buckets = bulk.get_buckets(meta.side_rank(), selector);
 
-  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded);
+  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data(dataNeededNGP, meta.spatial_dimension()) ;
@@ -899,7 +899,7 @@ void calc_projected_nodal_gradient_boundary(
   const stk::mesh::Selector selector = meta.locally_owned_part() | meta.globally_shared_part();
   const auto& buckets = bulk.get_buckets(meta.side_rank(), selector);
 
-  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded);
+  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data(dataNeededNGP, meta.spatial_dimension()) ;
@@ -970,7 +970,7 @@ void calc_dual_nodal_volume(
   const stk::mesh::Selector selector = meta.locally_owned_part() | meta.globally_shared_part();
   const auto& buckets = bulk.get_buckets(stk::topology::ELEM_RANK, selector);
 
-  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded);
+  sierra::nalu::ElemDataRequestsNGP dataNeededNGP(dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data(dataNeededNGP, meta.spatial_dimension()) ;


### PR DESCRIPTION
This is a small pre-requisite step towards bringing the
NGP classes ScratchViewsNGP and ElemDataRequestsGPU into
the mainstream.

Also cleaned up a minor error in KokkosInterface.h related
to 4D and 5D scratch-views. Kokkos doesn't let us use views
of that dimension, but still seemed reasonable to correct
the error in our API.