### PR TITLE
Finish off most of the gcc warnings.

### DIFF
--- a/include/kernel/KernelBuilder.h
+++ b/include/kernel/KernelBuilder.h
@@ -309,41 +309,37 @@ namespace nalu{
   {
     switch(faceTopo.value()) {
       case stk::topology::QUAD_4:
-        if ( elemTopo == stk::topology::HEX_8 ) {
-          return new T<AlgTraitsQuad4Hex8>(std::forward<Args>(args)...);
-        }
-        else if ( elemTopo == stk::topology::PYRAMID_5 ) {
-          return new T<AlgTraitsQuad4Pyr5>(std::forward<Args>(args)...);
-        }
-        else if ( elemTopo == stk::topology::WEDGE_6 ) {
-          return new T<AlgTraitsQuad4Wed6>(std::forward<Args>(args)...);
-        }
-        else {
-          ThrowRequireMsg(false,
-                          "Quad4 exposed face is not attached to either a hex8, pyr5, or wedge6.");
+        switch(elemTopo) {
+          case stk::topology::HEX_8: 
+            return new T<AlgTraitsQuad4Hex8>(std::forward<Args>(args)...);
+          case stk::topology::PYRAMID_5:
+            return new T<AlgTraitsQuad4Pyr5>(std::forward<Args>(args)...);
+          case stk::topology::WEDGE_6:
+            return new T<AlgTraitsQuad4Wed6>(std::forward<Args>(args)...);
+          default:
+            ThrowRequireMsg(false,
+              "Quad4 exposed face is not attached to either a hex8, pyr5, or wedge6.");
         }
       case stk::topology::QUAD_9:
         return new T<AlgTraitsQuad9Hex27>(std::forward<Args>(args)...);
       case stk::topology::TRI_3:
-        if ( elemTopo == stk::topology::TET_4 ) {
-          return new T<AlgTraitsTri3Tet4>(std::forward<Args>(args)...);
-        }
-        else if ( elemTopo == stk::topology::PYRAMID_5 ) {
-          return new T<AlgTraitsTri3Pyr5>(std::forward<Args>(args)...);
-        }
-        else if ( elemTopo == stk::topology::WEDGE_6 ) {
-          return new T<AlgTraitsTri3Wed6>(std::forward<Args>(args)...);
-        }
-        else {   
-          ThrowRequireMsg(false,
-                          "Tri3 exposed face is not attached to either a tet4, pyr5, or wedge6.");
+        switch(elemTopo) {
+          case stk::topology::TET_4:
+            return new T<AlgTraitsTri3Tet4>(std::forward<Args>(args)...);
+          case stk::topology::PYRAMID_5:
+            return new T<AlgTraitsTri3Pyr5>(std::forward<Args>(args)...);
+          case stk::topology::WEDGE_6:
+            return new T<AlgTraitsTri3Wed6>(std::forward<Args>(args)...);
+          default :
+            ThrowRequireMsg(false,
+              "Tri3 exposed face is not attached to either a tet4, pyr5, or wedge6.");
         }
       case stk::topology::LINE_2:
-        if (elemTopo == stk::topology::TRI_3_2D) {
-          return new T<AlgTraitsEdge2DTri32D>(std::forward<Args>(args)...);
-        }
-        else {
-          return new T<AlgTraitsEdge2DQuad42D>(std::forward<Args>(args)...);
+        switch(elemTopo) {
+          case stk::topology::TRI_3_2D: 
+            return new T<AlgTraitsEdge2DTri32D>(std::forward<Args>(args)...);
+          default :
+            return new T<AlgTraitsEdge2DQuad42D>(std::forward<Args>(args)...);
         }
       case stk::topology::LINE_3:
         return new T<AlgTraitsEdge32DQuad92D>(std::forward<Args>(args)...);

--- a/include/utils/LinearInterpolation.h
+++ b/include/utils/LinearInterpolation.h
@@ -116,7 +116,7 @@ linear_interp(
         << "WARNING: Out of bound values encountered during interpolation"
         << std::endl;
     // no break here... allow fallthrough
-
+        __attribute__ ((fallthrough));
     case OutOfBounds::CLAMP:
       yout = yinp[idx.second];
       break;

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -535,7 +535,8 @@ HypreLinearSystem::get_entity_hypre_id(const stk::mesh::Entity& node)
   HypreIntType hid = *stk::mesh::field_data(*realm_.hypreGlobalId_, mnode);
 
 #ifndef NDEBUG
-  if ((hid < 0) || (((hid+1) * numDof_ - 1) > maxRowID_)) {
+  HypreIntType chk = ((hid+1) * numDof_ - 1);
+  if ((hid < 0) || (chk > maxRowID_)) {
     std::cerr << bulk.parallel_rank() << "\t"
               << hid << "\t" << iLower_ << "\t" << iUpper_ << std::endl;
     throw std::runtime_error("BAD STK to hypre conversion");

--- a/src/master_element/MasterElementWork.F
+++ b/src/master_element/MasterElementWork.F
@@ -1811,6 +1811,7 @@ c***********************************************************************
 c
 c
       implicit none
+      integer nelem, npe, nint, nerr
       dimension cordel(2,npe,nelem),
      .          vol(nelem,nint),
      .          err(nelem)
@@ -1819,7 +1820,6 @@ c
       double precision cordel, vol, err
       double precision deriv, shape_fcn
       double precision xi, xigp
-      integer nelem, npe, nint, nerr
 c
 c     Gaussian quadrature points within an interval [-.25,+.25]
 c
@@ -1964,10 +1964,10 @@ c***********************************************************************
 c
       implicit none
 c
+      integer nelem, npe, nint
       dimension cordel(2,npe,nelem),
      *          area_vec(2,nelem,nint)
       double precision cordel, area_vec
-      integer nelem, npe, nint
 c
       dimension coord_mid_face(2,4)
       double precision coord_mid_face
@@ -2072,10 +2072,10 @@ c***********************************************************************
 c
       implicit none
 c
+      integer nelem, npe, nint
       dimension cordel(2,npe,nelem),
      *          area_vec(2,nelem,nint)
       double precision cordel, area_vec
-      integer nelem, npe, nint
 c
       dimension coord_mid_face(2,3)
       double precision coord_mid_face
@@ -2177,11 +2177,11 @@ c***********************************************************************
 c
       implicit none
 c
+      integer nelem, npe, nint, nerr
       dimension cordel(2,npe,nelem),
      .          vol(nelem,nint),
      .          err(nelem)
       double precision cordel, vol, err
-      integer nelem, npe, nint, nerr
 
       dimension deriv(2,4), shape_fcn(4)
       dimension xyval(2,4,3)

--- a/unit_tests/UnitTestMijTensor.C
+++ b/unit_tests/UnitTestMijTensor.C
@@ -328,11 +328,11 @@ TEST(MijTensorNGP, hex27_simd) {
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double *coords = stk::mesh::field_data(coordField, nodes[j]);
 
-    DoubleType coordsDT[dim];
+    std::vector<DoubleType> coordsDT(dim);
     for (int k = 0; k < dim; ++k)
       coordsDT[k] = coords[k];
 
-    sierra::nalu::matvec33(QDT, coordsDT, &v_coords(j, 0));
+    sierra::nalu::matvec33(QDT, coordsDT.data(), &v_coords(j, 0));
   }
 
   Kokkos::View<DoubleType ***> mij_tensor("mij_tensor", AlgTraits::numScsIp_,


### PR DESCRIPTION
Just rearrange some code to avoid warnings.

There was one fall-through case statement where I added
   __attribute__ ((fallthrough));
to prevent the warning. A Google search turned up several
ways to avoid the warning but this seemed the most
explicit but it might be gcc only.  C++17 has a [[fallthrough]]
once we move to C++17.

There are still warnings about floating point equality comparisons.
This is comparing to zero which I think is valid in this case and
did not want to change to a comparison to epsilon. I think we could
disable this one warning.