### PR TITLE
Allow some usage of face elem kernels with promoted hex elements

### DIFF
--- a/include/element_promotion/LagrangeBasis.h
+++ b/include/element_promotion/LagrangeBasis.h
@@ -64,7 +64,7 @@ public:
 
   double tensor_lagrange_interpolant(unsigned dimension, const double* x, const int* node_ordinals) const;
 
-  unsigned num_nodes() { return numNodes_; }
+  unsigned num_nodes() const { return numNodes_; }
 
   std::vector<std::vector<int>> indicesMap_;
 

--- a/include/element_promotion/PromotedPartHelper.h
+++ b/include/element_promotion/PromotedPartHelper.h
@@ -33,8 +33,8 @@ namespace nalu {
 
   std::string super_element_part_name(std::string base_name);
 
-  std::string super_subset_part_name(const std::string& base_name, int numElemNodes, int numSideNodes);
-  std::string super_subset_part_name(const std::string& base_name);
+  std::string super_subset_part_name(std::string base_name, int numElemNodes, int numSideNodes);
+  std::string super_subset_part_name(std::string base_name);
 
   stk::mesh::Part* super_elem_part(const stk::mesh::Part& part);
 
@@ -65,6 +65,8 @@ namespace nalu {
   stk::mesh::PartVector append_super_elems_to_part_vector(stk::mesh::PartVector parts);
 
   size_t count_entities(const stk::mesh::BucketVector& buckets);
+
+  stk::topology get_promoted_elem_topo(int dim, int order);
 
 } // namespace nalu
 } // namespace Sierra

--- a/include/master_element/MasterElementHO.h
+++ b/include/master_element/MasterElementHO.h
@@ -15,6 +15,9 @@
 #include <element_promotion/HexNElementDescription.h>
 #include <element_promotion/QuadNElementDescription.h>
 
+#include <AlgTraits.h>
+#include <KokkosInterface.h>
+
 #include <vector>
 #include <array>
 
@@ -169,6 +172,10 @@ public:
     return shapeDerivs_;
   }
 
+  void face_grad_op(
+    int face_ordinal,
+    SharedMemView<DoubleType**>& coords,
+    SharedMemView<DoubleType***>& gradop) final;
 
 private:
   void set_interior_info();
@@ -189,6 +196,8 @@ private:
   std::vector<double> expFaceShapeDerivs_;
   std::vector<ContourData> ipInfo_;
   int ipsPerFace_;
+
+  AlignedViewType<DoubleType**[3]> expRefGradWeights_;
 };
 
 // 3D Quad 9

--- a/include/utils/StkHelpers.h
+++ b/include/utils/StkHelpers.h
@@ -1,6 +1,8 @@
 #ifndef STKHELPERS_H
 #define STKHELPERS_H
 
+#include <element_promotion/PromotedPartHelper.h>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Ghosting.hpp>
@@ -37,6 +39,10 @@ void populate_ghost_comm_procs(const stk::mesh::BulkData& bulk_data, stk::mesh::
 inline
 stk::topology get_elem_topo(const Realm& realm, const stk::mesh::Part& surfacePart)
 {
+  if (realm.doPromotion_) {
+    return get_promoted_elem_topo(realm.spatialDimension_, realm.promotionOrder_);
+  }
+
   std::vector<const stk::mesh::Part*> blockParts = realm.meta_data().get_blocks_touching_surface(&surfacePart);
 
   ThrowRequireMsg(blockParts.size() >= 1, "Error, expected at least 1 block for surface "<<surfacePart.name());

--- a/src/element_promotion/LagrangeBasis.C
+++ b/src/element_promotion/LagrangeBasis.C
@@ -96,7 +96,7 @@ LagrangeBasis::LagrangeBasis(
   :  indicesMap_(indicesMap),
      basis1D_(nodeLocs),
      numNodes1D_(nodeLocs.size()),
-     polyOrder_(numNodes1D_),
+     polyOrder_(numNodes1D_-1),
      dim_(indicesMap[0].size())
 {
   for (auto& indices : indicesMap) {

--- a/src/element_promotion/PromotedPartHelper.C
+++ b/src/element_promotion/PromotedPartHelper.C
@@ -88,7 +88,7 @@ namespace nalu{
     return (base_name + super_element_suffix());
   }
   //--------------------------------------------------------------------------
-  std::string super_subset_part_name(const std::string& base_name)
+  std::string super_subset_part_name(std::string base_name)
   {
     // subsetted part name.  Goes like "surfacese_super_superside_1"
     // Ioss doesn't recognize "superside" but does recognize the "super" tag
@@ -104,7 +104,7 @@ namespace nalu{
 
     return name;
   }
-  std::string super_subset_part_name(const std::string& base_name, int  /* numElemNodes */, int  /* numSideNodes */)
+  std::string super_subset_part_name(std::string base_name, int  /* numElemNodes */, int  /* numSideNodes */)
   {
     // subsetted part name.  Goes like "surfacese_super512_superside64_1"
     // Ioss doesn't recognize "superside" but does recognize the "super" tag
@@ -288,6 +288,11 @@ namespace nalu{
       numEntities += ib->size();
     }
     return numEntities;
+  }
+  //--------------------------------------------------------------------------
+  stk::topology get_promoted_elem_topo(int dim, int order)
+  {
+    return (stk::create_superelement_topology(static_cast<unsigned>(std::pow(order+1, dim))));
   }
 
 } // namespace nalu

--- a/src/master_element/Hex27CVFEM.C
+++ b/src/master_element/Hex27CVFEM.C
@@ -331,9 +331,11 @@ HexahedralP2Element::eval_shape_derivs_at_shifted_ips()
 void
 HexahedralP2Element::eval_shape_derivs_at_face_ips()
 {
-  expFaceShapeDerivs_.resize(numIntPoints_*nodesPerElement_*nDim_);
+  const int numFaceIntPoints = intgExpFace_.size() / 3; // 216, same as numIntPoints_
+  ThrowAssert(intgExpFace_.size() % 3 == 0);
+  expFaceShapeDerivs_.resize(numFaceIntPoints*nodesPerElement_*nDim_);
   hex27_shape_deriv(
-    numIntPoints_,
+    numFaceIntPoints,
     intgExpFace_.data(),
     expFaceShapeDerivs_.data()
   );


### PR DESCRIPTION
* Just hooks up face_grad_op for hexs
* This hooks up the ability to use face-elem kernels with the tensor-product CVFEM code.  The tensor-product stuff will need its own BCs eventually, but they can use the usual promoted element versions for the time being.  
* Some misc clean up