### PR TITLE
Consolidate warning options into one option and enable it by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,8 @@ option(ENABLE_PARAVIEW_CATALYST
       "Enable ParaView Catalyst. Requires external installation of Trilinos Catalyst IOSS adapter."
        OFF)
 option(ENABLE_TIOGA "Use TIOGA TPL to perform overset connectivity" OFF)
-option(ENABLE_WARNINGS "Add -Wall to show compiler warnings" ON)
-option(ENABLE_EXTRA_WARNINGS "Add -Wextra to show even more compiler warnings" OFF)
+option(ENABLE_ALL_WARNINGS "Show most warnings for most compilers" ON)
+option(ENABLE_WERROR "Warnings are errors" OFF)
 
 set(CMAKE_CXX_STANDARD 11)       # Set nalu-wind C++11 standard
 set(CMAKE_CXX_EXTENSIONS OFF)    # Do not enable GNU extensions
@@ -137,13 +137,17 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
   set(EXTRA_Fortran_FLAGS "")
 endif()
 
-if(ENABLE_WARNINGS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wall")
+if(ENABLE_ALL_WARNINGS)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
+    if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wall")
+    else()
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -diag-disable:11074,11076")
+    endif()
 endif()
-if(ENABLE_EXTRA_WARNINGS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wextra -pedantic")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wextra -pedantic")
+if(ENABLE_WERROR)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Werror")
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")


### PR DESCRIPTION
My proposed path forward regarding warnings. I also created and option for enabling `-Werror` and turned it off by default. I added some warning suppressions for Intel remarks regarding optimization I don't want to worry about at the moment. Intel Fortran also doesn't accept `-Wall`.