### PR TITLE
Remove pedantic warnings about extra semicolons

### DIFF
--- a/src/kernel/ContinuityAdvElemKernel.C
+++ b/src/kernel/ContinuityAdvElemKernel.C
@@ -159,7 +159,7 @@ ContinuityAdvElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ContinuityAdvElemKernel);
+INSTANTIATE_KERNEL(ContinuityAdvElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ContinuityInflowElemKernel.C
+++ b/src/kernel/ContinuityInflowElemKernel.C
@@ -115,7 +115,7 @@ ContinuityInflowElemKernel<BcAlgTraits>::execute(
   } 
 }
 
-INSTANTIATE_KERNEL_FACE(ContinuityInflowElemKernel);
+INSTANTIATE_KERNEL_FACE(ContinuityInflowElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ContinuityMassElemKernel.C
+++ b/src/kernel/ContinuityMassElemKernel.C
@@ -121,7 +121,7 @@ ContinuityMassElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ContinuityMassElemKernel);
+INSTANTIATE_KERNEL(ContinuityMassElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ContinuityMassHOElemKernel.C
+++ b/src/kernel/ContinuityMassHOElemKernel.C
@@ -89,7 +89,7 @@ ContinuityMassHOElemKernel<AlgTraits>::execute(
   tensor_assembly::density_dt_rhs(ops_, vol, gamma_, rhom1, rhop0, rhop1, v_rhs);
 }
 
-INSTANTIATE_KERNEL_HOSGL(ContinuityMassHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(ContinuityMassHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/ContinuityOpenElemKernel.C
+++ b/src/kernel/ContinuityOpenElemKernel.C
@@ -204,7 +204,7 @@ ContinuityOpenElemKernel<BcAlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL_FACE_ELEMENT(ContinuityOpenElemKernel);
+INSTANTIATE_KERNEL_FACE_ELEMENT(ContinuityOpenElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumActuatorSrcElemKernel.C
+++ b/src/kernel/MomentumActuatorSrcElemKernel.C
@@ -103,7 +103,7 @@ MomentumActuatorSrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumActuatorSrcElemKernel);
+INSTANTIATE_KERNEL(MomentumActuatorSrcElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumAdvDiffElemKernel.C
+++ b/src/kernel/MomentumAdvDiffElemKernel.C
@@ -187,7 +187,7 @@ MomentumAdvDiffElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumAdvDiffElemKernel);
+INSTANTIATE_KERNEL(MomentumAdvDiffElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumAdvDiffHOElemKernel.C
+++ b/src/kernel/MomentumAdvDiffHOElemKernel.C
@@ -111,7 +111,7 @@ MomentumAdvDiffHOElemKernel<AlgTraits>::execute(
   tensor_assembly::momentum_advdiff_lhs(ops_, mdot, laplacian_metric, v_lhs, reduced_sens_);
 }
 
-INSTANTIATE_KERNEL_HOSGL(MomentumAdvDiffHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(MomentumAdvDiffHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
+++ b/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
@@ -93,7 +93,7 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumBuoyancyBoussinesqSrcElemKernel);
+INSTANTIATE_KERNEL(MomentumBuoyancyBoussinesqSrcElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumBuoyancySrcElemKernel.C
+++ b/src/kernel/MomentumBuoyancySrcElemKernel.C
@@ -91,7 +91,7 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumBuoyancySrcElemKernel);
+INSTANTIATE_KERNEL(MomentumBuoyancySrcElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumBuoyancySrcHOElemKernel.C
+++ b/src/kernel/MomentumBuoyancySrcHOElemKernel.C
@@ -90,7 +90,7 @@ MomentumBuoyancySrcHOElemKernel<AlgTraits>::execute(
   ops_.volume(buoyancy_src, v_rhs);
 }
 
-INSTANTIATE_KERNEL_HOSGL(MomentumBuoyancySrcHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(MomentumBuoyancySrcHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/MomentumCoriolisSrcElemKernel.C
+++ b/src/kernel/MomentumCoriolisSrcElemKernel.C
@@ -126,7 +126,7 @@ MomentumCoriolisSrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumCoriolisSrcElemKernel);
+INSTANTIATE_KERNEL(MomentumCoriolisSrcElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/MomentumHybridTurbElemKernel.C
+++ b/src/kernel/MomentumHybridTurbElemKernel.C
@@ -203,7 +203,7 @@ MomentumHybridTurbElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumHybridTurbElemKernel);
+INSTANTIATE_KERNEL(MomentumHybridTurbElemKernel)
 
 } // namespace nalu
 } // namespace sierra

--- a/src/kernel/MomentumMassElemKernel.C
+++ b/src/kernel/MomentumMassElemKernel.C
@@ -170,7 +170,7 @@ MomentumMassElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumMassElemKernel);
+INSTANTIATE_KERNEL(MomentumMassElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumMassHOElemKernel.C
+++ b/src/kernel/MomentumMassHOElemKernel.C
@@ -120,7 +120,7 @@ MomentumMassHOElemKernel<AlgTraits>::execute(
   tensor_assembly::momentum_dt_lhs(ops_, vol, gamma_[0], rhop1, v_lhs);
 }
 
-INSTANTIATE_KERNEL_HOSGL(MomentumMassHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(MomentumMassHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -386,7 +386,7 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL_FACE_ELEMENT(MomentumOpenAdvDiffElemKernel);
+INSTANTIATE_KERNEL_FACE_ELEMENT(MomentumOpenAdvDiffElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -165,7 +165,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL_FACE_ELEMENT(MomentumSymmetryElemKernel);
+INSTANTIATE_KERNEL_FACE_ELEMENT(MomentumSymmetryElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumUpwAdvDiffElemKernel.C
+++ b/src/kernel/MomentumUpwAdvDiffElemKernel.C
@@ -322,7 +322,7 @@ MomentumUpwAdvDiffElemKernel<AlgTraits>::van_leer(
   return limit;
 }
 
-INSTANTIATE_KERNEL(MomentumUpwAdvDiffElemKernel);
+INSTANTIATE_KERNEL(MomentumUpwAdvDiffElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/MomentumWallFunctionElemKernel.C
+++ b/src/kernel/MomentumWallFunctionElemKernel.C
@@ -158,7 +158,7 @@ MomentumWallFunctionElemKernel<BcAlgTraits>::execute(
   }  
 }
 
-INSTANTIATE_KERNEL_FACE(MomentumWallFunctionElemKernel);
+INSTANTIATE_KERNEL_FACE(MomentumWallFunctionElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/PressurePoissonHOElemKernel.C
+++ b/src/kernel/PressurePoissonHOElemKernel.C
@@ -94,7 +94,7 @@ PressurePoissonHOElemKernel<AlgTraits>::execute(
   tensor_assembly::scalar_diffusion_lhs(ops_, metric, v_lhs, reduced_sens_);
 }
 
-INSTANTIATE_KERNEL_HOSGL(PressurePoissonHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(PressurePoissonHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/ProjectedNodalGradientHOElemKernel.C
+++ b/src/kernel/ProjectedNodalGradientHOElemKernel.C
@@ -79,7 +79,7 @@ ProjectedNodalGradientHOElemKernel<AlgTraits>::execute(
   tensor_assembly::green_gauss_lhs(ops_, vol, v_lhs);
 }
 
-INSTANTIATE_KERNEL_HOSGL(ProjectedNodalGradientHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(ProjectedNodalGradientHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/ScalarAdvDiffElemKernel.C
+++ b/src/kernel/ScalarAdvDiffElemKernel.C
@@ -128,7 +128,7 @@ ScalarAdvDiffElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ScalarAdvDiffElemKernel);
+INSTANTIATE_KERNEL(ScalarAdvDiffElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ScalarAdvDiffHOElemKernel.C
+++ b/src/kernel/ScalarAdvDiffHOElemKernel.C
@@ -107,7 +107,7 @@ ScalarAdvDiffHOElemKernel<AlgTraits>::execute(
   tensor_assembly::scalar_advdiff_rhs(ops_, mdot, metric, scalar, v_rhs);
 }
 
-INSTANTIATE_KERNEL_HOSGL(ScalarAdvDiffHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(ScalarAdvDiffHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/ScalarDiffElemKernel.C
+++ b/src/kernel/ScalarDiffElemKernel.C
@@ -111,7 +111,7 @@ ScalarDiffElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ScalarDiffElemKernel);
+INSTANTIATE_KERNEL(ScalarDiffElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ScalarDiffFemKernel.C
+++ b/src/kernel/ScalarDiffFemKernel.C
@@ -115,7 +115,7 @@ ScalarDiffFemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ScalarDiffFemKernel);
+INSTANTIATE_KERNEL(ScalarDiffFemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ScalarDiffHOElemKernel.C
+++ b/src/kernel/ScalarDiffHOElemKernel.C
@@ -84,7 +84,7 @@ ScalarDiffHOElemKernel<AlgTraits>::execute(
   timer_resid += std::chrono::duration_cast<std::chrono::duration<double>>(end_time_resid - start_time_resid).count();
 }
 
-INSTANTIATE_KERNEL_HOSGL(ScalarDiffHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(ScalarDiffHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -166,7 +166,7 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL_FACE_ELEMENT(ScalarFluxPenaltyElemKernel);
+INSTANTIATE_KERNEL_FACE_ELEMENT(ScalarFluxPenaltyElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ScalarMassElemKernel.C
+++ b/src/kernel/ScalarMassElemKernel.C
@@ -158,7 +158,7 @@ ScalarMassElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ScalarMassElemKernel);
+INSTANTIATE_KERNEL(ScalarMassElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ScalarMassHOElemKernel.C
+++ b/src/kernel/ScalarMassHOElemKernel.C
@@ -110,7 +110,7 @@ ScalarMassHOElemKernel<AlgTraits>::execute(
   tensor_assembly::scalar_dt_lhs(ops_, vol, gamma_[0], rhop1, v_lhs);
 }
 
-INSTANTIATE_KERNEL_HOSGL(ScalarMassHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(ScalarMassHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/kernel/ScalarOpenAdvElemKernel.C
+++ b/src/kernel/ScalarOpenAdvElemKernel.C
@@ -195,7 +195,7 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL_FACE_ELEMENT(ScalarOpenAdvElemKernel);
+INSTANTIATE_KERNEL_FACE_ELEMENT(ScalarOpenAdvElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/ScalarUpwAdvDiffElemKernel.C
+++ b/src/kernel/ScalarUpwAdvDiffElemKernel.C
@@ -269,7 +269,7 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::van_leer(
   return limit;
 }
 
-INSTANTIATE_KERNEL(ScalarUpwAdvDiffElemKernel);
+INSTANTIATE_KERNEL(ScalarUpwAdvDiffElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
+++ b/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
@@ -208,7 +208,7 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(SpecificDissipationRateSSTSrcElemKernel);
+INSTANTIATE_KERNEL(SpecificDissipationRateSSTSrcElemKernel)
 
 } // namespace nalu
 } // namespace sierra

--- a/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
@@ -153,7 +153,7 @@ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::execute(
   }
 } 
   
-INSTANTIATE_KERNEL(TurbKineticEnergyKsgsDesignOrderSrcElemKernel);
+INSTANTIATE_KERNEL(TurbKineticEnergyKsgsDesignOrderSrcElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/TurbKineticEnergyKsgsSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsSrcElemKernel.C
@@ -113,7 +113,7 @@ TurbKineticEnergyKsgsSrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(TurbKineticEnergyKsgsSrcElemKernel);
+INSTANTIATE_KERNEL(TurbKineticEnergyKsgsSrcElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
@@ -199,7 +199,7 @@ TurbKineticEnergySSTDESSrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(TurbKineticEnergySSTDESSrcElemKernel);
+INSTANTIATE_KERNEL(TurbKineticEnergySSTDESSrcElemKernel)
 
 } // namespace nalu
 } // namespace sierra

--- a/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
@@ -173,7 +173,7 @@ TurbKineticEnergySSTSrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(TurbKineticEnergySSTSrcElemKernel);
+INSTANTIATE_KERNEL(TurbKineticEnergySSTSrcElemKernel)
 
 } // namespace nalu
 } // namespace sierra

--- a/src/nso/MomentumNSOElemKernel.C
+++ b/src/nso/MomentumNSOElemKernel.C
@@ -315,7 +315,7 @@ MomentumNSOElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumNSOElemKernel);
+INSTANTIATE_KERNEL(MomentumNSOElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/nso/MomentumNSOKeElemKernel.C
+++ b/src/nso/MomentumNSOKeElemKernel.C
@@ -238,7 +238,7 @@ MomentumNSOKeElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumNSOKeElemKernel);
+INSTANTIATE_KERNEL(MomentumNSOKeElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/nso/MomentumNSOSijElemKernel.C
+++ b/src/nso/MomentumNSOSijElemKernel.C
@@ -236,7 +236,7 @@ MomentumNSOSijElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(MomentumNSOSijElemKernel);
+INSTANTIATE_KERNEL(MomentumNSOSijElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/nso/ScalarNSOElemKernel.C
+++ b/src/nso/ScalarNSOElemKernel.C
@@ -259,7 +259,7 @@ ScalarNSOElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ScalarNSOElemKernel);
+INSTANTIATE_KERNEL(ScalarNSOElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/nso/ScalarNSOKeElemKernel.C
+++ b/src/nso/ScalarNSOKeElemKernel.C
@@ -226,7 +226,7 @@ ScalarNSOKeElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(ScalarNSOKeElemKernel);
+INSTANTIATE_KERNEL(ScalarNSOKeElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/pmr/RadTransAbsorptionBlackBodyElemKernel.C
+++ b/src/pmr/RadTransAbsorptionBlackBodyElemKernel.C
@@ -106,7 +106,7 @@ RadTransAbsorptionBlackBodyElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(RadTransAbsorptionBlackBodyElemKernel);
+INSTANTIATE_KERNEL(RadTransAbsorptionBlackBodyElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/pmr/RadTransAdvectionSUCVElemKernel.C
+++ b/src/pmr/RadTransAdvectionSUCVElemKernel.C
@@ -208,7 +208,7 @@ RadTransAdvectionSUCVElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(RadTransAdvectionSUCVElemKernel);
+INSTANTIATE_KERNEL(RadTransAdvectionSUCVElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/pmr/RadTransIsotropicScatteringElemKernel.C
+++ b/src/pmr/RadTransIsotropicScatteringElemKernel.C
@@ -88,7 +88,7 @@ RadTransIsotropicScatteringElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(RadTransIsotropicScatteringElemKernel);
+INSTANTIATE_KERNEL(RadTransIsotropicScatteringElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/pmr/RadTransWallElemKernel.C
+++ b/src/pmr/RadTransWallElemKernel.C
@@ -117,7 +117,7 @@ RadTransWallElemKernel<BcAlgTraits>::execute(
   } 
 }
 
-INSTANTIATE_KERNEL_FACE(RadTransWallElemKernel);
+INSTANTIATE_KERNEL_FACE(RadTransWallElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
+++ b/src/user_functions/SteadyThermal3dContactSrcElemKernel.C
@@ -90,7 +90,7 @@ SteadyThermal3dContactSrcElemKernel<AlgTraits>::execute(
   }
 }
 
-INSTANTIATE_KERNEL(SteadyThermal3dContactSrcElemKernel);
+INSTANTIATE_KERNEL(SteadyThermal3dContactSrcElemKernel)
 
 }  // nalu
 }  // sierra

--- a/src/user_functions/SteadyThermalContactSrcHOElemKernel.C
+++ b/src/user_functions/SteadyThermalContactSrcHOElemKernel.C
@@ -67,7 +67,7 @@ SteadyThermalContactSrcHOElemKernel<AlgTraits>::execute(
   });
 }
 
-INSTANTIATE_KERNEL_HOSGL(SteadyThermalContactSrcHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(SteadyThermalContactSrcHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/user_functions/TGMMSHOElemKernel.C
+++ b/src/user_functions/TGMMSHOElemKernel.C
@@ -82,7 +82,7 @@ TGMMSHOElemKernel<AlgTraits>::execute(
   ops_.volume(sourceVec, v_rhs);
 }
 
-INSTANTIATE_KERNEL_HOSGL(TGMMSHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(TGMMSHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/user_functions/VariableDensityContinuityMMSHOElemKernel.C
+++ b/src/user_functions/VariableDensityContinuityMMSHOElemKernel.C
@@ -84,7 +84,7 @@ VariableDensityContinuityMMSHOElemKernel<AlgTraits>::execute(
   });
 }
 
-INSTANTIATE_KERNEL_HOSGL(VariableDensityContinuityMMSHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(VariableDensityContinuityMMSHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/user_functions/VariableDensityEnthalpyMMSHOElemKernel.C
+++ b/src/user_functions/VariableDensityEnthalpyMMSHOElemKernel.C
@@ -74,7 +74,7 @@ VariableDensityEnthalpyMMSHOElemKernel<AlgTraits>::execute(
   });
 }
 
-INSTANTIATE_KERNEL_HOSGL(VariableDensityEnthalpyMMSHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(VariableDensityEnthalpyMMSHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/user_functions/VariableDensityMomentumMMSHOElemKernel.C
+++ b/src/user_functions/VariableDensityMomentumMMSHOElemKernel.C
@@ -100,7 +100,7 @@ VariableDensityMomentumMMSHOElemKernel<AlgTraits>::execute(
   ops_.volume(sourceVec, v_rhs);
 }
 
-INSTANTIATE_KERNEL_HOSGL(VariableDensityMomentumMMSHOElemKernel);
+INSTANTIATE_KERNEL_HOSGL(VariableDensityMomentumMMSHOElemKernel)
 
 } // namespace nalu
 } // namespace Sierra

--- a/src/wind_energy/SyntheticLidar.C
+++ b/src/wind_energy/SyntheticLidar.C
@@ -17,7 +17,7 @@ SpinnerLidarSegmentGenerator::SpinnerLidarSegmentGenerator(
 : innerPrism_(inner),
   outerPrism_(outer),
   beamLength_(in_beamLength)
-{};
+{}
 
 void
 SpinnerLidarSegmentGenerator::load(const YAML::Node& node)

--- a/unit_tests/UnitTestHOMasterElements.C
+++ b/unit_tests/UnitTestHOMasterElements.C
@@ -849,16 +849,16 @@ constexpr int MAX_POLY_ORDER = 5;
     } \
 }
 
-TEST_IPS(check_interpolation_quad, 10, 1.0e-10);
-TEST_IPS(check_interpolation_hex, 10, 1.0e-10);
-TEST_IPS(check_derivative_quad, 10, 1.0e-10);
-TEST_IPS(check_derivative_hex, 10, 1.0e-10);
-TEST_POLY_SINGLE(check_volume_quadrature_quad, 1.0e-10);
-TEST_POLY_SINGLE(check_volume_quadrature_hex, 1.0e-10);
-TEST_POLY_SINGLE(check_is_in_element_quad, 1.0e-10);
-TEST_POLY_SINGLE(check_is_in_element_hex, 1.0e-10);
-TEST_POLY_SINGLE(check_is_not_in_element_quad, 1.0e-10);
-TEST_POLY_SINGLE(check_is_not_in_element_hex, 1.0e-10);
-TEST_POLY_SINGLE(check_point_interpolation_quad, 1.0e-8);
-TEST_POLY_SINGLE(check_point_interpolation_hex, 1.0e-8);
-TEST_POLY_SINGLE(check_scv_grad_op_hex, 1.0e-8);
+TEST_IPS(check_interpolation_quad, 10, 1.0e-10)
+TEST_IPS(check_interpolation_hex, 10, 1.0e-10)
+TEST_IPS(check_derivative_quad, 10, 1.0e-10)
+TEST_IPS(check_derivative_hex, 10, 1.0e-10)
+TEST_POLY_SINGLE(check_volume_quadrature_quad, 1.0e-10)
+TEST_POLY_SINGLE(check_volume_quadrature_hex, 1.0e-10)
+TEST_POLY_SINGLE(check_is_in_element_quad, 1.0e-10)
+TEST_POLY_SINGLE(check_is_in_element_hex, 1.0e-10)
+TEST_POLY_SINGLE(check_is_not_in_element_quad, 1.0e-10)
+TEST_POLY_SINGLE(check_is_not_in_element_hex, 1.0e-10)
+TEST_POLY_SINGLE(check_point_interpolation_quad, 1.0e-8)
+TEST_POLY_SINGLE(check_point_interpolation_hex, 1.0e-8)
+TEST_POLY_SINGLE(check_scv_grad_op_hex, 1.0e-8)

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -605,21 +605,21 @@ protected:
     TEST_F(x, hex8##_##y)   { y(stk::topology::HEX_8); }
 
 // Patch tests: pyramids fail
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scs_interpolation);
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scs_derivative);
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scv_interpolation);
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, volume_integration);
+TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scs_interpolation)
+TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scs_derivative)
+TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scv_interpolation)
+TEST_F_ALL_TOPOS_NO_PYR(MasterElement, volume_integration)
 
 // Pyramid fails since the reference element
 // since the constant Jacobian assumption is violated
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, is_in_element);
+TEST_F_ALL_TOPOS_NO_PYR(MasterElement, is_in_element)
 
 // Pyramid works. Doesn't work for higher-order elements sicne they have more ips than nodes
-TEST_F_ALL_P1_TOPOS(MasterElement, scv_shifted_ips_are_nodal);
-TEST_F_ALL_P1_TOPOS(MasterElement, exposed_face_shifted_ips_are_nodal);
+TEST_F_ALL_P1_TOPOS(MasterElement, scv_shifted_ips_are_nodal)
+TEST_F_ALL_P1_TOPOS(MasterElement, exposed_face_shifted_ips_are_nodal)
 
 // works fore everything
-TEST_F_ALL_TOPOS(MasterElement, is_not_in_element);
-TEST_F_ALL_TOPOS(MasterElement, particle_interpolation); // includes an isInElement call
+TEST_F_ALL_TOPOS(MasterElement, is_not_in_element)
+TEST_F_ALL_TOPOS(MasterElement, particle_interpolation)
 
-TEST_F_ALL_P1_TOPOS(MasterElement, general_shape_fcn);
+TEST_F_ALL_P1_TOPOS(MasterElement, general_shape_fcn)

--- a/unit_tests/UnitTestSideIsInElement.C
+++ b/unit_tests/UnitTestSideIsInElement.C
@@ -127,5 +127,5 @@ namespace
     TEST(x, hex8##_##y)   { y(stk::topology::HEX_8); } \
     TEST(x, hex27##_##y)  { y(stk::topology::HEX_27); }
 
-TEST_ALL_VALID_TOPOS(SideIsInElement, check_side_is_in_element);
+TEST_ALL_VALID_TOPOS(SideIsInElement, check_side_is_in_element)
 

--- a/unit_tests/UnitTestSideNodeOrdinals.C
+++ b/unit_tests/UnitTestSideNodeOrdinals.C
@@ -31,7 +31,7 @@ namespace {
     TEST(x, hex8##_##y)   { y(stk::topology::HEX_8); } \
     TEST(x, hex27##_##y)   { y(stk::topology::HEX_27); }
 
-TEST_ALL_TOPOS(MasterElementSideNodeOrdinals, side_node_ordinals_are_same_as_stk);
+TEST_ALL_TOPOS(MasterElementSideNodeOrdinals, side_node_ordinals_are_same_as_stk)
 
 
 

--- a/unit_tests/UnitTestSidePCoords.C
+++ b/unit_tests/UnitTestSidePCoords.C
@@ -119,5 +119,5 @@ namespace
     TEST(x, hex8##_##y)   { y(stk::topology::HEX_8); } \
     TEST(x, hex27##_##y)  { y(stk::topology::HEX_27); }
 
-TEST_ALL_TOPOS_NO_PYR(SidePCoords, check_elem_to_side_coords);
+TEST_ALL_TOPOS_NO_PYR(SidePCoords, check_elem_to_side_coords)
 

--- a/unit_tests/ho_kernels/UnitTestDiffusionHO.C
+++ b/unit_tests/ho_kernels/UnitTestDiffusionHO.C
@@ -497,11 +497,11 @@ void laplacian_residual_timing()
 }
 //--------------------------------------------------------------
 TEST_POLY(HexDiffusion, check_diffusion_jacobian_is_consistent, 4)
-TEST_POLY(HexDiffusion, check_diffusion_jacobian, 4);
-TEST_POLY(HexDiffusion, mms, 20);
+TEST_POLY(HexDiffusion, check_diffusion_jacobian, 4)
+TEST_POLY(HexDiffusion, mms, 20)
 
 #ifndef DNDEBUG
-TEST_POLY(HexDiffusion, check_laplacian_coefficients, 18);
+TEST_POLY(HexDiffusion, check_laplacian_coefficients, 18)
 TEST_POLY_to5(HexDiffusion, laplacian_jacobian_timing)
 TEST_POLY_to5(HexDiffusion, laplacian_residual_timing)
 #endif

--- a/unit_tests/ho_kernels/UnitTestDiffusionMetricHO.C
+++ b/unit_tests/ho_kernels/UnitTestDiffusionMetricHO.C
@@ -120,7 +120,7 @@ namespace {
 
 }
 
-TEST_POLY(DiffusionMetricHO, check_orthogonal, 4);
+TEST_POLY(DiffusionMetricHO, check_orthogonal, 4)
 
 }
 }

--- a/unit_tests/ho_kernels/UnitTestMomentumAdvDiffHO.C
+++ b/unit_tests/ho_kernels/UnitTestMomentumAdvDiffHO.C
@@ -156,6 +156,6 @@ template <int p> void mms()
 
 }
 //--------------------------------------------------------------
-TEST_POLY(HexMomentumAdvDiff, mms, 20);
+TEST_POLY(HexMomentumAdvDiff, mms, 20)
 }}
 

--- a/unit_tests/ho_kernels/UnitTestOperatorsHO.C
+++ b/unit_tests/ho_kernels/UnitTestOperatorsHO.C
@@ -381,7 +381,7 @@ template <int p> void scv_integration_hex()
 
 
 }
-TEST_POLY(HOOperators, scs_interp_hex, 5);
-TEST_POLY(HOOperators, scs_grad_hex, 5);
-TEST_POLY(HOOperators, nodal_grad_hex, 5);
-TEST_POLY(HOOperators, scv_integration_hex, 5);
+TEST_POLY(HOOperators, scs_interp_hex, 5)
+TEST_POLY(HOOperators, scs_grad_hex, 5)
+TEST_POLY(HOOperators, nodal_grad_hex, 5)
+TEST_POLY(HOOperators, scv_integration_hex, 5)

--- a/unit_tests/ho_kernels/UnitTestPressurePoissonHO.C
+++ b/unit_tests/ho_kernels/UnitTestPressurePoissonHO.C
@@ -125,5 +125,5 @@ namespace {
   }
 }
 //--------------------------------------------------------------
-TEST_POLY(PressurePoissonHex, mms, 22);
+TEST_POLY(PressurePoissonHex, mms, 22)
 }}

--- a/unit_tests/ho_kernels/UnitTestScalarAdvDiffHO.C
+++ b/unit_tests/ho_kernels/UnitTestScalarAdvDiffHO.C
@@ -144,5 +144,5 @@ template <int p> void mms()
 
 }
 //--------------------------------------------------------------
-TEST_POLY(ScalarAdvDiff, mms, 22);
+TEST_POLY(ScalarAdvDiff, mms, 22)
 }}

--- a/unit_tests/ho_kernels/UnitTestVolumeMetricHO.C
+++ b/unit_tests/ho_kernels/UnitTestVolumeMetricHO.C
@@ -84,7 +84,7 @@ template <int p> void check_scv_volumes()
 
 }
 
-TEST_POLY(VolumeHO, check_scv_volumes, 4);
+TEST_POLY(VolumeHO, check_scv_volumes, 4)
 
 }
 }


### PR DESCRIPTION
@marchdf wrote a script and I ran it to remove 90 `Wpedantic` warnings about extra semicolons.