### PR TITLE
WIP: Discuss design for transitioning field pointers to field ordinals in Kernels

### DIFF
--- a/include/kernel/Kernel.h
+++ b/include/kernel/Kernel.h
@@ -24,6 +24,28 @@ namespace nalu {
 class TimeIntegrator;
 class SolutionOptions;
 
+template<typename AlgTraits, typename ViewType>
+void get_scv_ipnodemap(const int* ipNodeMap, ViewType& ip_view)
+{
+  static_assert(ViewType::Rank == 1u, "1D View");
+  ThrowRequireMsg(ip_view.extent_int(0) == AlgTraits::numScvIp_,
+                  "Inconsistent number of scv IPs");
+
+  for (int i=0; i < AlgTraits::numScvIp_; ++i)
+    ip_view(i) = ipNodeMap[i];
+}
+
+template<typename AlgTraits, typename ViewType>
+void get_scs_ipnodemap(const int* ipNodeMap, ViewType& ip_view)
+{
+  static_assert(ViewType::Rank == 1u, "1D View");
+  ThrowRequireMsg(ip_view.extent_int(0) == AlgTraits::numScsIp_,
+                  "Inconsistent number of scs IPs");
+
+  for (int i=0; i < AlgTraits::numScsIp_; ++i)
+    ip_view(i) = ipNodeMap[i];
+}
+
 template<typename AlgTraits, typename LambdaFunction, typename ViewType>
 void get_scv_shape_fn_data(LambdaFunction lambdaFunction, ViewType& shape_fn_view)
 {

--- a/include/kernel/MomentumMassElemKernel.h
+++ b/include/kernel/MomentumMassElemKernel.h
@@ -54,14 +54,14 @@ public:
 private:
   MomentumMassElemKernel() = delete;
 
-  VectorFieldType *velocityNm1_{nullptr};
-  VectorFieldType *velocityN_{nullptr};
-  VectorFieldType *velocityNp1_{nullptr};
-  ScalarFieldType *densityNm1_{nullptr};
-  ScalarFieldType *densityN_{nullptr};
-  ScalarFieldType *densityNp1_{nullptr};
-  VectorFieldType *Gjp_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned velocityNm1_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityN_   {stk::mesh::InvalidOrdinal};
+  unsigned velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNm1_  {stk::mesh::InvalidOrdinal};
+  unsigned densityN_    {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_  {stk::mesh::InvalidOrdinal};
+  unsigned Gjp_         {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   double dt_{0.0};
   double gamma1_{0.0};

--- a/include/kernel/MomentumMassElemKernel.h
+++ b/include/kernel/MomentumMassElemKernel.h
@@ -71,7 +71,7 @@ private:
   const bool lumpedMass_;
 
   /// Integration point to node mapping
-  const int* ipNodeMap_;
+  Kokkos::View<int[AlgTraits::numScvIp_]> ipNodeMap_{"ip_node_map"};
 
   /// Shape functions
   AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ {"view_shape_func"};

--- a/include/utils/StkHelpers.h
+++ b/include/utils/StkHelpers.h
@@ -83,6 +83,37 @@ void compute_precise_ghosting_lists(
   stk::mesh::EntityProcVec& curSendGhosts,
   std::vector<stk::mesh::EntityKey>& recvGhostsToRemove);
 
+/** Return a field ordinal given the name of the field
+ */
+inline
+unsigned get_field_ordinal(
+  const stk::mesh::MetaData& meta,
+  const std::string fieldName,
+  const stk::mesh::EntityRank entity_rank = stk::topology::NODE_RANK)
+{
+  stk::mesh::FieldBase* field = meta.get_field(entity_rank, fieldName);
+  ThrowAssertMsg((field != nullptr), "Requested field does not exist: " + fieldName);
+  return field->mesh_meta_data_ordinal();
+}
+
+/** Return a field ordinal for a particular state
+ *
+ */
+inline
+unsigned get_field_ordinal(
+  const stk::mesh::MetaData& meta,
+  const std::string fieldName,
+  const stk::mesh::FieldState state,
+  const stk::mesh::EntityRank entity_rank = stk::topology::NODE_RANK)
+{
+  const auto* field = meta.get_field(entity_rank, fieldName);
+  ThrowAssertMsg((field != nullptr), "Requested field does not exist: " + fieldName);
+  ThrowAssertMsg((field->is_state_valid(state)), "Requested invalid state: " + fieldName);
+
+  const auto* fState = field->field_state(state);
+  return fState->mesh_meta_data_ordinal();
+}
+
 } // namespace nalu
 } // namespace sierra
 

--- a/src/kernel/MomentumMassElemKernel.C
+++ b/src/kernel/MomentumMassElemKernel.C
@@ -32,8 +32,7 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   ElemDataRequests& dataPreReqs,
   const bool lumpedMass)
   : Kernel(),
-    lumpedMass_(lumpedMass),
-    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+    lumpedMass_(lumpedMass)
 {
 
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
@@ -61,6 +60,8 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
 
   MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
+  // Initialize ipNodeMap_
+  get_scv_ipnodemap<AlgTraits>(meSCV->ipNodeMap(), ipNodeMap_);
   // compute shape function
   if ( lumpedMass_ )
     get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shifted_shape_fcn(ptr);}, v_shape_function_);

--- a/src/kernel/MomentumMassElemKernel.C
+++ b/src/kernel/MomentumMassElemKernel.C
@@ -14,6 +14,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -41,23 +42,22 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "density");
 
-  velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+  velocityN_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateN);
+  velocityNp1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNP1);
   if (velocity->number_of_states() == 2)
     velocityNm1_ = velocityN_;
   else
-    velocityNm1_ = &(velocity->field_of_state(stk::mesh::StateNM1));
+    velocityNm1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNM1);
 
-  densityN_ = &(density->field_of_state(stk::mesh::StateN));
-  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+  densityN_ = get_field_ordinal(metaData, "density", stk::mesh::StateN);
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
   if (density->number_of_states() == 2)
     densityNm1_ = densityN_;
   else
-    densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
+    densityNm1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNM1);
 
-  Gjp_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  Gjp_ = get_field_ordinal(metaData, "dpdx");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
@@ -71,14 +71,15 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*velocityNm1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*velocityN_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*Gjp_, AlgTraits::nDim_);
+  const auto& fields = metaData.get_fields();
+  dataPreReqs.add_coordinates_field(*fields[coordinates_], AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(*fields[densityNm1_], 1);
+  dataPreReqs.add_gathered_nodal_field(*fields[densityN_], 1);
+  dataPreReqs.add_gathered_nodal_field(*fields[densityNp1_], 1);
+  dataPreReqs.add_gathered_nodal_field(*fields[velocityNm1_], AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*fields[velocityN_], AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*fields[velocityNp1_], AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(*fields[Gjp_], AlgTraits::nDim_);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 
   const std::string dofName = "velocity";
@@ -111,13 +112,13 @@ MomentumMassElemKernel<AlgTraits>::execute(
   NALU_ALIGNED DoubleType w_uNp1 [AlgTraits::nDim_];
   NALU_ALIGNED DoubleType w_Gjp  [AlgTraits::nDim_];
 
-  SharedMemView<DoubleType*>& v_densityNm1 = scratchViews.get_scratch_view_1D(*densityNm1_);
-  SharedMemView<DoubleType*>& v_densityN = scratchViews.get_scratch_view_1D(*densityN_);
-  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
-  SharedMemView<DoubleType**>& v_velocityNm1 = scratchViews.get_scratch_view_2D(*velocityNm1_);
-  SharedMemView<DoubleType**>& v_velocityN = scratchViews.get_scratch_view_2D(*velocityN_);
-  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType**>& v_Gpdx = scratchViews.get_scratch_view_2D(*Gjp_);
+  SharedMemView<DoubleType*>& v_densityNm1 = scratchViews.get_scratch_view_1D(densityNm1_);
+  SharedMemView<DoubleType*>& v_densityN = scratchViews.get_scratch_view_1D(densityN_);
+  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(densityNp1_);
+  SharedMemView<DoubleType**>& v_velocityNm1 = scratchViews.get_scratch_view_2D(velocityNm1_);
+  SharedMemView<DoubleType**>& v_velocityN = scratchViews.get_scratch_view_2D(velocityN_);
+  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(velocityNp1_);
+  SharedMemView<DoubleType**>& v_Gpdx = scratchViews.get_scratch_view_2D(Gjp_);
 
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 


### PR DESCRIPTION
This pull request is to start discussions around possible designs to transition the field pointer references within Kernels to field ordinals and unit test them on CPU. Testing on GPU would also require `MasterElement` and `ipNodeMap_` data to be handled correctly on GPU. 

Currently, there are two commits. The first is just introducing some utility functions, the second modifies `MomentumMassElemKernel` for a working example of the transition from field pointer to ordinals. The unit test passes on CPU. 

```
$ ./unittestX --gtest_filter=MomentumKernelHex8Mesh.momentum_time_*
Note: Google Test filter = MomentumKernelHex8Mesh.momentum_time_*
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from MomentumKernelHex8Mesh
[ RUN      ] MomentumKernelHex8Mesh.momentum_time_derivative
[       OK ] MomentumKernelHex8Mesh.momentum_time_derivative (5 ms)
[ RUN      ] MomentumKernelHex8Mesh.momentum_time_derivative_lumped
[       OK ] MomentumKernelHex8Mesh.momentum_time_derivative_lumped (2 ms)
[----------] 2 tests from MomentumKernelHex8Mesh (7 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (7 ms total)
[  PASSED  ] 2 tests.
```