### PR TITLE
Support 64-byte integer in TIOGA interface 

### DIFF
--- a/src/overset/TiogaBlock.C
+++ b/src/overset/TiogaBlock.C
@@ -242,9 +242,9 @@ void TiogaBlock::get_donor_info(TIOGA::tioga& tg, stk::mesh::EntityProcVec& egve
   int idx = 0;
   for(int i=0; i<(4*dcount); i += 4) {
     int procid = receptorInfo[i];
-    int nweights = receptorInfo[i+3];           // Offset to get the donor element
+    int nweights = receptorInfo[i+3];       // Offset to get the donor element
     int elemid_tmp = inode[idx + nweights]; // Local index for lookup
-    int elemID = elemid_map_[elemid_tmp];       // Global ID of element
+    auto elemID = elemid_map_[elemid_tmp];  // Global ID of element
 
     // Move the offset index for next call
     idx += nweights + 1;

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -408,10 +408,20 @@ TiogaSTKIface::get_receptor_info()
   //   - the STK global ID for the donor element
   //
   size_t ncount = receptors.size();
-  for (size_t i=0; i<ncount; i+=3) {
+  stk::mesh::EntityId  donorID = std::numeric_limits<stk::mesh::EntityId>::max();
+#ifdef TIOGA_HAS_UINT64T
+  int rec_offset = 4;
+#else
+  int rec_offset = 3;
+#endif
+  for (size_t i=0; i<ncount; i+=rec_offset) {
     int nid = receptors[i];                          // TiogaBlock node index
     int mtag = receptors[i+1] - 1;                   // Block index
-    int donorID = receptors[i+2];                    // STK Global ID of the donor element
+#ifdef TIOGA_HAS_UINT64T
+    std::memcpy(&donorID, &receptors[i+2], sizeof(uint64_t));
+#else
+    donorID = receptors[i+2];                    // STK Global ID of the donor element
+#endif
     auto nodeID = blocks_[mtag]->node_id_map()[nid]; // STK Global ID of the fringe node
     stk::mesh::Entity node = bulk_.get_entity(stk::topology::NODE_RANK, nodeID);
 

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -412,7 +412,7 @@ TiogaSTKIface::get_receptor_info()
     int nid = receptors[i];                          // TiogaBlock node index
     int mtag = receptors[i+1] - 1;                   // Block index
     int donorID = receptors[i+2];                    // STK Global ID of the donor element
-    int nodeID = blocks_[mtag]->node_id_map()[nid];  // STK Global ID of the fringe node
+    auto nodeID = blocks_[mtag]->node_id_map()[nid]; // STK Global ID of the fringe node
     stk::mesh::Entity node = bulk_.get_entity(stk::topology::NODE_RANK, nodeID);
 
     if (!bulk_.bucket(node).owned()) {


### PR DESCRIPTION
- Fixes `stk::mesh::EntityId` being coerced to `int`

- Adds support for meshes where number of nodes/elements are greater than what can be supported in a signed integer. 