### PR TITLE
Fix a bug from my 'fix intel segfault' commit.

### DIFF
--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -73,8 +73,8 @@ void copy_and_interleave(const MultiDimViewsType ** data,
     for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
       src[simdIndex] = data[simdIndex]->get_1D_view_by_index(viewIndex).data();
       NGP_ThrowAssert(data[simdIndex]->get_1D_view_by_index(viewIndex).size() == simdData.get_1D_view_by_index(viewIndex).size());
-      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_1D_view_by_index(viewIndex).data()[0]);
       NGP_ThrowAssert(src[simdIndex] != nullptr);
+      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_1D_view_by_index(viewIndex).data()[0]);
     }
     interleave(simdData.get_1D_view_by_index(viewIndex), src, simdElems);
   }
@@ -84,8 +84,8 @@ void copy_and_interleave(const MultiDimViewsType ** data,
     for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
       src[simdIndex] = data[simdIndex]->get_2D_view_by_index(viewIndex).data();
       NGP_ThrowAssert(data[simdIndex]->get_2D_view_by_index(viewIndex).size() == simdData.get_2D_view_by_index(viewIndex).size());
-      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_2D_view_by_index(viewIndex).data()[0]);
       NGP_ThrowAssert(src[simdIndex] != nullptr);
+      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_2D_view_by_index(viewIndex).data()[0]);
     }
     interleave(simdData.get_2D_view_by_index(viewIndex), src, simdElems);
   }
@@ -95,8 +95,8 @@ void copy_and_interleave(const MultiDimViewsType ** data,
     for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
       src[simdIndex] = data[simdIndex]->get_3D_view_by_index(viewIndex).data();
       NGP_ThrowAssert(data[simdIndex]->get_3D_view_by_index(viewIndex).size() == simdData.get_3D_view_by_index(viewIndex).size());
-      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_3D_view_by_index(viewIndex).data()[0]);
       NGP_ThrowAssert(src[simdIndex] != nullptr);
+      NGP_ThrowAssert(src[simdIndex][0] == data[simdIndex]->get_3D_view_by_index(viewIndex).data()[0]);
     }
     interleave(simdData.get_3D_view_by_index(viewIndex), src, simdElems);
   }

--- a/include/MultiDimViews.h
+++ b/include/MultiDimViews.h
@@ -42,11 +42,11 @@ public:
   static constexpr unsigned bytesPerUnsigned = sizeof(unsigned);
 
   KOKKOS_FUNCTION
-  MultiDimViews(const TEAMHANDLETYPE& /* team */,
-                unsigned /* maxOrdinal */,
+  MultiDimViews(const TEAMHANDLETYPE& team,
+                unsigned maxOrdinal,
                 const NumNeededViews& numNeededViews)
-  : //indices(get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team,
-    //        adjust_up_to_alignment_boundary((maxOrdinal+1)*bytesPerUnsigned, KOKKOS_MEMORY_ALIGNMENT)/bytesPerUnsigned)),
+  : indices(get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team,
+            adjust_up_to_alignment_boundary((maxOrdinal+1)*bytesPerUnsigned, KOKKOS_MEMORY_ALIGNMENT)/bytesPerUnsigned)),
     views_1D(), views_2D(), views_3D(), views_4D(), 
     views_1D_size(0), views_2D_size(0), views_3D_size(0), views_4D_size(0)
   {
@@ -236,10 +236,8 @@ public:
 
 public:
   static const unsigned maxViewsPerDim = 25;
-  static const unsigned maxPossibleOrdinals = 128;
 
-//  SharedMemView<int*,SHMEM> indices;
-  NALU_ALIGNED int indices[maxPossibleOrdinals];
+  SharedMemView<int*,SHMEM> indices;
 #ifndef KOKKOS_ENABLE_CUDA
   SharedMemView1D* views_1D[maxViewsPerDim];
   SharedMemView2D* views_2D[maxViewsPerDim];


### PR DESCRIPTION
I wasn't allowing for how big 'maxOrdinal' could be
in MultiDimViews, and didn't have a runtime check on it.
Now I'm storing the ordinals in a view sized at runtime
so there's no need for maxOrdinal.
This was a clear array-bounds issue, I don't know how it
got through before...