### PR TITLE
Use global node IDs to minimize fringe/field mismatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,9 @@ if(ENABLE_TIOGA)
   endif()
   include_directories(${TIOGA_INCLUDE_DIRS})
   add_definitions("-DNALU_USES_TIOGA")
+  if(TIOGA_HAS_NODEGID)
+    add_definitions("-DTIOGA_HAS_NODEGID")
+  endif()
 endif()
 
 ########################### NALU #####################################

--- a/src/overset/TiogaBlock.C
+++ b/src/overset/TiogaBlock.C
@@ -485,6 +485,9 @@ void TiogaBlock::register_block(TIOGA::tioga& tg)
     num_cells_.data(),  // Number of cells for each topology
     tioga_conn_,        // Element node connectivity information
     elemid_map_.data()  // Global ID for the element array
+#ifdef TIOGA_HAS_NODEGID
+    ,nodeid_map_.data() // Global ID for the node array
+#endif
   );
   // Indicate that we want element IBLANK information returned
   tg.set_cell_iblank(meshtag_, iblank_cell_.data());


### PR DESCRIPTION
Pass global Node IDs to TIOGA API for use in determining unique nodes
across processor interface and minimize the fringe/field mismatches.