### PR TITLE
Finish off this master element GPU unit test.

### DIFF
--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -165,18 +165,38 @@ protected:
     const double *pointCoord,
     double *isoParCoord);
 
-  const double scsDist_;
-  const int nodes1D_;
-  const int numQuad_;
+  const double scsDist_ = std::sqrt(3.0)/3.0;
+  const int nodes1D_    = 3;
+  const int numQuad_    = 2;
 
   // quadrature info
-  std::vector<double> gaussAbscissae1D_;
-  std::vector<double> gaussAbscissae_;
-  std::vector<double> gaussAbscissaeShift_;
-  std::vector<double> gaussWeight_;
-  std::vector<double> scsEndLoc_;
+  const double gaussAbscissae_[2] = {-1.0/std::sqrt(3.0), 1.0/std::sqrt(3.0)};
+  const double gaussWeight_[2]    = {0.5, 0.5};
+  const double gaussAbscissaeShift_[6] = {-1.0, -1.0, 0.0, 0.0,  1.0, 1.0};
 
-  std::vector<int> stkNodeMap_;
+  const double scsEndLoc_[4] =  { -1.0, -scsDist_, scsDist_, 1.0 };
+ 
+  // map the standard stk node numbering to a tensor-product style node numbering (i.e. node (m,l,k) -> m+npe*l+npe^2*k)
+  const int    stkNodeMap_[27] = {
+                   0,  8,  1, // bottom front edge
+                  11, 21,  9, // bottom mid-front edge
+                   3, 10,  2, // bottom back edge
+                  12, 25, 13, // mid-top front edge
+                  23, 20, 24, // mid-top mid-front edge
+                  15, 26, 14, // mid-top back edge
+                   4, 16,  5, // top front edge
+                  19, 22, 17, // top mid-front edge
+                   7, 18,  6  // top back edge
+                };
+
+  const int  sideNodeOrdinals_[54] = {
+       0, 1, 5, 4, 8,13,16,12,25, //ordinal 0
+       1, 2, 6, 5, 9,14,17,13,24, //ordinal 1
+       2, 3, 7, 6,10,15,18,14,26, //ordinal 2
+       0, 4, 7, 3,12,19,15,11,23, //ordinal 3
+       0, 3, 2, 1,11,10, 9, 8,21, //ordinal 4
+       4, 5, 6, 7,16,17,18,19,22  //ordinal 5
+  };
 
   std::vector<double> shapeFunctions_;
   std::vector<double> shapeFunctionsShift_;
@@ -209,6 +229,7 @@ public:
   using MasterElement::grad_op;
   using MasterElement::shifted_grad_op;
 
+  template<typename ViewType> KOKKOS_FUNCTION void shape_fcn(ViewType &shpfc);
   void shape_fcn(SharedMemView<DoubleType**> &shpfc) final;
   void shifted_shape_fcn(SharedMemView<DoubleType**> &shpfc) final;
   void determinant(SharedMemView<DoubleType**>& coords, SharedMemView<DoubleType*>& volume) final;
@@ -286,8 +307,17 @@ public:
   using MasterElement::shifted_shape_fcn;
   using MasterElement::determinant;
 
+  template<typename ViewType> KOKKOS_FUNCTION void shape_fcn(ViewType &shpfc);
   void shape_fcn(SharedMemView<DoubleType**> &shpfc);
   void shifted_shape_fcn(SharedMemView<DoubleType**> &shpfc);
+
+  template<typename ViewTypeCoord, typename ViewTypeGrad>
+  KOKKOS_FUNCTION
+  void grad_op(
+    ViewTypeCoord& coords,
+    ViewTypeGrad&  gradop,
+    ViewTypeGrad&  deriv);
+ 
 
   void grad_op(
     SharedMemView<DoubleType**>&coords,
@@ -564,6 +594,44 @@ private:
   std::vector<double> ipWeight_;
   const int surfaceDimension_;
 };
+
+template<typename ViewType> 
+KOKKOS_FUNCTION void Hex27SCV::shape_fcn(ViewType &shpfc)
+{
+  for (int ip = 0; ip < AlgTraits::numScvIp_; ++ip) {
+    for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
+      shpfc(ip,n) = interpWeights_(ip,n);
+    }
+  }
+}
+template<typename ViewType> 
+KOKKOS_FUNCTION void Hex27SCS::shape_fcn(ViewType &shpfc)
+{
+  for (int ip = 0; ip < AlgTraits::numScsIp_; ++ip) {
+    for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
+      shpfc(ip,n) = interpWeights_(ip,n);
+    }
+  }
+}
+
+
+template<typename ViewTypeCoord, typename ViewTypeGrad>
+KOKKOS_FUNCTION void Hex27SCS::grad_op(
+  ViewTypeCoord& coords,
+  ViewTypeGrad&  gradop,
+  ViewTypeGrad&  deriv)
+{
+  generic_grad_op<AlgTraits>(referenceGradWeights_, coords, gradop);
+
+  // copy derivs as well.  These aren't used, but are part of the interface
+  for (int ip = 0; ip < AlgTraits::numScsIp_; ++ip) {
+    for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
+      for (int d = 0; d < AlgTraits::nDim_; ++d) {
+        deriv(ip,n,d) = referenceGradWeights_(ip,n,d);
+      }
+    }
+  }
+}
 
 
 } // namespace nalu

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -358,7 +358,6 @@ protected:
   int numQuad_;
 
   //quadrature info
-  std::vector<double> gaussAbscissae1D_;
   std::vector<double> gaussAbscissae_;
   std::vector<double> gaussAbscissaeShift_;
   std::vector<double> gaussWeight_;

--- a/src/master_element/Hex27CVFEM.C
+++ b/src/master_element/Hex27CVFEM.C
@@ -26,52 +26,10 @@ namespace nalu{
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
 HexahedralP2Element::HexahedralP2Element()
-  : MasterElement(),
-    scsDist_(std::sqrt(3.0)/3.0),
-    nodes1D_(3),
-    numQuad_(2)
+  : MasterElement()
 {
   nDim_ = 3;
   nodesPerElement_ = nodes1D_ * nodes1D_ * nodes1D_;
-
-  // map the standard stk node numbering to a tensor-product style node numbering (i.e. node (m,l,k) -> m+npe*l+npe^2*k)
-  stkNodeMap_ = {
-                   0,  8,  1, // bottom front edge
-                  11, 21,  9, // bottom mid-front edge
-                   3, 10,  2, // bottom back edge
-                  12, 25, 13, // mid-top front edge
-                  23, 20, 24, // mid-top mid-front edge
-                  15, 26, 14, // mid-top back edge
-                   4, 16,  5, // top front edge
-                  19, 22, 17, // top mid-front edge
-                   7, 18,  6  // top back edge
-                };
-
-  sideNodeOrdinals_ = {
-       0, 1, 5, 4, 8,13,16,12,25, //ordinal 0
-       1, 2, 6, 5, 9,14,17,13,24, //ordinal 1
-       2, 3, 7, 6,10,15,18,14,26, //ordinal 2
-       0, 4, 7, 3,12,19,15,11,23, //ordinal 3
-       0, 3, 2, 1,11,10, 9, 8,21, //ordinal 4
-       4, 5, 6, 7,16,17,18,19,22  //ordinal 5
-  };
-
-  // a padded list of the scs locations
-  scsEndLoc_ = { -1.0, -scsDist_, scsDist_, 1.0 };
-}
-
-//--------------------------------------------------------------------------
-//-------- set_quadrature_rule ---------------------------------------------
-//--------------------------------------------------------------------------
-void
-HexahedralP2Element::set_quadrature_rule()
-{
-  gaussAbscissaeShift_ = {-1.0,-1.0,0.0,0.0,+1.0,+1.0};
-
-  std::tie(gaussAbscissae_, gaussWeight_) = gauss_legendre_rule(numQuad_);
-  for (unsigned j = 0; j < gaussWeight_.size(); ++j) {
-    gaussWeight_[j] *= 0.5; // change from standard Gauss weights
-  }
 }
 
 //--------------------------------------------------------------------------
@@ -624,9 +582,6 @@ HexahedralP2Element::hex27_shape_deriv(
 Hex27SCV::Hex27SCV()
   : HexahedralP2Element()
 {
-  // set up the one-dimensional quadrature rule
-  set_quadrature_rule();
-
   // set up integration rule and relevant maps for scvs
   set_interior_info();
 
@@ -860,9 +815,6 @@ void Hex27SCV::Mij(
 Hex27SCS::Hex27SCS()
   : HexahedralP2Element()
 {
-  // set up the one-dimensional quadrature rule
-  set_quadrature_rule();
-
   // set up integration rule and relevant maps on scs
   set_interior_info();
 
@@ -1804,9 +1756,6 @@ Quad93DSCS::Quad93DSCS()
   : HexahedralP2Element(),
     surfaceDimension_(2)
 {
-  // set up the one-dimensional quadrature rule
-  set_quadrature_rule();
-
   // set up integration rule and relevant maps on scs
   set_interior_info();
 

--- a/unit_tests/UnitTestHexMasterElementsNgp.C
+++ b/unit_tests/UnitTestHexMasterElementsNgp.C
@@ -206,6 +206,7 @@ void check_interpolation(
   for (int j = 0 ; j < num_int_pt; ++j) {
     EXPECT_NEAR(stk::simd::get_data(hostResults(j),0), polyResult[j], 1.0e-12);
   }
+  sierra::nalu::MasterElementRepo::clear();
 }
 
 template <typename AlgTraits>
@@ -376,7 +377,8 @@ TEST_F(MasterElementHexSerialNGP, hex8_scs_derivatives)
 {
   if (stk::parallel_machine_size(comm) == 1) {
     setup_poly_order_1_hex_8();
-    check_derivatives<sierra::nalu::AlgTraitsHex8>(meta, bulk);
+    using AlgTraits = sierra::nalu::AlgTraitsHex8;
+    check_derivatives<AlgTraits>(meta, bulk);
   }
 }
 
@@ -384,8 +386,8 @@ TEST_F(MasterElementHexSerialNGP, hex27_scs_interpolation)
 {
   if (stk::parallel_machine_size(comm) == 1) {
     setup_poly_order_2_hex_27();
-    //using AlgTraits = sierra::nalu::AlgTraitsHex27;
-    //check_interpolation<AlgTraits, AlgTraits::masterElementScs_, true>(meta, bulk);
+    using AlgTraits = sierra::nalu::AlgTraitsHex27;
+    check_interpolation<AlgTraits, AlgTraits::masterElementScs_, true>(meta, bulk);
   }
 }
 
@@ -393,8 +395,8 @@ TEST_F(MasterElementHexSerialNGP, hex27_scv_interpolation)
 {
   if (stk::parallel_machine_size(comm) == 1) {
     setup_poly_order_2_hex_27();
-    sierra::nalu::Hex27SCV hex27scv;
-    //check_interpolation<sierra::nalu::AlgTraitsHex27>(meta, bulk, hex27scv);
+    using AlgTraits = sierra::nalu::AlgTraitsHex27;
+    check_interpolation<AlgTraits, AlgTraits::masterElementScv_, false>(meta, bulk);
   }
 }
 
@@ -402,8 +404,8 @@ TEST_F(MasterElementHexSerialNGP, hex27_scs_derivatives)
 {
   if (stk::parallel_machine_size(comm) == 1) {
     setup_poly_order_2_hex_27();
-    sierra::nalu::Hex27SCS hex27scs;
-    //check_derivatives<3,2>(bulk, topo, hex27scs);
+    using AlgTraits = sierra::nalu::AlgTraitsHex27;
+    check_derivatives<AlgTraits>(meta, bulk);
   }
 }
 


### PR DESCRIPTION
This converts a couple of functions in the Hex8 and Hex27
master element classes to work on the GPU. I notice that
the Hex27 used some Kokkos views instead of static length
data arrays. Both are valid for the GPU but the Views
should be able to take the place of std::vector for
variable sized data arrays.