### PR TITLE
GCL term enhancement and related modifications in mesh motion framework

### DIFF
--- a/include/ContinuityGclNodeSuppAlg.h
+++ b/include/ContinuityGclNodeSuppAlg.h
@@ -37,7 +37,9 @@ public:
   
   ScalarFieldType *densityNp1_;
   ScalarFieldType *divV_;
-  ScalarFieldType *dualNodalVolume_;
+  ScalarFieldType *dualNdVolNm1_;
+  ScalarFieldType *dualNdVolN_;
+  ScalarFieldType *dualNdVolNp1_;
   double dt_;
   double gamma1_;
 };

--- a/include/ContinuityGclNodeSuppAlg.h
+++ b/include/ContinuityGclNodeSuppAlg.h
@@ -42,6 +42,8 @@ public:
   ScalarFieldType *dualNdVolNp1_;
   double dt_;
   double gamma1_;
+  double gamma2_;
+  double gamma3_;
 };
 
 } // namespace nalu

--- a/include/MomentumGclSrcNodeSuppAlg.h
+++ b/include/MomentumGclSrcNodeSuppAlg.h
@@ -42,7 +42,10 @@ public:
   ScalarFieldType *dualNdVolN_;
   ScalarFieldType *dualNdVolNp1_;
   int nDim_;
-
+  double dt_;
+  double gamma1_;
+  double gamma2_;
+  double gamma3_;
 };
 
 } // namespace nalu

--- a/include/MomentumGclSrcNodeSuppAlg.h
+++ b/include/MomentumGclSrcNodeSuppAlg.h
@@ -38,7 +38,9 @@ public:
   VectorFieldType *velocityNp1_;
   ScalarFieldType *densityNp1_;
   ScalarFieldType *divV_;
-  ScalarFieldType *dualNodalVolume_;
+  ScalarFieldType *dualNdVolNm1_;
+  ScalarFieldType *dualNdVolN_;
+  ScalarFieldType *dualNdVolNp1_;
   int nDim_;
 
 };

--- a/include/mesh_motion/FrameBase.h
+++ b/include/mesh_motion/FrameBase.h
@@ -49,7 +49,7 @@ public:
     return isInertial_;
   }
 
-  virtual void post_work()
+  virtual void post_compute_geometry()
   {
   }
 

--- a/include/mesh_motion/FrameNonInertial.h
+++ b/include/mesh_motion/FrameNonInertial.h
@@ -27,6 +27,8 @@ public:
 
   void update_coordinates_velocity(const double time);
 
+  void post_compute_geometry();
+
 private:
   FrameNonInertial() = delete;
   FrameNonInertial(const FrameNonInertial&) = delete;
@@ -38,8 +40,6 @@ private:
   MotionBase::TransMatType compute_transformation(
     const double,
     const double*);
-
-  void post_work();
 };
 
 } // nalu

--- a/include/mesh_motion/MeshMotionAlg.h
+++ b/include/mesh_motion/MeshMotionAlg.h
@@ -21,6 +21,8 @@ public:
 
   void execute(const double);
 
+  void post_compute_geometry();
+
 private:
   MeshMotionAlg() = delete;
   MeshMotionAlg(const MeshMotionAlg&) = delete;

--- a/include/mesh_motion/MotionBase.h
+++ b/include/mesh_motion/MotionBase.h
@@ -38,12 +38,14 @@ public:
    * @param[in] time           Current time
    * @param[in] compTrans      Transformation matrix
    *                           for points other than xyz
-   * @param[in] xyz            Transformed coordinates
+   * @param[in] mxyz           Model coordinates
+   * @param[in] mxyz           Transformed coordinates
    */
   virtual ThreeDVecType compute_velocity(
     const double time,
     const TransMatType& compTrans,
-    const double* xyz ) = 0;
+    const double* mxyz,
+    const double* cxyz ) = 0;
 
   /** Composite addition of motions
    *
@@ -65,7 +67,7 @@ public:
     std::copy_n(centroid.begin(), threeDVecSize, origin_.begin());
   }
 
-  virtual void post_work(
+  virtual void post_compute_geometry(
     stk::mesh::BulkData&,
     stk::mesh::PartVector&,
     stk::mesh::PartVector&,

--- a/include/mesh_motion/MotionPulsatingSphere.h
+++ b/include/mesh_motion/MotionPulsatingSphere.h
@@ -11,7 +11,7 @@ class MotionPulsatingSphere : public MotionBase
 public:
   MotionPulsatingSphere(
     stk::mesh::MetaData&,
-      const YAML::Node&);
+    const YAML::Node&);
 
   virtual ~MotionPulsatingSphere()
   {

--- a/include/mesh_motion/MotionPulsatingSphere.h
+++ b/include/mesh_motion/MotionPulsatingSphere.h
@@ -22,21 +22,23 @@ public:
   /** Function to compute motion-specific velocity
    *
    * @param[in] time           Current time
-   * @param[in] comp_trans_mat Transformation matrix
+   * @param[in] compTrans      Transformation matrix
    *                           for points other than xyz
-   * @param[in] xyz            Transformed coordinates
+   * @param[in] mxyz           Model coordinates
+   * @param[in] mxyz           Transformed coordinates
    */
   virtual ThreeDVecType compute_velocity(
     const double time,
     const TransMatType& compTrans,
-    const double* xyz );
+    const double* mxyz,
+    const double* cxyz );
 
-  /** perform post work for this motion
+  /** perform post compute geometry work for this motion
    *
    * @param[in] computedMeshVelDiv flag to denote if divergence of
    *                               mesh velocity already computed
    */
-  void post_work(
+  void post_compute_geometry(
     stk::mesh::BulkData&,
     stk::mesh::PartVector&,
     stk::mesh::PartVector&,

--- a/include/mesh_motion/MotionRotation.h
+++ b/include/mesh_motion/MotionRotation.h
@@ -22,12 +22,14 @@ public:
    * @param[in] time           Current time
    * @param[in] compTrans      Transformation matrix
    *                           for points other than xyz
-   * @param[in] xyz            Transformed coordinates
+   * @param[in] mxyz           Model coordinates
+   * @param[in] mxyz           Transformed coordinates
    */
   virtual ThreeDVecType compute_velocity(
     const double time,
     const TransMatType& compTrans,
-    const double* xyz );
+    const double* mxyz,
+    const double* cxyz );
 
 private:
   MotionRotation() = delete;

--- a/include/mesh_motion/MotionScaling.h
+++ b/include/mesh_motion/MotionScaling.h
@@ -9,11 +9,12 @@ namespace nalu{
 class MotionScaling : public MotionBase
 {
 public:
-  MotionScaling(const YAML::Node&);
+  MotionScaling(
+    stk::mesh::MetaData&,
+    const YAML::Node&);
 
   virtual ~MotionScaling()
   {
-
   }
 
   virtual void build_transformation(const double, const double* = nullptr);
@@ -25,14 +26,21 @@ public:
    *                           for points other than xyz
    * @param[in] xyz            Transformed coordinates
    */
-  virtual ThreeDVecType compute_velocity(
+  ThreeDVecType compute_velocity(
     const double /* time */,
     const TransMatType& /* compTrans */,
-    const double* /* xyz */)
-  {
-    throw std::runtime_error(
-      "MotionScaling:compute_velocity() Scaling is not setup to be used as a non-inertial motion");
-  }
+    const double* /* xyz */);
+
+  /** perform post work for this motion
+   *
+   * @param[in] computedMeshVelDiv flag to denote if divergence of
+   *                               mesh velocity already computed
+   */
+  void post_work(
+    stk::mesh::BulkData&,
+    stk::mesh::PartVector&,
+    stk::mesh::PartVector&,
+    bool& computedMeshVelDiv );
 
 private:
   MotionScaling() = delete;
@@ -43,6 +51,9 @@ private:
   void scaling_mat(const ThreeDVecType&);
 
   ThreeDVecType factor_ = {{0.0,0.0,0.0}};
+  ThreeDVecType rate_ = {{0.0,0.0,0.0}};
+
+  bool useRate_ = false;
 };
 
 

--- a/include/mesh_motion/MotionScaling.h
+++ b/include/mesh_motion/MotionScaling.h
@@ -24,19 +24,21 @@ public:
    * @param[in] time           Current time
    * @param[in] compTrans      Transformation matrix
    *                           for points other than xyz
-   * @param[in] xyz            Transformed coordinates
+   * @param[in] mxyz           Model coordinates
+   * @param[in] mxyz           Transformed coordinates
    */
-  ThreeDVecType compute_velocity(
-    const double /* time */,
-    const TransMatType& /* compTrans */,
-    const double* /* xyz */);
+  virtual ThreeDVecType compute_velocity(
+    const double time,
+    const TransMatType& compTrans,
+    const double* mxyz,
+    const double* cxyz );
 
-  /** perform post work for this motion
+  /** perform post compute geometry work for this motion
    *
    * @param[in] computedMeshVelDiv flag to denote if divergence of
    *                               mesh velocity already computed
    */
-  void post_work(
+  void post_compute_geometry(
     stk::mesh::BulkData&,
     stk::mesh::PartVector&,
     stk::mesh::PartVector&,

--- a/include/mesh_motion/MotionTranslation.h
+++ b/include/mesh_motion/MotionTranslation.h
@@ -22,12 +22,14 @@ public:
    * @param[in] time           Current time
    * @param[in] compTrans      Transformation matrix
    *                           for points other than xyz
-   * @param[in] xyz            Transformed coordinates
+   * @param[in] mxyz           Model coordinates
+   * @param[in] mxyz           Transformed coordinates
    */
   virtual ThreeDVecType compute_velocity(
     const double time,
     const TransMatType& compTrans,
-    const double* xyz );
+    const double* mxyz,
+    const double* cxyz );
 
 private:
   MotionTranslation() = delete;

--- a/src/ContinuityGclNodeSuppAlg.C
+++ b/src/ContinuityGclNodeSuppAlg.C
@@ -50,7 +50,7 @@ ContinuityGclNodeSuppAlg::ContinuityGclNodeSuppAlg(
   divV_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity");
 
   ScalarFieldType *dualNdVol = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  dualNdVolNm1_ = &(dualNdVol->field_of_state(stk::mesh::StateNM1));
+  dualNdVolNm1_ = realm_.number_of_states() == 2 ? &(dualNdVol->field_of_state(stk::mesh::StateN)) : &(dualNdVol->field_of_state(stk::mesh::StateNM1));
   dualNdVolN_ = &(dualNdVol->field_of_state(stk::mesh::StateN));
   dualNdVolNp1_ = &(dualNdVol->field_of_state(stk::mesh::StateNP1));
 }

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -197,8 +197,9 @@ HeatCondEquationSystem::register_nodal_fields(
   tTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "tTmp"));
   stk::mesh::put_field_on_mesh(*tTmp_, *part, nullptr);
 
-  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume"));
+  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
+  realm_.augment_restart_variable_list("dual_nodal_volume");
 
   coordinates_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates"));
   stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);
@@ -230,6 +231,16 @@ HeatCondEquationSystem::register_nodal_fields(
                                stk::topology::NODE_RANK);
 
     copyStateAlg_.push_back(theCopyAlgA);
+
+    ScalarFieldType &dualNdVolN = dualNodalVolume_->field_of_state(stk::mesh::StateN);
+    ScalarFieldType &dualNdVolNp1 = dualNodalVolume_->field_of_state(stk::mesh::StateNP1);
+
+    CopyFieldAlgorithm *theCopyAlgDlNdVol
+      = new CopyFieldAlgorithm(realm_, part,
+                               &dualNdVolNp1, &dualNdVolN,
+                               0, 1,
+                               stk::topology::NODE_RANK);
+    copyStateAlg_.push_back(theCopyAlgDlNdVol);
   }
 }
 

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -197,7 +197,8 @@ HeatCondEquationSystem::register_nodal_fields(
   tTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "tTmp"));
   stk::mesh::put_field_on_mesh(*tTmp_, *part, nullptr);
 
-  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numStates));
+  const int numVolStates = realm_.does_mesh_move ? realm_.number_of_states() : 1;
+  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
   realm_.augment_restart_variable_list("dual_nodal_volume");
 
@@ -231,6 +232,8 @@ HeatCondEquationSystem::register_nodal_fields(
                                stk::topology::NODE_RANK);
 
     copyStateAlg_.push_back(theCopyAlgA);
+
+    if ( numVolStates <= 2 ) return;
 
     ScalarFieldType &dualNdVolN = dualNodalVolume_->field_of_state(stk::mesh::StateN);
     ScalarFieldType &dualNdVolNp1 = dualNodalVolume_->field_of_state(stk::mesh::StateNP1);

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -200,7 +200,7 @@ HeatCondEquationSystem::register_nodal_fields(
   const int numVolStates = realm_.does_mesh_move() ? realm_.number_of_states() : 1;
   dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
-  realm_.augment_restart_variable_list("dual_nodal_volume");
+  if (numVolStates > 1) realm_.augment_restart_variable_list("dual_nodal_volume");
 
   coordinates_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates"));
   stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -197,7 +197,7 @@ HeatCondEquationSystem::register_nodal_fields(
   tTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "tTmp"));
   stk::mesh::put_field_on_mesh(*tTmp_, *part, nullptr);
 
-  const int numVolStates = realm_.does_mesh_move ? realm_.number_of_states() : 1;
+  const int numVolStates = realm_.does_mesh_move() ? realm_.number_of_states() : 1;
   dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
   realm_.augment_restart_variable_list("dual_nodal_volume");

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -311,7 +311,8 @@ LowMachEquationSystem::register_nodal_fields(
   realm_.augment_property_map(VISCOSITY_ID, viscosity_);
 
   // dual nodal volume (should push up...)
-  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numStates));
+  const int numVolStates = realm_.does_mesh_move ? realm_.number_of_states() : 1;
+  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
   realm_.augment_restart_variable_list("dual_nodal_volume");
 
@@ -326,6 +327,8 @@ LowMachEquationSystem::register_nodal_fields(
                                0, 1,
                                stk::topology::NODE_RANK);
     copyStateAlg_.push_back(theCopyAlgDens);
+
+    if ( numVolStates <= 2 ) return;
 
     ScalarFieldType &dualNdVolN = dualNodalVolume_->field_of_state(stk::mesh::StateN);
     ScalarFieldType &dualNdVolNp1 = dualNodalVolume_->field_of_state(stk::mesh::StateNP1);

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -314,7 +314,7 @@ LowMachEquationSystem::register_nodal_fields(
   const int numVolStates = realm_.does_mesh_move() ? realm_.number_of_states() : 1;
   dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
-  realm_.augment_restart_variable_list("dual_nodal_volume");
+  if (numVolStates > 1) realm_.augment_restart_variable_list("dual_nodal_volume");
 
   // make sure all states are properly populated (restart can handle this)
   if ( numStates > 2 && (!realm_.restarted_simulation() || realm_.support_inconsistent_restart()) ) {

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -311,7 +311,7 @@ LowMachEquationSystem::register_nodal_fields(
   realm_.augment_property_map(VISCOSITY_ID, viscosity_);
 
   // dual nodal volume (should push up...)
-  const int numVolStates = realm_.does_mesh_move ? realm_.number_of_states() : 1;
+  const int numVolStates = realm_.does_mesh_move() ? realm_.number_of_states() : 1;
   dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
   realm_.augment_restart_variable_list("dual_nodal_volume");

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -311,20 +311,31 @@ LowMachEquationSystem::register_nodal_fields(
   realm_.augment_property_map(VISCOSITY_ID, viscosity_);
 
   // dual nodal volume (should push up...)
-  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume"));
+  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
+  realm_.augment_restart_variable_list("dual_nodal_volume");
 
   // make sure all states are properly populated (restart can handle this)
   if ( numStates > 2 && (!realm_.restarted_simulation() || realm_.support_inconsistent_restart()) ) {
     ScalarFieldType &densityN = density_->field_of_state(stk::mesh::StateN);
     ScalarFieldType &densityNp1 = density_->field_of_state(stk::mesh::StateNP1);
 
-    CopyFieldAlgorithm *theCopyAlg
+    CopyFieldAlgorithm *theCopyAlgDens
       = new CopyFieldAlgorithm(realm_, part,
                                &densityNp1, &densityN,
                                0, 1,
                                stk::topology::NODE_RANK);
-    copyStateAlg_.push_back(theCopyAlg);
+    copyStateAlg_.push_back(theCopyAlgDens);
+
+    ScalarFieldType &dualNdVolN = dualNodalVolume_->field_of_state(stk::mesh::StateN);
+    ScalarFieldType &dualNdVolNp1 = dualNodalVolume_->field_of_state(stk::mesh::StateNP1);
+
+    CopyFieldAlgorithm *theCopyAlgDlNdVol
+      = new CopyFieldAlgorithm(realm_, part,
+                               &dualNdVolNp1, &dualNdVolN,
+                               0, 1,
+                               stk::topology::NODE_RANK);
+    copyStateAlg_.push_back(theCopyAlgDlNdVol);
   }
 }
 

--- a/src/MomentumGclSrcNodeSuppAlg.C
+++ b/src/MomentumGclSrcNodeSuppAlg.C
@@ -11,6 +11,7 @@
 #include <Realm.h>
 #include <SolutionOptions.h>
 #include <SupplementalAlgorithm.h>
+#include <TimeIntegrator.h>
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/Entity.hpp>
@@ -35,17 +36,25 @@ MomentumGclSrcNodeSuppAlg::MomentumGclSrcNodeSuppAlg(
     velocityNp1_(NULL),
     densityNp1_(NULL),
     divV_(NULL),
-    dualNodalVolume_(NULL),
+    dualNdVolN_(NULL),
+    dualNdVolNp1_(NULL),
     nDim_(1)
 {
   // save off fields
   stk::mesh::MetaData & meta_data = realm_.meta_data();
   VectorFieldType *velocity = meta_data.get_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
   velocityNp1_ = &(velocity->field_of_state(stk::mesh::StateNP1));
+
   ScalarFieldType *density = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
   densityNp1_ = &(density->field_of_state(stk::mesh::StateNP1));
+
   divV_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity");
-  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+
+  ScalarFieldType *dualNdVol = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+  dualNdVolNm1_ = &(dualNdVol->field_of_state(stk::mesh::StateNM1));
+  dualNdVolN_ = &(dualNdVol->field_of_state(stk::mesh::StateN));
+  dualNdVolNp1_ = &(dualNdVol->field_of_state(stk::mesh::StateNP1));
+
   nDim_ = meta_data.spatial_dimension();
 }
 
@@ -67,14 +76,26 @@ MomentumGclSrcNodeSuppAlg::node_execute(
   double *rhs,
   stk::mesh::Entity node)
 {
+  auto* inactivePart = realm_.meta_data().get_part("out-HEX");
+
+  stk::mesh::PartVector partVec;
+  partVec.push_back(inactivePart);
+
+  if(realm_.bulk_data().bucket(node).member_any(partVec)) return;
+
   // rhs-= rho*u*div(v)
   const double *uNp1 = stk::mesh::field_data(*velocityNp1_, node );
   const double rhoNp1 = *stk::mesh::field_data(*densityNp1_, node );
   const double divV = *stk::mesh::field_data(*divV_, node );
-  const double dualVolume = *stk::mesh::field_data(*dualNodalVolume_, node );
-  const int nDim = nDim_;
-  const double fac = rhoNp1*divV*dualVolume;
-  for ( int i = 0; i < nDim; ++i ) {
+  const double dualVolumeNm1 = *stk::mesh::field_data(*dualNdVolNm1_, node );
+  const double dualVolumeN = *stk::mesh::field_data(*dualNdVolN_, node );
+  const double dualVolumeNp1 = *stk::mesh::field_data(*dualNdVolNp1_, node );
+
+  double dt = realm_.timeIntegrator_->get_time_step();
+  double volRate = (1.5*dualVolumeNp1 - 2.0*dualVolumeN + 0.5*dualVolumeNm1) / dt / dualVolumeNp1;
+
+  const double fac = rhoNp1*divV*dualVolumeNp1;
+  for ( int i = 0; i < nDim_; ++i ) {
     rhs[i] -= fac*uNp1[i];
   }
 }

--- a/src/MomentumGclSrcNodeSuppAlg.C
+++ b/src/MomentumGclSrcNodeSuppAlg.C
@@ -54,7 +54,7 @@ MomentumGclSrcNodeSuppAlg::MomentumGclSrcNodeSuppAlg(
   divV_ = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity");
 
   ScalarFieldType *dualNdVol = meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  dualNdVolNm1_ = &(dualNdVol->field_of_state(stk::mesh::StateNM1));
+  dualNdVolNm1_ = realm_.number_of_states() == 2 ? &(dualNdVol->field_of_state(stk::mesh::StateN)) : &(dualNdVol->field_of_state(stk::mesh::StateNM1));
   dualNdVolN_ = &(dualNdVol->field_of_state(stk::mesh::StateN));
   dualNdVolNp1_ = &(dualNdVol->field_of_state(stk::mesh::StateNP1));
 

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -531,7 +531,8 @@ Realm::initialize()
 
   compute_geometry();
 
-  meshMotionAlg_->post_compute_geometry();
+  if ( solutionOptions_->meshMotion_ )
+    meshMotionAlg_->post_compute_geometry();
 
   if ( hasNonConformal_ )
     initialize_non_conformal();

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -531,6 +531,8 @@ Realm::initialize()
 
   compute_geometry();
 
+  meshMotionAlg_->post_compute_geometry();
+
   if ( hasNonConformal_ )
     initialize_non_conformal();
 
@@ -1886,7 +1888,10 @@ Realm::pre_timestep_work()
   if ( solutionOptions_->meshMotion_ ) {
 
     meshMotionAlg_->execute( get_current_time() );
+
     compute_geometry();
+
+    meshMotionAlg_->post_compute_geometry();
 
     // and non-conformal algorithm
     if ( hasNonConformal_ )

--- a/src/mesh_motion/FrameBase.C
+++ b/src/mesh_motion/FrameBase.C
@@ -55,7 +55,7 @@ void FrameBase::load(const YAML::Node& node)
     else if (type == "rotation")
       meshMotionVec_[i].reset(new MotionRotation(motion_def));
     else if (type == "scaling")
-      meshMotionVec_[i].reset(new MotionScaling(motion_def));
+      meshMotionVec_[i].reset(new MotionScaling(meta_,motion_def));
     else if (type == "translation")
       meshMotionVec_[i].reset(new MotionTranslation(motion_def));
     else

--- a/src/mesh_motion/FrameNonInertial.C
+++ b/src/mesh_motion/FrameNonInertial.C
@@ -71,7 +71,7 @@ void FrameNonInertial::update_coordinates_velocity(const double time)
       // motions in current motion frame
       for (auto& mm: meshMotionVec_)
       {
-        MotionBase::ThreeDVecType mm_vel = mm->compute_velocity(time,trans_mat,cX);
+        MotionBase::ThreeDVecType mm_vel = mm->compute_velocity(time,trans_mat,mX,cX);
 
         for (int d = 0; d < nDim; d++)
           velxyz[d] += mm_vel[d];
@@ -100,13 +100,13 @@ MotionBase::TransMatType FrameNonInertial::compute_transformation(
   return comp_trans_mat;
 }
 
-void FrameNonInertial::post_work()
+void FrameNonInertial::post_compute_geometry()
 {
   // flag denoting if mesh velocity divergence already computed
   bool computedMeshVelDiv = false;
 
   for (auto& mm: meshMotionVec_)
-    mm->post_work(bulk_,partVec_,partVecBc_,computedMeshVelDiv);
+    mm->post_compute_geometry(bulk_,partVec_,partVecBc_,computedMeshVelDiv);
 }
 
 } // nalu

--- a/src/mesh_motion/FrameNonInertial.C
+++ b/src/mesh_motion/FrameNonInertial.C
@@ -63,7 +63,7 @@ void FrameNonInertial::update_coordinates_velocity(const double time)
         dx[d] = xyz[d] - mX[d];
       } // end for loop - d index
 
-      // copy over model coordinates
+      // copy over current coordinates
       for ( int i = 0; i < nDim; ++i )
         cX[i] = xyz[i];
 

--- a/src/mesh_motion/MeshMotionAlg.C
+++ b/src/mesh_motion/MeshMotionAlg.C
@@ -93,9 +93,13 @@ void MeshMotionAlg::execute(const double time)
 
     if( !frameVec_[i]->is_inertial() )
       frameVec_[i]->update_coordinates_velocity(time);
-
-    frameVec_[i]->post_work();
   }
+}
+
+void MeshMotionAlg::post_compute_geometry()
+{
+  for (size_t i=0; i < frameVec_.size(); i++)
+    frameVec_[i]->post_compute_geometry();
 }
 
 } // nalu

--- a/src/mesh_motion/MotionPulsatingSphere.C
+++ b/src/mesh_motion/MotionPulsatingSphere.C
@@ -100,15 +100,16 @@ void MotionPulsatingSphere::scaling_mat(
 MotionBase::ThreeDVecType MotionPulsatingSphere::compute_velocity(
   const double time,
   const TransMatType&  /* compTrans */,
-  const double* xyz )
+  const double* mxyz,
+  const double* /* cxyz */ )
 {
   ThreeDVecType vel = {};
 
   if( (time < startTime_) || (time > endTime_) ) return vel;
 
-  double radius = std::sqrt( std::pow(xyz[0]-origin_[0],2)
-                            +std::pow(xyz[1]-origin_[1],2)
-                            +std::pow(xyz[2]-origin_[2],2));
+  double radius = std::sqrt( std::pow(mxyz[0]-origin_[0],2)
+                            +std::pow(mxyz[1]-origin_[1],2)
+                            +std::pow(mxyz[2]-origin_[2],2));
 
   double pulsatingVelocity =
     amplitude_ * std::sin(2*M_PI*frequency_*time) * 2*M_PI*frequency_ / radius;
@@ -117,12 +118,12 @@ MotionBase::ThreeDVecType MotionPulsatingSphere::compute_velocity(
   if(radius == 0) pulsatingVelocity = 0;
 
   for (int d=0; d < threeDVecSize; d++)
-    vel[d] = pulsatingVelocity * (xyz[d]-origin_[d]);
+    vel[d] = pulsatingVelocity * (mxyz[d]-origin_[d]);
 
   return vel;
 }
 
-void MotionPulsatingSphere::post_work(
+void MotionPulsatingSphere::post_compute_geometry(
   stk::mesh::BulkData& bulk,
   stk::mesh::PartVector& partVec,
   stk::mesh::PartVector& partVecBc,

--- a/src/mesh_motion/MotionPulsatingSphere.C
+++ b/src/mesh_motion/MotionPulsatingSphere.C
@@ -69,6 +69,7 @@ void MotionPulsatingSphere::scaling_mat(
   double curr_radius = radius + amplitude_*(1 - std::cos(2*M_PI*frequency_*time));
 
   double uniform_scaling = curr_radius/radius;
+  if(radius == 0.0) uniform_scaling = 1.0;
 
   // Build matrix for translating object to cartesian origin
   transMat_[0][3] = -origin_[0];
@@ -112,13 +113,11 @@ MotionBase::ThreeDVecType MotionPulsatingSphere::compute_velocity(
   double pulsatingVelocity =
     amplitude_ * std::sin(2*M_PI*frequency_*time) * 2*M_PI*frequency_ / radius;
 
-  double eps = std::numeric_limits<double>::epsilon();
+  // account for zero radius
+  if(radius == 0) pulsatingVelocity = 0;
 
   for (int d=0; d < threeDVecSize; d++)
-  {
-    int signum = (-eps < xyz[d]-origin_[d]) - (xyz[d]-origin_[d] < eps);
-    vel[d] = signum * pulsatingVelocity * (xyz[d]-origin_[d]);
-  }
+    vel[d] = pulsatingVelocity * (xyz[d]-origin_[d]);
 
   return vel;
 }

--- a/src/mesh_motion/MotionRotation.C
+++ b/src/mesh_motion/MotionRotation.C
@@ -120,7 +120,8 @@ void MotionRotation::rotation_mat(const double angle)
 MotionBase::ThreeDVecType MotionRotation::compute_velocity(
   const double time,
   const TransMatType& compTrans,
-  const double* xyz )
+  const double* /* mxyz */,
+  const double* cxyz )
 {
   ThreeDVecType vel = {};
 
@@ -151,7 +152,7 @@ MotionBase::ThreeDVecType MotionRotation::compute_velocity(
   ThreeDVecType relCoord = {};
   ThreeDVecType vecOmega = {};
   for (int d=0; d < threeDVecSize; d++) {
-    relCoord[d] = xyz[d] - transOrigin[d];
+    relCoord[d] = cxyz[d] - transOrigin[d];
     vecOmega[d] = omega_*unitVec[d];
   }
 

--- a/src/mesh_motion/MotionScaling.C
+++ b/src/mesh_motion/MotionScaling.C
@@ -108,20 +108,30 @@ void MotionScaling::scaling_mat(const ThreeDVecType& factor)
 
 MotionBase::ThreeDVecType MotionScaling::compute_velocity(
   const double time,
-  const TransMatType&  /* compTrans */,
-  const double* xyz )
+  const TransMatType& compTrans,
+  const double* mxyz,
+  const double* /* cxyz */ )
 {
   ThreeDVecType vel = {};
 
   if( (time < startTime_) || (time > endTime_) ) return vel;
 
+  // transform the origin of the scaling body
+  ThreeDVecType transOrigin = {};
+  for (int d = 0; d < threeDVecSize; d++) {
+    transOrigin[d] = compTrans[d][0]*origin_[0]
+                    +compTrans[d][1]*origin_[1]
+                    +compTrans[d][2]*origin_[2]
+                    +compTrans[d][3];
+  }
+
   for (int d=0; d < threeDVecSize; d++)
-    vel[d] = rate_[d] * (xyz[d]-origin_[d]);
+    vel[d] = rate_[d] * (mxyz[d]-transOrigin[d]);
 
   return vel;
 }
 
-void MotionScaling::post_work(
+void MotionScaling::post_compute_geometry(
   stk::mesh::BulkData& bulk,
   stk::mesh::PartVector& partVec,
   stk::mesh::PartVector& partVecBc,

--- a/src/mesh_motion/MotionScaling.C
+++ b/src/mesh_motion/MotionScaling.C
@@ -2,20 +2,50 @@
 #include "mesh_motion/MotionScaling.h"
 
 #include <NaluParsing.h>
+#include "utils/ComputeVectorDivergence.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/FieldBLAS.hpp>
 
 #include <cmath>
 
 namespace sierra{
 namespace nalu{
 
-MotionScaling::MotionScaling(const YAML::Node& node)
+MotionScaling::MotionScaling(
+  stk::mesh::MetaData& meta,
+  const YAML::Node& node)
   : MotionBase()
 {
   load(node);
+
+  if( useRate_ ) {
+    // declare divergence of mesh velocity for this motion
+    ScalarFieldType *divV = &(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity"));
+    stk::mesh::put_field_on_mesh(*divV, meta.universal_part(), nullptr);
+    stk::mesh::field_fill(0.0, *divV);
+  }
 }
 
 void MotionScaling::load(const YAML::Node& node)
 {
+  // perturb start and end times with a small value for
+  // accurate comparison with floats
+  double eps = std::numeric_limits<double>::epsilon();
+
+  get_if_present(node, "start_time", startTime_, startTime_);
+  startTime_ = startTime_-eps;
+
+  get_if_present(node, "end_time", endTime_, endTime_);
+  endTime_ = endTime_+eps;
+
+  // translation could be based on rate or factor
+  if( node["rate"] )
+     rate_ = node["rate"].as<ThreeDVecType>();
+
+  // default approach is to use a constant displacement
+  useRate_ = ( node["rate"] ? true : false);
+
   if( node["factor"] )
     factor_ = node["factor"].as<ThreeDVecType>();
 
@@ -25,10 +55,25 @@ void MotionScaling::load(const YAML::Node& node)
 }
 
 void MotionScaling::build_transformation(
-  const double  /* time */,
-  const double*  /* xyz */)
+  const double time,
+  const double* /* xyz */)
 {
-  scaling_mat(factor_);
+  if(time < (startTime_)) return;
+
+  double motionTime = (time < endTime_)? time : endTime_;
+
+  // determine translation based on user defined input
+  if (useRate_)
+  {
+    ThreeDVecType curr_fac = {};
+
+    for (int d=0; d < threeDVecSize; d++)
+      curr_fac[d] = rate_[d]*(motionTime-startTime_) + 1.0;
+
+    scaling_mat(curr_fac);
+  }
+  else
+    scaling_mat(factor_);
 }
 
 void MotionScaling::scaling_mat(const ThreeDVecType& factor)
@@ -59,6 +104,40 @@ void MotionScaling::scaling_mat(const ThreeDVecType& factor)
 
   // composite addition of motions
   transMat_ = add_motion(currTransMat,transMat_);
+}
+
+MotionBase::ThreeDVecType MotionScaling::compute_velocity(
+  const double time,
+  const TransMatType&  /* compTrans */,
+  const double* xyz )
+{
+  ThreeDVecType vel = {};
+
+  if( (time < startTime_) || (time > endTime_) ) return vel;
+
+  for (int d=0; d < threeDVecSize; d++)
+    vel[d] = rate_[d] * (xyz[d]-origin_[d]);
+
+  return vel;
+}
+
+void MotionScaling::post_work(
+  stk::mesh::BulkData& bulk,
+  stk::mesh::PartVector& partVec,
+  stk::mesh::PartVector& partVecBc,
+  bool& computedMeshVelDiv)
+{
+  if(computedMeshVelDiv || !useRate_) return;
+
+  // compute divergence of mesh velocity
+  VectorFieldType* meshVelocity = bulk.mesh_meta_data().get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "mesh_velocity");
+
+  ScalarFieldType* meshDivVelocity = bulk.mesh_meta_data().get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "div_mesh_velocity");
+
+  compute_vector_divergence(bulk, partVec, partVecBc, meshVelocity, meshDivVelocity, true);
+  computedMeshVelDiv = true;
 }
 
 } // nalu

--- a/src/mesh_motion/MotionTranslation.C
+++ b/src/mesh_motion/MotionTranslation.C
@@ -39,7 +39,7 @@ void MotionTranslation::load(const YAML::Node& node)
 
 void MotionTranslation::build_transformation(
   const double time,
-  const double*  /* xyz */)
+  const double* /* mxyz */ )
 {
   if(time < (startTime_)) return;
 
@@ -71,7 +71,8 @@ void MotionTranslation::translation_mat(const ThreeDVecType& curr_disp)
 MotionBase::ThreeDVecType MotionTranslation::compute_velocity(
   const double time,
   const TransMatType&  /* compTrans */,
-  const double*  /* xyz */ )
+  const double* /* mxyz */,
+  const double* /* cxyz */ )
 {
   ThreeDVecType vel = {};
 

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -405,7 +405,7 @@ RadiativeTransportEquationSystem::register_nodal_fields(
   iTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "iTmp"));
   stk::mesh::put_field_on_mesh(*iTmp_, *part, nullptr);
 
-  const int numVolStates = realm_.does_mesh_move ? realm_.number_of_states() : 1;
+  const int numVolStates = realm_.does_mesh_move() ? realm_.number_of_states() : 1;
   dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
   realm_.augment_restart_variable_list("dual_nodal_volume");

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -408,7 +408,7 @@ RadiativeTransportEquationSystem::register_nodal_fields(
   const int numVolStates = realm_.does_mesh_move() ? realm_.number_of_states() : 1;
   dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
-  realm_.augment_restart_variable_list("dual_nodal_volume");
+  if (numVolStates > 1) realm_.augment_restart_variable_list("dual_nodal_volume");
 
   coordinates_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "coordinates"));
   stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -405,7 +405,8 @@ RadiativeTransportEquationSystem::register_nodal_fields(
   iTmp_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "iTmp"));
   stk::mesh::put_field_on_mesh(*iTmp_, *part, nullptr);
 
-  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numStates));
+  const int numVolStates = realm_.does_mesh_move ? realm_.number_of_states() : 1;
+  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
   stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
   realm_.augment_restart_variable_list("dual_nodal_volume");
 
@@ -445,7 +446,7 @@ RadiativeTransportEquationSystem::register_nodal_fields(
     realm_.augment_property_map(SCATTERING_COEFF_ID, scatteringCoeff_);
   
   // make sure all states are properly populated (restart can handle this)
-  if ( numStates > 2 && (!realm_.restarted_simulation() || realm_.support_inconsistent_restart()) ) {
+  if ( numVolStates > 2 && (!realm_.restarted_simulation() || realm_.support_inconsistent_restart()) ) {
     ScalarFieldType &dualNdVolN = dualNodalVolume_->field_of_state(stk::mesh::StateN);
     ScalarFieldType &dualNdVolNp1 = dualNodalVolume_->field_of_state(stk::mesh::StateNP1);
 

--- a/unit_tests/mesh_motion/UnitTestCompositeFrames.C
+++ b/unit_tests/mesh_motion/UnitTestCompositeFrames.C
@@ -55,6 +55,7 @@ namespace {
   const double testTol = 1e-12;
 
   sierra::nalu::MotionBase::TransMatType eval_transformation(
+    sierra::nalu::Realm& realm,
     double time,
     const double* xyz)
   {
@@ -63,7 +64,7 @@ namespace {
       = sierra::nalu::MotionBase::identityMat_;
 
     // perform scaling transformation
-    sierra::nalu::MotionScaling scaleClass(scaleNode);
+    sierra::nalu::MotionScaling scaleClass(realm.meta_data(), scaleNode);
     scaleClass.build_transformation(time, xyz);
     comp_trans = scaleClass.add_motion(scaleClass.get_trans_mat(), comp_trans);
 
@@ -186,7 +187,7 @@ TEST(meshMotion, meshMotionAlg_initialize)
       double*  vel = stk::mesh::field_data(*meshVelocity, node);
 
       sierra::nalu::MotionBase::TransMatType transMat =
-        eval_transformation(currTime, oxyz);
+        eval_transformation(realm, currTime, oxyz);
 
       std::vector<double> gold_norm_xyz = eval_coords(transMat, oxyz);
       std::vector<double> gold_norm_vel = eval_vel(currTime, transMat, &gold_norm_xyz[0]);
@@ -254,7 +255,7 @@ TEST(meshMotion, meshMotionAlg_execute)
       double*  vel = stk::mesh::field_data(*meshVelocity, node);
 
       sierra::nalu::MotionBase::TransMatType transMat =
-        eval_transformation(currTime, oxyz);
+        eval_transformation(realm,currTime, oxyz);
 
       std::vector<double> gold_norm_xyz = eval_coords(transMat, oxyz);
       std::vector<double> gold_norm_vel = eval_vel(currTime, transMat, &gold_norm_xyz[0]);

--- a/unit_tests/mesh_motion/UnitTestCompositeFrames.C
+++ b/unit_tests/mesh_motion/UnitTestCompositeFrames.C
@@ -111,14 +111,15 @@ namespace {
   std::vector<double> eval_vel(
     const double time,
     const sierra::nalu::MotionBase::TransMatType& transMat,
-    double* xyz )
+    const double* mxyz,
+    const double* cxyz )
   {
     std::vector<double> vel(3,0.0);
 
     // perform rotation transformation
     sierra::nalu::MotionRotation rotClass(rotNode);
     sierra::nalu::MotionBase::ThreeDVecType motionVel =
-      rotClass.compute_velocity(time, transMat, xyz);
+      rotClass.compute_velocity(time, transMat, mxyz, cxyz);
 
     for (size_t d = 0; d < vel.size(); d++)
       vel[d] += motionVel[d];
@@ -130,7 +131,7 @@ namespace {
     if( (time >= (startTime-testTol)) && (time <= (endTime+testTol)) )
     {
       sierra::nalu::MotionTranslation transClass(transNode);
-      motionVel = transClass.compute_velocity(time, transMat, xyz);
+      motionVel = transClass.compute_velocity(time, transMat, mxyz, cxyz);
 
       for (size_t d = 0; d < vel.size(); d++)
         vel[d] += motionVel[d];
@@ -190,7 +191,7 @@ TEST(meshMotion, meshMotionAlg_initialize)
         eval_transformation(realm, currTime, oxyz);
 
       std::vector<double> gold_norm_xyz = eval_coords(transMat, oxyz);
-      std::vector<double> gold_norm_vel = eval_vel(currTime, transMat, &gold_norm_xyz[0]);
+      std::vector<double> gold_norm_vel = eval_vel(currTime, transMat, oxyz, &gold_norm_xyz[0]);
 
       EXPECT_NEAR(xyz[0], gold_norm_xyz[0], testTol);
       EXPECT_NEAR(xyz[1], gold_norm_xyz[1], testTol);
@@ -258,7 +259,7 @@ TEST(meshMotion, meshMotionAlg_execute)
         eval_transformation(realm,currTime, oxyz);
 
       std::vector<double> gold_norm_xyz = eval_coords(transMat, oxyz);
-      std::vector<double> gold_norm_vel = eval_vel(currTime, transMat, &gold_norm_xyz[0]);
+      std::vector<double> gold_norm_vel = eval_vel(currTime, transMat, oxyz, &gold_norm_xyz[0]);
 
       EXPECT_NEAR(xyz[0], gold_norm_xyz[0], testTol);
       EXPECT_NEAR(xyz[1], gold_norm_xyz[1], testTol);

--- a/unit_tests/mesh_motion/UnitTestCompositeMotions.C
+++ b/unit_tests/mesh_motion/UnitTestCompositeMotions.C
@@ -66,7 +66,7 @@ TEST(meshMotion, composite_motions)
 
   // compute rotational velocity in absence of translation
   sierra::nalu::MotionBase::ThreeDVecType rotVel =
-    rotClass.compute_velocity(time, rotClass.get_trans_mat(), &rotCoord[0]);
+    rotClass.compute_velocity(time, rotClass.get_trans_mat(), xyz, &rotCoord[0]);
 
   // initialize the mesh translation class
   sierra::nalu::MotionTranslation transClass(transNode);
@@ -76,7 +76,7 @@ TEST(meshMotion, composite_motions)
 
   // compute rotational velocity in absence of translation
   sierra::nalu::MotionBase::ThreeDVecType compVelRot =
-    rotClass.compute_velocity(time, comp_trans, &newCoord[0]);
+    rotClass.compute_velocity(time, comp_trans, xyz, &newCoord[0]);
 
   // ensure the rotational componenets of the velocity remains same
   EXPECT_NEAR(compVelRot[0], rotVel[0], testTol);

--- a/unit_tests/mesh_motion/UnitTestMotionTypes.C
+++ b/unit_tests/mesh_motion/UnitTestMotionTypes.C
@@ -60,7 +60,7 @@ TEST(meshMotion, rotation_omega)
   EXPECT_NEAR(norm[2], gold_norm_z, testTol);
 
   sierra::nalu::MotionBase::ThreeDVecType vel =
-    rotClass.compute_velocity(time, rotClass.get_trans_mat(), &xyz[0]);
+    rotClass.compute_velocity(time, rotClass.get_trans_mat(), nullptr, &xyz[0]);
 
   const double gold_norm_vx = -3.0;
   const double gold_norm_vy =  6.6;

--- a/unit_tests/mesh_motion/UnitTestMotionTypes.C
+++ b/unit_tests/mesh_motion/UnitTestMotionTypes.C
@@ -5,6 +5,8 @@
 #include "mesh_motion/MotionScaling.h"
 #include "mesh_motion/MotionTranslation.h"
 
+#include "UnitTestRealm.h"
+
 namespace {
 
   const double testTol = 1e-14;
@@ -108,8 +110,12 @@ TEST(meshMotion, scaling)
 
   YAML::Node scaleNode = YAML::Load(scaleInfo);
 
+  // create realm
+  unit_test_utils::NaluTest naluObj;
+  sierra::nalu::Realm& realm = naluObj.create_realm();
+
   // initialize the mesh scaling class
-  sierra::nalu::MotionScaling scaleClass(scaleNode);
+  sierra::nalu::MotionScaling scaleClass(realm.meta_data(), scaleNode);
 
   // build transformation
   const double time = 0.0;


### PR DESCRIPTION
This pull request addresses the following points - 

1) The GCL term has been modified to account for the error due to discretization between `dV/dT` and `divV`. This requires dual nodal volume to have multiple states which have been introduced as and where required. This pull request is designed such that dual nodal volumes have multiple states only if the mesh moves.

2) The computation of `divV` in presence of mesh motion has been moved to after call to `compute_geometry`. Consequently `post_work` within the mesh motion framework has been changed to `post_compute_geometry` for an explicit understanding of anyone who reads the code.

3) General cleanup and minor modification of the mesh motion framework was performed including adding a rate-based scaling motion. This motion acts as a guideline for motions that may be added in the future involving deforming meshes.  