### PR TITLE
Change output behavior of Nalu-Wind

### DIFF
--- a/include/OutputInfo.h
+++ b/include/OutputInfo.h
@@ -71,6 +71,8 @@ public:
   Ioss::PropertyManager *restartPropertyManager_;
 
   std::set<std::string> outputFieldNameSet_;
+  //! List of fields explicity disabled by user for output
+  std::set<std::string> disabledOutputSet_;
   std::set<std::string> restartFieldNameSet_;
 
 };

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -279,6 +279,7 @@ EnthalpyEquationSystem::register_nodal_fields(
   // temperature required in restart
   temperature_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature"));
   stk::mesh::put_field_on_mesh(*temperature_, *part, nullptr);
+  realm_.augment_output_variable_list("temperature");
   realm_.augment_restart_variable_list("temperature");
 
   dhdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dhdx"));

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1043,6 +1043,7 @@ MomentumEquationSystem::register_nodal_fields(
   // register dof; set it as a restart variable
   velocity_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity", numStates));
   stk::mesh::put_field_on_mesh(*velocity_, *part, nDim, nullptr);
+  realm_.augment_output_variable_list("velocity");
   realm_.augment_restart_variable_list("velocity");
 
   dudx_ =  &(meta_data.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx"));
@@ -1061,6 +1062,7 @@ MomentumEquationSystem::register_nodal_fields(
   if ( realm_.is_turbulent() ) {
     tvisc_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_viscosity"));
     stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
+    realm_.augment_output_variable_list("turbulent_viscosity");
     evisc_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "effective_viscosity_u"));
     stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
   }
@@ -2704,6 +2706,7 @@ ContinuityEquationSystem::register_nodal_fields(
   // register dof; set it as a restart variable
   pressure_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure"));
   stk::mesh::put_field_on_mesh(*pressure_, *part, nullptr);
+  realm_.augment_output_variable_list("pressure");
   realm_.augment_restart_variable_list("pressure");
 
   dpdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx"));

--- a/src/OutputInfo.C
+++ b/src/OutputInfo.C
@@ -146,6 +146,15 @@ OutputInfo::load(
         outputFieldNameSet_.insert(fieldName);
       }
     }
+
+    if (y_output["disabled_output_variables"]) {
+      auto& node = y_output["disabled_output_variables"];
+      auto numFields = node.size();
+      for (size_t i =0; i < numFields; ++i) {
+        auto fieldName = node[i].as<std::string>();
+        disabledOutputSet_.insert(fieldName);
+      }
+    }
   }
   
   // output for restart

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -161,6 +161,7 @@ SpecificDissipationRateEquationSystem::register_nodal_fields(
   // register dof; set it as a restart variable
   sdr_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_dissipation_rate", numStates));
   stk::mesh::put_field_on_mesh(*sdr_, *part, nullptr);
+  realm_.augment_output_variable_list("specific_dissipation_rate");
   realm_.augment_restart_variable_list("specific_dissipation_rate");
 
   dwdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dwdx"));

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -185,6 +185,7 @@ TurbKineticEnergyEquationSystem::register_nodal_fields(
   // register dof; set it as a restart variable
   tke_ =  &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "turbulent_ke", numStates));
   stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);
+  realm_.augment_output_variable_list("turbulent_ke");
   realm_.augment_restart_variable_list("turbulent_ke");
 
   dkdx_ =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dkdx"));

--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -291,12 +291,14 @@ TurbulenceAveragingPostProcessing::setup()
         const std::string vorticityName = "vorticity";
         VectorFieldType *vortField = &(metaData.declare_field<VectorFieldType>(stk::topology::NODE_RANK, vorticityName));
         stk::mesh::put_field_on_mesh(*vortField, *targetPart, vortSize, nullptr);
+        realm_.augment_output_variable_list(vorticityName);
       }
 
       if ( avInfo->computeQcriterion_ ) {
         const std::string QcritName = "q_criterion";
         const int sizeOfField = 1;
         register_field(QcritName, sizeOfField, metaData, targetPart);
+        realm_.augment_output_variable_list(QcritName);
       }
 
       if ( avInfo->computeLambdaCI_ ) {
@@ -554,14 +556,6 @@ TurbulenceAveragingPostProcessing::review(
       NaluEnv::self().naluOutputP0() << "Sub-filter scale Stress will be computed; add sfs_stress to output"<< std::endl;
   }
 
-  if ( avInfo->computeVorticity_ ) {
-    NaluEnv::self().naluOutputP0() << "Vorticity will be computed; add vorticity to output"<< std::endl;
-  }
-  
-  if ( avInfo->computeQcriterion_ ) {
-    NaluEnv::self().naluOutputP0() << "Q criterion will be computed; add q_criterion to output"<< std::endl;
-  }
-  
   if ( avInfo->computeLambdaCI_ ) {
     NaluEnv::self().naluOutputP0() << "Lambda CI will be computed; add lambda_ci to output"<< std::endl;
   }


### PR DESCRIPTION
Currently, Nalu-Wind requires user to explicitly list the variables in the
output section. This commit changes the default behavior so that certain
variables are automatically added to the output list without the user explicitly
listing them in the `output_variables` list. The new list
`disabled_output_variables` is provided to explicitly disable output of these
variables.