### PR TITLE
ScratchViews and ScratchViewsNGP now have the same template parameters.

### DIFF
--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -74,7 +74,7 @@ public:
                     "AssembleElemSolverAlgorithm expected nodesPerEntity_ = "
                     <<nodesPerEntity_<<", but b.topology().num_nodes() = "<<b.topology().num_nodes());
  
-     SharedMemData smdata(team, bulk_data, dataNeededNGP, nodesPerEntity_, rhsSize_);
+     SharedMemData smdata(team, meta_data.spatial_dimension(), dataNeededNGP, nodesPerEntity_, rhsSize_);
 
      const size_t bucketLen   = b.size();
      const size_t simdBucketLen = get_num_simd_groups(bucketLen);
@@ -94,7 +94,7 @@ public:
        copy_and_interleave(smdata.prereqData, numSimdElems, smdata.simdPrereqData, interleaveMEViews_);
  
        if (!interleaveMEViews_) {
-         fill_master_element_views(dataNeededNGP, bulk_data, smdata.simdPrereqData);
+         fill_master_element_views(dataNeededNGP, smdata.simdPrereqData);
        }
 
        lambdaFunc(smdata);

--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -84,7 +84,7 @@ public:
                        "AssembleFaceElemSolverAlgorithm expected nodesPerEntity_ = "
                        <<nodesPerFace_<<", but b.topology().num_nodes() = "<<b.topology().num_nodes());
 
-        SharedMemData_FaceElem smdata(team, bulk, faceDataNGP, elemDataNGP, meElemInfo, rhsSize);
+        SharedMemData_FaceElem smdata(team, nDim, faceDataNGP, elemDataNGP, meElemInfo, rhsSize);
 
         const size_t bucketLen   = b.size();
         const size_t simdBucketLen = sierra::nalu::get_num_simd_groups(bucketLen);
@@ -119,8 +119,8 @@ public:
   
             copy_and_interleave(smdata.faceViews, smdata.numSimdFaces, smdata.simdFaceViews, interleaveMeViews);
             copy_and_interleave(smdata.elemViews, smdata.numSimdFaces, smdata.simdElemViews, interleaveMeViews);
-            fill_master_element_views(faceDataNGP, bulk, smdata.simdFaceViews, smdata.elemFaceOrdinal);
-            fill_master_element_views(elemDataNGP, bulk, smdata.simdElemViews, smdata.elemFaceOrdinal);
+            fill_master_element_views(faceDataNGP, smdata.simdFaceViews, smdata.elemFaceOrdinal);
+            fill_master_element_views(elemDataNGP, smdata.simdElemViews, smdata.elemFaceOrdinal);
   
             lamdbaFunc(smdata);
           } while(numFacesProcessed < simdGroupLen);

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -135,19 +135,19 @@ public:
   SharedMemView<T***> metric;
 };
 
-template<typename T>
+template<typename T, typename TEAMHANDLETYPE=TeamHandleType, typename SHMEM=HostShmem>
 class ScratchViews
 {
 public:
   typedef T value_type;
 
-  ScratchViews(const TeamHandleType& team,
-               const stk::mesh::BulkData& bulkData,
+  ScratchViews(const TEAMHANDLETYPE& team,
+               unsigned nDim,
                int nodesPerEntity,
                const ElemDataRequestsNGP& dataNeeded);
 
-  ScratchViews(const TeamHandleType& team,
-               const stk::mesh::BulkData& bulkData,
+  ScratchViews(const TEAMHANDLETYPE& team,
+               unsigned nDim,
                const ScratchMeInfo &meInfo,
                const ElemDataRequestsNGP& dataNeeded);
 
@@ -155,16 +155,16 @@ public:
   }
 
   inline
-  SharedMemView<T*>& get_scratch_view_1D(const stk::mesh::FieldBase& field);
+  SharedMemView<T*,SHMEM>& get_scratch_view_1D(const stk::mesh::FieldBase& field);
 
   inline
-  SharedMemView<T**>& get_scratch_view_2D(const stk::mesh::FieldBase& field);
+  SharedMemView<T**,SHMEM>& get_scratch_view_2D(const stk::mesh::FieldBase& field);
 
   inline
-  SharedMemView<T***>& get_scratch_view_3D(const stk::mesh::FieldBase& field);
+  SharedMemView<T***,SHMEM>& get_scratch_view_3D(const stk::mesh::FieldBase& field);
 
   inline
-  SharedMemView<T****>& get_scratch_view_4D(const stk::mesh::FieldBase& field);
+  SharedMemView<T****,SHMEM>& get_scratch_view_4D(const stk::mesh::FieldBase& field);
 
   inline
   MasterElementViews<T>& get_me_views(const COORDS_TYPES cType)
@@ -178,52 +178,51 @@ public:
 
   const stk::mesh::Entity* elemNodes;
 
-  inline const MultiDimViews<T,TeamHandleType,HostShmem>& get_field_views() const { return fieldViews; }
-  inline MultiDimViews<T,TeamHandleType,HostShmem>& get_field_views() { return fieldViews; }
+  inline       MultiDimViews<T,TEAMHANDLETYPE,SHMEM>& get_field_views()       { return fieldViews; }
+  inline const MultiDimViews<T,TEAMHANDLETYPE,SHMEM>& get_field_views() const { return fieldViews; }
 
 private:
-  void create_needed_field_views(const TeamHandleType& team,
+  void create_needed_field_views(const TEAMHANDLETYPE& team,
                                  const ElemDataRequestsNGP& dataNeeded,
-                                 const stk::mesh::BulkData& bulkData,
                                  int nodesPerElem);
 
-  void create_needed_master_element_views(const TeamHandleType& team,
+  void create_needed_master_element_views(const TEAMHANDLETYPE& team,
                                           const ElemDataRequestsNGP& dataNeeded,
                                           int nDim, int nodesPerFace, int nodesPerElem,
                                           int numFaceIp, int numScsIp, int numScvIp, int numFemIp);
 
-  MultiDimViews<T,TeamHandleType, HostShmem> fieldViews;
+  MultiDimViews<T,TEAMHANDLETYPE, SHMEM> fieldViews;
   MasterElementViews<T> meViews[MAX_COORDS_TYPES];
   bool hasCoordField[MAX_COORDS_TYPES] = {false, false};
   int num_bytes_required{0};
 };
 
-template<typename T>
-SharedMemView<T*>& ScratchViews<T>::get_scratch_view_1D(const stk::mesh::FieldBase& field)
+template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
+SharedMemView<T*,SHMEM>& ScratchViews<T,TEAMHANDLETYPE,SHMEM>::get_scratch_view_1D(const stk::mesh::FieldBase& field)
 { 
 //  ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 1D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
 //  ViewT<SharedMemView<T*>>* vt = static_cast<ViewT<SharedMemView<T*>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
   return fieldViews.get_scratch_view_1D(field.mesh_meta_data_ordinal());
 }
 
-template<typename T>
-SharedMemView<T**>& ScratchViews<T>::get_scratch_view_2D(const stk::mesh::FieldBase& field)
+template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
+SharedMemView<T**,SHMEM>& ScratchViews<T,TEAMHANDLETYPE,SHMEM>::get_scratch_view_2D(const stk::mesh::FieldBase& field)
 { 
 //  ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 2D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
 //  ViewT<SharedMemView<T**>>* vt = static_cast<ViewT<SharedMemView<T**>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
   return fieldViews.get_scratch_view_2D(field.mesh_meta_data_ordinal());
 }
 
-template<typename T>
-SharedMemView<T***>& ScratchViews<T>::get_scratch_view_3D(const stk::mesh::FieldBase& field)
+template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
+SharedMemView<T***,SHMEM>& ScratchViews<T,TEAMHANDLETYPE,SHMEM>::get_scratch_view_3D(const stk::mesh::FieldBase& field)
 { 
 //  ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 3D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
 //  ViewT<SharedMemView<T***>>* vt = static_cast<ViewT<SharedMemView<T***>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
   return fieldViews.get_scratch_view_3D(field.mesh_meta_data_ordinal());
 }
 
-template<typename T>
-SharedMemView<T****>& ScratchViews<T>::get_scratch_view_4D(const stk::mesh::FieldBase& field)
+template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
+SharedMemView<T****,SHMEM>& ScratchViews<T,TEAMHANDLETYPE,SHMEM>::get_scratch_view_4D(const stk::mesh::FieldBase& field)
 {
 //  ThrowAssertMsg(fieldViews[field.mesh_meta_data_ordinal()] != nullptr, "ScratchViews ERROR, trying to get 4D scratch-view for field "<<field.name()<<" which wasn't declared as pre-req field.");
 //  ViewT<SharedMemView<T****>>* vt = static_cast<ViewT<SharedMemView<T****>>*>(fieldViews[field.mesh_meta_data_ordinal()]);
@@ -562,9 +561,9 @@ void MasterElementViews<T>::fill_master_element_views_new_me(
   }
 }
 
-template<typename T>
-ScratchViews<T>::ScratchViews(const TeamHandleType& team,
-             const stk::mesh::BulkData& bulkData,
+template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
+ScratchViews<T,TEAMHANDLETYPE,SHMEM>::ScratchViews(const TEAMHANDLETYPE& team,
+             unsigned nDim,
              int nodalGatherSize,
              const ElemDataRequestsNGP& dataNeeded)
  : fieldViews(team, dataNeeded.get_total_num_fields(), count_needed_field_views(dataNeeded))
@@ -575,7 +574,6 @@ ScratchViews<T>::ScratchViews(const TeamHandleType& team,
   MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
   MasterElement *meFEM = dataNeeded.get_fem_volume_me();
 
-  int nDim = bulkData.mesh_meta_data().spatial_dimension();
   int nodesPerFace = meFC != nullptr ? meFC->nodesPerElement_ : 0;
   int nodesPerElem = meSCS != nullptr
           ? meSCS->nodesPerElement_ : meSCV != nullptr
@@ -586,27 +584,25 @@ ScratchViews<T>::ScratchViews(const TeamHandleType& team,
   int numScvIp = meSCV != nullptr ? meSCV->numIntPoints_ : 0;
   int numFemIp = meFEM != nullptr ? meFEM->numIntPoints_ : 0;
 
-  create_needed_field_views(team, dataNeeded, bulkData, nodalGatherSize);
+  create_needed_field_views(team, dataNeeded, nodalGatherSize);
 
   create_needed_master_element_views(team, dataNeeded, nDim, nodesPerFace, nodesPerElem, numFaceIp, numScsIp, numScvIp, numFemIp);
 }
 
-template<typename T>
-ScratchViews<T>::ScratchViews(const TeamHandleType& team,
-             const stk::mesh::BulkData& bulkData,
+template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
+ScratchViews<T,TEAMHANDLETYPE,SHMEM>::ScratchViews(const TEAMHANDLETYPE& team,
+             unsigned nDim,
              const ScratchMeInfo &meInfo,
              const ElemDataRequestsNGP& dataNeeded)
  : fieldViews(team, dataNeeded.get_total_num_fields(), count_needed_field_views(dataNeeded))
 {
-  int nDim = bulkData.mesh_meta_data().spatial_dimension();
-  create_needed_field_views(team, dataNeeded, bulkData, meInfo.nodalGatherSize_);
+  create_needed_field_views(team, dataNeeded, meInfo.nodalGatherSize_);
   create_needed_master_element_views(team, dataNeeded, nDim, meInfo.nodesPerFace_, meInfo.nodesPerElement_, meInfo.numFaceIp_, meInfo.numScsIp_, meInfo.numScvIp_, meInfo.numFemIp_);
 }
 
-template<typename T>
-void ScratchViews<T>::create_needed_field_views(const TeamHandleType& team,
+template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
+void ScratchViews<T,TEAMHANDLETYPE,SHMEM>::create_needed_field_views(const TEAMHANDLETYPE& team,
                                const ElemDataRequestsNGP& dataNeeded,
-                               const stk::mesh::BulkData& bulkData,
                                int nodesPerEntity)
 {
   int numScalars = 0;
@@ -655,8 +651,8 @@ void ScratchViews<T>::create_needed_field_views(const TeamHandleType& team,
   num_bytes_required += numScalars * sizeof(T);
 }
 
-template<typename T>
-void ScratchViews<T>::create_needed_master_element_views(const TeamHandleType& team,
+template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
+void ScratchViews<T,TEAMHANDLETYPE,SHMEM>::create_needed_master_element_views(const TEAMHANDLETYPE& team,
                                         const ElemDataRequestsNGP& dataNeeded,
                                         int nDim, int nodesPerFace, int nodesPerElem,
                                         int numFaceIp, int numScsIp, int numScvIp, int numFemIp)
@@ -685,7 +681,6 @@ void fill_pre_req_data(ElemDataRequestsNGP& dataNeeded,
                        bool fillMEViews = true);
 
 void fill_master_element_views(ElemDataRequestsNGP& dataNeeded,
-                               const stk::mesh::BulkData& bulkData,
                                ScratchViews<DoubleType>& prereqData,
                                int faceOrdinal = 0);
 

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -22,14 +22,14 @@ namespace nalu{
 
 struct SharedMemData {
     SharedMemData(const sierra::nalu::TeamHandleType& team,
-         const stk::mesh::BulkData& bulk,
+         unsigned nDim,
          const ElemDataRequestsNGP& dataNeededByKernels,
          unsigned nodesPerEntity,
          unsigned rhsSize)
-     : simdPrereqData(team, bulk, nodesPerEntity, dataNeededByKernels)
+     : simdPrereqData(team, nDim, nodesPerEntity, dataNeededByKernels)
     {
         for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
-          prereqData[simdIndex] = std::unique_ptr<ScratchViews<double> >(new ScratchViews<double>(team, bulk, nodesPerEntity, dataNeededByKernels));
+          prereqData[simdIndex] = std::unique_ptr<ScratchViews<double> >(new ScratchViews<double>(team, nDim, nodesPerEntity, dataNeededByKernels));
         }
         simdrhs = get_shmem_view_1D<DoubleType>(team, rhsSize);
         simdlhs = get_shmem_view_2D<DoubleType>(team, rhsSize, rhsSize);
@@ -55,17 +55,17 @@ struct SharedMemData {
 
 struct SharedMemData_FaceElem {
     SharedMemData_FaceElem(const sierra::nalu::TeamHandleType& team,
-         const stk::mesh::BulkData& bulk,
+         unsigned nDim,
          const ElemDataRequestsNGP& faceDataNeeded,
          const ElemDataRequestsNGP& elemDataNeeded,
          const ScratchMeInfo& meElemInfo,
          unsigned rhsSize)
-     : simdFaceViews(team, bulk, meElemInfo.nodesPerFace_, faceDataNeeded),
-       simdElemViews(team, bulk, meElemInfo, elemDataNeeded)
+     : simdFaceViews(team, nDim, meElemInfo.nodesPerFace_, faceDataNeeded),
+       simdElemViews(team, nDim, meElemInfo, elemDataNeeded)
     {
         for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
-          faceViews[simdIndex] = std::unique_ptr<ScratchViews<double> >(new ScratchViews<double>(team, bulk, meElemInfo.nodesPerFace_, faceDataNeeded));
-          elemViews[simdIndex] = std::unique_ptr<ScratchViews<double> >(new ScratchViews<double>(team, bulk, meElemInfo, elemDataNeeded));
+          faceViews[simdIndex] = std::unique_ptr<ScratchViews<double> >(new ScratchViews<double>(team, nDim, meElemInfo.nodesPerFace_, faceDataNeeded));
+          elemViews[simdIndex] = std::unique_ptr<ScratchViews<double> >(new ScratchViews<double>(team, nDim, meElemInfo, elemDataNeeded));
         }
         simdrhs = get_shmem_view_1D<DoubleType>(team, rhsSize);
         simdlhs = get_shmem_view_2D<DoubleType>(team, rhsSize, rhsSize);

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -729,7 +729,7 @@ HeatCondEquationSystem::register_wall_bc(
     stk::mesh::put_field_on_mesh(*alphaField, *part, nullptr);
   
     // aux algs
-    AuxFunctionAlgorithm *alphaAuxAlg;
+    AuxFunctionAlgorithm *alphaAuxAlg = nullptr;
     if (isRobinCHT)
     {
       RobinCouplingParameter alpha = userData.robinCouplingParameter_;
@@ -743,7 +743,7 @@ HeatCondEquationSystem::register_wall_bc(
                                              stk::topology::NODE_RANK);
     }
 
-    AuxFunctionAlgorithm *htcAuxAlg;
+    AuxFunctionAlgorithm *htcAuxAlg = nullptr;
     if (isConvectionCHT)
     {
       HeatTransferCoefficient htc = userData.heatTransferCoefficient_;

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -421,7 +421,6 @@ void fill_pre_req_data(
 
 void fill_master_element_views(
   ElemDataRequestsNGP& dataNeeded,
-  const stk::mesh::BulkData& bulkData,
   ScratchViews<DoubleType>& prereqData,
   int faceOrdinal)
 {

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -135,7 +135,7 @@ public:
           stk::topology topo = bkt.topology();
           sierra::nalu::MasterElement* meSCS = dataNeededNGP.get_cvfem_surface_me();
 
-          sierra::nalu::ScratchViews<double> prereqData(team, bulkData_, topo.num_nodes(), dataNeededNGP);
+          sierra::nalu::ScratchViews<double> prereqData(team, meta.spatial_dimension(), topo.num_nodes(), dataNeededNGP);
 
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team, bkt.size()), [&](const size_t& jj)
           {

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -125,7 +125,7 @@ public:
           const stk::mesh::Bucket& bkt = *elemBuckets[team.league_rank()];
           stk::topology topo = bkt.topology();
 
-          sierra::nalu::ScratchViews<double> prereqData(team, bulkData_, topo.num_nodes(), dataNeededNGP);
+          sierra::nalu::ScratchViews<double> prereqData(team, meta.spatial_dimension(), topo.num_nodes(), dataNeededNGP);
 
           // See get_num_bytes_pre_req_data for padding
           EXPECT_EQ(static_cast<unsigned>(bytes_per_thread), prereqData.total_bytes() + 8 * sizeof(double));

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -598,7 +598,7 @@ void calc_mass_flow_rate_scs(
       EXPECT_EQ(b.topology(), topo);
 
       sierra::nalu::ScratchViews<double> preReqData(
-        team, bulk, topo.num_nodes(), dataNeededNGP);
+        team, ndim, topo.num_nodes(), dataNeededNGP);
 
       Kokkos::parallel_for(
         Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
@@ -680,7 +680,7 @@ void calc_projected_nodal_gradient_interior(
     EXPECT_EQ(b.topology(), topo);
 
     sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo.num_nodes(), dataNeededNGP);
+      team, ndim, topo.num_nodes(), dataNeededNGP);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
@@ -759,7 +759,7 @@ void calc_projected_nodal_gradient_interior(
     EXPECT_EQ(b.topology(), topo);
 
     sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo.num_nodes(), dataNeededNGP);
+      team, ndim, topo.num_nodes(), dataNeededNGP);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
@@ -840,7 +840,7 @@ void calc_projected_nodal_gradient_boundary(
 
     EXPECT_EQ(b.topology(), topo);
 
-    sierra::nalu::ScratchViews<double> preReqData(team, bulk, topo.num_nodes(), dataNeededNGP);
+    sierra::nalu::ScratchViews<double> preReqData(team, ndim, topo.num_nodes(), dataNeededNGP);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
@@ -915,7 +915,7 @@ void calc_projected_nodal_gradient_boundary(
     EXPECT_EQ(b.topology(), topo);
 
     sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo.num_nodes(), dataNeededNGP);
+      team, ndim, topo.num_nodes(), dataNeededNGP);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
@@ -986,7 +986,7 @@ void calc_dual_nodal_volume(
     EXPECT_EQ(b.topology(), topo);
 
     sierra::nalu::ScratchViews<double> preReqData(
-      team, bulk, topo.num_nodes(), dataNeededNGP);
+      team, ndim, topo.num_nodes(), dataNeededNGP);
 
     Kokkos::parallel_for(
       Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {


### PR DESCRIPTION
And take the same constructor arguments except for ElemDataRequestsNGP
vs ElemDataRequestsGPU.

Also make arguments consistent for fill_master_element_views.