### PR TITLE
MasterElement creation and usage within Kernel on GPUs

### DIFF
--- a/include/master_element/Edge22DCVFEM.h
+++ b/include/master_element/Edge22DCVFEM.h
@@ -39,7 +39,7 @@ public:
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     const int nelem,

--- a/include/master_element/Edge32DCVFEM.h
+++ b/include/master_element/Edge32DCVFEM.h
@@ -43,7 +43,7 @@ public:
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     const int nelem,

--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -241,7 +241,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~Hex27SCV() {}
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
@@ -428,7 +428,7 @@ public:
 
   virtual const int * adjacentNodes() final;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   int opposingNodes(
     const int ordinal, const int node);

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -50,11 +50,13 @@ class HexSCV : public MasterElement
 public:
   using AlgTraits = AlgTraitsHex8;
 
+  KOKKOS_FUNCTION
   HexSCV();
+
   KOKKOS_FUNCTION
   virtual ~HexSCV() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   using MasterElement::determinant;
   using MasterElement::shifted_grad_op;
@@ -158,11 +160,13 @@ public:
   using MasterElement::adjacentNodes;
 
 
+  KOKKOS_FUNCTION
   HexSCS();
+
   KOKKOS_FUNCTION
   virtual ~HexSCS() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   using MasterElement::determinant;
 

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -191,8 +191,13 @@ public:
     throw std::runtime_error("scsIpEdgeOrd not implemented");
     }
 
-  virtual const int * ipNodeMap(int /* ordinal */ = 0) const {
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int /* ordinal */ = 0) const {
+#ifndef KOKKOS_ENABLE_CUDA
       throw std::runtime_error("ipNodeMap not implemented");
+#else
+      printf("Invalid ipNodeMap call on GPUs");
+      return nullptr;
+#endif
      }
 
   virtual void shape_fcn(

--- a/include/master_element/MasterElementFactory.h
+++ b/include/master_element/MasterElementFactory.h
@@ -38,11 +38,11 @@ namespace nalu{
       std::string quadType = "GaussLegendre");
 
     template<typename AlgTraits>
-    static typename AlgTraits::masterElementScv_*
+    static MasterElement*
     get_volume_master_element();
 
     template<typename AlgTraits>
-    static typename AlgTraits::masterElementScs_*
+    static MasterElement*
     get_surface_master_element();
 
     static void clear();
@@ -54,13 +54,15 @@ namespace nalu{
     static std::map<stk::topology, MasterElement*> &surfaceMeMapDev();
 
     template<typename AlgTraits, typename ME>
-    static ME* get_master_element(
+    static MasterElement* get_master_element(
       std::map<stk::topology, MasterElement*> &meMapDev
     );
   };
 
-  template<typename AlgTraits, typename ME>
-  ME* MasterElementRepo::get_master_element(std::map<stk::topology, MasterElement*> &meMap)
+  template <typename AlgTraits, typename ME>
+  MasterElement*
+  MasterElementRepo::get_master_element(
+    std::map<stk::topology, MasterElement*>& meMap)
   {
     const stk::topology theTopo = AlgTraits::topo_;
 
@@ -69,19 +71,17 @@ namespace nalu{
       meMap[theTopo] = sierra::nalu::create_device_expression<ME>();
     }
     MasterElement* theElem = meMap.at(theTopo);
-    ME* theME = dynamic_cast<ME*>(theElem);
-    ThrowRequire(theME);
-    return theME;
+    return theElem;
   }
 
   template<typename AlgTraits>
-  typename AlgTraits::masterElementScv_* MasterElementRepo::get_volume_master_element()
+  MasterElement* MasterElementRepo::get_volume_master_element()
   {
     return get_master_element<AlgTraits, typename AlgTraits::masterElementScv_>(volumeMeMapDev());
   }
 
   template<typename AlgTraits>
-  typename AlgTraits::masterElementScs_* MasterElementRepo::get_surface_master_element()
+  MasterElement* MasterElementRepo::get_surface_master_element()
   {
     return get_master_element<AlgTraits, typename AlgTraits::masterElementScs_>(surfaceMeMapDev());
   }

--- a/include/master_element/MasterElementHO.h
+++ b/include/master_element/MasterElementHO.h
@@ -52,7 +52,7 @@ public:
   virtual ~HigherOrderHexSCV() {}
 
   void shape_fcn(double *shpfc) final;
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     const int nelem,
@@ -165,7 +165,7 @@ public:
 
   const int * adjacentNodes() final;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   const int * side_node_ordinals(int ordinal = 0) const final;
 
@@ -241,7 +241,7 @@ public:
 
   void shape_fcn(double *shpfc) final;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     const int nelem,
@@ -304,7 +304,7 @@ public:
 
   void shape_fcn(double *shpfc) final;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     const int nelem,
@@ -414,7 +414,7 @@ public:
 
   const int * adjacentNodes() final;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   int opposingNodes(
     const int ordinal, const int node) final;
@@ -481,7 +481,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~HigherOrderEdge2DSCS() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     const int nelem,

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -48,7 +48,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~PyrSCV() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**>& coords,
@@ -148,7 +148,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~PyrSCS() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**>& coords,

--- a/include/master_element/Quad42DCVFEM.h
+++ b/include/master_element/Quad42DCVFEM.h
@@ -41,7 +41,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~Quad42DSCV() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**> &coords,
@@ -128,7 +128,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~Quad42DSCS() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**>& coords,

--- a/include/master_element/Quad43DCVFEM.h
+++ b/include/master_element/Quad43DCVFEM.h
@@ -28,7 +28,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~Quad3DSCS() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
  
   // NGP-ready methods first
   void shape_fcn(

--- a/include/master_element/Quad92DCVFEM.h
+++ b/include/master_element/Quad92DCVFEM.h
@@ -162,7 +162,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~Quad92DSCV() {}
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final ;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final ;
 
   void determinant(
     SharedMemView<DoubleType**> &coords,
@@ -302,7 +302,7 @@ public:
 
   virtual const int * adjacentNodes() final ;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final ;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final ;
 
   int opposingNodes(
     const int ordinal, const int node) override ;

--- a/include/master_element/Quad93DCVFEM.h
+++ b/include/master_element/Quad93DCVFEM.h
@@ -39,7 +39,7 @@ public:
 
   using MasterElement::determinant;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;

--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -30,7 +30,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~TetSCV() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**>& coords,
@@ -121,7 +121,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~TetSCS() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   virtual void determinant(
     SharedMemView<DoubleType**>&coords,

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -41,7 +41,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~Tri32DSCV() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**> &coords,
@@ -129,7 +129,7 @@ public:
   KOKKOS_FUNCTION
   virtual ~Tri32DSCS() = default;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**>& coords,

--- a/include/master_element/Tri33DCVFEM.h
+++ b/include/master_element/Tri33DCVFEM.h
@@ -42,7 +42,7 @@ public:
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     const int nelem,

--- a/include/master_element/Wed6CVFEM.h
+++ b/include/master_element/Wed6CVFEM.h
@@ -31,7 +31,7 @@ public:
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**>& coords,
@@ -125,7 +125,7 @@ public:
   using MasterElement::shifted_shape_fcn;
   using MasterElement::adjacentNodes;
 
-  virtual const int * ipNodeMap(int ordinal = 0) const final;
+  KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(
     SharedMemView<DoubleType**>& coords,

--- a/src/master_element/MasterElementFactory.C
+++ b/src/master_element/MasterElementFactory.C
@@ -275,7 +275,7 @@ namespace nalu{
     for (std::pair<stk::topology, MasterElement*> a : volumeMeMapDev()) {
       const std::string debuggingName(typeid(MasterElement).name());
       MasterElement* A=a.second;
-      kokkos_parallel_for(debuggingName, 1, [&] (const int /* i */) {
+      Kokkos::parallel_for(debuggingName, 1, KOKKOS_LAMBDA (const int /* i */) {
         A->~MasterElement();
       });
       sierra::nalu::kokkos_free_on_device(a.second);
@@ -284,7 +284,7 @@ namespace nalu{
     for (std::pair<stk::topology, MasterElement*> a : surfaceMeMapDev()) {
       const std::string debuggingName(typeid(MasterElement).name());
       MasterElement* A=a.second;
-      kokkos_parallel_for(debuggingName, 1, [&] (const int /* i */) {
+      Kokkos::parallel_for(debuggingName, 1, KOKKOS_LAMBDA (const int /* i */) {
         A->~MasterElement();
       });
       sierra::nalu::kokkos_free_on_device(a.second);

--- a/unit_tests/ngp_kernels/UTNgpKernelUtils.h
+++ b/unit_tests/ngp_kernels/UTNgpKernelUtils.h
@@ -37,10 +37,9 @@ public:
     velocity_    = sierra::nalu::get_field_ordinal(meta, "velocity");
     pressure_    = sierra::nalu::get_field_ordinal(meta, "pressure");
 
-    auto* meSCS =
-      sierra::nalu::MasterElementRepo::get_surface_master_element(stk::topology::HEX_8);
+    meSCS_ = sierra::nalu::MasterElementRepo::get_surface_master_element<AlgTraits>();
 
-    dataReq.add_cvfem_surface_me(meSCS);
+    dataReq.add_cvfem_surface_me(meSCS_);
 
     dataReq.add_coordinates_field(coordinates_, AlgTraits::nDim_,
                                   sierra::nalu::CURRENT_COORDINATES);
@@ -64,6 +63,8 @@ private:
   unsigned coordinates_ {stk::mesh::InvalidOrdinal};
   unsigned velocity_    {stk::mesh::InvalidOrdinal};
   unsigned pressure_    {stk::mesh::InvalidOrdinal};
+
+  sierra::nalu::MasterElement* meSCS_;
 };
 
 template<typename AlgTraits>
@@ -86,10 +87,15 @@ TestContinuityKernel<AlgTraits>::execute(
   sierra::nalu::SharedMemView<DoubleType*, ShmemType>& rhs,
   sierra::nalu::ScratchViews<double, TeamType, ShmemType>& scratchViews)
 {
+  // Get the integration point to node mapping
+  const int* ipNodeMap = meSCS_->ipNodeMap(3);
+
   auto& v_velocity = scratchViews.get_scratch_view_2D(velocity_);
   auto& v_pressure = scratchViews.get_scratch_view_1D(pressure_);
 
   rhs(0) = v_velocity(0, 0) + v_pressure(0);
+
+  printf("ipNodeMap[2] = %d; expected = 7\n", ipNodeMap[2]);
 }
 
 } // unit_test_ngp_kernels


### PR DESCRIPTION
- Update `MasterElementRepo` to properly run on GPUs
- Kokkos-ify `MasterElement::ipNodeMap` method for demonstration on GPUs
- Create an instance of `HexSCS` on GPU from within Kernel constructor (executing on CPU), and run the `ipNodeMap` virtual method from `Kernel::execute` method (executing on GPU) that is called from within `AssembleElemSolverAlgorithm::execute` method
- Register the `HexSCS` instance created on GPU with `ElemDataRequests` for use within ScratchViews. 