### PR TITLE
Fix the intel seg-fault.

### DIFF
--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -68,28 +68,37 @@ void copy_and_interleave(const MultiDimViewsType ** data,
                          SimdMultiDimViewsType& simdData)
 {
   const double* src[stk::simd::ndoubles] = {nullptr};
-  unsigned numViews = simdData.views_1D_size;
+  unsigned numViews = simdData.get_num_1D_views();
   for(unsigned viewIndex=0; viewIndex<numViews; ++viewIndex) {
     for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
-      src[simdIndex] = data[simdIndex]->views_1D[viewIndex].data();
+      src[simdIndex] = data[simdIndex]->get_1D_view_by_index(viewIndex).data();
+      NGP_ThrowAssert(data[simdIndex]->get_1D_view_by_index(viewIndex).size() == simdData.get_1D_view_by_index(viewIndex).size());
+      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_1D_view_by_index(viewIndex).data()[0]);
+      NGP_ThrowAssert(src[simdIndex] != nullptr);
     }
-    interleave(simdData.views_1D[viewIndex], src, simdElems);
+    interleave(simdData.get_1D_view_by_index(viewIndex), src, simdElems);
   }
 
-  numViews = simdData.views_2D_size;
+  numViews = simdData.get_num_2D_views();
   for(unsigned viewIndex=0; viewIndex<numViews; ++viewIndex) {
     for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
-      src[simdIndex] = data[simdIndex]->views_2D[viewIndex].data();
+      src[simdIndex] = data[simdIndex]->get_2D_view_by_index(viewIndex).data();
+      NGP_ThrowAssert(data[simdIndex]->get_2D_view_by_index(viewIndex).size() == simdData.get_2D_view_by_index(viewIndex).size());
+      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_2D_view_by_index(viewIndex).data()[0]);
+      NGP_ThrowAssert(src[simdIndex] != nullptr);
     }
-    interleave(simdData.views_2D[viewIndex], src, simdElems);
+    interleave(simdData.get_2D_view_by_index(viewIndex), src, simdElems);
   }
 
-  numViews = simdData.views_3D_size;
+  numViews = simdData.get_num_3D_views();
   for(unsigned viewIndex=0; viewIndex<numViews; ++viewIndex) {
     for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
-      src[simdIndex] = data[simdIndex]->views_3D[viewIndex].data();
+      src[simdIndex] = data[simdIndex]->get_3D_view_by_index(viewIndex).data();
+      NGP_ThrowAssert(data[simdIndex]->get_3D_view_by_index(viewIndex).size() == simdData.get_3D_view_by_index(viewIndex).size());
+      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_3D_view_by_index(viewIndex).data()[0]);
+      NGP_ThrowAssert(src[simdIndex] != nullptr);
     }
-    interleave(simdData.views_3D[viewIndex], src, simdElems);
+    interleave(simdData.get_3D_view_by_index(viewIndex), src, simdElems);
   }
 }
 

--- a/include/MultiDimViews.h
+++ b/include/MultiDimViews.h
@@ -45,8 +45,8 @@ public:
   MultiDimViews(const TEAMHANDLETYPE& team,
                 unsigned maxOrdinal,
                 const NumNeededViews& numNeededViews)
-  : indices(get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team,
-            adjust_up_to_alignment_boundary((maxOrdinal+1)*bytesPerUnsigned, KOKKOS_MEMORY_ALIGNMENT)/bytesPerUnsigned)),
+  : //indices(get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team,
+    //        adjust_up_to_alignment_boundary((maxOrdinal+1)*bytesPerUnsigned, KOKKOS_MEMORY_ALIGNMENT)/bytesPerUnsigned)),
     views_1D(), views_1D_size(0),
     views_2D(), views_2D_size(0),
     views_3D(), views_3D_size(0),
@@ -61,10 +61,27 @@ public:
                numNeededViews.num1DViews, numNeededViews.num2DViews, numNeededViews.num3DViews, numNeededViews.num4DViews,
                maxViewsPerDim);
     }
+#ifndef KOKKOS_ENABLE_CUDA
+    for(unsigned i=0; i<numNeededViews.num1DViews; ++i) { views_1D[i] = nullptr; }
+    for(unsigned i=0; i<numNeededViews.num2DViews; ++i) { views_2D[i] = nullptr; }
+    for(unsigned i=0; i<numNeededViews.num3DViews; ++i) { views_3D[i] = nullptr; }
+    for(unsigned i=0; i<numNeededViews.num4DViews; ++i) { views_4D[i] = nullptr; }
+#else
     for(unsigned i=0; i<numNeededViews.num1DViews; ++i) { new (&views_1D[i]) SharedMemView1D; }
     for(unsigned i=0; i<numNeededViews.num2DViews; ++i) { new (&views_2D[i]) SharedMemView2D; }
     for(unsigned i=0; i<numNeededViews.num3DViews; ++i) { new (&views_3D[i]) SharedMemView3D; }
     for(unsigned i=0; i<numNeededViews.num4DViews; ++i) { new (&views_4D[i]) SharedMemView4D; }
+#endif
+  }
+
+  ~MultiDimViews()
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    for(unsigned i=0; i<get_num_1D_views(); ++i) { delete views_1D[i]; }
+    for(unsigned i=0; i<get_num_2D_views(); ++i) { delete views_2D[i]; }
+    for(unsigned i=0; i<get_num_3D_views(); ++i) { delete views_3D[i]; }
+    for(unsigned i=0; i<get_num_4D_views(); ++i) { delete views_4D[i]; }
+#endif
   }
 
   KOKKOS_FUNCTION
@@ -85,71 +102,160 @@ public:
   KOKKOS_FUNCTION
   SharedMemView1D& get_scratch_view_1D(unsigned ordinal)
   {
-    SharedMemView1D& vref = views_1D[indices(ordinal)];
-    return vref;
+#ifndef KOKKOS_ENABLE_CUDA
+    return *views_1D[indices[ordinal]];
+#else
+    return views_1D[indices[ordinal]];
+#endif
   }
 
   KOKKOS_FUNCTION
   SharedMemView2D& get_scratch_view_2D(unsigned ordinal)
   {
-    return views_2D[indices(ordinal)];
+#ifndef KOKKOS_ENABLE_CUDA
+    return *views_2D[indices[ordinal]];
+#else
+    return views_2D[indices[ordinal]];
+#endif
   }
 
   KOKKOS_FUNCTION
   SharedMemView3D& get_scratch_view_3D(unsigned ordinal)
   {
-    return views_3D[indices(ordinal)];
+#ifndef KOKKOS_ENABLE_CUDA
+    return *views_3D[indices[ordinal]];
+#else
+    return views_3D[indices[ordinal]];
+#endif
   }
 
   KOKKOS_FUNCTION
   SharedMemView4D& get_scratch_view_4D(unsigned ordinal)
   {
-    return views_4D[indices(ordinal)];
+#ifndef KOKKOS_ENABLE_CUDA
+    return *views_4D[indices[ordinal]];
+#else
+    return views_4D[indices[ordinal]];
+#endif
   }
 
   KOKKOS_FUNCTION
   void add_1D_view(unsigned ordinal, const SharedMemView1D& view)
   {
+#ifndef KOKKOS_ENABLE_CUDA
+    views_1D[views_1D_size] = new SharedMemView1D;
+    *views_1D[views_1D_size] = view;
+#else
     views_1D[views_1D_size] = view;
-    indices(ordinal) = views_1D_size;
+#endif
+    indices[ordinal] = views_1D_size;
     ++views_1D_size;
   }
 
   KOKKOS_FUNCTION
   void add_2D_view(unsigned ordinal, const SharedMemView2D& view)
   {
+#ifndef KOKKOS_ENABLE_CUDA
+    views_2D[views_2D_size] = new SharedMemView2D;
+    *views_2D[views_2D_size] = view;
+#else
     views_2D[views_2D_size] = view;
-    indices(ordinal) = views_2D_size;
+#endif
+    indices[ordinal] = views_2D_size;
     ++views_2D_size;
   }
 
   KOKKOS_FUNCTION
   void add_3D_view(unsigned ordinal, const SharedMemView3D& view)
   {
+#ifndef KOKKOS_ENABLE_CUDA
+    views_3D[views_3D_size] = new SharedMemView3D;
+    *views_3D[views_3D_size] = view;
+#else
     views_3D[views_3D_size] = view;
-    indices(ordinal) = views_3D_size;
+#endif
+    indices[ordinal] = views_3D_size;
     ++views_3D_size;
   }
 
   KOKKOS_FUNCTION
   void add_4D_view(unsigned ordinal, const SharedMemView4D& view)
   {
+#ifndef KOKKOS_ENABLE_CUDA
+    views_4D[views_4D_size] = new SharedMemView4D;
+    *views_4D[views_4D_size] = view;
+#else
     views_4D[views_4D_size] = view;
-    indices(ordinal) = views_4D_size;
+#endif
+    indices[ordinal] = views_4D_size;
     ++views_4D_size;
   }
 
+  KOKKOS_FUNCTION
+  const SharedMemView1D& get_1D_view_by_index(unsigned idx) const
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    return *views_1D[idx];
+#else
+    return views_1D[idx];
+#endif
+  }
+
+  KOKKOS_FUNCTION
+  const SharedMemView2D& get_2D_view_by_index(unsigned idx) const
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    return *views_2D[idx];
+#else
+    return views_2D[idx];
+#endif
+  }
+
+  KOKKOS_FUNCTION
+  const SharedMemView3D& get_3D_view_by_index(unsigned idx) const
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    return *views_3D[idx];
+#else
+    return views_3D[idx];
+#endif
+  }
+
+  KOKKOS_FUNCTION
+  const SharedMemView4D& get_4D_view_by_index(unsigned idx) const
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    return *views_4D[idx];
+#else
+    return views_4D[idx];
+#endif
+  }
+
+  KOKKOS_FUNCTION unsigned get_num_1D_views() const { return views_1D_size; }
+  KOKKOS_FUNCTION unsigned get_num_2D_views() const { return views_2D_size; }
+  KOKKOS_FUNCTION unsigned get_num_3D_views() const { return views_3D_size; }
+  KOKKOS_FUNCTION unsigned get_num_4D_views() const { return views_4D_size; }
+
 public:
   static const unsigned maxViewsPerDim = 25;
+  static const unsigned maxPossibleOrdinals = 128;
 
-  SharedMemView<int*,SHMEM> indices;
+//  SharedMemView<int*,SHMEM> indices;
+  NALU_ALIGNED int indices[maxPossibleOrdinals];
+#ifndef KOKKOS_ENABLE_CUDA
+  SharedMemView1D* views_1D[maxViewsPerDim];
+  SharedMemView2D* views_2D[maxViewsPerDim];
+  SharedMemView3D* views_3D[maxViewsPerDim];
+  SharedMemView4D* views_4D[maxViewsPerDim];
+#else
   SharedMemView1D views_1D[maxViewsPerDim];
-  unsigned views_1D_size;
   SharedMemView2D views_2D[maxViewsPerDim];
-  unsigned views_2D_size;
   SharedMemView3D views_3D[maxViewsPerDim];
-  unsigned views_3D_size;
   SharedMemView4D views_4D[maxViewsPerDim];
+#endif
+  unsigned views_1D_size;
+  unsigned views_2D_size;
+  unsigned views_3D_size;
   unsigned views_4D_size;
 };
 


### PR DESCRIPTION
Still not completely clear on why it was seg-faulting. But it seems
related to the fact that MultiDimViews was packing the shared-mem-views
by value into flat arrays. So instead, and only if not using Cuda, we
now store them in separate pointers. I.e., an array of pointers. This
requires a new and delete operation, which we won't do on GPU.