### PR TITLE
More warning reduction.

### DIFF
--- a/src/ABLProfileFunction.C
+++ b/src/ABLProfileFunction.C
@@ -143,7 +143,7 @@ NeutralABLProfileFunction::~NeutralABLProfileFunction()
 //-------- velocity ---------------------------------------------------------
 //--------------------------------------------------------------------------
 double
-NeutralABLProfileFunction::velocity(const double znorm) const
+NeutralABLProfileFunction::velocity(const double /* znorm */) const
 {
   return 0.0;
 }
@@ -152,7 +152,7 @@ NeutralABLProfileFunction::velocity(const double znorm) const
 //-------- temperature ---------------------------------------------------------
 //--------------------------------------------------------------------------
 double
-NeutralABLProfileFunction::temperature(const double znorm) const
+NeutralABLProfileFunction::temperature(const double /* znorm */) const
 {
   return 0.0;
 }

--- a/src/Actuator.C
+++ b/src/Actuator.C
@@ -45,7 +45,7 @@ namespace nalu{
 
 Actuator::Actuator(
     Realm &realm,
-    const YAML::Node &node):realm_(realm),
+    const YAML::Node & /* node */):realm_(realm),
     searchMethod_(stk::search::KDTREE),
     needToGhostCount_(0),
     actuatorGhosting_(NULL){}
@@ -355,7 +355,7 @@ Actuator::gather_field_for_interp(
 //--------------------------------------------------------------------------
 double
 Actuator::compute_volume(
-  const int &nDim,
+  const int & /* nDim */,
   stk::mesh::Entity elem,
   const stk::mesh::BulkData & bulkData)
 {

--- a/src/AssembleScalarElemDiffSolverAlgorithm.C
+++ b/src/AssembleScalarElemDiffSolverAlgorithm.C
@@ -42,7 +42,7 @@ AssembleScalarElemDiffSolverAlgorithm::AssembleScalarElemDiffSolverAlgorithm(
   stk::mesh::Part *part,
   EquationSystem *eqSystem,
   ScalarFieldType *scalarQ,
-  VectorFieldType *dqdx,
+  VectorFieldType * /* dqdx */,
   ScalarFieldType *diffFluxCoeff)
   : SolverAlgorithm(realm, part, eqSystem),
     scalarQ_(scalarQ),

--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -626,7 +626,7 @@ DataProbePostProcessing::create_transfer()
 //--------------------------------------------------------------------------
 void
 DataProbePostProcessing::review(
-  const DataProbeInfo *probeInfo)
+  const DataProbeInfo * /* probeInfo */)
 {
   // may or may not want this
 }

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -260,7 +260,7 @@ HeatCondEquationSystem::register_edge_fields(
 void
 HeatCondEquationSystem::register_element_fields(
   stk::mesh::Part *part,
-  const stk::topology &theTopo)
+  const stk::topology & /* theTopo */)
 {
   stk::mesh::MetaData &meta_data = realm_.meta_data();
   

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -384,7 +384,7 @@ HypreLinearSystem::sumInto(
   const SharedMemView<const double**>& lhs,
   const SharedMemView<int*>&,
   const SharedMemView<int*>&,
-  const char* trace_tag)
+  const char*  /* trace_tag */)
 {
   const size_t n_obj = numEntities;
   HypreIntType numRows = n_obj * numDof_;
@@ -430,11 +430,11 @@ HypreLinearSystem::sumInto(
 void
 HypreLinearSystem::sumInto(
   const std::vector<stk::mesh::Entity>& entities,
-  std::vector<int>& scratchIds,
+  std::vector<int>&  /* scratchIds */,
   std::vector<double>& scratchVals,
   const std::vector<double>& rhs,
   const std::vector<double>& lhs,
-  const char* trace_tag)
+  const char*  /* trace_tag */)
 {
   const size_t n_obj = entities.size();
   HypreIntType numRows = n_obj * numDof_;

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -147,7 +147,7 @@ HypreUVWLinearSystem::sumInto(
   const SharedMemView<const double**>& lhs,
   const SharedMemView<int*>&,
   const SharedMemView<int*>&,
-  const char* trace_tag)
+  const char*  /* trace_tag */)
 {
   HypreIntType numRows = numEntities;
   const HypreIntType bufSize = idBuffer_.size();
@@ -193,11 +193,11 @@ HypreUVWLinearSystem::sumInto(
 void
 HypreUVWLinearSystem::sumInto(
   const std::vector<stk::mesh::Entity>& entities,
-  std::vector<int>& scratchIds,
+  std::vector<int>&  /* scratchIds */,
   std::vector<double>& scratchVals,
   const std::vector<double>& rhs,
   const std::vector<double>& lhs,
-  const char* trace_tag)
+  const char*  /* trace_tag */)
 {
   const size_t n_obj = entities.size();
   HypreIntType numRows = n_obj;

--- a/src/InputOutputRealm.C
+++ b/src/InputOutputRealm.C
@@ -170,7 +170,7 @@ InputOutputRealm::load(const YAML::Node & node)
 //--------------------------------------------------------------------------
 double
 InputOutputRealm::populate_restart(
-  double &timeStepNm1, int &timeStepCount)
+  double & /* timeStepNm1 */, int & /* timeStepCount */)
 {
   return get_current_time();
 }

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1068,8 +1068,8 @@ MomentumEquationSystem::register_nodal_fields(
 //--------------------------------------------------------------------------
 void
 MomentumEquationSystem::register_element_fields(
-  stk::mesh::Part *part,
-  const stk::topology &theTopo)
+  stk::mesh::Part * /* part */,
+  const stk::topology & /* theTopo */)
 {
   // nothing as of yet
 }
@@ -1079,7 +1079,7 @@ MomentumEquationSystem::register_element_fields(
 //--------------------------------------------------------------------------
 void
 MomentumEquationSystem::register_edge_fields(
-  stk::mesh::Part *part)
+  stk::mesh::Part * /* part */)
 {
   // nothing as of yet
 }
@@ -2006,7 +2006,7 @@ void
 MomentumEquationSystem::register_symmetry_bc(
   stk::mesh::Part *part,
   const stk::topology &partTopo,
-  const SymmetryBoundaryConditionData & symmetryBCData)
+  const SymmetryBoundaryConditionData &  /* symmetryBCData */)
 {
   // algorithm type
   const AlgorithmType algType = SYMMETRY;
@@ -2521,8 +2521,8 @@ ContinuityEquationSystem::register_nodal_fields(
 //--------------------------------------------------------------------------
 void
 ContinuityEquationSystem::register_element_fields(
-  stk::mesh::Part *part,
-  const stk::topology &theTopo)
+  stk::mesh::Part * /* part */,
+  const stk::topology & /* theTopo */)
 {
   // nothing as of yet
 }
@@ -2925,7 +2925,7 @@ void
 ContinuityEquationSystem::register_open_bc(
   stk::mesh::Part *part,
   const stk::topology &partTopo,
-  const OpenBoundaryConditionData &openBCData)
+  const OpenBoundaryConditionData & /* openBCData */)
 {
 
   const AlgorithmType algType = OPEN;
@@ -3050,7 +3050,7 @@ void
 ContinuityEquationSystem::register_wall_bc(
   stk::mesh::Part *part,
   const stk::topology &/*theTopo*/,
-  const WallBoundaryConditionData &wallBCData)
+  const WallBoundaryConditionData & /* wallBCData */)
 {
 
   // algorithm type
@@ -3081,7 +3081,7 @@ void
 ContinuityEquationSystem::register_symmetry_bc(
   stk::mesh::Part *part,
   const stk::topology &/*theTopo*/,
-  const SymmetryBoundaryConditionData &symmetryBCData)
+  const SymmetryBoundaryConditionData & /* symmetryBCData */)
 {
 
   // algorithm type

--- a/src/MassFractionEquationSystem.C
+++ b/src/MassFractionEquationSystem.C
@@ -542,7 +542,7 @@ void
 MassFractionEquationSystem::register_symmetry_bc(
   stk::mesh::Part *part,
   const stk::topology &/*theTopo*/,
-  const SymmetryBoundaryConditionData &symmetryBCData)
+  const SymmetryBoundaryConditionData & /* symmetryBCData */)
 {
 
   // algorithm type

--- a/src/MaterialProperty.C
+++ b/src/MaterialProperty.C
@@ -44,7 +44,7 @@ MaterialProperty::~MaterialProperty()
 //-------- load ------------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-MaterialProperty::load(const YAML::Node &node) 
+MaterialProperty::load(const YAML::Node & /* node */) 
 {
   // nothing...
 }

--- a/src/MomentumABLForceSrcNodeSuppAlg.C
+++ b/src/MomentumABLForceSrcNodeSuppAlg.C
@@ -25,7 +25,7 @@ MomentumABLForceSrcNodeSuppAlg::MomentumABLForceSrcNodeSuppAlg(
 
 void
 MomentumABLForceSrcNodeSuppAlg::node_execute(
-  double* lhs, double* rhs, stk::mesh::Entity node)
+  double*  /* lhs */, double* rhs, stk::mesh::Entity node)
 {
   const double dualVol = *stk::mesh::field_data(*dualNodalVolume_, node);
   const double* pt = stk::mesh::field_data(*coords_, node);

--- a/src/MomentumBuoyancySrcElemSuppAlgDep.C
+++ b/src/MomentumBuoyancySrcElemSuppAlgDep.C
@@ -92,7 +92,7 @@ MomentumBuoyancySrcElemSuppAlgDep::setup()
 //--------------------------------------------------------------------------
 void
 MomentumBuoyancySrcElemSuppAlgDep::elem_execute(
-  double *lhs,
+  double * /* lhs */,
   double *rhs,
   stk::mesh::Entity element,
   MasterElement */*meSCS*/,

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -1166,7 +1166,7 @@ namespace YAML
   }
 
   bool convert<sierra::nalu::SymmetryUserData>::decode(const Node& node,
-    sierra::nalu::SymmetryUserData& symmetryData)
+    sierra::nalu::SymmetryUserData&  /* symmetryData */)
   {
     // Normal temperature gradient for ABL top BC is now implemented in
     // abltop_boundary_condition. Throw error to inform user of the change

--- a/src/ScalarGclNodeSuppAlg.C
+++ b/src/ScalarGclNodeSuppAlg.C
@@ -30,7 +30,7 @@ namespace nalu{
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 ScalarGclNodeSuppAlg::ScalarGclNodeSuppAlg(
-  ScalarFieldType *scalarQNp1,
+  ScalarFieldType * /* scalarQNp1 */,
   Realm &realm)
   : SupplementalAlgorithm(realm),
     scalarQNp1_(NULL),

--- a/src/ScratchViewsNGP.C
+++ b/src/ScratchViewsNGP.C
@@ -347,7 +347,7 @@ void fill_pre_req_data(
   stk::mesh::EntityRank entityRank,
   stk::mesh::Entity entity,
   ScratchViewsNGP<double,DeviceTeamHandleType,DeviceShmem>& prereqData,
-  bool fillMEViews)
+  bool  /* fillMEViews */)
 {
   //MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
   //MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -644,7 +644,7 @@ void
 SpecificDissipationRateEquationSystem::register_symmetry_bc(
   stk::mesh::Part *part,
   const stk::topology &/*theTopo*/,
-  const SymmetryBoundaryConditionData &symmetryBCData)
+  const SymmetryBoundaryConditionData & /* symmetryBCData */)
 {
 
   // algorithm type

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -515,7 +515,7 @@ TpetraLinearSystem::buildFaceElemToNodeGraph(const stk::mesh::PartVector & parts
 }
 
 void
-TpetraLinearSystem::buildNonConformalNodeGraph(const stk::mesh::PartVector &parts)
+TpetraLinearSystem::buildNonConformalNodeGraph(const stk::mesh::PartVector & /* parts */)
 {
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
   beginLinearSystemConstruction();
@@ -569,7 +569,7 @@ TpetraLinearSystem::buildNonConformalNodeGraph(const stk::mesh::PartVector &part
 }
 
 void
-TpetraLinearSystem::buildOversetNodeGraph(const stk::mesh::PartVector &parts)
+TpetraLinearSystem::buildOversetNodeGraph(const stk::mesh::PartVector & /* parts */)
 {
   // extract the rank
   const int theRank = NaluEnv::self().parallel_rank();
@@ -673,7 +673,7 @@ void add_to_length(ViewType& v_owned, ViewType& v_shared, unsigned numDof,
     }
 }
 
-void add_lengths_to_comm(const stk::mesh::BulkData& bulk,
+void add_lengths_to_comm(const stk::mesh::BulkData&  /* bulk */,
                          stk::CommNeighbors& commNeighbors,
                          int entity_a_owner,
                          stk::mesh::EntityId entityId_a,
@@ -1236,7 +1236,7 @@ void fill_in_extra_dof_rows_per_node(LocalGraphArrays& csg, int numDof)
   }
 }
 
-void verify_no_empty_connections(const std::vector<stk::mesh::Entity>& rowEntities,
+void verify_no_empty_connections(const std::vector<stk::mesh::Entity>&  /* rowEntities */,
         const std::vector<std::vector<stk::mesh::Entity> >& connections)
 {
   for(const std::vector<stk::mesh::Entity>& vec : connections) {
@@ -1453,7 +1453,7 @@ TpetraLinearSystem::sumInto(
       const SharedMemView<const double**> & lhs,
       const SharedMemView<int*> & localIds,
       const SharedMemView<int*> & sortPermutation,
-      const char * trace_tag)
+      const char *  /* trace_tag */)
 {
   constexpr bool forceAtomic = !std::is_same<sierra::nalu::DeviceSpace, Kokkos::Serial>::value;
 
@@ -1516,10 +1516,10 @@ void
 TpetraLinearSystem::sumInto(
   const std::vector<stk::mesh::Entity> & entities,
   std::vector<int> &scratchIds,
-  std::vector<double> &scratchVals,
+  std::vector<double> & /* scratchVals */,
   const std::vector<double> & rhs,
   const std::vector<double> & lhs,
-  const char *trace_tag
+  const char * /* trace_tag */
   )
 {
   const size_t n_obj = entities.size();

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -798,7 +798,7 @@ void
 TurbKineticEnergyEquationSystem::register_symmetry_bc(
   stk::mesh::Part *part,
   const stk::topology &/*theTopo*/,
-  const SymmetryBoundaryConditionData &symmetryBCData)
+  const SymmetryBoundaryConditionData & /* symmetryBCData */)
 {
 
   // algorithm type

--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -1052,7 +1052,7 @@ TurbulenceAveragingPostProcessing::compute_resolved_stress(
 //--------------------------------------------------------------------------
 void
 TurbulenceAveragingPostProcessing::compute_sfs_stress(
-  const std::string &averageBlockName,
+  const std::string & /* averageBlockName */,
   const double &oldTimeFilter,
   const double &zeroCurrent,
   const double &dt,
@@ -1177,7 +1177,7 @@ TurbulenceAveragingPostProcessing::compute_temperature_sfs_flux(
 //--------------------------------------------------------------------------
 void
 TurbulenceAveragingPostProcessing::compute_vorticity(
-  const std::string &averageBlockName,
+  const std::string & /* averageBlockName */,
   stk::mesh::Selector s_all_nodes)
 {
   stk::mesh::MetaData & metaData = realm_.meta_data();
@@ -1222,7 +1222,7 @@ TurbulenceAveragingPostProcessing::compute_vorticity(
 //--------------------------------------------------------------------------
 void
 TurbulenceAveragingPostProcessing::compute_q_criterion(
-  const std::string &averageBlockName,
+  const std::string & /* averageBlockName */,
   stk::mesh::Selector s_all_nodes)
 {
   stk::mesh::MetaData & metaData = realm_.meta_data();
@@ -1277,7 +1277,7 @@ TurbulenceAveragingPostProcessing::compute_q_criterion(
 //--------------------------------------------------------------------------
 void
 TurbulenceAveragingPostProcessing::compute_lambda_ci(
-  const std::string &averageBlockName,
+  const std::string & /* averageBlockName */,
   stk::mesh::Selector s_all_nodes)
 {
   stk::mesh::MetaData & metaData = realm_.meta_data();
@@ -1401,7 +1401,7 @@ TurbulenceAveragingPostProcessing::compute_lambda_ci(
 //--------------------------------------------------------------------------
 void
 TurbulenceAveragingPostProcessing::compute_mean_resolved_ke(
-  const std::string &averageBlockName,
+  const std::string & /* averageBlockName */,
   stk::mesh::Selector s_all_nodes)
 {
   stk::mesh::MetaData & metaData = realm_.meta_data();

--- a/src/UnitTests.C
+++ b/src/UnitTests.C
@@ -28,7 +28,7 @@ namespace nalu{
 //-------- destructor ------------------------------------------------------
 //--------------------------------------------------------------------------
 
-void UnitTests::load(const YAML::Node & node)
+void UnitTests::load(const YAML::Node &  /* node */)
 {
 }
 

--- a/src/element_promotion/ElementCondenser.C
+++ b/src/element_promotion/ElementCondenser.C
@@ -150,7 +150,7 @@ ElementCondenser::condense(
 //--------------------------------------------------------------------------
 void ElementCondenser::compute_interior_update(
   double* lhs, const double* rhs,
-  const double* boundary_values, double* delta_interior_values)
+  const double* /* boundary_values */, double* delta_interior_values)
 {
   // Computes an update to the interior values given the updated rhs vector
   // and the elemental linear system

--- a/src/element_promotion/PromoteElement.C
+++ b/src/element_promotion/PromoteElement.C
@@ -138,7 +138,7 @@ promote_elements_hex(
   const VectorFieldType& coordField,
   const stk::mesh::PartVector& partsToBePromoted,
   stk::mesh::Part& edgePart,
-  stk::mesh::Part& facePart)
+  stk::mesh::Part&  /* facePart */)
 {
   ThrowRequire(check_parts_for_promotion(partsToBePromoted));
   ThrowRequireMsg(!bulk.is_automatic_aura_on(), "Promotion not yet tested for automatic aura");
@@ -598,7 +598,7 @@ add_face_nodes_to_elem_connectivity(
 //--------------------------------------------------------------------------
 void
 add_volume_nodes_to_elem_connectivity(
-  const stk::mesh::BulkData& bulk,
+  const stk::mesh::BulkData&  /* bulk */,
   const ElementDescription& desc,
   const ConnectivityMap& volumeConnectivity,
   const stk::mesh::Entity elem,

--- a/src/element_promotion/PromotedPartHelper.C
+++ b/src/element_promotion/PromotedPartHelper.C
@@ -104,7 +104,7 @@ namespace nalu{
 
     return name;
   }
-  std::string super_subset_part_name(const std::string& base_name, int numElemNodes, int numSideNodes)
+  std::string super_subset_part_name(const std::string& base_name, int  /* numElemNodes */, int numSideNodes)
   {
     // subsetted part name.  Goes like "surfacese_super512_superside64_1"
     // Ioss doesn't recognize "superside" but does recognize the "super" tag

--- a/src/kernel/ContinuityMassHOElemKernel.C
+++ b/src/kernel/ContinuityMassHOElemKernel.C
@@ -72,7 +72,7 @@ ContinuityMassHOElemKernel<AlgTraits>::setup(const TimeIntegrator& timeIntegrato
 //--------------------------------------------------------------------------
 template <class AlgTraits> void
 ContinuityMassHOElemKernel<AlgTraits>::execute(
-  SharedMemView<DoubleType**>& lhs,
+  SharedMemView<DoubleType**>&  /* lhs */,
   SharedMemView<DoubleType*>& rhs,
   ScratchViewsHO<DoubleType>& scratchViews)
 {

--- a/src/kernel/MomentumBuoyancySrcHOElemKernel.C
+++ b/src/kernel/MomentumBuoyancySrcHOElemKernel.C
@@ -61,7 +61,7 @@ MomentumBuoyancySrcHOElemKernel<AlgTraits>::MomentumBuoyancySrcHOElemKernel(
 //--------------------------------------------------------------------------
 template <class AlgTraits> void
 MomentumBuoyancySrcHOElemKernel<AlgTraits>::execute(
-  SharedMemView<DoubleType**>& lhs,
+  SharedMemView<DoubleType**>&  /* lhs */,
   SharedMemView<DoubleType*>& rhs,
   ScratchViewsHO<DoubleType>& scratchViews)
 {

--- a/src/master_element/Hex27CVFEM.C
+++ b/src/master_element/Hex27CVFEM.C
@@ -731,7 +731,7 @@ void Hex27SCV::shifted_shape_fcn(SharedMemView<DoubleType**> &shpfc)
 //-------- determinant -----------------------------------------------------
 //--------------------------------------------------------------------------
 void Hex27SCV::determinant(
-  const int nelem,
+  const int  /* nelem */,
   const double *coords,
   double *volume,
   double *error)
@@ -849,7 +849,7 @@ void Hex27SCV::Mij(
 void Hex27SCV::Mij(
   SharedMemView<DoubleType**>& coords,
   SharedMemView<DoubleType***>& metric,
-  SharedMemView<DoubleType***>& deriv)
+  SharedMemView<DoubleType***>&  /* deriv */)
 {
   generic_Mij_3d<AlgTraits>(referenceGradWeights_, coords, metric);
 }
@@ -1703,7 +1703,7 @@ void Hex27SCS::Mij(
 void Hex27SCS::Mij(
   SharedMemView<DoubleType**>& coords,
   SharedMemView<DoubleType***>& metric,
-  SharedMemView<DoubleType***>& deriv)
+  SharedMemView<DoubleType***>&  /* deriv */)
 {
   generic_Mij_3d<AlgTraits>(referenceGradWeights_, coords, metric);
 }
@@ -1713,7 +1713,7 @@ void Hex27SCS::Mij(
 //--------------------------------------------------------------------------
 void
 Hex27SCS::general_face_grad_op(
-  const int face_ordinal,
+  const int  /* face_ordinal */,
   const double *isoParCoord,
   const double *coords,
   double *gradop,
@@ -2032,7 +2032,7 @@ Quad93DSCS::determinant(
   const int nelem,
   const double *coords,
   double *areav,
-  double *error)
+  double * /* error */)
 {
   std::array<double,3> areaVector;
 

--- a/src/master_element/Hex8CVFEM.C
+++ b/src/master_element/Hex8CVFEM.C
@@ -927,7 +927,7 @@ HexSCS::general_shape_fcn(
 //--------------------------------------------------------------------------
 void
 HexSCS::general_face_grad_op(
-  const int face_ordinal,
+  const int  /* face_ordinal */,
   const double *isoParCoord,
   const double *coords,
   double *gradop,

--- a/src/master_element/MasterElementHO.C
+++ b/src/master_element/MasterElementHO.C
@@ -758,7 +758,7 @@ HigherOrderHexSCS::opposingFace(
 //--------------------------------------------------------------------------
 void
 HigherOrderHexSCS::determinant(
-  const int nelem,
+  const int  /* nelem */,
   const double *coords,
   double *areav,
   double *error)

--- a/src/master_element/Pyr5CVFEM.C
+++ b/src/master_element/Pyr5CVFEM.C
@@ -175,7 +175,7 @@ PyrSCV::ipNodeMap(
   return &ipNodeMap_[0];
 }
 
-DoubleType polyhedral_volume_by_faces(int ncoords, const DoubleType volcoords[][3],
+DoubleType polyhedral_volume_by_faces(int  /* ncoords */, const DoubleType volcoords[][3],
                                       int ntriangles, const int triangleFaceTable[][3])
 {
   DoubleType xface[3];
@@ -1184,7 +1184,7 @@ double PyrSCS::isInElement(
 //--------------------------------------------------------------------------
 void 
 PyrSCS::general_face_grad_op(
-  const int face_ordinal,
+  const int  /* face_ordinal */,
   const double *isoParCoord,
   const double *coords,
   double *gradop,

--- a/src/master_element/Quad42DCVFEM.C
+++ b/src/master_element/Quad42DCVFEM.C
@@ -1060,7 +1060,7 @@ Quad42DSCS::general_shape_fcn(
 //--------------------------------------------------------------------------
 void 
 Quad42DSCS::general_face_grad_op(
-  const int face_ordinal,
+  const int  /* face_ordinal */,
   const double *isoParCoord,
   const double *coords,
   double *gradop,

--- a/src/master_element/Quad43DCVFEM.C
+++ b/src/master_element/Quad43DCVFEM.C
@@ -128,7 +128,7 @@ Quad3DSCS::shifted_shape_fcn(SharedMemView<DoubleType**> &shpfc)
 //--------------------------------------------------------------------------
 void
 Quad3DSCS::quad4_shape_fcn(
-  const int  &npts,
+  const int  & /* npts */,
   const double *isoParCoord,
   SharedMemView<DoubleType**> &shape_fcn)
 {

--- a/src/master_element/Quad92DCVFEM.C
+++ b/src/master_element/Quad92DCVFEM.C
@@ -232,7 +232,7 @@ void Quad92DSCV::shifted_grad_op(
 }
 
 void Quad92DSCV::determinant(
-  const int nelem,
+  const int  /* nelem */,
   const double *coords,
   double *volume,
   double *error)

--- a/src/master_element/Wed6CVFEM.C
+++ b/src/master_element/Wed6CVFEM.C
@@ -1216,7 +1216,7 @@ WedSCS::parametric_distance(const std::vector<double> &x)
 //--------------------------------------------------------------------------
 void
 WedSCS::general_face_grad_op(
-  const int face_ordinal,
+  const int  /* face_ordinal */,
   const double *isoParCoord,
   const double *coords,
   double *gradop,

--- a/src/mesh_motion/MeshDisplacementEquationSystem.C
+++ b/src/mesh_motion/MeshDisplacementEquationSystem.C
@@ -214,8 +214,8 @@ MeshDisplacementEquationSystem::register_nodal_fields(
 //--------------------------------------------------------------------------
 void
 MeshDisplacementEquationSystem::register_element_fields(
-  stk::mesh::Part *part,
-  const stk::topology &theTopo)
+  stk::mesh::Part * /* part */,
+  const stk::topology & /* theTopo */)
 {
   // n/a
 }
@@ -284,7 +284,7 @@ MeshDisplacementEquationSystem::register_interior_algorithm(
 void
 MeshDisplacementEquationSystem::register_wall_bc(
   stk::mesh::Part *part,
-  const stk::topology &theTopo,
+  const stk::topology & /* theTopo */,
   const WallBoundaryConditionData &wallBCData)
 {
 

--- a/src/mesh_motion/MotionPulsatingSphere.C
+++ b/src/mesh_motion/MotionPulsatingSphere.C
@@ -80,7 +80,7 @@ void MotionPulsatingSphere::scaling_mat(
 
 MotionBase::ThreeDVecType MotionPulsatingSphere::compute_velocity(
   double time,
-  const TransMatType& compTrans,
+  const TransMatType&  /* compTrans */,
   double* xyz )
 {
   ThreeDVecType vel = {};

--- a/src/mesh_motion/MotionRotation.C
+++ b/src/mesh_motion/MotionRotation.C
@@ -41,7 +41,7 @@ void MotionRotation::load(const YAML::Node& node)
 
 void MotionRotation::build_transformation(
   const double time,
-  const double* xyz)
+  const double*  /* xyz */)
 {
   double eps = std::numeric_limits<double>::epsilon();
 

--- a/src/mesh_motion/MotionScaling.C
+++ b/src/mesh_motion/MotionScaling.C
@@ -29,8 +29,8 @@ void MotionScaling::load(const YAML::Node& node)
 }
 
 void MotionScaling::build_transformation(
-  const double time,
-  const double* xyz)
+  const double  /* time */,
+  const double*  /* xyz */)
 {
   scaling_mat(factor_);
 }

--- a/src/mesh_motion/MotionTranslation.C
+++ b/src/mesh_motion/MotionTranslation.C
@@ -33,7 +33,7 @@ void MotionTranslation::load(const YAML::Node& node)
 
 void MotionTranslation::build_transformation(
   const double time,
-  const double* xyz)
+  const double*  /* xyz */)
 {
   double eps = std::numeric_limits<double>::epsilon();
 
@@ -65,8 +65,8 @@ void MotionTranslation::translation_mat(const ThreeDVecType& curr_disp)
 
 MotionBase::ThreeDVecType MotionTranslation::compute_velocity(
   double time,
-  const TransMatType& compTrans,
-  double* xyz )
+  const TransMatType&  /* compTrans */,
+  double*  /* xyz */ )
 {
   ThreeDVecType vel = {};
 

--- a/src/pmr/RadTransIsotropicScatteringElemKernel.C
+++ b/src/pmr/RadTransIsotropicScatteringElemKernel.C
@@ -61,7 +61,7 @@ RadTransIsotropicScatteringElemKernel<AlgTraits>::~RadTransIsotropicScatteringEl
 template<typename AlgTraits>
 void
 RadTransIsotropicScatteringElemKernel<AlgTraits>::execute(
-  SharedMemView<DoubleType **>&lhs,
+  SharedMemView<DoubleType **>& /* lhs */,
   SharedMemView<DoubleType *>&rhs,
   ScratchViews<DoubleType>& scratchViews)
 {

--- a/src/pmr/RadTransWallElemKernel.C
+++ b/src/pmr/RadTransWallElemKernel.C
@@ -26,7 +26,7 @@ template<typename BcAlgTraits>
 RadTransWallElemKernel<BcAlgTraits>::RadTransWallElemKernel(
   const stk::mesh::BulkData& bulkData,
   RadiativeTransportEquationSystem *radEqSystem,
-  const bool &useShifted,
+  const bool & /* useShifted */,
   ElemDataRequests &dataPreReqs)
   : Kernel(),
     radEqSystem_(radEqSystem),

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -471,8 +471,8 @@ RadiativeTransportEquationSystem::register_edge_fields(
 //--------------------------------------------------------------------------
 void
 RadiativeTransportEquationSystem::register_element_fields(
-  stk::mesh::Part *part,
-  const stk::topology &theTopo)
+  stk::mesh::Part * /* part */,
+  const stk::topology & /* theTopo */)
 {
   // n/a
 }

--- a/src/property_evaluator/ConstantPropertyEvaluator.C
+++ b/src/property_evaluator/ConstantPropertyEvaluator.C
@@ -38,7 +38,7 @@ ConstantPropertyEvaluator::~ConstantPropertyEvaluator()
 //--------------------------------------------------------------------------
 double
 ConstantPropertyEvaluator::execute(
-  double *indVarList,
+  double * /* indVarList */,
   stk::mesh::Entity /*node*/)
 {
   return value_;

--- a/src/property_evaluator/WaterPropertyEvaluator.C
+++ b/src/property_evaluator/WaterPropertyEvaluator.C
@@ -27,7 +27,7 @@ namespace nalu{
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 WaterDensityTPropertyEvaluator::WaterDensityTPropertyEvaluator(
-  stk::mesh::MetaData &metaData)
+  stk::mesh::MetaData & /* metaData */)
   : PropertyEvaluator(),
     aw_(+765.33),
     bw_(+1.8142),
@@ -66,7 +66,7 @@ WaterDensityTPropertyEvaluator::execute(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 WaterViscosityTPropertyEvaluator::WaterViscosityTPropertyEvaluator(
-  stk::mesh::MetaData &metaData)
+  stk::mesh::MetaData & /* metaData */)
   : PropertyEvaluator(),
     aw_(+9.67e-2),
     bw_(-8.207e-4),
@@ -106,7 +106,7 @@ WaterViscosityTPropertyEvaluator::execute(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 WaterSpecHeatTPropertyEvaluator::WaterSpecHeatTPropertyEvaluator(
-  stk::mesh::MetaData &metaData)
+  stk::mesh::MetaData & /* metaData */)
   : PropertyEvaluator(),
     aw_(28.07),
     bw_(-2.817e-1),
@@ -147,7 +147,7 @@ WaterSpecHeatTPropertyEvaluator::execute(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 WaterEnthalpyTPropertyEvaluator::WaterEnthalpyTPropertyEvaluator(
-  stk::mesh::MetaData &metaData)
+  stk::mesh::MetaData & /* metaData */)
   : PropertyEvaluator(),
     aw_(28.07),
     bw_(-2.817e-1),
@@ -174,7 +174,7 @@ WaterEnthalpyTPropertyEvaluator::~WaterEnthalpyTPropertyEvaluator()
 double
 WaterEnthalpyTPropertyEvaluator::execute(
   double *indVarList,
-  stk::mesh::Entity node)
+  stk::mesh::Entity  /* node */)
 {
   const double T = indVarList[0];
   const double hWT = compute_h(T);
@@ -203,7 +203,7 @@ WaterEnthalpyTPropertyEvaluator::compute_h(
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 WaterThermalCondTPropertyEvaluator::WaterThermalCondTPropertyEvaluator(
-  stk::mesh::MetaData &metaData)
+  stk::mesh::MetaData & /* metaData */)
   : PropertyEvaluator(),
     aw_(-0.5752),
     bw_(+6.397e-3),

--- a/src/tabular_props/BSpline.C
+++ b/src/tabular_props/BSpline.C
@@ -1033,7 +1033,7 @@ BSpline5D::BSpline5D( const int order,
   compute_control_pts( x1, x2, x3, x4, x5, phi );
 }
 //--------------------------------------------------------------------
-BSpline5D::BSpline5D( const bool allowClipping )
+BSpline5D::BSpline5D( const bool  /* allowClipping */ )
   : BSpline( 0, 5 ),
     n1_(0), n2_(0), n3_(0), n4_(0), n5_(0),
     sp1_( NULL )

--- a/src/user_functions/BoussinesqNonIsoVelocityAuxFunction.C
+++ b/src/user_functions/BoussinesqNonIsoVelocityAuxFunction.C
@@ -31,7 +31,7 @@ BoussinesqNonIsoVelocityAuxFunction::BoussinesqNonIsoVelocityAuxFunction(
 void
 BoussinesqNonIsoVelocityAuxFunction::do_evaluate(
   const double *coords,
-  const double t,
+  const double /* t */,
   const unsigned /*spatialDimension*/,
   const unsigned numPoints,
   double * fieldPtr,

--- a/src/user_functions/FlowPastCylinderTempAuxFunction.C
+++ b/src/user_functions/FlowPastCylinderTempAuxFunction.C
@@ -56,7 +56,7 @@ FlowPastCylinderTempAuxFunction::FlowPastCylinderTempAuxFunction() :
 void
 FlowPastCylinderTempAuxFunction::do_evaluate(
   const double *coords,
-  const double t,
+  const double /* t */,
   const unsigned spatialDimension,
   const unsigned numPoints,
   double * fieldPtr,

--- a/src/user_functions/PerturbedShearLayerAuxFunctions.C
+++ b/src/user_functions/PerturbedShearLayerAuxFunctions.C
@@ -69,11 +69,11 @@ public:
 void
 PerturbedShearLayerVelocityAuxFunction::do_evaluate(
   const double *coords,
-  const double t,
+  const double /* t */,
   const unsigned /*spatialDimension*/,
   const unsigned numPoints,
   double * fieldPtr,
-  const unsigned fieldSize,
+  const unsigned  /* fieldSize */,
   const unsigned /*beginPos*/,
   const unsigned /*endPos*/) const
 {
@@ -101,11 +101,11 @@ PerturbedShearLayerMixFracAuxFunction::PerturbedShearLayerMixFracAuxFunction() :
 void
 PerturbedShearLayerMixFracAuxFunction::do_evaluate(
   const double *coords,
-  const double t,
+  const double /* t */,
   const unsigned spatialDimension,
   const unsigned numPoints,
   double * fieldPtr,
-  const unsigned fieldSize,
+  const unsigned  /* fieldSize */,
   const unsigned /*beginPos*/,
   const unsigned /*endPos*/) const
 {

--- a/src/user_functions/SteadyThermal3dContactAuxFunction.C
+++ b/src/user_functions/SteadyThermal3dContactAuxFunction.C
@@ -30,7 +30,7 @@ SteadyThermal3dContactAuxFunction::SteadyThermal3dContactAuxFunction() :
 void
 SteadyThermal3dContactAuxFunction::do_evaluate(
   const double *coords,
-  const double t,
+  const double /* t */,
   const unsigned spatialDimension,
   const unsigned numPoints,
   double * fieldPtr,

--- a/src/user_functions/SteadyThermalContactAuxFunction.C
+++ b/src/user_functions/SteadyThermalContactAuxFunction.C
@@ -30,7 +30,7 @@ SteadyThermalContactAuxFunction::SteadyThermalContactAuxFunction() :
 void
 SteadyThermalContactAuxFunction::do_evaluate(
   const double *coords,
-  const double t,
+  const double /* t */,
   const unsigned spatialDimension,
   const unsigned numPoints,
   double * fieldPtr,

--- a/src/user_functions/TaylorGreenPressureAuxFunction.C
+++ b/src/user_functions/TaylorGreenPressureAuxFunction.C
@@ -31,7 +31,7 @@ TaylorGreenPressureAuxFunction::TaylorGreenPressureAuxFunction() :
 void
 TaylorGreenPressureAuxFunction::do_evaluate(
   const double *coords,
-  const double t,
+  const double /* t */,
   const unsigned spatialDimension,
   const unsigned numPoints,
   double * fieldPtr,

--- a/src/user_functions/TaylorGreenVelocityAuxFunction.C
+++ b/src/user_functions/TaylorGreenVelocityAuxFunction.C
@@ -33,7 +33,7 @@ TaylorGreenVelocityAuxFunction::TaylorGreenVelocityAuxFunction(
 void
 TaylorGreenVelocityAuxFunction::do_evaluate(
   const double *coords,
-  const double t,
+  const double /* t */,
   const unsigned /*spatialDimension*/,
   const unsigned numPoints,
   double * fieldPtr,

--- a/src/user_functions/WindEnergyTaylorVortexPressureAuxFunction.C
+++ b/src/user_functions/WindEnergyTaylorVortexPressureAuxFunction.C
@@ -64,7 +64,7 @@ WindEnergyTaylorVortexPressureAuxFunction::do_evaluate(
   const unsigned spatialDimension,
   const unsigned numPoints,
   double * fieldPtr,
-  const unsigned fieldSize,
+  const unsigned  /* fieldSize */,
   const unsigned /*beginPos*/,
   const unsigned /*endPos*/) const
 {

--- a/src/utils/StkHelpers.C
+++ b/src/utils/StkHelpers.C
@@ -45,7 +45,7 @@ add_downward_relations(
 
 void
 keep_elems_not_already_ghosted(
-  const stk::mesh::BulkData& bulk,
+  const stk::mesh::BulkData&  /* bulk */,
   const stk::mesh::EntityProcVec& alreadyGhosted,
   stk::mesh::EntityProcVec& elemsToGhost)
 {


### PR DESCRIPTION
Use handy macro to rip over source files for unused variables.