### PR TITLE
Jroverf/gpu master element unit test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 ############################ FFTW ######################################
 if(ENABLE_FFTW)
   set(CMAKE_PREFIX_PATH ${FFTW_DIR} ${CMAKE_PREFIX_PATH})
-  find_package(FFTW REQUIRED)
+  find_package(FFTW QUIET REQUIRED)
   if(FFTW_FOUND)
     message("-- Found FFTW = ${FFTW_DIR}")
   endif()
@@ -89,7 +89,6 @@ endif(ENABLE_FFTW)
 ############################ HYPRE #####################################
 if(ENABLE_HYPRE)
   set(CMAKE_PREFIX_PATH ${HYPRE_DIR} ${CMAKE_PREFIX_PATH})
-  # Quiet down HYPRE's own "found" output to be consistent with others
   find_package(HYPRE QUIET REQUIRED)
   if(HYPRE_FOUND)
     message("-- Found HYPRE = ${HYPRE_DIR}")

--- a/include/AlgTraits.h
+++ b/include/AlgTraits.h
@@ -16,6 +16,8 @@ namespace nalu {
 
 class HexSCS;
 class HexSCV;
+class Hex27SCS;
+class Hex27SCV;
 
 // limited supported now (P=1 3D elements)
 struct AlgTraitsHex8 {
@@ -36,6 +38,8 @@ struct AlgTraitsHex27 {
   static constexpr int numScvIp_ = 216;
   static constexpr int numGp_ = 27; // for FEM (not supported)
   static constexpr stk::topology::topology_t topo_ = stk::topology::HEX_27;
+  using            masterElementScs_ = Hex27SCS;
+  using            masterElementScv_ = Hex27SCV;
 };
 
 struct AlgTraitsTet4 {

--- a/include/AssembleElemSolverAlgorithmHO.h
+++ b/include/AssembleElemSolverAlgorithmHO.h
@@ -35,7 +35,7 @@ class MasterElement;
 
 
 inline std::array<stk::mesh::Entity, simdLen>
-load_simd_elems(const stk::mesh::Bucket& b, int bktIndex, int bucketLen, int numSimdElems)
+load_simd_elems(const stk::mesh::Bucket& b, int bktIndex, int /* bucketLen */, int numSimdElems)
 {
   std::array<stk::mesh::Entity, simdLen> simdElems;
   for (int simdElemIndex = 0; simdElemIndex < numSimdElems; ++simdElemIndex) {

--- a/include/AuxFunction.h
+++ b/include/AuxFunction.h
@@ -55,7 +55,7 @@ public:
     else
       do_evaluate(coords, time, spatialDimension, numPoints, fieldPtr, fieldSize, beginPos_, endPos_);
   }
-  virtual void setup(const double time) {}
+  virtual void setup(const double /* time */) {}
 
 protected:
 

--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -62,14 +62,14 @@ public:
 
   // base class with desired default no-op
   virtual void register_nodal_fields(
-    stk::mesh::Part *part) {}
+    stk::mesh::Part * /* part */) {}
 
   virtual void register_edge_fields(
-    stk::mesh::Part *part) {}
+    stk::mesh::Part * /* part */) {}
 
   virtual void register_element_fields(
-    stk::mesh::Part *part,
-    const stk::topology &theTopo) {}
+    stk::mesh::Part * /* part */,
+    const stk::topology & /* theTopo */) {}
 
   // since Equation systems hold other equations systems
   // defaults are provided for all methods below
@@ -148,7 +148,7 @@ public:
     stk::mesh::FieldBase *deltaSolution);
   virtual void predict_state() {}
   virtual void register_interior_algorithm(
-    stk::mesh::Part *part) {}
+    stk::mesh::Part * /* part */) {}
   virtual void provide_output() {}
   virtual void pre_timestep_work();
   virtual void reinitialize_linear_system() {}
@@ -160,24 +160,24 @@ public:
   virtual bool system_is_converged();
   
   virtual void register_wall_bc(
-    stk::mesh::Part *part,
-    const stk::topology &theTopo,
-    const WallBoundaryConditionData &wallBCData) {}
+    stk::mesh::Part * /* part */,
+    const stk::topology & /* theTopo */,
+    const WallBoundaryConditionData & /* wallBCData */) {}
 
   virtual void register_inflow_bc(
-    stk::mesh::Part *part,
-    const stk::topology &theTopo,
-    const InflowBoundaryConditionData &inflowBCData) {}
+    stk::mesh::Part * /* part */,
+    const stk::topology & /* theTopo */,
+    const InflowBoundaryConditionData & /* inflowBCData */) {}
 
   virtual void register_open_bc(
-    stk::mesh::Part *part,
-    const stk::topology &theTopo,
-    const OpenBoundaryConditionData &openBCData) {}
+    stk::mesh::Part * /* part */,
+    const stk::topology & /* theTopo */,
+    const OpenBoundaryConditionData & /* openBCData */) {}
 
   virtual void register_symmetry_bc(
-    stk::mesh::Part *part,
-    const stk::topology &theTopo,
-    const SymmetryBoundaryConditionData &symmetryBCData) {}
+    stk::mesh::Part * /* part */,
+    const stk::topology & /* theTopo */,
+    const SymmetryBoundaryConditionData & /* symmetryBCData */) {}
 
   virtual void register_abltop_bc(
     stk::mesh::Part *part,
@@ -188,15 +188,15 @@ public:
     }
 
   virtual void register_periodic_bc(
-    stk::mesh::Part *partMaster,
-    stk::mesh::Part *partSlave,
-    const stk::topology &theTopoMaster,
-    const stk::topology &theTopoSlave,
-    const PeriodicBoundaryConditionData &periodicBCData) {}
+    stk::mesh::Part * /* partMaster */,
+    stk::mesh::Part * /* partSlave */,
+    const stk::topology & /* theTopoMaster */,
+    const stk::topology & /* theTopoSlave */,
+    const PeriodicBoundaryConditionData & /* periodicBCData */) {}
   
   virtual void register_non_conformal_bc(
-    stk::mesh::Part *part,
-    const stk::topology &theTopo) {}
+    stk::mesh::Part * /* part */,
+    const stk::topology & /* theTopo */) {}
 
   virtual void register_overset_bc() {}
 
@@ -204,13 +204,13 @@ public:
     stk::mesh::FieldBase *theField);
 
   virtual void register_surface_pp_algorithm(
-    const PostProcessingData &theData,
-    stk::mesh::PartVector &partVector) {}
+    const PostProcessingData & /* theData */,
+    stk::mesh::PartVector & /* partVector */) {}
 
   virtual void register_initial_condition_fcn(
-    stk::mesh::Part *part,
-    const std::map<std::string, std::string> &theNames,
-    const std::map<std::string, std::vector<double> > &theParams) {}
+    stk::mesh::Part * /* part */,
+    const std::map<std::string, std::string> & /* theNames */,
+    const std::map<std::string, std::vector<double> > & /* theParams */) {}
 
   // rip through the propertyAlg_
   virtual void evaluate_properties();

--- a/include/HypreLinearSystem.h
+++ b/include/HypreLinearSystem.h
@@ -196,8 +196,8 @@ public:
    */
   virtual void loadComplete();
 
-  virtual void writeToFile(const char * filename, bool useOwned=true) {}
-  virtual void writeSolutionToFile(const char * filename, bool useOwned=true) {}
+  virtual void writeToFile(const char * /* filename */, bool /* useOwned */ =true) {}
+  virtual void writeSolutionToFile(const char * /* filename */, bool /* useOwned */ =true) {}
 
 protected:
   /** Prepare the instance for system construction

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -248,7 +248,7 @@ class Realm {
   virtual void populate_boundary_data();
   virtual void boundary_data_to_state_data();
   virtual double populate_variables_from_input(const double currentTime);
-  virtual void populate_external_variables_from_input(const double currentTime) {}
+  virtual void populate_external_variables_from_input(const double /* currentTime */) {}
   virtual double populate_restart( double &timeStepNm1, int &timeStepCount);
   virtual void populate_derived_quantities();
   virtual void evaluate_properties();

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -233,7 +233,7 @@ template<typename T>
 int MasterElementViews<T>::create_master_element_views(
   const TeamHandleType& team,
   const ElemDataRequestsNGP::DataEnumView& dataEnums,
-  int nDim, int nodesPerFace, int nodesPerElem,
+  int nDim, int /* nodesPerFace */, int nodesPerElem,
   int numFaceIp, int numScsIp, int numScvIp, int numFemIp)
 {
   int numScalars = 0;
@@ -394,11 +394,11 @@ template<typename T>
 void MasterElementViews<T>::fill_master_element_views(
   const ElemDataRequestsNGP::DataEnumView& dataEnums,
   SharedMemView<double**>* coordsView,
-  MasterElement* meFC,
+  MasterElement* /* meFC */,
   MasterElement* meSCS,
   MasterElement* meSCV,
   MasterElement* meFEM,
-  int faceOrdinal)
+  int /* faceOrdinal */)
 {
   // Guard against calling MasterElement methods on SIMD data structures
   static_assert(std::is_same<T, double>::value,
@@ -478,7 +478,7 @@ template<typename T>
 void MasterElementViews<T>::fill_master_element_views_new_me(
   const ElemDataRequestsNGP::DataEnumView& dataEnums,
   SharedMemView<DoubleType**>* coordsView,
-  MasterElement* meFC,
+  MasterElement* /* meFC */,
   MasterElement* meSCS,
   MasterElement* meSCV,
   MasterElement* meFEM,

--- a/include/ScratchViewsHO.h
+++ b/include/ScratchViewsHO.h
@@ -97,7 +97,7 @@ private:
 template<typename T>
 ScratchViewsHO<T>::ScratchViewsHO(const TeamHandleType& team,
              const stk::mesh::BulkData& bulkData,
-             int order, int dim,
+             int order, int /* dim */,
              const ElemDataRequests& dataNeeded)
 {
   int numScalars = 0;

--- a/include/ScratchViewsNGP.h
+++ b/include/ScratchViewsNGP.h
@@ -556,7 +556,7 @@ NumNeededViews count_needed_field_views(const ElemDataRequestsGPU& dataNeeded)
 template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
 KOKKOS_FUNCTION
 ScratchViewsNGP<T,TEAMHANDLETYPE,SHMEM>::ScratchViewsNGP(const TEAMHANDLETYPE& team,
-             unsigned nDim,
+             unsigned /* nDim */,
              int nodalGatherSize,
              const ElemDataRequestsGPU& dataNeeded)
  : fieldViews(team, dataNeeded.get_total_num_fields(), count_needed_field_views(dataNeeded))

--- a/include/SupplementalAlgorithm.h
+++ b/include/SupplementalAlgorithm.h
@@ -33,20 +33,20 @@ public:
   virtual void setup() {}
 
   virtual void elem_execute(
-    double *lhs,
-    double *rhs,
-    stk::mesh::Entity element,
-    MasterElement *meSCS,
-    MasterElement *meSCV) {}
+    double * /* lhs */,
+    double * /* rhs */,
+    stk::mesh::Entity  /* element */,
+    MasterElement * /* meSCS */,
+    MasterElement * /* meSCV */) {}
   
   virtual void node_execute(
-    double *lhs,
-    double *rhs,
-    stk::mesh::Entity node) {}
+    double * /* lhs */,
+    double * /* rhs */,
+    stk::mesh::Entity  /* node */) {}
   
   virtual void elem_resize(
-    MasterElement *meSCS,
-    MasterElement *meSCV) {}
+    MasterElement * /* meSCS */,
+    MasterElement * /* meSCV */) {}
 
   Realm &realm_;  
 };

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -126,7 +126,7 @@ public:
   void writeToFile(const char * filename, bool useOwned=true);
   void printInfo(bool useOwned=true);
   void writeSolutionToFile(const char * filename, bool useOwned=true);
-  size_t lookup_myLID(MyLIDMapType& myLIDs, stk::mesh::EntityId entityId, const char* msg=nullptr, stk::mesh::Entity entity = stk::mesh::Entity())
+  size_t lookup_myLID(MyLIDMapType& myLIDs, stk::mesh::EntityId entityId, const char* /* msg */ =nullptr, stk::mesh::Entity /* entity */ = stk::mesh::Entity())
   {
     return myLIDs[entityId];
   }
@@ -143,7 +143,7 @@ private:
 
   void beginLinearSystemConstruction();
 
-  void checkError( const int err_code, const char * msg) {}
+  void checkError( const int /* err_code */, const char * /* msg */) {}
 
   void compute_send_lengths(const std::vector<stk::mesh::Entity>& rowEntities,
          const std::vector<std::vector<stk::mesh::Entity> >& connections,

--- a/include/kernel/Kernel.h
+++ b/include/kernel/Kernel.h
@@ -108,26 +108,26 @@ public:
    *  the linear solve
    */
   virtual void execute(
-    SharedMemView<DoubleType**> &lhs,
-    SharedMemView<DoubleType*> &rhs,
-    ScratchViews<DoubleType> &scratchViews)
+    SharedMemView<DoubleType**> & /* lhs */,
+    SharedMemView<DoubleType*> & /* rhs */,
+    ScratchViews<DoubleType> & /* scratchViews */)
   {}
 
   virtual void execute(
-    SharedMemView<DoubleType**> &lhs,
-    SharedMemView<DoubleType*> &rhs,
-    ScratchViewsHO<DoubleType> &scratchViews)
+    SharedMemView<DoubleType**> & /* lhs */,
+    SharedMemView<DoubleType*> & /* rhs */,
+    ScratchViewsHO<DoubleType> & /* scratchViews */)
   {}
 
   /** Special execute for face-element kernels
    *
    */
   virtual void execute(
-    SharedMemView<DoubleType**> &lhs,
-    SharedMemView<DoubleType*> &rhs,
-    ScratchViews<DoubleType> &faceScratchViews,
-    ScratchViews<DoubleType> &elemScratchViews,
-    int elemFaceOrdinal)
+    SharedMemView<DoubleType**> & /* lhs */,
+    SharedMemView<DoubleType*> & /* rhs */,
+    ScratchViews<DoubleType> & /* faceScratchViews */,
+    ScratchViews<DoubleType> & /* elemScratchViews */,
+    int /* elemFaceOrdinal */)
   {}
 };
 

--- a/include/kernel/KernelBuilder.h
+++ b/include/kernel/KernelBuilder.h
@@ -303,7 +303,7 @@ namespace nalu{
   };
 
    template <template <typename> class T, typename... Args>
-  Kernel* build_face_elem_topo_kernel(int dimension,
+  Kernel* build_face_elem_topo_kernel(int /* dimension */,
                                       stk::topology faceTopo, stk::topology elemTopo,
                                       Args&&... args)
   {
@@ -462,7 +462,7 @@ namespace nalu{
 
   inline std::pair<AssembleFaceElemSolverAlgorithm*, bool>
   build_or_add_part_to_face_elem_solver_alg(
-    AlgorithmType algType,
+    AlgorithmType /* algType */,
     EquationSystem& eqSys,
     stk::mesh::Part& part,
     stk::topology elemTopo,

--- a/include/master_element/CVFEMCoefficients.h
+++ b/include/master_element/CVFEMCoefficients.h
@@ -19,7 +19,7 @@ namespace coefficients {
 /* Computes 1D coefficient matrices (e.g. for the derivative) for CVFEM */
 
 template <int p, typename Scalar = DoubleType>
-nodal_matrix_view<p, Scalar> nodal_integration_weights(const double* nodeLocs, const double* scsLocs)
+nodal_matrix_view<p, Scalar> nodal_integration_weights(const double* /* nodeLocs */, const double* scsLocs)
 {
   constexpr int nodes1D = p+1;
   auto scsEndLoc = pad_end_points(p, scsLocs);

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -492,7 +492,7 @@ template<typename ViewType>
 KOKKOS_FUNCTION
 void
 HexSCS::hex8_shape_fcn(
-  const int  &npts,
+  const int  & /* npts */,
   const double *isoParCoord,
   ViewType &shape_fcn)
 {

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -15,6 +15,33 @@
 namespace sierra{
 namespace nalu{
 
+template<typename ViewType>
+KOKKOS_INLINE_FUNCTION
+void hex8_shape_fcn(
+  const int    & npts,
+  const double * isoParCoord,
+  ViewType &shape_fcn)
+{
+  const DoubleType half   = 0.50;
+  const DoubleType one4th = 0.25;
+  const DoubleType one8th = 0.125;
+  for ( int j = 0; j < npts; ++j ) {
+
+    const DoubleType s1 = isoParCoord[j*3];
+    const DoubleType s2 = isoParCoord[j*3+1];
+    const DoubleType s3 = isoParCoord[j*3+2];
+
+    shape_fcn(j,0) = one8th + one4th*(-s1 - s2 - s3) + half*( s2*s3 + s3*s1 + s1*s2 ) - s1*s2*s3;
+    shape_fcn(j,1) = one8th + one4th*( s1 - s2 - s3) + half*( s2*s3 - s3*s1 - s1*s2 ) + s1*s2*s3;
+    shape_fcn(j,2) = one8th + one4th*( s1 + s2 - s3) + half*(-s2*s3 - s3*s1 + s1*s2 ) - s1*s2*s3;
+    shape_fcn(j,3) = one8th + one4th*(-s1 + s2 - s3) + half*(-s2*s3 + s3*s1 - s1*s2 ) + s1*s2*s3;
+    shape_fcn(j,4) = one8th + one4th*(-s1 - s2 + s3) + half*(-s2*s3 - s3*s1 + s1*s2 ) + s1*s2*s3;
+    shape_fcn(j,5) = one8th + one4th*( s1 - s2 + s3) + half*(-s2*s3 + s3*s1 - s1*s2 ) - s1*s2*s3;
+    shape_fcn(j,6) = one8th + one4th*( s1 + s2 + s3) + half*( s2*s3 + s3*s1 + s1*s2 ) + s1*s2*s3;
+    shape_fcn(j,7) = one8th + one4th*(-s1 + s2 + s3) + half*( s2*s3 - s3*s1 - s1*s2 ) - s1*s2*s3;
+  }
+}
+
 // Hex 8 subcontrol volume
 class HexSCV : public MasterElement
 {
@@ -28,6 +55,8 @@ public:
 
   using MasterElement::determinant;
   using MasterElement::shifted_grad_op;
+  using MasterElement::shifted_shape_fcn;
+  using MasterElement::shape_fcn;
 
   // NGP-ready methods first
   void determinant(
@@ -68,14 +97,47 @@ public:
     double *metric,
     double *deriv);
 
-  using MasterElement::shape_fcn;
-  using MasterElement::shifted_shape_fcn;
+
+  template<typename ViewType>
+  KOKKOS_FUNCTION
+  void shape_fcn(ViewType &shpfc);
 
   void shape_fcn(
     double *shpfc);
 
   void shifted_shape_fcn(
     double *shpfc);
+
+
+  const int nDim_ = 3;
+  const int nodesPerElement_ = 8;
+  const int numIntPoints_ = 8;
+ 
+   // define ip node mappings
+  const int ipNodeMap_[8] = {0, 1, 2, 3, 4, 5, 6, 7};
+ 
+   // standard integration location
+  const double intgLoc_[24] = {
+   -0.25,  -0.25,  -0.25,
+   +0.25,  -0.25,  -0.25,
+   +0.25,  +0.25,  -0.25,
+   -0.25,  +0.25,  -0.25,
+   -0.25,  -0.25,  +0.25,
+   +0.25,  -0.25,  +0.25,
+   +0.25,  +0.25,  +0.25,
+   -0.25,  +0.25,  +0.25};
+ 
+  // shifted integration location
+  const double intgLocShift_[24] = {
+   -0.5,  -0.5,  -0.5,
+   +0.5,  -0.5,  -0.5,
+   +0.5,  +0.5,  -0.5,
+   -0.5,  +0.5,  -0.5,
+   -0.5,  -0.5,  +0.5,
+   +0.5,  -0.5,  +0.5,
+   +0.5,  +0.5,  +0.5,
+   -0.5,  +0.5,  +0.5};
+
 };
 
 // Hex 8 subcontrol surface
@@ -103,13 +165,6 @@ public:
 
   void shifted_shape_fcn(
     SharedMemView<DoubleType**> &shpfc);
-
-  template<typename ViewType>
-  KOKKOS_FUNCTION
-  void hex8_shape_fcn(
-    const int  &numIp,
-    const double *isoParCoord,
-    ViewType &shpfc);
 
   void hex8_gradient_operator(
     const int nodesPerElem,
@@ -469,6 +524,14 @@ void hex8_derivative(
   }
 }
 
+template<typename ViewType>
+KOKKOS_FUNCTION
+void
+HexSCV::shape_fcn(ViewType &shpfc)
+{
+  hex8_shape_fcn(numIntPoints_, &intgLoc_[0], shpfc);
+}
+
 template<typename ViewTypeCoord, typename ViewTypeGrad>
 KOKKOS_FUNCTION
 void HexSCS::grad_op(
@@ -486,42 +549,6 @@ void
 HexSCS::shape_fcn(ViewType &shpfc)
 {
   hex8_shape_fcn(numIntPoints_, &intgLoc_[0], shpfc);
-}
-
-template<typename ViewType>
-KOKKOS_FUNCTION
-void
-HexSCS::hex8_shape_fcn(
-  const int  & /* npts */,
-  const double *isoParCoord,
-  ViewType &shape_fcn)
-{
-  const DoubleType half = 0.50;
-  const DoubleType one4th = 0.25;
-  const DoubleType one8th = 0.125;
-  for ( int j = 0; j < numIntPoints_; ++j ) {
-
-    const DoubleType s1 = isoParCoord[j*3];
-    const DoubleType s2 = isoParCoord[j*3+1];
-    const DoubleType s3 = isoParCoord[j*3+2];
-
-    shape_fcn(j,0) = one8th + one4th*(-s1 - s2 - s3)
-      + half*( s2*s3 + s3*s1 + s1*s2 ) - s1*s2*s3;
-    shape_fcn(j,1) = one8th + one4th*( s1 - s2 - s3)
-      + half*( s2*s3 - s3*s1 - s1*s2 ) + s1*s2*s3;
-    shape_fcn(j,2) = one8th + one4th*( s1 + s2 - s3)
-      + half*(-s2*s3 - s3*s1 + s1*s2 ) - s1*s2*s3;
-    shape_fcn(j,3) = one8th + one4th*(-s1 + s2 - s3)
-      + half*(-s2*s3 + s3*s1 - s1*s2 ) + s1*s2*s3;
-    shape_fcn(j,4) = one8th + one4th*(-s1 - s2 + s3)
-      + half*(-s2*s3 - s3*s1 + s1*s2 ) + s1*s2*s3;
-    shape_fcn(j,5) = one8th + one4th*( s1 - s2 + s3)
-      + half*(-s2*s3 + s3*s1 - s1*s2 ) - s1*s2*s3;
-    shape_fcn(j,6) = one8th + one4th*( s1 + s2 + s3)
-      + half*( s2*s3 + s3*s1 + s1*s2 ) + s1*s2*s3;
-    shape_fcn(j,7) = one8th + one4th*(-s1 + s2 + s3)
-      + half*( s2*s3 - s3*s1 - s1*s2 ) - s1*s2*s3;
-  }
 }
 
 

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -52,140 +52,140 @@ public:
 
   // NGP-ready methods first
   virtual void shape_fcn(
-    SharedMemView<DoubleType**> &shpfc) {
+    SharedMemView<DoubleType**> &/* shpfc */) {
     throw std::runtime_error("shape_fcn using SharedMemView is not implemented");}
 
   virtual void shifted_shape_fcn(
-    SharedMemView<DoubleType**> &shpfc) {
+    SharedMemView<DoubleType**> &/* shpfc */) {
     throw std::runtime_error("shifted_shape_fcn using SharedMemView is not implemented");}
 
   virtual void grad_op(
-    SharedMemView<DoubleType**>&coords,
-    SharedMemView<DoubleType***>&gradop,
-    SharedMemView<DoubleType***>&deriv) {
+    SharedMemView<DoubleType**>&/* coords */,
+    SharedMemView<DoubleType***>&/* gradop */,
+    SharedMemView<DoubleType***>&/* deriv */) {
     throw std::runtime_error("grad_op using SharedMemView is not implemented");}
 
   virtual void shifted_grad_op(
-    SharedMemView<DoubleType**>&coords,
-    SharedMemView<DoubleType***>&gradop,
-    SharedMemView<DoubleType***>&deriv) {
+    SharedMemView<DoubleType**>&/* coords */,
+    SharedMemView<DoubleType***>&/* gradop */,
+    SharedMemView<DoubleType***>&/* deriv */) {
     throw std::runtime_error("shifted_grad_op using SharedMemView is not implemented");}
 
   virtual void face_grad_op(
-    int face_ordinal,
-    SharedMemView<DoubleType**>& coords,
-    SharedMemView<DoubleType***>& gradop) {
+    int /* face_ordinal */,
+    SharedMemView<DoubleType**>& /* coords */,
+    SharedMemView<DoubleType***>& /* gradop */) {
     throw std::runtime_error("face_grad_op using SharedMemView is not implemented");}
 
   virtual void shifted_face_grad_op(
-    int face_ordinal,
-    SharedMemView<DoubleType**>& coords,
-    SharedMemView<DoubleType***>& gradop) {
+    int /* face_ordinal */,
+    SharedMemView<DoubleType**>& /* coords */,
+    SharedMemView<DoubleType***>& /* gradop */) {
     throw std::runtime_error("shifted_face_grad_op using SharedMemView is not implemented");}
 
   virtual void grad_op_fem(
-    SharedMemView<DoubleType**>&coords,
-    SharedMemView<DoubleType***>&gradop,
-    SharedMemView<DoubleType***>&deriv,
-    SharedMemView<DoubleType*>&det_j) {
+    SharedMemView<DoubleType**>&/* coords */,
+    SharedMemView<DoubleType***>&/* gradop */,
+    SharedMemView<DoubleType***>&/* deriv */,
+    SharedMemView<DoubleType*>& /*det_j*/) {
     throw std::runtime_error("grad_op using SharedMemView is not implemented");}
 
   virtual void shifted_grad_op_fem(
-    SharedMemView<DoubleType**>&coords,
-    SharedMemView<DoubleType***>&gradop,
-    SharedMemView<DoubleType***>&deriv,
-    SharedMemView<DoubleType*>&det_j) {
+    SharedMemView<DoubleType**>&/* coords */,
+    SharedMemView<DoubleType***>&/* gradop */,
+    SharedMemView<DoubleType***>&/* deriv */,
+    SharedMemView<DoubleType*>& /*det_j*/) {
     throw std::runtime_error("shifted_grad_op using SharedMemView is not implemented");}
 
   virtual void determinant(
-    SharedMemView<DoubleType**>&coords,
-    SharedMemView<DoubleType**>&areav) {
+    SharedMemView<DoubleType**>&/* coords */,
+    SharedMemView<DoubleType**>&/* areav */) {
     throw std::runtime_error("determinant using SharedMemView is not implemented");}
 
   virtual void gij(
-    SharedMemView<DoubleType**>& coords,
-    SharedMemView<DoubleType***>& gupper,
-    SharedMemView<DoubleType***>& glower,
-    SharedMemView<DoubleType***>& deriv) {
+    SharedMemView<DoubleType**>& /* coords */,
+    SharedMemView<DoubleType***>& /* gupper */,
+    SharedMemView<DoubleType***>& /* glower */,
+    SharedMemView<DoubleType***>& /* deriv */) {
     throw std::runtime_error("gij using SharedMemView is not implemented");
   }
 
   virtual void Mij(
-    SharedMemView<DoubleType**>& coords,
-    SharedMemView<DoubleType***>& metric,
-    SharedMemView<DoubleType***>& deriv) {
+    SharedMemView<DoubleType**>& /* coords */,
+    SharedMemView<DoubleType***>& /* metric */,
+    SharedMemView<DoubleType***>& /* deriv */) {
     throw std::runtime_error("Mij using SharedMemView is not implemented");
   }
 
   virtual void determinant(
-    SharedMemView<DoubleType**>& coords,
-    SharedMemView<DoubleType*>& volume) {
+    SharedMemView<DoubleType**>& /* coords */,
+    SharedMemView<DoubleType*>& /* volume */) {
     throw std::runtime_error("scv determinant using SharedMemView is not implemented");
   }
 
   // non-NGP-ready methods second
   virtual void determinant(
-    const int nelem,
-    const double *coords,
-    double *volume,
-    double * error ) {
+    const int /* nelem */,
+    const double * /* coords */,
+    double * /* volume */,
+    double * /* error  */) {
     throw std::runtime_error("determinant not implemented");}
 
   virtual void grad_op(
-    const int nelem,
-    const double *coords,
-    double *gradop,
-    double *deriv,
-    double *det_j,
-    double * error ) {
+    const int /* nelem */,
+    const double * /* coords */,
+    double * /* gradop */,
+    double * /* deriv */,
+    double * /* det_j */,
+    double * /* error  */) {
     throw std::runtime_error("grad_op not implemented");}
 
   virtual void shifted_grad_op(
-    const int nelem,
-    const double *coords,
-    double *gradop,
-    double *deriv,
-    double *det_j,
-    double * error ) {
+    const int /* nelem */,
+    const double * /* coords */,
+    double * /* gradop */,
+    double * /* deriv */,
+    double * /* det_j */,
+    double * /* error  */) {
     throw std::runtime_error("shifted_grad_op not implemented");}
 
   virtual void gij(
-    const double *coords,
-    double *gupperij,
-    double *glowerij,
-    double *deriv) {
+    const double * /* coords */,
+    double * /* gupperij */,
+    double * /* glowerij */,
+    double * /* deriv */) {
     throw std::runtime_error("gij not implemented");}
 
   virtual void Mij(
-    const double *coords,
-    double *metric,
-    double *deriv) {
+    const double * /* coords */,
+    double * /* metric */,
+    double * /* deriv */) {
     throw std::runtime_error("Mij not implemented");}
 
   virtual void nodal_grad_op(
-    const int nelem,
-    double *deriv,
-    double * error ) {
+    const int /* nelem */,
+    double * /* deriv */,
+    double * /* error  */) {
     throw std::runtime_error("nodal_grad_op not implemented");}
 
 
   virtual void face_grad_op(
-    const int nelem,
-    const int face_ordinal,
-    const double *coords,
-    double *gradop,
-    double *det_j,
-    double * error ) {
+    const int /* nelem */,
+    const int /* face_ordinal */,
+    const double * /* coords */,
+    double * /* gradop */,
+    double * /* det_j */,
+    double * /* error  */) {
     throw std::runtime_error("face_grad_op not implemented; avoid this element type at open bcs, walls and symms");}
 
 
   virtual void shifted_face_grad_op(
-     const int nelem,
-     const int face_ordinal,
-     const double *coords,
-     double *gradop,
-     double *det_j,
-     double * error ) {
+     const int /* nelem */,
+     const int /* face_ordinal */,
+     const double * /* coords */,
+     double * /* gradop */,
+     double * /* det_j */,
+     double * /* error  */) {
      throw std::runtime_error("shifted_face_grad_op not implemented");}
 
   virtual const int * adjacentNodes() {
@@ -196,70 +196,70 @@ public:
     throw std::runtime_error("scsIpEdgeOrd not implemented");
     }
 
-  virtual const int * ipNodeMap(int ordinal = 0) {
+  virtual const int * ipNodeMap(int /* ordinal */ = 0) {
       throw std::runtime_error("ipNodeMap not implemented");
      }
 
   virtual void shape_fcn(
-    double *shpfc) {
+    double * /* shpfc */) {
     throw std::runtime_error("shape_fcn not implemented"); }
 
   virtual void shifted_shape_fcn(
-    double *shpfc) {
+    double * /* shpfc */) {
     throw std::runtime_error("shifted_shape_fcn not implemented"); }
 
   virtual int opposingNodes(
-    const int ordinal, const int node) {
+    const int /* ordinal */, const int /* node */) {
     throw std::runtime_error("opposingNodes not implemented"); }
 
   virtual int opposingFace(
-    const int ordinal, const int node) {
+    const int /* ordinal */, const int /* node */) {
     throw std::runtime_error("opposingFace not implemented"); 
     }
 
   virtual double isInElement(
-    const double *elemNodalCoord,
-    const double *pointCoord,
-    double *isoParCoord) {
+    const double * /* elemNodalCoord */,
+    const double * /* pointCoord */,
+    double * /* isoParCoord */) {
     throw std::runtime_error("isInElement not implemented"); 
     }
 
   virtual void interpolatePoint(
-    const int &nComp,
-    const double *isoParCoord,
-    const double *field,
-    double *result) {
+    const int & /* nComp */,
+    const double * /* isoParCoord */,
+    const double * /* field */,
+    double * /* result */) {
     throw std::runtime_error("interpolatePoint not implemented"); }
   
   virtual void general_shape_fcn(
-    const int numIp,
-    const double *isoParCoord,
-    double *shpfc) {
+    const int /* numIp */,
+    const double * /* isoParCoord */,
+    double * /* shpfc */) {
     throw std::runtime_error("general_shape_fcn not implement"); }
 
   virtual void general_face_grad_op(
-    const int face_ordinal,
-    const double *isoParCoord,
-    const double *coords,
-    double *gradop,
-    double *det_j,
-    double * error ) {
+    const int /* face_ordinal */,
+    const double * /* isoParCoord */,
+    const double * /* coords */,
+    double * /* gradop */,
+    double * /* det_j */,
+    double * /* error  */) {
     throw std::runtime_error("general_face_grad_op not implemented");}
 
   virtual void general_normal(
-    const double *isoParCoord,
-    const double *coords,
-    double *normal) {
+    const double * /* isoParCoord */,
+    const double * /* coords */,
+    double * /* normal */) {
     throw std::runtime_error("general_normal not implemented");}
 
   virtual void sidePcoords_to_elemPcoords(
-    const int & side_ordinal,
-    const int & npoints,
-    const double *side_pcoords,
-    double *elem_pcoords) {
+    const int & /* side_ordinal */,
+    const int & /* npoints */,
+    const double * /* side_pcoords */,
+    double * /* elem_pcoords */) {
     throw std::runtime_error("sidePcoords_to_elemPcoords");}
 
-  virtual const int* side_node_ordinals(int sideOrdinal) {
+  virtual const int* side_node_ordinals(int /* sideOrdinal */) {
     throw std::runtime_error("side_node_ordinals not implemented");
   }
 

--- a/include/mesh_motion/MotionScaling.h
+++ b/include/mesh_motion/MotionScaling.h
@@ -23,9 +23,9 @@ public:
    * @param[in] xyz            Transformed coordinates
    */
   virtual ThreeDVecType compute_velocity(
-    double time,
-    const TransMatType& compTrans,
-    double* xyz ) {
+    double /* time */,
+    const TransMatType& /* compTrans */,
+    double* /* xyz */) {
     throw std::runtime_error(
       "MotionScaling:compute_velocity() Scaling is not setup to be used as a non-inertial motion");
   }

--- a/include/utils/CreateDeviceExpression.h
+++ b/include/utils/CreateDeviceExpression.h
@@ -16,7 +16,7 @@ T* create_device_expression(const T & rhs)
   T* t = kokkos_malloc_on_device<T>(debuggingName);
   // Bring rhs into local scope for capture to device.
   const T RHS(rhs);
-  kokkos_parallel_for(debuggingName, 1, [&] (const int i) {
+  kokkos_parallel_for(debuggingName, 1, [&] (const int /* i */) {
     new (t) T(RHS); 
   });
   return t;
@@ -28,7 +28,7 @@ T* create_device_expression()
 {
   const std::string debuggingName(typeid(T).name());
   T* t = kokkos_malloc_on_device<T>(debuggingName);
-  kokkos_parallel_for(debuggingName, 1, [&] (const int i) {
+  kokkos_parallel_for(debuggingName, 1, [&] (const int /* i */) {
     new (t) T(); 
   });
   return t;

--- a/src/master_element/Hex8CVFEM.C
+++ b/src/master_element/Hex8CVFEM.C
@@ -26,36 +26,9 @@ namespace nalu{
 HexSCV::HexSCV()
   : MasterElement()
 {
-  nDim_ = 3;
-  nodesPerElement_ = 8;
-  numIntPoints_ = 8;
-
-  // define ip node mappings
-  ipNodeMap_.resize(8);
-  ipNodeMap_[0] = 0; ipNodeMap_[1] = 1; ipNodeMap_[2] = 2; ipNodeMap_[3] = 3;
-  ipNodeMap_[4] = 4; ipNodeMap_[5] = 5; ipNodeMap_[6] = 6; ipNodeMap_[7] = 7;
-
-  // standard integration location
-  intgLoc_.resize(24);
-  intgLoc_[0]  = -0.25; intgLoc_[1]  = -0.25; intgLoc_[2]  = -0.25;
-  intgLoc_[3]  = +0.25; intgLoc_[4]  = -0.25; intgLoc_[5]  = -0.25;
-  intgLoc_[6]  = +0.25; intgLoc_[7]  = +0.25; intgLoc_[8]  = -0.25;
-  intgLoc_[9]  = -0.25; intgLoc_[10] = +0.25; intgLoc_[11] = -0.25;
-  intgLoc_[12] = -0.25; intgLoc_[13] = -0.25; intgLoc_[14] = +0.25;
-  intgLoc_[15] = +0.25; intgLoc_[16] = -0.25; intgLoc_[17] = +0.25;
-  intgLoc_[18] = +0.25; intgLoc_[19] = +0.25; intgLoc_[20] = +0.25;
-  intgLoc_[21] = -0.25; intgLoc_[22] = +0.25; intgLoc_[23] = +0.25;
-
-  // shifted integration location
-  intgLocShift_.resize(24);
-  intgLocShift_[0]  = -0.5; intgLocShift_[1]  = -0.5; intgLocShift_[2]  = -0.5;
-  intgLocShift_[3]  = +0.5; intgLocShift_[4]  = -0.5; intgLocShift_[5]  = -0.5;
-  intgLocShift_[6]  = +0.5; intgLocShift_[7]  = +0.5; intgLocShift_[8]  = -0.5;
-  intgLocShift_[9]  = -0.5; intgLocShift_[10] = +0.5; intgLocShift_[11] = -0.5;
-  intgLocShift_[12] = -0.5; intgLocShift_[13] = -0.5; intgLocShift_[14] = +0.5;
-  intgLocShift_[15] = +0.5; intgLocShift_[16] = -0.5; intgLocShift_[17] = +0.5;
-  intgLocShift_[18] = +0.5; intgLocShift_[19] = +0.5; intgLocShift_[20] = +0.5;
-  intgLocShift_[21] = -0.5; intgLocShift_[22] = +0.5; intgLocShift_[23] = +0.5;
+  MasterElement::ipNodeMap_       .assign(ipNodeMap_,        8+ipNodeMap_);
+  MasterElement::intgLoc_         .assign(intgLoc_,         24+intgLoc_);
+  MasterElement::intgLocShift_    .assign(intgLocShift_,    24+intgLocShift_);
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/MasterElementFactory.C
+++ b/src/master_element/MasterElementFactory.C
@@ -268,11 +268,23 @@ namespace nalu{
   {
     surfaceMeMap_.clear();
     volumeMeMap_.clear();
-    for (std::pair<stk::topology, MasterElement*> a : volumeMeMapDev()) 
+    for (std::pair<stk::topology, MasterElement*> a : volumeMeMapDev()) {
+      const std::string debuggingName(typeid(MasterElement).name());
+      MasterElement* A=a.second;
+      kokkos_parallel_for(debuggingName, 1, [&] (const int /* i */) {
+        A->~MasterElement();
+      });
       sierra::nalu::kokkos_free_on_device(a.second);
+    }
     volumeMeMapDev().clear();
-    for (std::pair<stk::topology, MasterElement*> a : surfaceMeMapDev()) 
+    for (std::pair<stk::topology, MasterElement*> a : surfaceMeMapDev()) {
+      const std::string debuggingName(typeid(MasterElement).name());
+      MasterElement* A=a.second;
+      kokkos_parallel_for(debuggingName, 1, [&] (const int /* i */) {
+        A->~MasterElement();
+      });
       sierra::nalu::kokkos_free_on_device(a.second);
+    }
     surfaceMeMapDev().clear();
   }
 

--- a/unit_tests/UnitTestHexMasterElementsNgp.C
+++ b/unit_tests/UnitTestHexMasterElementsNgp.C
@@ -315,6 +315,7 @@ void check_derivatives(
       EXPECT_NEAR(stk::simd::get_data(hostResults(j,d),0), polyResult[j][d], 1.0e-12);
     }
   }
+  sierra::nalu::MasterElementRepo::clear();
 }
 
 class MasterElementHexSerialNGP : public ::testing::Test

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -21,7 +21,7 @@ class TestKernel
 {
   public:
     TestKernel(unsigned vOrdinal, unsigned pOrdinal)
-     : velocityOrdinal(vOrdinal), pressureOrdinal(pOrdinal)
+     //: velocityOrdinal(vOrdinal), pressureOrdinal(pOrdinal)
    {}
 
   KOKKOS_FUNCTION
@@ -34,8 +34,8 @@ class TestKernel
   }
 
 private:
-  unsigned velocityOrdinal;
-  unsigned pressureOrdinal;
+  //unsigned velocityOrdinal;
+  //unsigned pressureOrdinal;
 };
 
 typedef Kokkos::DualView<int*, Kokkos::LayoutRight, sierra::nalu::DeviceSpace> IntViewType;


### PR DESCRIPTION
    The memory for the Hex 8 master element on the GPU is allocated
    through kokkos allocate memory and kokkos delete memory. But the
    actual class instance is formatted by a placement new executed
    on the GPU. So I think that it is necessary to call ~MasterElement()
    on the GPU to free the std::vectors that are in this base class and
    avoid the memory leak. Ran valgrind on the CPU and it is now clean.
