### PR TITLE
Kernel: convert field pointers to field ordinals

### DIFF
--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -98,20 +98,6 @@ public:
   {
   }
 
-  ElemDataRequests& operator=(const ElemDataRequests& other)
-  {
-    dataEnums = other.dataEnums;
-    coordsFields_ = other.coordsFields_;
-    fields = other.fields;
-    meFC_ = other.meFC_;
-    meSCS_ = other.meSCS_;
-    meSCV_ = other.meSCV_;
-    meFEM_ = other.meFEM_;
-
-    return *this;
-  }
-
-
   void add_master_element_call(
     ELEM_DATA_NEEDED data,
     COORDS_TYPES cType = CURRENT_COORDINATES

--- a/include/kernel/ContinuityAdvElemKernel.h
+++ b/include/kernel/ContinuityAdvElemKernel.h
@@ -54,12 +54,12 @@ private:
   ContinuityAdvElemKernel() = delete;
 
   // extract fields; nodal
-  VectorFieldType *velocityRTM_{nullptr};
-  VectorFieldType *Gpdx_{nullptr};
-  ScalarFieldType *pressure_{nullptr};
-  ScalarFieldType *densityNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  ScalarFieldType *Udiag_{nullptr};
+  unsigned velocityRTM_ {stk::mesh::InvalidOrdinal};
+  unsigned Gpdx_ {stk::mesh::InvalidOrdinal};
+  unsigned pressure_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned Udiag_ {stk::mesh::InvalidOrdinal};
 
   double projTimeScale_{1.0};
 

--- a/include/kernel/ContinuityInflowElemKernel.h
+++ b/include/kernel/ContinuityInflowElemKernel.h
@@ -53,9 +53,9 @@ public:
 private:
   ContinuityInflowElemKernel() = delete;
 
-  VectorFieldType *velocityBC_{nullptr};
-  ScalarFieldType *densityBC_{nullptr};
-  GenericFieldType *exposedAreaVec_{nullptr};
+  unsigned velocityBC_ {stk::mesh::InvalidOrdinal};
+  unsigned densityBC_ {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
 
   const bool useShifted_;
   double projTimeScale_;

--- a/include/kernel/ContinuityMassElemKernel.h
+++ b/include/kernel/ContinuityMassElemKernel.h
@@ -54,10 +54,10 @@ public:
 private:
   ContinuityMassElemKernel() = delete;
 
-  ScalarFieldType *densityNm1_{nullptr};
-  ScalarFieldType *densityN_{nullptr};
-  ScalarFieldType *densityNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned densityNm1_ {stk::mesh::InvalidOrdinal};
+  unsigned densityN_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   double dt_{0.0};
   double gamma1_{0.0};

--- a/include/kernel/ContinuityOpenElemKernel.h
+++ b/include/kernel/ContinuityOpenElemKernel.h
@@ -55,14 +55,14 @@ public:
 private:
   ContinuityOpenElemKernel() = delete;
 
-  VectorFieldType *velocityRTM_{nullptr};
-  VectorFieldType *Gpdx_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  ScalarFieldType *pressure_{nullptr};
-  ScalarFieldType *pressureBc_{nullptr};
-  ScalarFieldType *density_{nullptr};
-  ScalarFieldType *Udiag_{nullptr};
-  GenericFieldType *exposedAreaVec_{nullptr};
+  unsigned velocityRTM_ {stk::mesh::InvalidOrdinal};
+  unsigned Gpdx_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned pressure_ {stk::mesh::InvalidOrdinal};
+  unsigned pressureBc_ {stk::mesh::InvalidOrdinal};
+  unsigned density_ {stk::mesh::InvalidOrdinal};
+  unsigned Udiag_ {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
 
   double projTimeScale_{1.0};
   const double mdotCorrection_{0.0};

--- a/include/kernel/MomentumActuatorSrcElemKernel.h
+++ b/include/kernel/MomentumActuatorSrcElemKernel.h
@@ -49,9 +49,9 @@ public:
 private:
   MomentumActuatorSrcElemKernel() = delete;
 
-  VectorFieldType *actuator_source_{nullptr};
-  VectorFieldType *actuator_source_lhs_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned actuator_source_     {stk::mesh::InvalidOrdinal};
+  unsigned actuator_source_lhs_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_         {stk::mesh::InvalidOrdinal};
 
   const int* ipNodeMap_;
 

--- a/include/kernel/MomentumAdvDiffElemKernel.h
+++ b/include/kernel/MomentumAdvDiffElemKernel.h
@@ -50,10 +50,10 @@ public:
 private:
   MomentumAdvDiffElemKernel() = delete;
 
-  VectorFieldType *velocityNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  ScalarFieldType *viscosity_{nullptr};
-  GenericFieldType *massFlowRate_{nullptr};
+  unsigned velocityNp1_  {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_  {stk::mesh::InvalidOrdinal};
+  unsigned viscosity_    {stk::mesh::InvalidOrdinal};
+  unsigned massFlowRate_ {stk::mesh::InvalidOrdinal};
 
   const int* lrscv_;
 

--- a/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
+++ b/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
@@ -48,8 +48,8 @@ public:
 private:
   MomentumBuoyancyBoussinesqSrcElemKernel() = delete;
 
-  ScalarFieldType *temperatureNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned temperatureNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   double rhoRef_;
   double tRef_;

--- a/include/kernel/MomentumBuoyancySrcElemKernel.h
+++ b/include/kernel/MomentumBuoyancySrcElemKernel.h
@@ -48,8 +48,8 @@ public:
 private:
   MomentumBuoyancySrcElemKernel() = delete;
 
-  ScalarFieldType *densityNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   double rhoRef_;
   AlignedViewType<DoubleType[AlgTraits::nDim_]> gravity_{ "v_gravity"};

--- a/include/kernel/MomentumCoriolisSrcElemKernel.h
+++ b/include/kernel/MomentumCoriolisSrcElemKernel.h
@@ -45,9 +45,9 @@ private:
   MomentumCoriolisSrcElemKernel() = delete;
 
   CoriolisSrc cor_;
-  VectorFieldType *velocityNp1_{nullptr};
-  ScalarFieldType *densityNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   const int* ipNodeMap_;
 

--- a/include/kernel/MomentumHybridTurbElemKernel.h
+++ b/include/kernel/MomentumHybridTurbElemKernel.h
@@ -47,12 +47,12 @@ public:
 private:
   MomentumHybridTurbElemKernel() = delete;
 
-  VectorFieldType* velocityNp1_{nullptr};
-  ScalarFieldType* densityNp1_{nullptr};
-  ScalarFieldType* tkeNp1_{nullptr};
-  ScalarFieldType* alphaNp1_{nullptr};
-  GenericFieldType* mutij_{nullptr};
-  VectorFieldType* coordinates_{nullptr};
+  unsigned  velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  tkeNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  alphaNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  mutij_ {stk::mesh::InvalidOrdinal};
+  unsigned  coordinates_ {stk::mesh::InvalidOrdinal};
 
   // master element
   const int* lrscv_;

--- a/include/kernel/MomentumMassElemKernel.h
+++ b/include/kernel/MomentumMassElemKernel.h
@@ -54,14 +54,14 @@ public:
 private:
   MomentumMassElemKernel() = delete;
 
-  VectorFieldType *velocityNm1_{nullptr};
-  VectorFieldType *velocityN_{nullptr};
-  VectorFieldType *velocityNp1_{nullptr};
-  ScalarFieldType *densityNm1_{nullptr};
-  ScalarFieldType *densityN_{nullptr};
-  ScalarFieldType *densityNp1_{nullptr};
-  VectorFieldType *Gjp_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned velocityNm1_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityN_   {stk::mesh::InvalidOrdinal};
+  unsigned velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNm1_  {stk::mesh::InvalidOrdinal};
+  unsigned densityN_    {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_  {stk::mesh::InvalidOrdinal};
+  unsigned Gjp_         {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   double dt_{0.0};
   double gamma1_{0.0};

--- a/include/kernel/MomentumOpenAdvDiffElemKernel.h
+++ b/include/kernel/MomentumOpenAdvDiffElemKernel.h
@@ -62,15 +62,15 @@ public:
 private:
   MomentumOpenAdvDiffElemKernel() = delete;
 
-  ScalarFieldType *viscosity_{nullptr};
-  GenericFieldType *Gjui_{nullptr};
-  VectorFieldType *velocityNp1_{nullptr};
-  VectorFieldType *velocityRTM_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  ScalarFieldType *density_{nullptr};
-  GenericFieldType *exposedAreaVec_{nullptr};
-  GenericFieldType *openMassFlowRate_{nullptr};
-  VectorFieldType *velocityBc_{nullptr};
+  unsigned viscosity_ {stk::mesh::InvalidOrdinal};
+  unsigned Gjui_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityRTM_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned density_ {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
+  unsigned openMassFlowRate_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityBc_ {stk::mesh::InvalidOrdinal};
   
   // numerical parameters
   const double alphaUpw_;

--- a/include/kernel/MomentumSymmetryElemKernel.h
+++ b/include/kernel/MomentumSymmetryElemKernel.h
@@ -53,10 +53,10 @@ public:
 private:
   MomentumSymmetryElemKernel() = delete;
 
-  ScalarFieldType *viscosity_{nullptr};
-  VectorFieldType *velocityNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  GenericFieldType *exposedAreaVec_{nullptr};
+  unsigned viscosity_      {stk::mesh::InvalidOrdinal};
+  unsigned velocityNp1_    {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_    {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
 
   const double includeDivU_;
   const bool shiftedGradOp_;

--- a/include/kernel/MomentumUpwAdvDiffElemKernel.h
+++ b/include/kernel/MomentumUpwAdvDiffElemKernel.h
@@ -62,13 +62,13 @@ private:
 
   const SolutionOptions &solnOpts_;
   
-  VectorFieldType *velocityNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  ScalarFieldType *density_{nullptr};
-  ScalarFieldType *viscosity_{nullptr};
-  GenericFieldType *Gju_{nullptr};
-  GenericFieldType *massFlowRate_{nullptr};
-  VectorFieldType *velocityRTM_{nullptr};
+  unsigned velocityNp1_  {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_  {stk::mesh::InvalidOrdinal};
+  unsigned density_      {stk::mesh::InvalidOrdinal};
+  unsigned viscosity_    {stk::mesh::InvalidOrdinal};
+  unsigned Gju_          {stk::mesh::InvalidOrdinal};
+  unsigned massFlowRate_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityRTM_  {stk::mesh::InvalidOrdinal};
 
   const int* lrscv_;
 

--- a/include/kernel/MomentumWallFunctionElemKernel.h
+++ b/include/kernel/MomentumWallFunctionElemKernel.h
@@ -48,13 +48,13 @@ public:
 private:
   MomentumWallFunctionElemKernel() = delete;
   
-  VectorFieldType *velocityNp1_{nullptr};
-  VectorFieldType *bcVelocity_{nullptr};
-  ScalarFieldType *density_{nullptr};
-  ScalarFieldType *viscosity_{nullptr};
-  GenericFieldType *exposedAreaVec_{nullptr};
-  GenericFieldType *wallFrictionVelocityBip_{nullptr};
-  GenericFieldType *wallNormalDistanceBip_{nullptr};
+  unsigned velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned bcVelocity_ {stk::mesh::InvalidOrdinal};
+  unsigned density_ {stk::mesh::InvalidOrdinal};
+  unsigned viscosity_ {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
+  unsigned wallFrictionVelocityBip_ {stk::mesh::InvalidOrdinal};
+  unsigned wallNormalDistanceBip_ {stk::mesh::InvalidOrdinal};
 
   // turbulence model constants (constant over time and bc surfaces)
   const double elog_;

--- a/include/kernel/ScalarAdvDiffElemKernel.h
+++ b/include/kernel/ScalarAdvDiffElemKernel.h
@@ -50,10 +50,10 @@ public:
 private:
   ScalarAdvDiffElemKernel() = delete;
 
-  ScalarFieldType *scalarQ_{nullptr};
-  ScalarFieldType *diffFluxCoeff_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  GenericFieldType *massFlowRate_{nullptr};
+  unsigned scalarQ_ {stk::mesh::InvalidOrdinal};
+  unsigned diffFluxCoeff_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned massFlowRate_ {stk::mesh::InvalidOrdinal};
 
   /// Left right node indicators
   const int* lrscv_;

--- a/include/kernel/ScalarDiffElemKernel.h
+++ b/include/kernel/ScalarDiffElemKernel.h
@@ -50,9 +50,9 @@ public:
 private:
   ScalarDiffElemKernel() = delete;
 
-  ScalarFieldType *scalarQ_{nullptr};
-  ScalarFieldType *diffFluxCoeff_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned scalarQ_ {stk::mesh::InvalidOrdinal};
+  unsigned diffFluxCoeff_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   /// Left right node indicators
   const int* lrscv_;

--- a/include/kernel/ScalarDiffFemKernel.h
+++ b/include/kernel/ScalarDiffFemKernel.h
@@ -53,9 +53,9 @@ private:
   ScalarDiffFemKernel() = delete;
 
   const stk::mesh::BulkData* bulkData_;
-  ScalarFieldType *scalarQ_{nullptr};
-  ScalarFieldType *diffFluxCoeff_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned scalarQ_{stk::mesh::InvalidOrdinal};
+  unsigned diffFluxCoeff_{stk::mesh::InvalidOrdinal};
+  unsigned coordinates_{stk::mesh::InvalidOrdinal};
 
   // master element
   Hex8FEM * meFEM_;

--- a/include/kernel/ScalarFluxPenaltyElemKernel.h
+++ b/include/kernel/ScalarFluxPenaltyElemKernel.h
@@ -54,11 +54,11 @@ public:
 private:
   ScalarFluxPenaltyElemKernel() = delete;
 
-  ScalarFieldType *scalarQ_{nullptr};
-  ScalarFieldType *bcScalarQ_{nullptr};
-  ScalarFieldType *diffFluxCoeff_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  GenericFieldType *exposedAreaVec_{nullptr};
+  unsigned scalarQ_ {stk::mesh::InvalidOrdinal};
+  unsigned bcScalarQ_ {stk::mesh::InvalidOrdinal};
+  unsigned diffFluxCoeff_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
 
   const double penaltyFac_;
   const bool shiftedGradOp_;

--- a/include/kernel/ScalarMassElemKernel.h
+++ b/include/kernel/ScalarMassElemKernel.h
@@ -55,13 +55,13 @@ public:
 private:
   ScalarMassElemKernel() = delete;
 
-  ScalarFieldType *scalarQNm1_{nullptr};
-  ScalarFieldType *scalarQN_{nullptr};
-  ScalarFieldType *scalarQNp1_{nullptr};
-  ScalarFieldType *densityNm1_{nullptr};
-  ScalarFieldType *densityN_{nullptr};
-  ScalarFieldType *densityNp1_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
+  unsigned scalarQNm1_ {stk::mesh::InvalidOrdinal};
+  unsigned scalarQN_ {stk::mesh::InvalidOrdinal};
+  unsigned scalarQNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNm1_ {stk::mesh::InvalidOrdinal};
+  unsigned densityN_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   double dt_{0.0};
   double gamma1_{0.0};

--- a/include/kernel/ScalarOpenAdvElemKernel.h
+++ b/include/kernel/ScalarOpenAdvElemKernel.h
@@ -63,14 +63,14 @@ public:
 private:
   ScalarOpenAdvElemKernel() = delete;
 
-  ScalarFieldType *scalarQ_{nullptr};
-  ScalarFieldType *bcScalarQ_{nullptr};
-  VectorFieldType *Gjq_{nullptr};
-  ScalarFieldType *diffFluxCoeff_{nullptr};
-  VectorFieldType *velocityRTM_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  ScalarFieldType *density_{nullptr};
-  GenericFieldType *openMassFlowRate_{nullptr};
+  unsigned scalarQ_ {stk::mesh::InvalidOrdinal};
+  unsigned bcScalarQ_ {stk::mesh::InvalidOrdinal};
+  unsigned Gjq_ {stk::mesh::InvalidOrdinal};
+  unsigned diffFluxCoeff_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityRTM_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned density_ {stk::mesh::InvalidOrdinal};
+  unsigned openMassFlowRate_ {stk::mesh::InvalidOrdinal};
   
   // numerical parameters
   const double alphaUpw_;

--- a/include/kernel/ScalarUpwAdvDiffElemKernel.h
+++ b/include/kernel/ScalarUpwAdvDiffElemKernel.h
@@ -62,13 +62,13 @@ private:
 
   const SolutionOptions& solnOpts_;
 
-  ScalarFieldType *scalarQ_{nullptr};
-  VectorFieldType *Gjq_{nullptr};
-  ScalarFieldType *diffFluxCoeff_{nullptr};
-  VectorFieldType *velocityRTM_{nullptr};
-  ScalarFieldType *density_{nullptr};
-  VectorFieldType *coordinates_{nullptr};
-  GenericFieldType *massFlowRate_{nullptr};
+  unsigned scalarQ_ {stk::mesh::InvalidOrdinal};
+  unsigned Gjq_ {stk::mesh::InvalidOrdinal};
+  unsigned diffFluxCoeff_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityRTM_ {stk::mesh::InvalidOrdinal};
+  unsigned density_ {stk::mesh::InvalidOrdinal};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned massFlowRate_ {stk::mesh::InvalidOrdinal};
 
   /// Left right node indicators
   const int* lrscv_;

--- a/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
+++ b/include/kernel/SpecificDissipationRateSSTSrcElemKernel.h
@@ -46,13 +46,13 @@ public:
 private:
   SpecificDissipationRateSSTSrcElemKernel() = delete;
 
-  ScalarFieldType* tkeNp1_{nullptr};
-  ScalarFieldType* sdrNp1_{nullptr};
-  ScalarFieldType* densityNp1_{nullptr};
-  VectorFieldType* velocityNp1_{nullptr};
-  ScalarFieldType* tvisc_{nullptr};
-  ScalarFieldType* fOneBlend_{nullptr};
-  VectorFieldType* coordinates_{nullptr};
+  unsigned  tkeNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  sdrNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  tvisc_ {stk::mesh::InvalidOrdinal};
+  unsigned  fOneBlend_ {stk::mesh::InvalidOrdinal};
+  unsigned  coordinates_ {stk::mesh::InvalidOrdinal};
 
   const bool lumpedMass_;
   const bool shiftedGradOp_;

--- a/include/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h
@@ -48,12 +48,12 @@ public:
 private:
   TurbKineticEnergyKsgsDesignOrderSrcElemKernel() = delete;
   
-  VectorFieldType *coordinates_{nullptr};
-  VectorFieldType *velocityNp1_{nullptr};
-  ScalarFieldType *tkeNp1_{nullptr};
-  ScalarFieldType *densityNp1_{nullptr};
-  ScalarFieldType *tvisc_{nullptr};
-  ScalarFieldType *dualNodalVolume_{nullptr};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned tkeNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned tvisc_ {stk::mesh::InvalidOrdinal};
+  unsigned dualNodalVolume_ {stk::mesh::InvalidOrdinal};
 
   const double cEps_;
   const double tkeProdLimitRatio_;

--- a/include/kernel/TurbKineticEnergyKsgsSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergyKsgsSrcElemKernel.h
@@ -48,12 +48,12 @@ public:
 private:
   TurbKineticEnergyKsgsSrcElemKernel() = delete;
 
-  VectorFieldType *coordinates_{nullptr};
-  ScalarFieldType *tkeNp1_{nullptr};
-  ScalarFieldType *densityNp1_{nullptr};
-  ScalarFieldType *tvisc_{nullptr};
-  ScalarFieldType *dualNodalVolume_{nullptr};
-  GenericFieldType *Gju_{nullptr};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned tkeNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned tvisc_ {stk::mesh::InvalidOrdinal};
+  unsigned dualNodalVolume_ {stk::mesh::InvalidOrdinal};
+  unsigned Gju_ {stk::mesh::InvalidOrdinal};
 
   double cEps_{0.0};
   double tkeProdLimitRatio_{0.0};

--- a/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTDESSrcElemKernel.h
@@ -46,14 +46,14 @@ public:
 private:
   TurbKineticEnergySSTDESSrcElemKernel() = delete;
 
-  ScalarFieldType* tkeNp1_{nullptr};
-  ScalarFieldType* sdrNp1_{nullptr};
-  ScalarFieldType* densityNp1_{nullptr};
-  VectorFieldType* velocityNp1_{nullptr};
-  ScalarFieldType* tvisc_{nullptr};
-  ScalarFieldType* maxLengthScale_{nullptr};
-  ScalarFieldType* fOneBlend_{nullptr};
-  VectorFieldType* coordinates_{nullptr};
+  unsigned  tkeNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  sdrNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  tvisc_ {stk::mesh::InvalidOrdinal};
+  unsigned  maxLengthScale_ {stk::mesh::InvalidOrdinal};
+  unsigned  fOneBlend_ {stk::mesh::InvalidOrdinal};
+  unsigned  coordinates_ {stk::mesh::InvalidOrdinal};
 
   const bool lumpedMass_;
   const bool shiftedGradOp_;

--- a/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
+++ b/include/kernel/TurbKineticEnergySSTSrcElemKernel.h
@@ -46,12 +46,12 @@ public:
 private:
   TurbKineticEnergySSTSrcElemKernel() = delete;
 
-  ScalarFieldType* tkeNp1_{nullptr};
-  ScalarFieldType* sdrNp1_{nullptr};
-  ScalarFieldType* densityNp1_{nullptr};
-  VectorFieldType* velocityNp1_{nullptr};
-  ScalarFieldType* tvisc_{nullptr};
-  VectorFieldType* coordinates_{nullptr};
+  unsigned  tkeNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  sdrNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  velocityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned  tvisc_ {stk::mesh::InvalidOrdinal};
+  unsigned  coordinates_ {stk::mesh::InvalidOrdinal};
 
   const bool lumpedMass_;
   const bool shiftedGradOp_;

--- a/include/kernel/WallDistElemKernel.h
+++ b/include/kernel/WallDistElemKernel.h
@@ -42,7 +42,7 @@ private:
   WallDistElemKernel() = delete;
   WallDistElemKernel(const WallDistElemKernel&) = delete;
 
-  VectorFieldType *coordinates_{nullptr};
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
   // work arrays
   Kokkos::View<DoubleType[AlgTraits::numScsIp_][AlgTraits::nodesPerElement_]> v_shape_function_{"view_shape_function"};

--- a/include/utils/StkHelpers.h
+++ b/include/utils/StkHelpers.h
@@ -83,6 +83,37 @@ void compute_precise_ghosting_lists(
   stk::mesh::EntityProcVec& curSendGhosts,
   std::vector<stk::mesh::EntityKey>& recvGhostsToRemove);
 
+/** Return a field ordinal given the name of the field
+ */
+inline
+unsigned get_field_ordinal(
+  const stk::mesh::MetaData& meta,
+  const std::string fieldName,
+  const stk::mesh::EntityRank entity_rank = stk::topology::NODE_RANK)
+{
+  stk::mesh::FieldBase* field = meta.get_field(entity_rank, fieldName);
+  ThrowAssertMsg((field != nullptr), "Requested field does not exist: " + fieldName);
+  return field->mesh_meta_data_ordinal();
+}
+
+/** Return a field ordinal for a particular state
+ *
+ */
+inline
+unsigned get_field_ordinal(
+  const stk::mesh::MetaData& meta,
+  const std::string fieldName,
+  const stk::mesh::FieldState state,
+  const stk::mesh::EntityRank entity_rank = stk::topology::NODE_RANK)
+{
+  const auto* field = meta.get_field(entity_rank, fieldName);
+  ThrowAssertMsg((field != nullptr), "Requested field does not exist: " + fieldName);
+  ThrowAssertMsg((field->is_state_valid(state)), "Requested invalid state: " + fieldName);
+
+  const auto* fState = field->field_state(state);
+  return fState->mesh_meta_data_ordinal();
+}
+
 } // namespace nalu
 } // namespace sierra
 

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -54,6 +54,7 @@ AssembleElemSolverAlgorithm::AssembleElemSolverAlgorithm(
   unsigned nodesPerEntity,
   bool interleaveMEViews)
   : SolverAlgorithm(realm, part, eqSystem),
+    dataNeededByKernels_(realm.meta_data()),
     entityRank_(entityRank),
     nodesPerEntity_(nodesPerEntity),
     rhsSize_(nodesPerEntity*eqSystem->linsys_->numDof()),

--- a/src/AssembleElemSolverAlgorithmHO.C
+++ b/src/AssembleElemSolverAlgorithmHO.C
@@ -51,7 +51,8 @@ AssembleElemSolverAlgorithmHO::AssembleElemSolverAlgorithmHO(
     rhsSize_(nodesPerEntity * ndof_),
     lhsSize_(rhsSize_*rhsSize_),
     defaultPermutation_(make_node_map(polyOrder_, dim_, part->topology().is_super_topology())),
-    gatherer_(polyOrder_+1, defaultPermutation_)
+    gatherer_(polyOrder_+1, defaultPermutation_),
+    dataNeededByKernels_(realm.meta_data())
 {
   vecDefaultPermutation_ = Kokkos::View<int*>("inverse_permutation", rhsSize_);
   for (int j = 0; j < nodesPerEntity_; ++j) {

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -56,6 +56,8 @@ AssembleFaceElemSolverAlgorithm::AssembleFaceElemSolverAlgorithm(
   unsigned nodesPerElem,
   bool interleaveMEViews)
   : SolverAlgorithm(realm, part, eqSystem),
+    faceDataNeeded_(realm.meta_data()),
+    elemDataNeeded_(realm.meta_data()),
     numDof_(eqSystem->linsys_->numDof()),
     nodesPerFace_(nodesPerFace),
     nodesPerElem_(nodesPerElem),

--- a/src/kernel/ContinuityInflowElemKernel.C
+++ b/src/kernel/ContinuityInflowElemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -36,11 +37,12 @@ ContinuityInflowElemKernel<BcAlgTraits>::ContinuityInflowElemKernel(
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_)->ipNodeMap())
  {
   // save off fields
-  const stk::mesh::MetaData &metaData = bulkData.mesh_meta_data();
-  velocityBC_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.activateOpenMdotCorrection_ 
-                                                    ? "velocity_bc" : "cont_velocity_bc");
-  densityBC_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
+  const std::string velbc_name =
+    solnOpts.activateOpenMdotCorrection_ ? "velocity_bc" : "cont_velocity_bc";
+  velocityBC_ = get_field_ordinal(metaData, velbc_name);
+  densityBC_ = get_field_ordinal(metaData, "density");
+  exposedAreaVec_ = get_field_ordinal(metaData, "exposed_area_vector", metaData.side_rank());
   
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_);
   
@@ -48,9 +50,9 @@ ContinuityInflowElemKernel<BcAlgTraits>::ContinuityInflowElemKernel(
   dataPreReqs.add_cvfem_face_me(meFC);
   
   // required fields
-  dataPreReqs.add_gathered_nodal_field(*velocityBC_, BcAlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*densityBC_, 1);
-  dataPreReqs.add_face_field(*exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(velocityBC_, BcAlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(densityBC_, 1);
+  dataPreReqs.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
   
   if ( useShifted )
     get_face_shape_fn_data<BcAlgTraits>([&](double* ptr){meFC->shifted_shape_fcn(ptr);}, vf_shape_function_);
@@ -81,9 +83,9 @@ ContinuityInflowElemKernel<BcAlgTraits>::execute(
   NALU_ALIGNED DoubleType w_uBip[BcAlgTraits::nDim_];
   NALU_ALIGNED DoubleType w_rho_uBip[BcAlgTraits::nDim_];
   
-  SharedMemView<DoubleType**>& vf_velocityBC = scratchViews.get_scratch_view_2D(*velocityBC_);
-  SharedMemView<DoubleType*>& vf_density = scratchViews.get_scratch_view_1D(*densityBC_);
-  SharedMemView<DoubleType**>& vf_exposedAreaVec = scratchViews.get_scratch_view_2D(*exposedAreaVec_);
+  SharedMemView<DoubleType**>& vf_velocityBC = scratchViews.get_scratch_view_2D(velocityBC_);
+  SharedMemView<DoubleType*>& vf_density = scratchViews.get_scratch_view_1D(densityBC_);
+  SharedMemView<DoubleType**>& vf_exposedAreaVec = scratchViews.get_scratch_view_2D(exposedAreaVec_);
   
   for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     

--- a/src/kernel/ContinuityMassElemKernel.C
+++ b/src/kernel/ContinuityMassElemKernel.C
@@ -14,6 +14,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -39,14 +40,13 @@ ContinuityMassElemKernel<AlgTraits>::ContinuityMassElemKernel(
 
   ScalarFieldType* density = metaData.get_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "density");
-  densityN_ = &(density->field_of_state(stk::mesh::StateN));
-  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+  densityN_ = density->field_of_state(stk::mesh::StateN).mesh_meta_data_ordinal();
+  densityNp1_ = density->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal();
   if (density->number_of_states() == 2)
     densityNm1_ = densityN_;
   else
-    densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+    densityNm1_ = density->field_of_state(stk::mesh::StateNM1).mesh_meta_data_ordinal();
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
@@ -60,10 +60,10 @@ ContinuityMassElemKernel<AlgTraits>::ContinuityMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(densityNm1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityN_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
@@ -91,11 +91,11 @@ ContinuityMassElemKernel<AlgTraits>::execute(
   const DoubleType projTimeScale = dt_/gamma1_;
 
   SharedMemView<DoubleType*>& v_densityNm1 = scratchViews.get_scratch_view_1D(
-    *densityNm1_);
+    densityNm1_);
   SharedMemView<DoubleType*>& v_densityN = scratchViews.get_scratch_view_1D(
-    *densityN_);
+    densityN_);
   SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
-    *densityNp1_);
+    densityNp1_);
 
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 

--- a/src/kernel/ContinuityOpenElemKernel.C
+++ b/src/kernel/ContinuityOpenElemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -36,18 +37,18 @@ ContinuityOpenElemKernel<BcAlgTraits>::ContinuityOpenElemKernel(
     om_interpTogether_(1.0 - interpTogether_),
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
 {
-  if ( solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
-  else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  Gpdx_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  pressure_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
-  pressureBc_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, solnOpts.activateOpenMdotCorrection_ 
-                                                    ? "pressure" : "pressure_bc");
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  Udiag_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "momentum_diag");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  const std::string vrtm_name =
+    solnOpts.does_mesh_move() ? "velocity_rtm" : "velocity";
+  const std::string pbc_name =
+    solnOpts.activateOpenMdotCorrection_ ? "pressure" : "pressure_bc";
+  velocityRTM_ = get_field_ordinal(metaData, vrtm_name);
+  Gpdx_ = get_field_ordinal(metaData, "dpdx");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  pressure_ = get_field_ordinal(metaData, "pressure");
+  pressureBc_ = get_field_ordinal(metaData, pbc_name);
+  density_ = get_field_ordinal(metaData, "density");
+  Udiag_ = get_field_ordinal(metaData, "momentum_diag");
+  exposedAreaVec_ = get_field_ordinal(metaData, "exposed_area_vector", metaData.side_rank());
   
   // extract master elements
   MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
@@ -57,15 +58,15 @@ ContinuityOpenElemKernel<BcAlgTraits>::ContinuityOpenElemKernel(
   elemDataPreReqs.add_cvfem_surface_me(meSCS_);
 
   // fields and data; face and then element
-  faceDataPreReqs.add_gathered_nodal_field(*pressure_, 1);
-  faceDataPreReqs.add_gathered_nodal_field(*pressureBc_, 1);
-  faceDataPreReqs.add_gathered_nodal_field(*density_, 1);
-  faceDataPreReqs.add_gathered_nodal_field(*Udiag_, 1);
-  faceDataPreReqs.add_gathered_nodal_field(*velocityRTM_, BcAlgTraits::nDim_);
-  faceDataPreReqs.add_gathered_nodal_field(*Gpdx_, BcAlgTraits::nDim_);  
-  faceDataPreReqs.add_face_field(*exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
-  elemDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-  elemDataPreReqs.add_gathered_nodal_field(*pressure_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(pressure_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(pressureBc_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(density_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(Udiag_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(velocityRTM_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_gathered_nodal_field(Gpdx_, BcAlgTraits::nDim_);  
+  faceDataPreReqs.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_coordinates_field(coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  elemDataPreReqs.add_gathered_nodal_field(pressure_, 1);
 
   // manage dndx
   if ( !shiftedGradOp_ || !reducedSensitivities_ )
@@ -109,16 +110,16 @@ ContinuityOpenElemKernel<BcAlgTraits>::execute(
   const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
  
   // face
-  SharedMemView<DoubleType*>& vf_pressure = faceScratchViews.get_scratch_view_1D(*pressure_);
-  SharedMemView<DoubleType*>& vf_pressureBc = faceScratchViews.get_scratch_view_1D(*pressureBc_);
-  SharedMemView<DoubleType**>& vf_Gpdx = faceScratchViews.get_scratch_view_2D(*Gpdx_);
-  SharedMemView<DoubleType*>& vf_density = faceScratchViews.get_scratch_view_1D(*density_);
-  SharedMemView<DoubleType*>& vf_udiag = faceScratchViews.get_scratch_view_1D(*Udiag_);
-  SharedMemView<DoubleType**>& vf_vrtm = faceScratchViews.get_scratch_view_2D(*velocityRTM_);
-  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(*exposedAreaVec_);
+  SharedMemView<DoubleType*>& vf_pressure = faceScratchViews.get_scratch_view_1D(pressure_);
+  SharedMemView<DoubleType*>& vf_pressureBc = faceScratchViews.get_scratch_view_1D(pressureBc_);
+  SharedMemView<DoubleType**>& vf_Gpdx = faceScratchViews.get_scratch_view_2D(Gpdx_);
+  SharedMemView<DoubleType*>& vf_density = faceScratchViews.get_scratch_view_1D(density_);
+  SharedMemView<DoubleType*>& vf_udiag = faceScratchViews.get_scratch_view_1D(Udiag_);
+  SharedMemView<DoubleType**>& vf_vrtm = faceScratchViews.get_scratch_view_2D(velocityRTM_);
+  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(exposedAreaVec_);
  
   // element
-  SharedMemView<DoubleType*>& v_pressure = elemScratchViews.get_scratch_view_1D(*pressure_);
+  SharedMemView<DoubleType*>& v_pressure = elemScratchViews.get_scratch_view_1D(pressure_);
  
   // dndx for both rhs and lhs
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_ 

--- a/src/kernel/MomentumActuatorSrcElemKernel.C
+++ b/src/kernel/MomentumActuatorSrcElemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -33,11 +34,9 @@ MomentumActuatorSrcElemKernel<AlgTraits>::MomentumActuatorSrcElemKernel(
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  actuator_source_
-      = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source");
-  actuator_source_lhs_
-      = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source_lhs");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  actuator_source_ = get_field_ordinal(metaData, "actuator_source");
+  actuator_source_lhs_ = get_field_ordinal(metaData, "actuator_source_lhs");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
@@ -52,9 +51,9 @@ MomentumActuatorSrcElemKernel<AlgTraits>::MomentumActuatorSrcElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*actuator_source_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*actuator_source_lhs_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(actuator_source_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(actuator_source_lhs_, AlgTraits::nDim_);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
@@ -69,8 +68,8 @@ MomentumActuatorSrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  SharedMemView<DoubleType**>& v_actuator_source = scratchViews.get_scratch_view_2D(*actuator_source_);
-  SharedMemView<DoubleType**>& v_actuator_source_lhs = scratchViews.get_scratch_view_2D(*actuator_source_lhs_);
+  SharedMemView<DoubleType**>& v_actuator_source = scratchViews.get_scratch_view_2D(actuator_source_);
+  SharedMemView<DoubleType**>& v_actuator_source_lhs = scratchViews.get_scratch_view_2D(actuator_source_lhs_);
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {

--- a/src/kernel/MomentumAdvDiffElemKernel.C
+++ b/src/kernel/MomentumAdvDiffElemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -31,17 +32,15 @@ MomentumAdvDiffElemKernel<AlgTraits>::MomentumAdvDiffElemKernel(
   ScalarFieldType* viscosity,
   ElemDataRequests& dataPreReqs)
   : Kernel(),
-    viscosity_(viscosity),
+    viscosity_(viscosity->mesh_meta_data_ordinal()),
     lrscv_(sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     includeDivU_(solnOpts.includeDivU_),
     shiftedGradOp_(solnOpts.get_shifted_grad_op(velocity->name()))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  massFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+  velocityNp1_ = velocity->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal();
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  massFlowRate_ = get_field_ordinal(metaData, "mass_flow_rate_scs", stk::topology::ELEM_RANK);
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
 
@@ -54,10 +53,10 @@ MomentumAdvDiffElemKernel<AlgTraits>::MomentumAdvDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data; mdot not gathered as element data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*viscosity_, 1);
-  dataPreReqs.add_element_field(*massFlowRate_, AlgTraits::numScsIp_);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(viscosity_, 1);
+  dataPreReqs.add_element_field(massFlowRate_, AlgTraits::numScsIp_);
   dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
   if ( shiftedGradOp_ )
     dataPreReqs.add_master_element_call(SCS_SHIFTED_GRAD_OP, CURRENT_COORDINATES);
@@ -78,9 +77,9 @@ MomentumAdvDiffElemKernel<AlgTraits>::execute(
 {
   NALU_ALIGNED DoubleType w_uIp[AlgTraits::nDim_];
 
-  SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType*>& v_viscosity = scratchViews.get_scratch_view_1D(*viscosity_);
-  SharedMemView<DoubleType*>& v_mdot = scratchViews.get_scratch_view_1D(*massFlowRate_);
+  SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(velocityNp1_);
+  SharedMemView<DoubleType*>& v_viscosity = scratchViews.get_scratch_view_1D(viscosity_);
+  SharedMemView<DoubleType*>& v_mdot = scratchViews.get_scratch_view_1D(massFlowRate_);
 
   SharedMemView<DoubleType**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_

--- a/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
+++ b/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -33,10 +34,9 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::MomentumBuoyancyBoussinesqSr
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType *temperature = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
 
-  temperatureNp1_ = &(temperature->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  temperatureNp1_ = get_field_ordinal(metaData, "temperature", stk::mesh::StateNP1);
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
   
   const std::vector<double>& solnOptsGravity = solnOpts.get_gravity_vector(AlgTraits::nDim_);
   for (int i = 0; i < AlgTraits::nDim_; i++)
@@ -53,8 +53,8 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::MomentumBuoyancyBoussinesqSr
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*temperatureNp1_, 1);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(temperatureNp1_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
@@ -69,7 +69,7 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  SharedMemView<DoubleType*>& v_temperatureNp1 = scratchViews.get_scratch_view_1D(*temperatureNp1_);
+  SharedMemView<DoubleType*>& v_temperatureNp1 = scratchViews.get_scratch_view_1D(temperatureNp1_);
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {

--- a/src/kernel/MomentumBuoyancySrcElemKernel.C
+++ b/src/kernel/MomentumBuoyancySrcElemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -33,11 +34,8 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::MomentumBuoyancySrcElemKernel(
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
-  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
   
   const std::vector<double>& solnOptsGravity = solnOpts.get_gravity_vector(AlgTraits::nDim_);
   for (int i = 0; i < AlgTraits::nDim_; i++)
@@ -51,8 +49,8 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::MomentumBuoyancySrcElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
@@ -67,7 +65,7 @@ MomentumBuoyancySrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
+  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(densityNp1_);
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {

--- a/src/kernel/MomentumCoriolisSrcElemKernel.C
+++ b/src/kernel/MomentumCoriolisSrcElemKernel.C
@@ -15,6 +15,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -34,15 +35,14 @@ MomentumCoriolisSrcElemKernel<AlgTraits>::MomentumCoriolisSrcElemKernel(
   bool lumped)
   : Kernel(),
     cor_(solnOpts),
-    velocityNp1_(&velocity->field_of_state(stk::mesh::StateNP1)),
+    velocityNp1_(velocity->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal()),
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
   ThrowRequireMsg(metaData.spatial_dimension() == 3u, "Coriolis source term only available in 3D");
 
-  auto* density = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
@@ -57,9 +57,9 @@ MomentumCoriolisSrcElemKernel<AlgTraits>::MomentumCoriolisSrcElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
@@ -73,8 +73,8 @@ MomentumCoriolisSrcElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType *>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
+  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(velocityNp1_);
+  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(densityNp1_);
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for (int ip = 0; ip < AlgTraits::numScvIp_; ++ip) {

--- a/src/kernel/MomentumHybridTurbElemKernel.C
+++ b/src/kernel/MomentumHybridTurbElemKernel.C
@@ -14,6 +14,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -37,19 +38,13 @@ MomentumHybridTurbElemKernel<AlgTraits>::MomentumHybridTurbElemKernel(
     shiftedGradOp_(solnOpts.get_shifted_grad_op("velocity"))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  velocityNp1_ =
-    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  densityNp1_ =
-    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  tkeNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  alphaNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "adaptivity_parameter");
-  mutij_ = metaData.get_field<GenericFieldType>(
-    stk::topology::NODE_RANK, "tensor_turbulent_viscosity");
+  velocityNp1_ = get_field_ordinal(metaData, "velocity");
+  densityNp1_ = get_field_ordinal(metaData, "density");
+  tkeNp1_ = get_field_ordinal(metaData, "turbulent_ke");
+  alphaNp1_ = get_field_ordinal(metaData, "adaptivity_parameter");
+  mutij_ = get_field_ordinal(metaData, "tensor_turbulent_viscosity");
 
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement* meSCS =
     sierra::nalu::MasterElementRepo::get_surface_master_element(
@@ -62,13 +57,13 @@ MomentumHybridTurbElemKernel<AlgTraits>::MomentumHybridTurbElemKernel(
 
   // fields
   dataPreReqs.add_coordinates_field(
-    *coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*alphaNp1_, 1);
+    coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(alphaNp1_, 1);
   dataPreReqs.add_gathered_nodal_field(
-    *mutij_, AlgTraits::nDim_, AlgTraits::nDim_);
+    mutij_, AlgTraits::nDim_, AlgTraits::nDim_);
 
   // master element data
   dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
@@ -89,15 +84,15 @@ MomentumHybridTurbElemKernel<AlgTraits>::execute(
   NALU_ALIGNED DoubleType w_mutijScs[AlgTraits::nDim_ * AlgTraits::nDim_];
 
   SharedMemView<DoubleType**>& v_uNp1 =
-    scratchViews.get_scratch_view_2D(*velocityNp1_);
+    scratchViews.get_scratch_view_2D(velocityNp1_);
   SharedMemView<DoubleType*>& v_rhoNp1 =
-    scratchViews.get_scratch_view_1D(*densityNp1_);
+    scratchViews.get_scratch_view_1D(densityNp1_);
   SharedMemView<DoubleType*>& v_tkeNp1 =
-    scratchViews.get_scratch_view_1D(*tkeNp1_);
+    scratchViews.get_scratch_view_1D(tkeNp1_);
   SharedMemView<DoubleType*>& v_alphaNp1 =
-    scratchViews.get_scratch_view_1D(*alphaNp1_);
+    scratchViews.get_scratch_view_1D(alphaNp1_);
   SharedMemView<DoubleType***>& v_mutij =
-    scratchViews.get_scratch_view_3D(*mutij_);
+    scratchViews.get_scratch_view_3D(mutij_);
 
   SharedMemView<DoubleType**>& v_scs_areav =
     scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;

--- a/src/kernel/MomentumMassElemKernel.C
+++ b/src/kernel/MomentumMassElemKernel.C
@@ -14,6 +14,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -41,23 +42,22 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   ScalarFieldType *density = metaData.get_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "density");
 
-  velocityN_ = &(velocity->field_of_state(stk::mesh::StateN));
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+  velocityN_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateN);
+  velocityNp1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNP1);
   if (velocity->number_of_states() == 2)
     velocityNm1_ = velocityN_;
   else
-    velocityNm1_ = &(velocity->field_of_state(stk::mesh::StateNM1));
+    velocityNm1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNM1);
 
-  densityN_ = &(density->field_of_state(stk::mesh::StateN));
-  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+  densityN_ = get_field_ordinal(metaData, "density", stk::mesh::StateN);
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
   if (density->number_of_states() == 2)
     densityNm1_ = densityN_;
   else
-    densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
+    densityNm1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNM1);
 
-  Gjp_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  Gjp_ = get_field_ordinal(metaData, "dpdx");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
@@ -71,14 +71,14 @@ MomentumMassElemKernel<AlgTraits>::MomentumMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*velocityNm1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*velocityN_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*Gjp_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(densityNm1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityN_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(velocityNm1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(velocityN_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(Gjp_, AlgTraits::nDim_);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 
   const std::string dofName = "velocity";
@@ -111,13 +111,13 @@ MomentumMassElemKernel<AlgTraits>::execute(
   NALU_ALIGNED DoubleType w_uNp1 [AlgTraits::nDim_];
   NALU_ALIGNED DoubleType w_Gjp  [AlgTraits::nDim_];
 
-  SharedMemView<DoubleType*>& v_densityNm1 = scratchViews.get_scratch_view_1D(*densityNm1_);
-  SharedMemView<DoubleType*>& v_densityN = scratchViews.get_scratch_view_1D(*densityN_);
-  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(*densityNp1_);
-  SharedMemView<DoubleType**>& v_velocityNm1 = scratchViews.get_scratch_view_2D(*velocityNm1_);
-  SharedMemView<DoubleType**>& v_velocityN = scratchViews.get_scratch_view_2D(*velocityN_);
-  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType**>& v_Gpdx = scratchViews.get_scratch_view_2D(*Gjp_);
+  SharedMemView<DoubleType*>& v_densityNm1 = scratchViews.get_scratch_view_1D(densityNm1_);
+  SharedMemView<DoubleType*>& v_densityN = scratchViews.get_scratch_view_1D(densityN_);
+  SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(densityNp1_);
+  SharedMemView<DoubleType**>& v_velocityNm1 = scratchViews.get_scratch_view_2D(velocityNm1_);
+  SharedMemView<DoubleType**>& v_velocityN = scratchViews.get_scratch_view_2D(velocityN_);
+  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(velocityNp1_);
+  SharedMemView<DoubleType**>& v_Gpdx = scratchViews.get_scratch_view_2D(Gjp_);
 
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -14,6 +14,7 @@
 
 // template and scratch space
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -34,8 +35,8 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::MomentumOpenAdvDiffElemKernel(
   ElemDataRequests &faceDataPreReqs,
   ElemDataRequests &elemDataPreReqs)
   : Kernel(),
-    viscosity_(viscosity),
-    Gjui_(Gjui),
+    viscosity_(viscosity->mesh_meta_data_ordinal()),
+    Gjui_(Gjui->mesh_meta_data_ordinal()),
     alphaUpw_(solnOpts.get_alpha_upw_factor("velocity")),
     om_alphaUpw_(1.0-alphaUpw_),
     hoUpwind_(solnOpts.get_upw_factor("velocity")),
@@ -49,16 +50,16 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::MomentumOpenAdvDiffElemKernel(
     pecletFunction_(eqSystem->create_peclet_function<DoubleType>(velocity->name()))
 {
   // save off fields
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+  velocityNp1_ = velocity->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal();
   if ( solnOpts.does_mesh_move() )
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
+    velocityRTM_ = get_field_ordinal(metaData, "velocity_rtm");
   else
-    velocityRTM_ = velocity;
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
-  openMassFlowRate_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "open_mass_flow_rate");
-  velocityBc_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc");
+    velocityRTM_ = velocity->mesh_meta_data_ordinal();
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  density_ = get_field_ordinal(metaData, "density");
+  exposedAreaVec_ = get_field_ordinal(metaData, "exposed_area_vector", metaData.side_rank());
+  openMassFlowRate_ = get_field_ordinal(metaData, "open_mass_flow_rate", metaData.side_rank());
+  velocityBc_ = get_field_ordinal(metaData, "open_velocity_bc");
   
   // extract master elements
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
@@ -68,19 +69,19 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::MomentumOpenAdvDiffElemKernel(
   elemDataPreReqs.add_cvfem_surface_me(meSCS_);
 
   // fields and data; face and then element
-  faceDataPreReqs.add_gathered_nodal_field(*viscosity_, 1);
-  faceDataPreReqs.add_gathered_nodal_field(*velocityNp1_, BcAlgTraits::nDim_);
-  faceDataPreReqs.add_gathered_nodal_field(*velocityBc_, BcAlgTraits::nDim_);
-  faceDataPreReqs.add_gathered_nodal_field(*Gjui_, BcAlgTraits::nDim_, BcAlgTraits::nDim_);
-  faceDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-  faceDataPreReqs.add_face_field(*exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
-  faceDataPreReqs.add_face_field(*openMassFlowRate_, BcAlgTraits::numFaceIp_);
+  faceDataPreReqs.add_gathered_nodal_field(viscosity_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(velocityNp1_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_gathered_nodal_field(velocityBc_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_gathered_nodal_field(Gjui_, BcAlgTraits::nDim_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_coordinates_field(coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  faceDataPreReqs.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_face_field(openMassFlowRate_, BcAlgTraits::numFaceIp_);
 
-  elemDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-  elemDataPreReqs.add_gathered_nodal_field(*velocityNp1_, BcAlgTraits::nDim_);
-  elemDataPreReqs.add_gathered_nodal_field(*velocityRTM_, BcAlgTraits::nDim_);
-  elemDataPreReqs.add_gathered_nodal_field(*viscosity_, 1);
-  elemDataPreReqs.add_gathered_nodal_field(*density_, 1);
+  elemDataPreReqs.add_coordinates_field(coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  elemDataPreReqs.add_gathered_nodal_field(velocityNp1_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_gathered_nodal_field(velocityRTM_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_gathered_nodal_field(viscosity_, 1);
+  elemDataPreReqs.add_gathered_nodal_field(density_, 1);
  
   if ( shiftedGradOp_ )
     elemDataPreReqs.add_master_element_call(SCS_SHIFTED_FACE_GRAD_OP, CURRENT_COORDINATES);
@@ -128,20 +129,20 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
  
   // face
-  SharedMemView<DoubleType*>& vf_viscosity = faceScratchViews.get_scratch_view_1D(*viscosity_);
-  SharedMemView<DoubleType**>& vf_velocityNp1 = faceScratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType**>& vf_bcVelocity = faceScratchViews.get_scratch_view_2D(*velocityBc_);
-  SharedMemView<DoubleType***>& vf_Gjui = faceScratchViews.get_scratch_view_3D(*Gjui_);
-  SharedMemView<DoubleType**>& vf_coordinates = faceScratchViews.get_scratch_view_2D(*coordinates_);
-  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(*exposedAreaVec_);
-  SharedMemView<DoubleType*>& vf_openMassFlowRate = faceScratchViews.get_scratch_view_1D(*openMassFlowRate_);
+  SharedMemView<DoubleType*>& vf_viscosity = faceScratchViews.get_scratch_view_1D(viscosity_);
+  SharedMemView<DoubleType**>& vf_velocityNp1 = faceScratchViews.get_scratch_view_2D(velocityNp1_);
+  SharedMemView<DoubleType**>& vf_bcVelocity = faceScratchViews.get_scratch_view_2D(velocityBc_);
+  SharedMemView<DoubleType***>& vf_Gjui = faceScratchViews.get_scratch_view_3D(Gjui_);
+  SharedMemView<DoubleType**>& vf_coordinates = faceScratchViews.get_scratch_view_2D(coordinates_);
+  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(exposedAreaVec_);
+  SharedMemView<DoubleType*>& vf_openMassFlowRate = faceScratchViews.get_scratch_view_1D(openMassFlowRate_);
   
   // element
-  SharedMemView<DoubleType**>& v_coordinates = elemScratchViews.get_scratch_view_2D(*coordinates_);
-  SharedMemView<DoubleType**>& v_velocityNp1 = elemScratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType**>& v_vrtm = elemScratchViews.get_scratch_view_2D(*velocityRTM_);
-  SharedMemView<DoubleType*>& v_viscosity = elemScratchViews.get_scratch_view_1D(*viscosity_);
-  SharedMemView<DoubleType*>& v_density = elemScratchViews.get_scratch_view_1D(*density_);
+  SharedMemView<DoubleType**>& v_coordinates = elemScratchViews.get_scratch_view_2D(coordinates_);
+  SharedMemView<DoubleType**>& v_velocityNp1 = elemScratchViews.get_scratch_view_2D(velocityNp1_);
+  SharedMemView<DoubleType**>& v_vrtm = elemScratchViews.get_scratch_view_2D(velocityRTM_);
+  SharedMemView<DoubleType*>& v_viscosity = elemScratchViews.get_scratch_view_1D(viscosity_);
+  SharedMemView<DoubleType*>& v_density = elemScratchViews.get_scratch_view_1D(density_);
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_
     ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
     : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -12,6 +12,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -30,15 +31,14 @@ MomentumSymmetryElemKernel<BcAlgTraits>::MomentumSymmetryElemKernel(
   ElemDataRequests &faceDataPreReqs,
   ElemDataRequests &elemDataPreReqs)
   : Kernel(),
-    viscosity_(viscosity),
+    viscosity_(viscosity->mesh_meta_data_ordinal()),
     includeDivU_(solnOpts.includeDivU_),
     shiftedGradOp_(solnOpts.get_shifted_grad_op(velocity->name())),
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
 {
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  velocityNp1_ = velocity->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal();
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  exposedAreaVec_ = get_field_ordinal(metaData, "exposed_area_vector", metaData.side_rank());
 
   // extract master elements
   MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
@@ -48,10 +48,10 @@ MomentumSymmetryElemKernel<BcAlgTraits>::MomentumSymmetryElemKernel(
   elemDataPreReqs.add_cvfem_surface_me(meSCS_);
 
   // fields and data; face and then element
-  faceDataPreReqs.add_gathered_nodal_field(*viscosity_, 1);
-  faceDataPreReqs.add_face_field(*exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
-  elemDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-  elemDataPreReqs.add_gathered_nodal_field(*velocityNp1_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_gathered_nodal_field(viscosity_, 1);
+  faceDataPreReqs.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_coordinates_field(coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  elemDataPreReqs.add_gathered_nodal_field(velocityNp1_, BcAlgTraits::nDim_);
 
   if ( shiftedGradOp_ )
     elemDataPreReqs.add_master_element_call(SCS_SHIFTED_FACE_GRAD_OP, CURRENT_COORDINATES);
@@ -79,11 +79,11 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
   DoubleType w_nx[BcAlgTraits::nDim_];
 
   // face
-  SharedMemView<DoubleType*>& vf_viscosity = faceScratchViews.get_scratch_view_1D(*viscosity_);
-  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(*exposedAreaVec_);
+  SharedMemView<DoubleType*>& vf_viscosity = faceScratchViews.get_scratch_view_1D(viscosity_);
+  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(exposedAreaVec_);
  
   // element
-  SharedMemView<DoubleType**>& v_uNp1 = elemScratchViews.get_scratch_view_2D(*velocityNp1_);
+  SharedMemView<DoubleType**>& v_uNp1 = elemScratchViews.get_scratch_view_2D(velocityNp1_);
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_
     ? elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_shifted_fc_scs
     : elemScratchViews.get_me_views(CURRENT_COORDINATES).dndx_fc_scs;

--- a/src/kernel/MomentumUpwAdvDiffElemKernel.C
+++ b/src/kernel/MomentumUpwAdvDiffElemKernel.C
@@ -15,6 +15,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -36,8 +37,8 @@ MomentumUpwAdvDiffElemKernel<AlgTraits>::MomentumUpwAdvDiffElemKernel(
   ElemDataRequests& dataPreReqs)
   : Kernel(),
     solnOpts_(solnOpts),
-    viscosity_(viscosity),
-    Gju_(Gju),
+    viscosity_(viscosity->mesh_meta_data_ordinal()),
+    Gju_(Gju->mesh_meta_data_ordinal()),
     lrscv_(sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     dofName_(velocity->name()),
     alpha_(solnOpts.get_alpha_factor(dofName_)),
@@ -51,17 +52,14 @@ MomentumUpwAdvDiffElemKernel<AlgTraits>::MomentumUpwAdvDiffElemKernel(
     pecletFunction_(eqSystem->create_peclet_function<DoubleType>(dofName_))
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  if ( solnOpts_.does_mesh_move() )
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
-  else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  massFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
-  
+  const std::string vrtmName = solnOpts_.does_mesh_move()? "velocity_rtm" : "velocity";
+
+  velocityNp1_ = velocity->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal();
+  velocityRTM_ = get_field_ordinal(metaData, vrtmName);
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  density_ = get_field_ordinal(metaData, "density");
+  massFlowRate_ = get_field_ordinal(metaData, "mass_flow_rate_scs", stk::topology::ELEM_RANK);
+
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
 
   get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);
@@ -73,13 +71,13 @@ MomentumUpwAdvDiffElemKernel<AlgTraits>::MomentumUpwAdvDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data; mdot not gathered as element data
-  dataPreReqs.add_gathered_nodal_field(*Gju_, AlgTraits::nDim_, AlgTraits::nDim_);
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*density_, 1);
-  dataPreReqs.add_gathered_nodal_field(*viscosity_, 1);
-  dataPreReqs.add_element_field(*massFlowRate_, AlgTraits::numScsIp_);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(Gju_, AlgTraits::nDim_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(velocityRTM_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(density_, 1);
+  dataPreReqs.add_gathered_nodal_field(viscosity_, 1);
+  dataPreReqs.add_element_field(massFlowRate_, AlgTraits::numScsIp_);
   dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
   if ( shiftedGradOp_ )
     dataPreReqs.add_master_element_call(SCS_SHIFTED_GRAD_OP, CURRENT_COORDINATES);
@@ -127,13 +125,13 @@ MomentumUpwAdvDiffElemKernel<AlgTraits>::execute(
     w_limitR[i] = 1.0;
   }
   
-  SharedMemView<DoubleType***>& v_Gju = scratchViews.get_scratch_view_3D(*Gju_);
-  SharedMemView<DoubleType**>& v_coordinates = scratchViews.get_scratch_view_2D(*coordinates_);
-  SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType*>& v_density = scratchViews.get_scratch_view_1D(*density_);
-  SharedMemView<DoubleType*>& v_viscosity = scratchViews.get_scratch_view_1D(*viscosity_);
-  SharedMemView<DoubleType*>& v_mdot = scratchViews.get_scratch_view_1D(*massFlowRate_);
-  SharedMemView<DoubleType**>& v_velocityRTM = scratchViews.get_scratch_view_2D(*velocityRTM_);
+  SharedMemView<DoubleType***>& v_Gju = scratchViews.get_scratch_view_3D(Gju_);
+  SharedMemView<DoubleType**>& v_coordinates = scratchViews.get_scratch_view_2D(coordinates_);
+  SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(velocityNp1_);
+  SharedMemView<DoubleType*>& v_density = scratchViews.get_scratch_view_1D(density_);
+  SharedMemView<DoubleType*>& v_viscosity = scratchViews.get_scratch_view_1D(viscosity_);
+  SharedMemView<DoubleType*>& v_mdot = scratchViews.get_scratch_view_1D(massFlowRate_);
+  SharedMemView<DoubleType**>& v_velocityRTM = scratchViews.get_scratch_view_2D(velocityRTM_);
  
   SharedMemView<DoubleType**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_

--- a/src/kernel/MomentumWallFunctionElemKernel.C
+++ b/src/kernel/MomentumWallFunctionElemKernel.C
@@ -12,6 +12,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -34,18 +35,18 @@ MomentumWallFunctionElemKernel<BcAlgTraits>::MomentumWallFunctionElemKernel(
     ipNodeMap_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_)->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  bcVelocity_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "wall_velocity_bc");
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  viscosity_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
-  wallFrictionVelocityBip_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "wall_friction_velocity_bip");
-  wallNormalDistanceBip_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "wall_normal_distance_bip");
-  VectorFieldType *coordinates = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
- 
+  velocityNp1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNP1);
+  bcVelocity_ = get_field_ordinal(metaData, "wall_velocity_bc");
+  density_ = get_field_ordinal(metaData, "density");
+  viscosity_ = get_field_ordinal(metaData, "viscosity");
+  exposedAreaVec_ =
+    get_field_ordinal(metaData, "exposed_area_vector", metaData.side_rank());
+  wallFrictionVelocityBip_ = get_field_ordinal(
+    metaData, "wall_friction_velocity_bip", metaData.side_rank());
+  wallNormalDistanceBip_ = get_field_ordinal(
+    metaData, "wall_normal_distance_bip", metaData.side_rank());
+  unsigned coordinates = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::topo_);
  
   // compute and save shape function
@@ -55,14 +56,14 @@ MomentumWallFunctionElemKernel<BcAlgTraits>::MomentumWallFunctionElemKernel(
   dataPreReqs.add_cvfem_face_me(meFC);
  
   // fields and data; mdot not gathered as element data
-  dataPreReqs.add_coordinates_field(*coordinates, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, BcAlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*bcVelocity_, BcAlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*density_, 1);
-  dataPreReqs.add_gathered_nodal_field(*viscosity_, 1);
-  dataPreReqs.add_face_field(*exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
-  dataPreReqs.add_face_field(*wallFrictionVelocityBip_, BcAlgTraits::numFaceIp_);
-  dataPreReqs.add_face_field(*wallNormalDistanceBip_, BcAlgTraits::numFaceIp_);
+  dataPreReqs.add_coordinates_field(coordinates, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, BcAlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(bcVelocity_, BcAlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(density_, 1);
+  dataPreReqs.add_gathered_nodal_field(viscosity_, 1);
+  dataPreReqs.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  dataPreReqs.add_face_field(wallFrictionVelocityBip_, BcAlgTraits::numFaceIp_);
+  dataPreReqs.add_face_field(wallNormalDistanceBip_, BcAlgTraits::numFaceIp_);
 }
 
 template<class BcAlgTraits>
@@ -80,13 +81,13 @@ MomentumWallFunctionElemKernel<BcAlgTraits>::execute(
   DoubleType w_uBcBip[BcAlgTraits::nDim_];
   DoubleType w_unitNormal[BcAlgTraits::nDim_];
 
-  SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
-  SharedMemView<DoubleType**>& v_bcVelocity = scratchViews.get_scratch_view_2D(*bcVelocity_);
-  SharedMemView<DoubleType*>& v_density = scratchViews.get_scratch_view_1D(*density_);
-  SharedMemView<DoubleType*>& v_viscosity = scratchViews.get_scratch_view_1D(*viscosity_);
-  SharedMemView<DoubleType**>& vf_exposedAreaVec = scratchViews.get_scratch_view_2D(*exposedAreaVec_);
-  SharedMemView<DoubleType*>& vf_utau = scratchViews.get_scratch_view_1D(*wallFrictionVelocityBip_);
-  SharedMemView<DoubleType*>& vf_yp = scratchViews.get_scratch_view_1D(*wallNormalDistanceBip_);
+  SharedMemView<DoubleType**>& v_uNp1 = scratchViews.get_scratch_view_2D(velocityNp1_);
+  SharedMemView<DoubleType**>& v_bcVelocity = scratchViews.get_scratch_view_2D(bcVelocity_);
+  SharedMemView<DoubleType*>& v_density = scratchViews.get_scratch_view_1D(density_);
+  SharedMemView<DoubleType*>& v_viscosity = scratchViews.get_scratch_view_1D(viscosity_);
+  SharedMemView<DoubleType**>& vf_exposedAreaVec = scratchViews.get_scratch_view_2D(exposedAreaVec_);
+  SharedMemView<DoubleType*>& vf_utau = scratchViews.get_scratch_view_1D(wallFrictionVelocityBip_);
+  SharedMemView<DoubleType*>& vf_yp = scratchViews.get_scratch_view_1D(wallNormalDistanceBip_);
 
   for ( int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip ) {
         

--- a/src/kernel/ScalarAdvDiffElemKernel.C
+++ b/src/kernel/ScalarAdvDiffElemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -31,17 +32,15 @@ ScalarAdvDiffElemKernel<AlgTraits>::ScalarAdvDiffElemKernel(
   ScalarFieldType* diffFluxCoeff,
   ElemDataRequests& dataPreReqs)
   : Kernel(),
-    scalarQ_(scalarQ),
-    diffFluxCoeff_(diffFluxCoeff),
+    scalarQ_(scalarQ->mesh_meta_data_ordinal()),
+    diffFluxCoeff_(diffFluxCoeff->mesh_meta_data_ordinal()),
     lrscv_(sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ->name()))
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  massFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  massFlowRate_ = get_field_ordinal(metaData, "mass_flow_rate_scs", stk::topology::ELEM_RANK);
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
 
@@ -53,10 +52,10 @@ ScalarAdvDiffElemKernel<AlgTraits>::ScalarAdvDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
-  dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
-  dataPreReqs.add_element_field(*massFlowRate_, AlgTraits::numScsIp_);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(scalarQ_, 1);
+  dataPreReqs.add_gathered_nodal_field(diffFluxCoeff_, 1);
+  dataPreReqs.add_element_field(massFlowRate_, AlgTraits::numScsIp_);
   dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
   if ( shiftedGradOp_ )
     dataPreReqs.add_master_element_call(SCS_SHIFTED_GRAD_OP, CURRENT_COORDINATES);
@@ -75,9 +74,9 @@ ScalarAdvDiffElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(*scalarQ_);
-  SharedMemView<DoubleType*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
-  SharedMemView<DoubleType*>& v_mdot = scratchViews.get_scratch_view_1D(*massFlowRate_);
+  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(scalarQ_);
+  SharedMemView<DoubleType*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(diffFluxCoeff_);
+  SharedMemView<DoubleType*>& v_mdot = scratchViews.get_scratch_view_1D(massFlowRate_);
 
   SharedMemView<DoubleType**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_

--- a/src/kernel/ScalarDiffElemKernel.C
+++ b/src/kernel/ScalarDiffElemKernel.C
@@ -14,6 +14,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -32,15 +33,14 @@ ScalarDiffElemKernel<AlgTraits>::ScalarDiffElemKernel(
   ScalarFieldType* diffFluxCoeff,
   ElemDataRequests& dataPreReqs)
   : Kernel(),
-    scalarQ_(scalarQ),
-    diffFluxCoeff_(diffFluxCoeff),
+    scalarQ_(scalarQ->mesh_meta_data_ordinal()),
+    diffFluxCoeff_(diffFluxCoeff->mesh_meta_data_ordinal()),
     lrscv_(sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
-    shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ_->name()))
+    shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ->name()))
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   get_scs_shape_fn_data<AlgTraits>([&](double* ptr){meSCS->shape_fcn(ptr);}, v_shape_function_);
@@ -48,9 +48,9 @@ ScalarDiffElemKernel<AlgTraits>::ScalarDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
-  dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(scalarQ_, 1);
+  dataPreReqs.add_gathered_nodal_field(diffFluxCoeff_, 1);
   dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
   if ( shiftedGradOp_ )
     dataPreReqs.add_master_element_call(SCS_SHIFTED_GRAD_OP, CURRENT_COORDINATES);
@@ -69,8 +69,8 @@ ScalarDiffElemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(*scalarQ_);
-  SharedMemView<DoubleType*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
+  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(scalarQ_);
+  SharedMemView<DoubleType*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(diffFluxCoeff_);
 
   SharedMemView<DoubleType**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_

--- a/src/kernel/ScalarDiffFemKernel.C
+++ b/src/kernel/ScalarDiffFemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -32,18 +33,18 @@ ScalarDiffFemKernel<AlgTraits>::ScalarDiffFemKernel(
   ElemDataRequests& dataPreReqs)
   : Kernel(),
     bulkData_(&bulkData),
-    scalarQ_(scalarQ),
-    diffFluxCoeff_(diffFluxCoeff),
+    scalarQ_(scalarQ->mesh_meta_data_ordinal()),
+    diffFluxCoeff_(diffFluxCoeff->mesh_meta_data_ordinal()),
     meFEM_(new Hex8FEM()),
     ipWeight_(&meFEM_->weights_[0]),
-    shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ_->name()))
+    shiftedGradOp_(solnOpts.get_shifted_grad_op(scalarQ->name()))
 {
   ThrowRequireMsg(AlgTraits::topo_ == stk::topology::HEX_8,
                   "FEM_DIFF only available for hexes currently");
 
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates");
+  coordinates_ = get_field_ordinal(metaData, "coordinates");
 
   // master element, shape function is shifted consistently
   if ( shiftedGradOp_ )
@@ -54,9 +55,9 @@ ScalarDiffFemKernel<AlgTraits>::ScalarDiffFemKernel(
   dataPreReqs.add_fem_volume_me(meFEM_);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
-  dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(scalarQ_, 1);
+  dataPreReqs.add_gathered_nodal_field(diffFluxCoeff_, 1);
   if ( shiftedGradOp_ )
     dataPreReqs.add_master_element_call(FEM_SHIFTED_GRAD_OP, CURRENT_COORDINATES);
   else
@@ -76,8 +77,8 @@ ScalarDiffFemKernel<AlgTraits>::execute(
   SharedMemView<DoubleType*>& rhs,
   ScratchViews<DoubleType>& scratchViews)
 {
-  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(*scalarQ_);
-  SharedMemView<DoubleType*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
+  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(scalarQ_);
+  SharedMemView<DoubleType*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(diffFluxCoeff_);
   
   SharedMemView<DoubleType***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx_fem;
   SharedMemView<DoubleType*>& v_det_j = scratchViews.get_me_views(CURRENT_COORDINATES).det_j_fem;

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -13,6 +13,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -32,15 +33,15 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::ScalarFluxPenaltyElemKernel(
   ElemDataRequests &faceDataPreReqs,
   ElemDataRequests &elemDataPreReqs)
   : Kernel(),
-    scalarQ_(scalarQ),
-    bcScalarQ_(bcScalarQ),
-    diffFluxCoeff_(diffFluxCoeff),
+    scalarQ_(scalarQ->mesh_meta_data_ordinal()),
+    bcScalarQ_(bcScalarQ->mesh_meta_data_ordinal()),
+    diffFluxCoeff_(diffFluxCoeff->mesh_meta_data_ordinal()),
     penaltyFac_(2.0),
     shiftedGradOp_(solnOpts.get_shifted_grad_op("pressure")),
     meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_))
 {
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  exposedAreaVec_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "exposed_area_vector");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  exposedAreaVec_ = get_field_ordinal(metaData, "exposed_area_vector", metaData.side_rank());
   
   // extract master elements
   MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
@@ -50,12 +51,12 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::ScalarFluxPenaltyElemKernel(
   elemDataPreReqs.add_cvfem_surface_me(meSCS_);
 
   // fields and data; face and then element
-  faceDataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
-  faceDataPreReqs.add_gathered_nodal_field(*bcScalarQ_, 1);
-  faceDataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
-  faceDataPreReqs.add_face_field(*exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
-  elemDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-  elemDataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(scalarQ_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(bcScalarQ_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(diffFluxCoeff_, 1);
+  faceDataPreReqs.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_coordinates_field(coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  elemDataPreReqs.add_gathered_nodal_field(scalarQ_, 1);
   
   // manage dndx
   if ( shiftedGradOp_ )
@@ -84,13 +85,13 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
   const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
  
   // face
-  SharedMemView<DoubleType*>& vf_scalarQ = faceScratchViews.get_scratch_view_1D(*scalarQ_);
-  SharedMemView<DoubleType*>& vf_bcScalarQ = faceScratchViews.get_scratch_view_1D(*bcScalarQ_);
-  SharedMemView<DoubleType*>& vf_diffFluxCoeff = faceScratchViews.get_scratch_view_1D(*diffFluxCoeff_);
-  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(*exposedAreaVec_);
+  SharedMemView<DoubleType*>& vf_scalarQ = faceScratchViews.get_scratch_view_1D(scalarQ_);
+  SharedMemView<DoubleType*>& vf_bcScalarQ = faceScratchViews.get_scratch_view_1D(bcScalarQ_);
+  SharedMemView<DoubleType*>& vf_diffFluxCoeff = faceScratchViews.get_scratch_view_1D(diffFluxCoeff_);
+  SharedMemView<DoubleType**>& vf_exposedAreaVec = faceScratchViews.get_scratch_view_2D(exposedAreaVec_);
  
   // element
-  SharedMemView<DoubleType*>& v_scalarQ = elemScratchViews.get_scratch_view_1D(*scalarQ_);
+  SharedMemView<DoubleType*>& v_scalarQ = elemScratchViews.get_scratch_view_1D(scalarQ_);
 
   // dndx for both rhs and lhs
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_ 

--- a/src/kernel/ScalarMassElemKernel.C
+++ b/src/kernel/ScalarMassElemKernel.C
@@ -14,6 +14,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -38,24 +39,23 @@ ScalarMassElemKernel<AlgTraits>::ScalarMassElemKernel(
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
-  scalarQN_ = &(scalarQ->field_of_state(stk::mesh::StateN));
-  scalarQNp1_ = &(scalarQ->field_of_state(stk::mesh::StateNP1));
+  scalarQN_ = scalarQ->field_of_state(stk::mesh::StateN).mesh_meta_data_ordinal();
+  scalarQNp1_ = scalarQ->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal();
   if (scalarQ->number_of_states() == 2)
     scalarQNm1_ = scalarQN_;
   else
-    scalarQNm1_ = &(scalarQ->field_of_state(stk::mesh::StateNM1));
+    scalarQNm1_ = scalarQ->field_of_state(stk::mesh::StateNM1).mesh_meta_data_ordinal();
 
   ScalarFieldType* density = metaData.get_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "density");
-  densityN_ = &(density->field_of_state(stk::mesh::StateN));
-  densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+  densityN_ = density->field_of_state(stk::mesh::StateN).mesh_meta_data_ordinal();
+  densityNp1_ = density->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal();
 
   if (density->number_of_states() == 2)
     densityNm1_ = densityN_;
   else
-    densityNm1_ = &(density->field_of_state(stk::mesh::StateNM1));
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+    densityNm1_ = density->field_of_state(stk::mesh::StateNM1).mesh_meta_data_ordinal();
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
@@ -69,13 +69,13 @@ ScalarMassElemKernel<AlgTraits>::ScalarMassElemKernel(
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // fields and data
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*scalarQNm1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*scalarQN_, 1);
-  dataPreReqs.add_gathered_nodal_field(*scalarQNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNm1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityN_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(scalarQNm1_, 1);
+  dataPreReqs.add_gathered_nodal_field(scalarQN_, 1);
+  dataPreReqs.add_gathered_nodal_field(scalarQNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNm1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityN_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 
   diagRelaxFactor_ = solnOpts.get_relaxation_factor(scalarQ->name());
@@ -103,17 +103,17 @@ ScalarMassElemKernel<AlgTraits>::execute(
   ScratchViews<DoubleType>& scratchViews)
 {
   SharedMemView<DoubleType*>& v_qNm1 = scratchViews.get_scratch_view_1D(
-    *scalarQNm1_);
+    scalarQNm1_);
   SharedMemView<DoubleType*>& v_qN = scratchViews.get_scratch_view_1D(
-    *scalarQN_);
+    scalarQN_);
   SharedMemView<DoubleType*>& v_qNp1 = scratchViews.get_scratch_view_1D(
-    *scalarQNp1_);
+    scalarQNp1_);
   SharedMemView<DoubleType*>& v_rhoNm1 = scratchViews.get_scratch_view_1D(
-    *densityNm1_);
+    densityNm1_);
   SharedMemView<DoubleType*>& v_rhoN = scratchViews.get_scratch_view_1D(
-    *densityN_);
+    densityN_);
   SharedMemView<DoubleType*>& v_rhoNp1 = scratchViews.get_scratch_view_1D(
-    *densityNp1_);
+    densityNp1_);
 
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 

--- a/src/kernel/ScalarOpenAdvElemKernel.C
+++ b/src/kernel/ScalarOpenAdvElemKernel.C
@@ -14,6 +14,7 @@
 
 // template and scratch space
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -35,10 +36,10 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::ScalarOpenAdvElemKernel(
   ElemDataRequests &faceDataPreReqs,
   ElemDataRequests &elemDataPreReqs)
   : Kernel(),
-    scalarQ_(scalarQ),
-    bcScalarQ_(bcScalarQ),
-    Gjq_(Gjq),
-    diffFluxCoeff_(diffFluxCoeff),
+    scalarQ_(scalarQ->mesh_meta_data_ordinal()),
+    bcScalarQ_(bcScalarQ->mesh_meta_data_ordinal()),
+    Gjq_(Gjq->mesh_meta_data_ordinal()),
+    diffFluxCoeff_(diffFluxCoeff->mesh_meta_data_ordinal()),
     alphaUpw_(solnOpts.get_alpha_upw_factor(scalarQ->name())),
     om_alphaUpw_(1.0-alphaUpw_),
     hoUpwind_(solnOpts.get_upw_factor(scalarQ->name())),
@@ -47,13 +48,11 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::ScalarOpenAdvElemKernel(
     pecletFunction_(eqSystem->create_peclet_function<DoubleType>(scalarQ->name()))
 {
   // save off fields
-  if ( solnOpts.does_mesh_move() )
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm");
-  else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  coordinates_ = metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  density_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  openMassFlowRate_ = metaData.get_field<GenericFieldType>(metaData.side_rank(), "open_mass_flow_rate");
+  const std::string vrtm_name = solnOpts.does_mesh_move()? "velocity_rtm" : "velocity";
+  velocityRTM_ = get_field_ordinal(metaData, vrtm_name);
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  density_ = get_field_ordinal(metaData, "density");
+  openMassFlowRate_ = get_field_ordinal(metaData, "open_mass_flow_rate", metaData.side_rank());
   
   // extract master elements
   MasterElement *meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
@@ -63,21 +62,24 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::ScalarOpenAdvElemKernel(
   elemDataPreReqs.add_cvfem_surface_me(meSCS_);
 
   // fields and data; face and then element
-  faceDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-  faceDataPreReqs.add_gathered_nodal_field(*Gjq_, BcAlgTraits::nDim_);
-  faceDataPreReqs.add_gathered_nodal_field(*scalarQ_, 1);
-  faceDataPreReqs.add_gathered_nodal_field(*bcScalarQ_, 1);
-  faceDataPreReqs.add_face_field(*openMassFlowRate_, BcAlgTraits::numFaceIp_);
+  faceDataPreReqs.add_coordinates_field(coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  faceDataPreReqs.add_gathered_nodal_field(Gjq_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_gathered_nodal_field(scalarQ_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(bcScalarQ_, 1);
+  faceDataPreReqs.add_face_field(openMassFlowRate_, BcAlgTraits::numFaceIp_);
 
-  elemDataPreReqs.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-  elemDataPreReqs.add_gathered_nodal_field(*velocityRTM_, BcAlgTraits::nDim_);
-  elemDataPreReqs.add_gathered_nodal_field(*diffFluxCoeff_, 1);
-  elemDataPreReqs.add_gathered_nodal_field(*density_, 1);
+  elemDataPreReqs.add_coordinates_field(coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  elemDataPreReqs.add_gathered_nodal_field(velocityRTM_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_gathered_nodal_field(diffFluxCoeff_, 1);
+  elemDataPreReqs.add_gathered_nodal_field(density_, 1);
 
   // never shift properties
-  const bool skewSymmetric = solnOpts.get_skew_symmetric(scalarQ_->name());
-  get_face_shape_fn_data<BcAlgTraits>([&](double* ptr){skewSymmetric ? meFC->shifted_shape_fcn(ptr) : meFC->shape_fcn(ptr);}, 
-                                      vf_adv_shape_function_);
+  const bool skewSymmetric = solnOpts.get_skew_symmetric(scalarQ->name());
+  get_face_shape_fn_data<BcAlgTraits>(
+    [&](double* ptr) {
+      skewSymmetric ? meFC->shifted_shape_fcn(ptr) : meFC->shape_fcn(ptr);
+    },
+    vf_adv_shape_function_);
 }
 
 template<typename BcAlgTraits>
@@ -101,17 +103,17 @@ ScalarOpenAdvElemKernel<BcAlgTraits>::execute(
   const int *face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
  
   // face
-  SharedMemView<DoubleType*>& vf_scalarQ = faceScratchViews.get_scratch_view_1D(*scalarQ_);
-  SharedMemView<DoubleType*>& vf_bcScalarQ = faceScratchViews.get_scratch_view_1D(*bcScalarQ_);
-  SharedMemView<DoubleType**>& vf_Gjq = faceScratchViews.get_scratch_view_2D(*Gjq_);
-  SharedMemView<DoubleType**>& vf_coordinates = faceScratchViews.get_scratch_view_2D(*coordinates_);
-  SharedMemView<DoubleType*>& vf_openMassFlowRate = faceScratchViews.get_scratch_view_1D(*openMassFlowRate_);
+  SharedMemView<DoubleType*>& vf_scalarQ = faceScratchViews.get_scratch_view_1D(scalarQ_);
+  SharedMemView<DoubleType*>& vf_bcScalarQ = faceScratchViews.get_scratch_view_1D(bcScalarQ_);
+  SharedMemView<DoubleType**>& vf_Gjq = faceScratchViews.get_scratch_view_2D(Gjq_);
+  SharedMemView<DoubleType**>& vf_coordinates = faceScratchViews.get_scratch_view_2D(coordinates_);
+  SharedMemView<DoubleType*>& vf_openMassFlowRate = faceScratchViews.get_scratch_view_1D(openMassFlowRate_);
   
   // element
-  SharedMemView<DoubleType**>& v_coordinates = elemScratchViews.get_scratch_view_2D(*coordinates_);
-  SharedMemView<DoubleType**>& v_vrtm = elemScratchViews.get_scratch_view_2D(*velocityRTM_);
-  SharedMemView<DoubleType*>& v_diffFluxCoeff = elemScratchViews.get_scratch_view_1D(*diffFluxCoeff_);
-  SharedMemView<DoubleType*>& v_density = elemScratchViews.get_scratch_view_1D(*density_);
+  SharedMemView<DoubleType**>& v_coordinates = elemScratchViews.get_scratch_view_2D(coordinates_);
+  SharedMemView<DoubleType**>& v_vrtm = elemScratchViews.get_scratch_view_2D(velocityRTM_);
+  SharedMemView<DoubleType*>& v_diffFluxCoeff = elemScratchViews.get_scratch_view_1D(diffFluxCoeff_);
+  SharedMemView<DoubleType*>& v_density = elemScratchViews.get_scratch_view_1D(density_);
 
   for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     

--- a/src/kernel/ScalarUpwAdvDiffElemKernel.C
+++ b/src/kernel/ScalarUpwAdvDiffElemKernel.C
@@ -15,6 +15,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -36,9 +37,9 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::ScalarUpwAdvDiffElemKernel(
   ElemDataRequests& dataPreReqs)
   : Kernel(),
     solnOpts_(solnOpts),
-    scalarQ_(scalarQ),
-    Gjq_(Gjq),
-    diffFluxCoeff_(diffFluxCoeff),
+    scalarQ_(scalarQ->mesh_meta_data_ordinal()),
+    Gjq_(Gjq->mesh_meta_data_ordinal()),
+    diffFluxCoeff_(diffFluxCoeff->mesh_meta_data_ordinal()),
     lrscv_(sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_)->adjacentNodes()),
     dofName_(scalarQ->name()),
     alpha_(solnOpts.get_alpha_factor(dofName_)),
@@ -52,19 +53,12 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::ScalarUpwAdvDiffElemKernel(
 {
   // Save of required fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  massFlowRate_ = metaData.get_field<GenericFieldType>(
-    stk::topology::ELEMENT_RANK, "mass_flow_rate_scs");
-  density_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  massFlowRate_ = get_field_ordinal(metaData, "mass_flow_rate_scs", stk::topology::ELEM_RANK);
+  density_ = get_field_ordinal(metaData, "density");
 
-  if (solnOpts.does_mesh_move())
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-        stk::topology::NODE_RANK, "velocity_rtm");
-  else
-    velocityRTM_ = metaData.get_field<VectorFieldType>(
-      stk::topology::NODE_RANK, "velocity");
+  const std::string vrtm_name = solnOpts.does_mesh_move()? "velocity_rtm" : "velocity";
+  velocityRTM_ = get_field_ordinal(metaData, vrtm_name);
 
   MasterElement *meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
   
@@ -77,13 +71,13 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::ScalarUpwAdvDiffElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
 
   // fields and data; mdot not gathered
-  dataPreReqs.add_gathered_nodal_field(*velocityRTM_, AlgTraits::nDim_);
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*Gjq, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*scalarQ, 1);
-  dataPreReqs.add_gathered_nodal_field(*density_, 1);
-  dataPreReqs.add_gathered_nodal_field(*diffFluxCoeff, 1);
-  dataPreReqs.add_element_field(*massFlowRate_, AlgTraits::numScsIp_);
+  dataPreReqs.add_gathered_nodal_field(velocityRTM_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(Gjq_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(scalarQ_, 1);
+  dataPreReqs.add_gathered_nodal_field(density_, 1);
+  dataPreReqs.add_gathered_nodal_field(diffFluxCoeff_, 1);
+  dataPreReqs.add_element_field(massFlowRate_, AlgTraits::numScsIp_);
   dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
   if ( shiftedGradOp_ )
     dataPreReqs.add_master_element_call(SCS_SHIFTED_GRAD_OP, CURRENT_COORDINATES);
@@ -121,13 +115,13 @@ ScalarUpwAdvDiffElemKernel<AlgTraits>::execute(
   /// Scratch space to hold coordinates at the integration point
   NALU_ALIGNED DoubleType w_coordIp[AlgTraits::nDim_];
 
-  SharedMemView<DoubleType**>& v_velocityRTM = scratchViews.get_scratch_view_2D(*velocityRTM_);
-  SharedMemView<DoubleType**>& v_coordinates = scratchViews.get_scratch_view_2D(*coordinates_);
-  SharedMemView<DoubleType**>& v_Gjq = scratchViews.get_scratch_view_2D(*Gjq_);
-  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(*scalarQ_);
-  SharedMemView<DoubleType*>& v_density = scratchViews.get_scratch_view_1D(*density_);
-  SharedMemView<DoubleType*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(*diffFluxCoeff_);
-  SharedMemView<DoubleType*>& v_mdot = scratchViews.get_scratch_view_1D(*massFlowRate_);
+  SharedMemView<DoubleType**>& v_velocityRTM = scratchViews.get_scratch_view_2D(velocityRTM_);
+  SharedMemView<DoubleType**>& v_coordinates = scratchViews.get_scratch_view_2D(coordinates_);
+  SharedMemView<DoubleType**>& v_Gjq = scratchViews.get_scratch_view_2D(Gjq_);
+  SharedMemView<DoubleType*>& v_scalarQ = scratchViews.get_scratch_view_1D(scalarQ_);
+  SharedMemView<DoubleType*>& v_density = scratchViews.get_scratch_view_1D(density_);
+  SharedMemView<DoubleType*>& v_diffFluxCoeff = scratchViews.get_scratch_view_1D(diffFluxCoeff_);
+  SharedMemView<DoubleType*>& v_mdot = scratchViews.get_scratch_view_1D(massFlowRate_);
 
   SharedMemView<DoubleType**>& v_scs_areav = scratchViews.get_me_views(CURRENT_COORDINATES).scs_areav;
   SharedMemView<DoubleType***>& v_dndx = shiftedGradOp_

--- a/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
+++ b/src/kernel/SpecificDissipationRateSSTSrcElemKernel.C
@@ -11,6 +11,7 @@
 
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -43,24 +44,13 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::
                  ->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "specific_dissipation_rate");
-  sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* density =
-    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
-  VectorFieldType* velocity =
-    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
-  fOneBlend_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "sst_f_one_blending");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  tkeNp1_ = get_field_ordinal(metaData, "turbulent_ke", stk::mesh::StateNP1);
+  sdrNp1_ = get_field_ordinal(metaData, "specific_dissipation_rate", stk::mesh::StateNP1);
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
+  velocityNp1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNP1);
+  tvisc_ = get_field_ordinal(metaData, "turbulent_viscosity");
+  fOneBlend_ = get_field_ordinal(metaData, "sst_f_one_blending");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV =
     sierra::nalu::MasterElementRepo::get_volume_master_element(
@@ -79,13 +69,13 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::
 
   // fields and data
   dataPreReqs.add_coordinates_field(
-    *coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*sdrNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
-  dataPreReqs.add_gathered_nodal_field(*fOneBlend_, 1);
+    coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(sdrNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(tvisc_, 1);
+  dataPreReqs.add_gathered_nodal_field(fOneBlend_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
   if (shiftedGradOp_)
     dataPreReqs.add_master_element_call(
@@ -112,17 +102,17 @@ SpecificDissipationRateSSTSrcElemKernel<AlgTraits>::execute(
   NALU_ALIGNED DoubleType w_dwdx[AlgTraits::nDim_];
 
   SharedMemView<DoubleType*>& v_tkeNp1 =
-    scratchViews.get_scratch_view_1D(*tkeNp1_);
+    scratchViews.get_scratch_view_1D(tkeNp1_);
   SharedMemView<DoubleType*>& v_sdrNp1 =
-    scratchViews.get_scratch_view_1D(*sdrNp1_);
+    scratchViews.get_scratch_view_1D(sdrNp1_);
   SharedMemView<DoubleType*>& v_densityNp1 =
-    scratchViews.get_scratch_view_1D(*densityNp1_);
+    scratchViews.get_scratch_view_1D(densityNp1_);
   SharedMemView<DoubleType**>& v_velocityNp1 =
-    scratchViews.get_scratch_view_2D(*velocityNp1_);
+    scratchViews.get_scratch_view_2D(velocityNp1_);
   SharedMemView<DoubleType*>& v_tvisc =
-    scratchViews.get_scratch_view_1D(*tvisc_);
+    scratchViews.get_scratch_view_1D(tvisc_);
   SharedMemView<DoubleType*>& v_fOneBlend =
-    scratchViews.get_scratch_view_1D(*fOneBlend_);
+    scratchViews.get_scratch_view_1D(fOneBlend_);
   SharedMemView<DoubleType***>& v_dndx =
     shiftedGradOp_
       ? scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv_shifted

--- a/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.C
@@ -14,6 +14,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -36,18 +37,12 @@ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsD
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  VectorFieldType *velocity = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "velocity");
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tkeNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  densityNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
-  dualNodalVolume_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  tkeNp1_ = get_field_ordinal(metaData, "turbulent_ke", stk::mesh::StateNP1);
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
+  velocityNp1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNP1);
+  tvisc_ = get_field_ordinal(metaData, "turbulent_viscosity");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  dualNodalVolume_ = get_field_ordinal(metaData, "dual_nodal_volume");
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
   get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
@@ -56,12 +51,12 @@ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsD
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // required fields
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
-  dataPreReqs.add_gathered_nodal_field(*dualNodalVolume_, 1);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(tvisc_, 1);
+  dataPreReqs.add_gathered_nodal_field(dualNodalVolume_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
   dataPreReqs.add_master_element_call(SCV_GRAD_OP, CURRENT_COORDINATES);
 }
@@ -79,15 +74,15 @@ TurbKineticEnergyKsgsDesignOrderSrcElemKernel<AlgTraits>::execute(
 {
   NALU_ALIGNED DoubleType w_dudx [AlgTraits::nDim_][AlgTraits::nDim_];
  
-  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(*velocityNp1_);
+  SharedMemView<DoubleType**>& v_velocityNp1 = scratchViews.get_scratch_view_2D(velocityNp1_);
   SharedMemView<DoubleType*>& v_tkeNp1 = scratchViews.get_scratch_view_1D(
-    *tkeNp1_);
+    tkeNp1_);
   SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
-    *densityNp1_);
+    densityNp1_);
   SharedMemView<DoubleType*>& v_tvisc = scratchViews.get_scratch_view_1D(
-    *tvisc_);
+    tvisc_);
   SharedMemView<DoubleType*>& v_dualNodalVolume = scratchViews.get_scratch_view_1D(
-    *dualNodalVolume_);
+    dualNodalVolume_);
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
   SharedMemView<DoubleType***>& v_dndx = scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv;
 

--- a/src/kernel/TurbKineticEnergyKsgsSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergyKsgsSrcElemKernel.C
@@ -14,6 +14,7 @@
 // template and scratch space
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -36,17 +37,12 @@ TurbKineticEnergyKsgsSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsSrcElemKerne
 {
   // save off fields
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
-  tkeNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  densityNp1_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "density");
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
-  dualNodalVolume_ = metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  Gju_ = metaData.get_field<GenericFieldType>(
-    stk::topology::NODE_RANK, "dudx");
+  tkeNp1_ = get_field_ordinal(metaData, "turbulent_ke", stk::mesh::StateNP1);
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
+  tvisc_ = get_field_ordinal(metaData, "turbulent_viscosity");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  dualNodalVolume_ = get_field_ordinal(metaData, "dual_nodal_volume");
+  Gju_ = get_field_ordinal(metaData, "dudx");
 
   MasterElement *meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
@@ -54,12 +50,12 @@ TurbKineticEnergyKsgsSrcElemKernel<AlgTraits>::TurbKineticEnergyKsgsSrcElemKerne
   dataPreReqs.add_cvfem_volume_me(meSCV);
 
   // required fields
-  dataPreReqs.add_coordinates_field(*coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
-  dataPreReqs.add_gathered_nodal_field(*dualNodalVolume_, 1);
-  dataPreReqs.add_gathered_nodal_field(*Gju_, AlgTraits::nDim_, AlgTraits::nDim_);
+  dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(tvisc_, 1);
+  dataPreReqs.add_gathered_nodal_field(dualNodalVolume_, 1);
+  dataPreReqs.add_gathered_nodal_field(Gju_, AlgTraits::nDim_, AlgTraits::nDim_);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
 }
 
@@ -75,14 +71,14 @@ TurbKineticEnergyKsgsSrcElemKernel<AlgTraits>::execute(
   ScratchViews<DoubleType>& scratchViews)
 {
   SharedMemView<DoubleType*>& v_tkeNp1 = scratchViews.get_scratch_view_1D(
-    *tkeNp1_);
+    tkeNp1_);
   SharedMemView<DoubleType*>& v_densityNp1 = scratchViews.get_scratch_view_1D(
-    *densityNp1_);
+    densityNp1_);
   SharedMemView<DoubleType*>& v_tvisc = scratchViews.get_scratch_view_1D(
-    *tvisc_);
+    tvisc_);
   SharedMemView<DoubleType*>& v_dualNodalVolume = scratchViews.get_scratch_view_1D(
-    *dualNodalVolume_);
-  SharedMemView<DoubleType***>& v_Gju = scratchViews.get_scratch_view_3D(*Gju_);
+    dualNodalVolume_);
+  SharedMemView<DoubleType***>& v_Gju = scratchViews.get_scratch_view_3D(Gju_);
   SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {

--- a/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTDESSrcElemKernel.C
@@ -11,6 +11,7 @@
 
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -40,26 +41,15 @@ TurbKineticEnergySSTDESSrcElemKernel<AlgTraits>::
                  ->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "specific_dissipation_rate");
-  sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* density =
-    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
-  VectorFieldType* velocity =
-    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
-  maxLengthScale_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "sst_max_length_scale");
-  fOneBlend_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "sst_f_one_blending");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  tkeNp1_ = get_field_ordinal(metaData, "turbulent_ke", stk::mesh::StateNP1);
+  sdrNp1_ = get_field_ordinal(metaData, "specific_dissipation_rate", stk::mesh::StateNP1);
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
+  velocityNp1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNP1);
+  tvisc_ = get_field_ordinal(metaData, "turbulent_viscosity");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
+  maxLengthScale_ = get_field_ordinal(metaData, "sst_max_length_scale");
+  fOneBlend_ = get_field_ordinal(metaData, "sst_f_one_blending");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV =
     sierra::nalu::MasterElementRepo::get_volume_master_element(
@@ -78,14 +68,14 @@ TurbKineticEnergySSTDESSrcElemKernel<AlgTraits>::
 
   // fields and data
   dataPreReqs.add_coordinates_field(
-    *coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*sdrNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
-  dataPreReqs.add_gathered_nodal_field(*maxLengthScale_, 1);
-  dataPreReqs.add_gathered_nodal_field(*fOneBlend_, 1);
+    coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(sdrNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(tvisc_, 1);
+  dataPreReqs.add_gathered_nodal_field(maxLengthScale_, 1);
+  dataPreReqs.add_gathered_nodal_field(fOneBlend_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
   if (shiftedGradOp_)
     dataPreReqs.add_master_element_call(
@@ -110,19 +100,19 @@ TurbKineticEnergySSTDESSrcElemKernel<AlgTraits>::execute(
   NALU_ALIGNED DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
 
   SharedMemView<DoubleType*>& v_tkeNp1 =
-    scratchViews.get_scratch_view_1D(*tkeNp1_);
+    scratchViews.get_scratch_view_1D(tkeNp1_);
   SharedMemView<DoubleType*>& v_sdrNp1 =
-    scratchViews.get_scratch_view_1D(*sdrNp1_);
+    scratchViews.get_scratch_view_1D(sdrNp1_);
   SharedMemView<DoubleType*>& v_densityNp1 =
-    scratchViews.get_scratch_view_1D(*densityNp1_);
+    scratchViews.get_scratch_view_1D(densityNp1_);
   SharedMemView<DoubleType**>& v_velocityNp1 =
-    scratchViews.get_scratch_view_2D(*velocityNp1_);
+    scratchViews.get_scratch_view_2D(velocityNp1_);
   SharedMemView<DoubleType*>& v_tvisc =
-    scratchViews.get_scratch_view_1D(*tvisc_);
+    scratchViews.get_scratch_view_1D(tvisc_);
   SharedMemView<DoubleType*>& v_maxLengthScale =
-    scratchViews.get_scratch_view_1D(*maxLengthScale_);
+    scratchViews.get_scratch_view_1D(maxLengthScale_);
   SharedMemView<DoubleType*>& v_fOneBlend =
-    scratchViews.get_scratch_view_1D(*fOneBlend_);
+    scratchViews.get_scratch_view_1D(fOneBlend_);
   SharedMemView<DoubleType***>& v_dndx =
     shiftedGradOp_
       ? scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv_shifted

--- a/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
+++ b/src/kernel/TurbKineticEnergySSTSrcElemKernel.C
@@ -11,6 +11,7 @@
 
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -37,22 +38,12 @@ TurbKineticEnergySSTSrcElemKernel<AlgTraits>::TurbKineticEnergySSTSrcElemKernel(
                  ->ipNodeMap())
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
-  ScalarFieldType* tke = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_ke");
-  tkeNp1_ = &tke->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* sdr = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "specific_dissipation_rate");
-  sdrNp1_ = &sdr->field_of_state(stk::mesh::StateNP1);
-  ScalarFieldType* density =
-    metaData.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
-  densityNp1_ = &density->field_of_state(stk::mesh::StateNP1);
-  VectorFieldType* velocity =
-    metaData.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
-  velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
-  tvisc_ = metaData.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "turbulent_viscosity");
-  coordinates_ = metaData.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  tkeNp1_ = get_field_ordinal(metaData, "turbulent_ke", stk::mesh::StateNP1);
+  sdrNp1_ = get_field_ordinal(metaData, "specific_dissipation_rate", stk::mesh::StateNP1);
+  densityNp1_ = get_field_ordinal(metaData, "density", stk::mesh::StateNP1);
+  velocityNp1_ = get_field_ordinal(metaData, "velocity", stk::mesh::StateNP1);
+  tvisc_ = get_field_ordinal(metaData, "turbulent_viscosity");
+  coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
 
   MasterElement* meSCV =
     sierra::nalu::MasterElementRepo::get_volume_master_element(
@@ -71,12 +62,12 @@ TurbKineticEnergySSTSrcElemKernel<AlgTraits>::TurbKineticEnergySSTSrcElemKernel(
 
   // fields and data
   dataPreReqs.add_coordinates_field(
-    *coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
-  dataPreReqs.add_gathered_nodal_field(*tkeNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*sdrNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*densityNp1_, 1);
-  dataPreReqs.add_gathered_nodal_field(*velocityNp1_, AlgTraits::nDim_);
-  dataPreReqs.add_gathered_nodal_field(*tvisc_, 1);
+    coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataPreReqs.add_gathered_nodal_field(tkeNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(sdrNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(densityNp1_, 1);
+  dataPreReqs.add_gathered_nodal_field(velocityNp1_, AlgTraits::nDim_);
+  dataPreReqs.add_gathered_nodal_field(tvisc_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
   if (shiftedGradOp_)
     dataPreReqs.add_master_element_call(
@@ -101,15 +92,15 @@ TurbKineticEnergySSTSrcElemKernel<AlgTraits>::execute(
   NALU_ALIGNED DoubleType w_dudx[AlgTraits::nDim_][AlgTraits::nDim_];
 
   SharedMemView<DoubleType*>& v_tkeNp1 =
-    scratchViews.get_scratch_view_1D(*tkeNp1_);
+    scratchViews.get_scratch_view_1D(tkeNp1_);
   SharedMemView<DoubleType*>& v_sdrNp1 =
-    scratchViews.get_scratch_view_1D(*sdrNp1_);
+    scratchViews.get_scratch_view_1D(sdrNp1_);
   SharedMemView<DoubleType*>& v_densityNp1 =
-    scratchViews.get_scratch_view_1D(*densityNp1_);
+    scratchViews.get_scratch_view_1D(densityNp1_);
   SharedMemView<DoubleType**>& v_velocityNp1 =
-    scratchViews.get_scratch_view_2D(*velocityNp1_);
+    scratchViews.get_scratch_view_2D(velocityNp1_);
   SharedMemView<DoubleType*>& v_tvisc =
-    scratchViews.get_scratch_view_1D(*tvisc_);
+    scratchViews.get_scratch_view_1D(tvisc_);
   SharedMemView<DoubleType***>& v_dndx =
     shiftedGradOp_
       ? scratchViews.get_me_views(CURRENT_COORDINATES).dndx_scv_shifted

--- a/src/kernel/WallDistElemKernel.C
+++ b/src/kernel/WallDistElemKernel.C
@@ -13,6 +13,7 @@
 
 #include "BuildTemplates.h"
 #include "ScratchViews.h"
+#include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/BulkData.hpp"
 
@@ -33,8 +34,7 @@ WallDistElemKernel<AlgTraits>::WallDistElemKernel(
 {
   const auto& meta = bulkData.mesh_meta_data();
 
-  coordinates_ = meta.get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, solnOpts.get_coordinates_name());
+  coordinates_ = get_field_ordinal(meta, solnOpts.get_coordinates_name());
 
   MasterElement* meSCS =
     MasterElementRepo::get_surface_master_element(AlgTraits::topo_);
@@ -47,7 +47,7 @@ WallDistElemKernel<AlgTraits>::WallDistElemKernel(
   dataPreReqs.add_cvfem_surface_me(meSCS);
   dataPreReqs.add_cvfem_volume_me(meSCV);
   dataPreReqs.add_coordinates_field(
-    *coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+    coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
   dataPreReqs.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
 

--- a/unit_tests/UnitTestElemDataRequests.C
+++ b/unit_tests/UnitTestElemDataRequests.C
@@ -91,7 +91,7 @@ TEST_F(Hex8MeshWithNSOFields, ElemDataRequestsNGP)
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
   stk::topology elemTopo = stk::topology::HEX_8;
 
-  sierra::nalu::ElemDataRequests dataReq;
+  sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
   dataReq.add_cvfem_volume_me(meSCV);
 
@@ -111,7 +111,7 @@ TEST_F(Hex8MeshWithNSOFields, ElemDataRequestsGPU)
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
   stk::topology elemTopo = stk::topology::HEX_8;
 
-  sierra::nalu::ElemDataRequests dataReq;
+  sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
   dataReq.add_cvfem_volume_me(meSCV);
 

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -116,7 +116,9 @@ class TestElemAlgorithmWithSuppAlgViews
 {
 public:
   TestElemAlgorithmWithSuppAlgViews(stk::mesh::BulkData& bulk)
-  : suppAlgs_(), bulkData_(bulk)
+  : suppAlgs_(),
+    dataNeededByKernels_(bulk.mesh_meta_data()),
+    bulkData_(bulk)
   {}
 
   void execute()

--- a/unit_tests/UnitTestKokkosME.C
+++ b/unit_tests/UnitTestKokkosME.C
@@ -147,7 +147,7 @@ void test_ME_views(const std::vector<sierra::nalu::ELEM_DATA_NEEDED>& requests)
 
   // Register ME data requests
   for(sierra::nalu::ELEM_DATA_NEEDED request : requests) {
-    driver.dataNeeded_.add_master_element_call(request, sierra::nalu::CURRENT_COORDINATES);
+    driver.dataNeeded().add_master_element_call(request, sierra::nalu::CURRENT_COORDINATES);
   }
 
   sierra::nalu::MasterElement* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(AlgTraits::topo_);

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -29,8 +29,7 @@ public:
   KokkosMEViews(bool doInit=true, bool doPerturb=false)
     : comm_(MPI_COMM_WORLD),
       meta_(AlgTraits::nDim_),
-      bulk_(meta_, comm_),
-      dataNeeded_(meta_)
+      bulk_(meta_, comm_)
   {
     if (doInit)
       fill_mesh_and_init_data(doPerturb);
@@ -58,7 +57,10 @@ public:
       meta_.coordinate_field());
 
     EXPECT_TRUE(coordinates_ != nullptr);
-    dataNeeded_.add_coordinates_field(
+
+    const int numDof = 1;
+    helperObjs_.reset(new HelperObjects(bulk_, AlgTraits::topo_, numDof, partVec_[0]));
+    dataNeeded().add_coordinates_field(
       *coordinates_, AlgTraits::nDim_, sierra::nalu::CURRENT_COORDINATES);
   }
 
@@ -69,8 +71,8 @@ public:
     meSCV_ = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
 
     // Register them to ElemDataRequests
-    dataNeeded_.add_cvfem_surface_me(meSCS_);
-    dataNeeded_.add_cvfem_volume_me(meSCV_);
+    dataNeeded().add_cvfem_surface_me(meSCS_);
+    dataNeeded().add_cvfem_volume_me(meSCV_);
 
     // Initialize shape function views
     double scs_data[AlgTraits::numScsIp_*AlgTraits::nodesPerElement_];
@@ -91,14 +93,13 @@ public:
   template<typename LambdaFunction>
   void execute(LambdaFunction func)
   {
-    int numDof = 1;
     ThrowAssertMsg(partVec_.size()==1, "KokkosMEViews unit-test assumes partVec_.size==1");
 
-    HelperObjects helperObjs(bulk_, AlgTraits::topo_, numDof, partVec_[0]);
-    helperObjs.assembleElemSolverAlg->dataNeededByKernels_ = dataNeeded_;
-
-    helperObjs.assembleElemSolverAlg->run_algorithm(bulk_, func);
+    helperObjs_->assembleElemSolverAlg->run_algorithm(bulk_, func);
   }
+
+  inline sierra::nalu::ElemDataRequests& dataNeeded()
+  { return helperObjs_->assembleElemSolverAlg->dataNeededByKernels_; }
 
   stk::ParallelMachine comm_;
   stk::mesh::MetaData meta_;
@@ -106,7 +107,8 @@ public:
   stk::mesh::PartVector partVec_;
   const VectorFieldType* coordinates_{nullptr};
 
-  sierra::nalu::ElemDataRequests dataNeeded_;
+  std::unique_ptr<HelperObjects> helperObjs_{nullptr};
+
   sierra::nalu::MasterElement* meFC_{nullptr};
   sierra::nalu::MasterElement* meSCV_{nullptr};
   sierra::nalu::MasterElement* meSCS_{nullptr};

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -29,7 +29,8 @@ public:
   KokkosMEViews(bool doInit=true, bool doPerturb=false)
     : comm_(MPI_COMM_WORLD),
       meta_(AlgTraits::nDim_),
-      bulk_(meta_, comm_)
+      bulk_(meta_, comm_),
+      dataNeeded_(meta_)
   {
     if (doInit)
       fill_mesh_and_init_data(doPerturb);

--- a/unit_tests/UnitTestKokkosMEBC.C
+++ b/unit_tests/UnitTestKokkosMEBC.C
@@ -66,7 +66,8 @@ void test_MEBC_views(int faceOrdinal, const std::vector<sierra::nalu::ELEM_DATA_
 
   // Register ME data requests
   for(sierra::nalu::ELEM_DATA_NEEDED request : elem_requests) {
-    driver.elemDataNeeded_.add_master_element_call(request, sierra::nalu::CURRENT_COORDINATES);
+    driver.elemDataNeeded().add_master_element_call(
+      request, sierra::nalu::CURRENT_COORDINATES);
   }
 
   // Execute the loop and perform all tests

--- a/unit_tests/UnitTestKokkosMEBC.h
+++ b/unit_tests/UnitTestKokkosMEBC.h
@@ -30,7 +30,9 @@ public:
      : comm_(MPI_COMM_WORLD),
        meta_(BcAlgTraits::nDim_),
        bulk_(meta_, comm_),
-       faceOrdinal_(faceOrdinal)
+       faceOrdinal_(faceOrdinal),
+       faceDataNeeded_(meta_),
+       elemDataNeeded_(meta_)
    {
      if (doInit)
        fill_mesh_and_init_data(doPerturb);

--- a/unit_tests/UnitTestKokkosMEBC.h
+++ b/unit_tests/UnitTestKokkosMEBC.h
@@ -30,9 +30,7 @@ public:
      : comm_(MPI_COMM_WORLD),
        meta_(BcAlgTraits::nDim_),
        bulk_(meta_, comm_),
-       faceOrdinal_(faceOrdinal),
-       faceDataNeeded_(meta_),
-       elemDataNeeded_(meta_)
+       faceOrdinal_(faceOrdinal)
    {
      if (doInit)
        fill_mesh_and_init_data(doPerturb);
@@ -59,7 +57,14 @@ public:
      coordinates_ = static_cast<const VectorFieldType*>( meta_.coordinate_field());
 
      EXPECT_TRUE(coordinates_ != nullptr);
-     elemDataNeeded_.add_coordinates_field(*coordinates_, BcAlgTraits::nDim_, sierra::nalu::CURRENT_COORDINATES);
+
+     const int numDof = 1;
+     helperObjs_.reset(new FaceElemHelperObjects(
+       bulk_, BcAlgTraits::faceTopo_, BcAlgTraits::elemTopo_, numDof,
+       partVec_[0]));
+
+     elemDataNeeded().add_coordinates_field(
+       *coordinates_, BcAlgTraits::nDim_, sierra::nalu::CURRENT_COORDINATES);
    }
 
    void init_me_data()
@@ -67,24 +72,29 @@ public:
      meFC_ = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
      meSCS_ = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_);
      // Register them to ElemDataRequests
-    faceDataNeeded_.add_cvfem_face_me(meFC_);
-    elemDataNeeded_.add_cvfem_surface_me(meSCS_);
+    faceDataNeeded().add_cvfem_face_me(meFC_);
+    elemDataNeeded().add_cvfem_surface_me(meSCS_);
    }
 
    template<typename LambdaFunction>
    void execute(LambdaFunction func)
    {
-     int numDof = 1;
      ThrowRequireMsg(partVec_.size()==1, "KokkosMEViews unit-test assumes partVec_.size==1");
      ThrowRequireMsg(!bulk_.get_buckets(meta_.side_rank(), *partVec_[0]).empty(), "part does not contain side-ranked elements");
-     FaceElemHelperObjects helperObjs(bulk_, BcAlgTraits::faceTopo_, BcAlgTraits::elemTopo_, numDof, partVec_[0]);
 
-     sierra::nalu::AssembleFaceElemSolverAlgorithm& alg = *helperObjs.assembleFaceElemSolverAlg;
-     alg.faceDataNeeded_ = faceDataNeeded_;
-     alg.elemDataNeeded_ = elemDataNeeded_;
-
+     sierra::nalu::AssembleFaceElemSolverAlgorithm& alg = *(helperObjs_->assembleFaceElemSolverAlg);
      alg.run_face_elem_algorithm(bulk_, func);
    }
+
+  sierra::nalu::ElemDataRequests& faceDataNeeded()
+  {
+    return helperObjs_->assembleFaceElemSolverAlg->faceDataNeeded_;
+  }
+
+  sierra::nalu::ElemDataRequests& elemDataNeeded()
+  {
+    return helperObjs_->assembleFaceElemSolverAlg->elemDataNeeded_;
+  }
 
    stk::ParallelMachine comm_;
    stk::mesh::MetaData meta_;
@@ -93,8 +103,8 @@ public:
    stk::mesh::PartVector partVec_;
    const VectorFieldType* coordinates_{nullptr};
 
-   sierra::nalu::ElemDataRequests faceDataNeeded_;
-   sierra::nalu::ElemDataRequests elemDataNeeded_;
+   std::unique_ptr<FaceElemHelperObjects> helperObjs_;
+
    sierra::nalu::MasterElement* meFC_{nullptr};
    sierra::nalu::MasterElement* meSCV_{nullptr};
    sierra::nalu::MasterElement* meSCS_{nullptr};

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -52,7 +52,7 @@ typedef Kokkos::DualView<int*, Kokkos::LayoutRight, sierra::nalu::DeviceSpace> I
 void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* pressure, sierra::nalu::VectorFieldType* velocity)
 {
   stk::topology elemTopo = stk::topology::HEX_8;
-  sierra::nalu::ElemDataRequests dataReq;
+  sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
   dataReq.add_cvfem_volume_me(meSCV);
 
@@ -144,7 +144,7 @@ TEST_F(Hex8MeshWithNSOFields, ScratchViews)
 void do_the_smdata_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* pressure, sierra::nalu::VectorFieldType* velocity)
 {
   stk::topology elemTopo = stk::topology::HEX_8;
-  sierra::nalu::ElemDataRequests dataReq;
+  sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
   dataReq.add_cvfem_volume_me(meSCV);
 

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -103,7 +103,9 @@ class TestAlgorithm
 {
 public:
   TestAlgorithm(stk::mesh::BulkData& bulk)
-  : suppAlgs_(), bulkData_(bulk)
+  : suppAlgs_(),
+    dataNeededByKernels_(bulk.mesh_meta_data()),
+    bulkData_(bulk)
   {}
 
   void execute()
@@ -203,7 +205,7 @@ TEST_F(Hex8Mesh, inconsistent_field_requests)
 
     fill_mesh("generated:10x10x10");
 
-    sierra::nalu::ElemDataRequests prereqData;
+    sierra::nalu::ElemDataRequests prereqData(meta);
 
     prereqData.add_gathered_nodal_field(nodalScalarField, 1);
     EXPECT_THROW(prereqData.add_gathered_nodal_field(nodalScalarField, 2), std::logic_error);

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -565,7 +565,7 @@ void calc_mass_flow_rate_scs(
   const int ndim = meta.spatial_dimension();
   EXPECT_EQ(ndim, 3);
 
-  sierra::nalu::ElemDataRequests dataNeeded;
+  sierra::nalu::ElemDataRequests dataNeeded(meta);
 
   const ScalarFieldType& densityNp1 = density.field_of_state(stk::mesh::StateNP1);
   const VectorFieldType& velocityNp1 = velocity.field_of_state(stk::mesh::StateNP1);
@@ -650,7 +650,7 @@ void calc_projected_nodal_gradient_interior(
   const int ndim = meta.spatial_dimension();
   EXPECT_EQ(ndim, 3);
 
-  sierra::nalu::ElemDataRequests dataNeeded;
+  sierra::nalu::ElemDataRequests dataNeeded(meta);
 
   auto meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
 
@@ -729,7 +729,7 @@ void calc_projected_nodal_gradient_interior(
   const int ndim = meta.spatial_dimension();
   EXPECT_EQ(ndim, 3);
 
-  sierra::nalu::ElemDataRequests dataNeeded;
+  sierra::nalu::ElemDataRequests dataNeeded(meta);
 
   auto meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
 
@@ -811,7 +811,7 @@ void calc_projected_nodal_gradient_boundary(
   EXPECT_EQ(ndim, 3);
   EXPECT_EQ(topo.rank(), meta.side_rank());
 
-  sierra::nalu::ElemDataRequests dataNeeded;
+  sierra::nalu::ElemDataRequests dataNeeded(meta);
 
   auto meBC = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
 
@@ -885,7 +885,7 @@ void calc_projected_nodal_gradient_boundary(
   EXPECT_EQ(ndim, 3);
   EXPECT_EQ(topo.rank(), meta.side_rank());
 
-  sierra::nalu::ElemDataRequests dataNeeded;
+  sierra::nalu::ElemDataRequests dataNeeded(meta);
 
   auto meBC = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
 
@@ -959,7 +959,7 @@ void calc_dual_nodal_volume(
   const int ndim = meta.spatial_dimension();
   EXPECT_EQ(ndim, 3);
 
-  sierra::nalu::ElemDataRequests dataNeeded;
+  sierra::nalu::ElemDataRequests dataNeeded(meta);
 
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(topo);
 


### PR DESCRIPTION
In preparation for Kernel assembly on GPU, convert all pointer references within (non-HO) Kernel classes to field ordinals. 