### PR TITLE
Avoid GCC 4.9 compile error, use macro to check GCC version.

### DIFF
--- a/include/utils/LinearInterpolation.h
+++ b/include/utils/LinearInterpolation.h
@@ -6,6 +6,12 @@
 #include <stdexcept>
 #include <utility>
 
+#if defined (__GNUC__) && (4 < __GNUC__)
+#define NALU_CASE_FALLTHROUGH __attribute__ ((fallthrough));
+#else
+#define NALU_CASE_FALLTHROUGH 
+#endif
+
 namespace sierra {
 namespace nalu {
 namespace utils {
@@ -116,7 +122,7 @@ linear_interp(
         << "WARNING: Out of bound values encountered during interpolation"
         << std::endl;
     // no break here... allow fallthrough
-        __attribute__ ((fallthrough));
+        NALU_CASE_FALLTHROUGH   
     case OutOfBounds::CLAMP:
       yout = yinp[idx.second];
       break;


### PR DESCRIPTION
Gcc 4.9 ERRORS on the __attribute__ decoration for a case statement fall through which was an attempt to avoid compiler WARNING about fall through case statement.  Might be time to just rewrite the code to avoid the fall-through case statement.  