### PR TITLE
modifying the selector to include shared nodes

### DIFF
--- a/src/utils/ComputeVectorDivergence.C
+++ b/src/utils/ComputeVectorDivergence.C
@@ -48,7 +48,7 @@ void compute_vector_divergence(
 
   std::vector<double> mvIp(nDim,0.0);
 
-  stk::mesh::Selector sel = meta.locally_owned_part()
+  stk::mesh::Selector sel = ( meta.locally_owned_part() | meta.globally_shared_part() )
                           & stk::mesh::selectUnion(partVec);
   const auto& bkts =
       bulk.get_buckets( stk::topology::ELEMENT_RANK, sel );

--- a/unit_tests/utils/UnitTestComputeVectorDivergence.C
+++ b/unit_tests/utils/UnitTestComputeVectorDivergence.C
@@ -62,7 +62,8 @@ TEST(utils, compute_vector_divergence)
   VectorFieldType* modelCoords = realm.meta_data().get_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates");
 
   // get the universal part
-  stk::mesh::Selector sel = stk::mesh::Selector(realm.meta_data().universal_part());
+  stk::mesh::Selector sel = stk::mesh::Selector(realm.meta_data().universal_part())
+                          & (realm.meta_data().locally_owned_part() | realm.meta_data().globally_shared_part());
   const auto& bkts = realm.bulk_data().get_buckets(stk::topology::NODE_RANK, sel);
 
   // fill mesh velocity vector
@@ -91,13 +92,8 @@ TEST(utils, compute_vector_divergence)
                                            partVec, bndyPartVec,
                                            meshVec, divV );
 
-  // create new selector for locally owned parts
-  sel = stk::mesh::Selector(realm.meta_data().universal_part())
-      & realm.meta_data().locally_owned_part();
-  const auto& lclBkts = realm.bulk_data().get_buckets(stk::topology::NODE_RANK, sel);
-
   // check values
-  for (auto b: lclBkts) {
+  for (auto b: bkts) {
     for (size_t in=0; in < b->size(); in++) {
 
       auto node = (*b)[in]; // mesh node and NOT YAML node


### PR DESCRIPTION
In `compute_vector_divergence` the selector currently includes only locally owned nodes. This prevents from zeroing out the nodes along the shared processor boundaries which results in incorrect computation of the divergence in parallel. 