### PR TITLE
Minor fixes.

### DIFF
--- a/include/InterfaceBalancer.h
+++ b/include/InterfaceBalancer.h
@@ -14,6 +14,8 @@
 
 #include "stk_mesh/base/Types.hpp"
 
+namespace stk { namespace mesh { class BulkData; } }
+
 namespace sierra {
 namespace nalu {
 

--- a/unit_tests/UnitTestHexMasterElementsNgp.C
+++ b/unit_tests/UnitTestHexMasterElementsNgp.C
@@ -157,7 +157,6 @@ void check_interpolation(
   const auto* const coordField = bulk.mesh_meta_data().coordinate_field();
   EXPECT_TRUE(coordField != nullptr);
   ngp::Field<double> ngpCoordField(bulk, *coordField);
-  ngpCoordField.copy_host_to_device(bulk, *coordField);
 
   Kokkos::View<DoubleType*,sierra::nalu::MemSpace> ngpResults("ngpResults", num_int_pt);
   Kokkos::View<DoubleType*,sierra::nalu::MemSpace>::HostMirror hostResults = Kokkos::create_mirror_view(ngpResults);
@@ -256,7 +255,6 @@ void check_derivatives(
   const auto* const coordField = bulk.mesh_meta_data().coordinate_field();
   EXPECT_TRUE(coordField != nullptr);
   ngp::Field<double> ngpCoordField(bulk, *coordField);
-  ngpCoordField.copy_host_to_device(bulk, *coordField);
 
   Kokkos::View<DoubleType**,sierra::nalu::MemSpace> ngpResults("ngpResults", num_int_pt, dim);
   Kokkos::View<DoubleType**,sierra::nalu::MemSpace>::HostMirror hostResults = Kokkos::create_mirror_view(ngpResults);

--- a/unit_tests/UnitTestNgpMesh1.C
+++ b/unit_tests/UnitTestNgpMesh1.C
@@ -123,8 +123,8 @@ void test_ngp_mesh_field_values(const stk::mesh::BulkData& bulk,
 
   ngpVelocity.modify_on_device();
   ngpMassFlowRate.modify_on_device();
-  ngpVelocity.copy_device_to_host();
-  ngpMassFlowRate.copy_device_to_host();
+  ngpVelocity.sync_to_host();
+  ngpMassFlowRate.sync_to_host();
 
   const double tol = 1.0e-16;
   for (const stk::mesh::Bucket* b : elemBuckets)


### PR DESCRIPTION
Need a forward-declaration for BulkData in InterfaceBalancer.h since
a coming change in stk's Types.hpp eliminates BulkData from that file.

Also, remove a couple of usages of ngp::Field::copy_device_to_host since
those methods are being deprecated in favor of sync_to_host etc.