### PR TITLE
Fix array layout issue with NgpField in ScratchView gather 

### DIFF
--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -55,12 +55,11 @@ void gather_elem_tensor_field(const NGPDoubleFieldType& field,
                               int tensorDim2,
                               ViewType& shmemView)
 {
-  const double* dataPtr = static_cast<const double*>(&field.get(elem, 0));
   unsigned counter = 0;
-  for(int d1=0; d1<tensorDim1; ++d1) { 
+  for(int d1=0; d1<tensorDim1; ++d1) {
     for(int d2=0; d2<tensorDim2; ++d2) {
-      shmemView(d1,d2) = dataPtr[counter++];
-    }   
+      shmemView(d1,d2) = field.get(elem, counter++);
+    }
   }
 }
 

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -38,11 +38,10 @@ void gather_elem_node_tensor_field(const NGPDoubleFieldType& field,
       numNodes==(int)elemNodes.size(),
       "gather_elem_node_tensor_field, numNodes = mismatch with elemNodes.size()"  );   
   for(int i=0; i<numNodes; ++i) {
-    const double* dataPtr = static_cast<const double*>(&field.get(ngpMesh, elemNodes[i], 0));
     unsigned counter = 0;
     for(int d1=0; d1<tensorDim1; ++d1) { 
       for(int d2=0; d2<tensorDim2; ++d2) {
-        shmemView(i,d1,d2) = dataPtr[counter++];
+        shmemView(i,d1,d2) = field.get(ngpMesh, elemNodes[i], counter++);
       }   
     }   
   }
@@ -73,10 +72,9 @@ void gather_elem_node_field_3D(const NGPDoubleFieldType& field,
                                ViewType& shmemView)
 {
   for(unsigned i=0; i<elemNodes.size(); ++i) {
-    const double* dataPtr = &field.get(ngpMesh, elemNodes[i], 0); 
-    shmemView(i,0) = dataPtr[0];
-    shmemView(i,1) = dataPtr[1];
-    shmemView(i,2) = dataPtr[2];
+    shmemView(i,0) = field.get(ngpMesh, elemNodes[i], 0);
+    shmemView(i,1) = field.get(ngpMesh, elemNodes[i], 1);
+    shmemView(i,2) = field.get(ngpMesh, elemNodes[i], 2);
   }
 }
 
@@ -89,9 +87,8 @@ void gather_elem_node_field(const NGPDoubleFieldType& field,
                             ViewType& shmemView)
 {
   for(unsigned i=0; i<elemNodes.size(); ++i) {
-    const double* dataPtr = &field.get(ngpMesh, elemNodes[i], 0);
     for(int d=0; d<scalarsPerNode; ++d) {
-      shmemView(i,d) = dataPtr[d];
+      shmemView(i,d) = field.get(ngpMesh, elemNodes[i], d);
     }
   }
 }


### PR DESCRIPTION
The `gather_elem_node_field_3D` type functions grabbed the address of of `field.get(ngpMesh, elemNodes[i], 0)` and then tried to access data sequentially using pointer manipulation. This is only true on Host memory-layout and not on device memory layout. This commit fixes the issue by calling `NgpField::get` method appropriately to copy data into `SharedMemView` arrays. 