### PR TITLE
Add option to output linear system residuals for debugging.

### DIFF
--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -224,6 +224,9 @@ public:
     get_required(node, "name", userSuppliedName_);
     get_required(node, "max_iterations", maxIterations_);
     get_required(node, "convergence_tolerance", convergenceTolerance_);
+
+    get_if_present(node, "monitor_residuals", monitorResiduals_,
+                   monitorResiduals_);
   }
 
   Simulation *root();
@@ -243,6 +246,11 @@ public:
   const std::string eqnTypeName_;
   int maxIterations_;
   double convergenceTolerance_;
+
+  //! Create a residual field for output and debugging
+  bool monitorResiduals_{false};
+  std::string residualFieldName_;
+  stk::mesh::FieldBase* residualField_{nullptr};
 
   // driver that holds all solver algorithms
   SolverAlgorithmDriver *solverAlgDriver_;

--- a/include/HypreLinearSystem.h
+++ b/include/HypreLinearSystem.h
@@ -224,6 +224,8 @@ protected:
   //! the STK field data instance.
   double copy_hypre_to_stk(stk::mesh::FieldBase*);
 
+  virtual void copy_residual_to_stk();
+
   /** Flags indicating whether a particular row in the HYPRE matrix has been
    * filled or not.
    */

--- a/include/HypreUVWLinearSystem.h
+++ b/include/HypreUVWLinearSystem.h
@@ -111,6 +111,8 @@ protected:
 
   void copy_hypre_to_stk(stk::mesh::FieldBase*, std::vector<double>&);
 
+  virtual void copy_residual_to_stk();
+
 private:
   std::vector<std::string> vecNames_{"X", "Y", "Z"};
 

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -144,6 +144,7 @@ protected:
     const char * msg)=0;
 
   void sync_field(const stk::mesh::FieldBase *field);
+
   bool debug();
 
   Realm &realm_;

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -655,6 +655,8 @@ class Realm {
    */
   bool hypreIsActive_{false};
 
+  bool scaleResidualNorms_{false};
+
 };
 
 } // namespace nalu

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -168,6 +168,8 @@ private:
     const Teuchos::RCP<LinSys::Vector> tpetraVector,
     stk::mesh::FieldBase * stkField);
 
+  void copy_residual_to_stk();
+
   // This method copies a stk::mesh::field to a tpetra multivector. Each dof/node is written into a different
   // vector in the multivector.
   void copy_stk_to_tpetra(stk::mesh::FieldBase * stkField,

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -350,6 +350,13 @@ EnthalpyEquationSystem::register_nodal_fields(
     // personally manage enthalpy
     bdf2CopyStateAlg_.push_back(theCopyAlg);
   }
+
+  if (monitorResiduals_) {
+    residualFieldName_ = eqnTypeName_ + "_residual";
+    residualField_ = &(meta_data.declare_field<ScalarFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nullptr);
+  }
 }
 
 //--------------------------------------------------------------------------

--- a/src/EquationSystem.C
+++ b/src/EquationSystem.C
@@ -294,8 +294,15 @@ EquationSystem::assemble_and_solve(
   if ( realm_.hasPeriodic_) {
     timeA = NaluEnv::self().nalu_time();
     realm_.periodic_delta_solution_update(deltaSolution, linsys_->numDof());
+
+    if (monitorResiduals_) {
+      // Not delta solution, but the method copies field from base node to the image node
+      realm_.periodic_delta_solution_update(
+        residualField_, linsys_->numDof());
+    }
     timeB = NaluEnv::self().nalu_time();
     timerMisc_ += (timeB-timeA);
+
   }
 
   // handle statistics

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -231,6 +231,13 @@ HeatCondEquationSystem::register_nodal_fields(
 
     copyStateAlg_.push_back(theCopyAlgA);
   }
+
+  if (monitorResiduals_) {
+    residualFieldName_ = eqnTypeName_ + "_residual";
+    residualField_ = &(meta_data.declare_field<ScalarFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nullptr);
+  }
 }
 
 //--------------------------------------------------------------------------

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -291,6 +291,10 @@ LowMachEquationSystem::register_nodal_fields(
 
   stk::mesh::MetaData &meta_data = realm_.meta_data();
 
+  // Inform subsystems that residual field must be transferred to STK
+  momentumEqSys_->monitorResiduals_ = monitorResiduals_;
+  continuityEqSys_->monitorResiduals_ = monitorResiduals_;
+
   // add properties; denisty needs to be a restart field
   const int numStates = realm_.number_of_states();
   density_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density", numStates));
@@ -1060,6 +1064,13 @@ MomentumEquationSystem::register_nodal_fields(
     stk::mesh::put_field_on_mesh(*actuatorSource, *part, nullptr);
     stk::mesh::put_field_on_mesh(*actuatorSourceLHS, *part, nullptr);
     stk::mesh::put_field_on_mesh(*g, *part, nullptr);
+  }
+
+  if (monitorResiduals_) {
+    residualFieldName_ = eqnTypeName_ + "_residual";
+    residualField_ = &(meta_data.declare_field<VectorFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nDim, nullptr);
   }
 
 }
@@ -2499,6 +2510,13 @@ ContinuityEquationSystem::register_nodal_fields(
 
   coordinates_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates"));
   stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);
+
+  if (monitorResiduals_) {
+    residualFieldName_ = eqnTypeName_ + "_residual";
+    residualField_ = &(meta_data.declare_field<ScalarFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nullptr);
+  }
 
 }
 

--- a/src/MassFractionEquationSystem.C
+++ b/src/MassFractionEquationSystem.C
@@ -166,6 +166,12 @@ MassFractionEquationSystem::register_nodal_fields(
   evisc_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "effective_viscosity_y"));
   stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
 
+  if (monitorResiduals_) {
+    residualFieldName_ = eqnTypeName_ + "_residual";
+    residualField_ = &(meta_data.declare_field<ScalarFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nullptr);
+  }
 }
 
 //--------------------------------------------------------------------------

--- a/src/MixtureFractionEquationSystem.C
+++ b/src/MixtureFractionEquationSystem.C
@@ -236,6 +236,13 @@ MixtureFractionEquationSystem::register_nodal_fields(
                                stk::topology::NODE_RANK);
     copyStateAlg_.push_back(theCopyAlg);
   }
+
+  if (monitorResiduals_) {
+    residualFieldName_ = eqnTypeName_ + "_residual";
+    residualField_ = &(meta_data.declare_field<ScalarFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nullptr);
+  }
 }
 
 //--------------------------------------------------------------------------

--- a/src/ProjectedNodalGradientEquationSystem.C
+++ b/src/ProjectedNodalGradientEquationSystem.C
@@ -141,6 +141,13 @@ ProjectedNodalGradientEquationSystem::register_nodal_fields(
   // delta solution for linear solver
   qTmp_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, deltaName_));
   stk::mesh::put_field_on_mesh(*qTmp_, *part, nDim, nullptr);
+
+  if (monitorResiduals_) {
+    residualFieldName_ = eqnTypeName_ + "_residual";
+    residualField_ = &(meta_data.declare_field<VectorFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nDim, nullptr);
+  }
 }
 
 //--------------------------------------------------------------------------

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -532,7 +532,7 @@ Realm::initialize()
 
   initialize_post_processing_algorithms();
 
-  compute_l2_scaling();
+  if (scaleResidualNorms_) compute_l2_scaling();
 
   // Now that the inactive selectors have been processed; we are ready to setup
   // HYPRE IDs
@@ -729,6 +729,8 @@ Realm::load(const YAML::Node & node)
   if (node["balance_nodes_iterations"] || node["balance_nodes_target"] ) {
     doBalanceNodes_ = true;
   }
+
+  get_if_present(node, "activate_l2norm_scaling", scaleResidualNorms_, scaleResidualNorms_);
 
 
   //======================================

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -95,6 +95,10 @@ ShearStressTransportEquationSystem::register_nodal_fields(
   stk::mesh::MetaData &meta_data = realm_.meta_data();
   const int numStates = realm_.number_of_states();
 
+  // Inform subsystems that residual field must be copied to STK for output
+  tkeEqSys_->monitorResiduals_ = monitorResiduals_;
+  sdrEqSys_->monitorResiduals_ = monitorResiduals_;
+
   // re-register tke and sdr for convenience
   tke_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke", numStates));
   stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -189,6 +189,13 @@ SpecificDissipationRateEquationSystem::register_nodal_fields(
                                stk::topology::NODE_RANK);
     copyStateAlg_.push_back(theCopyAlg);
   }
+
+  if (monitorResiduals_) {
+    residualFieldName_ = "sdr_residual";
+    residualField_ = &(meta_data.declare_field<ScalarFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nullptr);
+  }
 }
 
 //--------------------------------------------------------------------------

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -213,6 +213,13 @@ TurbKineticEnergyEquationSystem::register_nodal_fields(
                                stk::topology::NODE_RANK);
     copyStateAlg_.push_back(theCopyAlg);
   }
+
+  if (monitorResiduals_) {
+    residualFieldName_ = "tke_residual";
+    residualField_ = &(meta_data.declare_field<ScalarFieldType>(
+                         stk::topology::NODE_RANK, residualFieldName_));
+    stk::mesh::put_field_on_mesh(*residualField_, *part, nullptr);
+  }
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
Provide `monitor_residuals: yes` option to the equation system and provide the
field in the list of fields to output.

Names of residual fields:
  - momentum_residual
  - continuity_residual
  - tke_residual
  - sdr_residual
  - enthalpy_residual
  - temperature_residual