### PR TITLE
Enable MasterElement data within ScratchViews

### DIFF
--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -38,8 +38,7 @@ public:
     stk::mesh::Part *part,
     EquationSystem *eqSystem,
     stk::mesh::EntityRank entityRank,
-    unsigned nodesPerEntity,
-    bool interleaveMeViews = true);
+    unsigned nodesPerEntity);
   virtual ~AssembleElemSolverAlgorithm() {}
   virtual void initialize_connectivity();
   virtual void execute();
@@ -72,7 +71,6 @@ public:
     const auto entityRank = entityRank_;
     const auto nodesPerEntity = nodesPerEntity_;
     const auto rhsSize = rhsSize_;
-    const auto interleaveMEViews = interleaveMEViews_;
 
     auto team_exec = sierra::nalu::get_device_team_policy(
       elem_buckets.size(), bytes_per_team, bytes_per_thread);
@@ -108,7 +106,7 @@ public:
                 ngpMesh.get_nodes(entityRank, elemIndex);
               fill_pre_req_data(
                 dataNeededNGP, ngpMesh, entityRank, element,
-                *smdata.prereqData[simdElemIndex], interleaveMEViews);
+                *smdata.prereqData[simdElemIndex]);
             }
 
 #ifndef KOKKOS_ENABLE_CUDA
@@ -118,11 +116,8 @@ public:
             // smdata.simdPrereqData to be a pointer/reference to
             // smdata.prereqData[0] in some way...
             copy_and_interleave(
-              smdata.prereqData, numSimdElems, smdata.simdPrereqData,
-              interleaveMEViews_);
-            if (!interleaveMEViews_) {
-              fill_master_element_views(dataNeededNGP, smdata.simdPrereqData);
-            }
+              smdata.prereqData, numSimdElems, smdata.simdPrereqData);
+            fill_master_element_views(dataNeededNGP, smdata.simdPrereqData);
 //for now this simply isn't ready for GPU.
 #endif
 
@@ -138,7 +133,6 @@ public:
   double diagRelaxFactor_{1.0};
   unsigned nodesPerEntity_;
   int rhsSize_;
-  const bool interleaveMEViews_;
 };
 
 } // namespace nalu

--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -110,17 +110,12 @@ public:
             }
 
 #ifndef KOKKOS_ENABLE_CUDA
-            // When we GPU-ize AssembleElemSolverAlgorithm, 'lambdaFunc' below
-            // will need to operate on smdata.prereqData[0] since we aren't going
-            // to copy_and_interleave. We will probably want to make
-            // smdata.simdPrereqData to be a pointer/reference to
-            // smdata.prereqData[0] in some way...
+            // No need to interleave on GPUs
             copy_and_interleave(
               smdata.prereqData, numSimdElems, smdata.simdPrereqData);
-            fill_master_element_views(dataNeededNGP, smdata.simdPrereqData);
-//for now this simply isn't ready for GPU.
 #endif
 
+            fill_master_element_views(dataNeededNGP, smdata.simdPrereqData);
             lambdaFunc(smdata);
           });
       });

--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -34,8 +34,7 @@ public:
     stk::mesh::Part *part,
     EquationSystem *eqSystem,
     unsigned nodesPerFace,
-    unsigned nodesPerElem,
-    bool interleaveMeViews = true);
+    unsigned nodesPerElem);
   virtual ~AssembleFaceElemSolverAlgorithm() {}
   virtual void initialize_connectivity();
   virtual void execute();
@@ -69,8 +68,6 @@ public:
       const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(
         lhsSize, rhsSize, scratchIdsSize, nDim, faceDataNGP, elemDataNGP,
         meElemInfo);
-
-      const bool interleaveMeViews = false;
 
       stk::mesh::Selector s_locally_owned_union =
         bulk.mesh_meta_data().locally_owned_part() &
@@ -132,10 +129,10 @@ public:
                   elemFaceOrdinal = thisElemFaceOrdinal;
                   sierra::nalu::fill_pre_req_data(
                     faceDataNGP, ngpMesh, sideRank, face,
-                    *smdata.faceViews[simdFaceIndex], interleaveMeViews);
+                    *smdata.faceViews[simdFaceIndex]);
                   sierra::nalu::fill_pre_req_data(
                     elemDataNGP, ngpMesh, stk::topology::ELEMENT_RANK, elems[0],
-                    *smdata.elemViews[simdFaceIndex], interleaveMeViews);
+                    *smdata.elemViews[simdFaceIndex]);
                   ++simdFaceIndex;
                 }
                 smdata.numSimdFaces = simdFaceIndex;
@@ -148,11 +145,9 @@ public:
                 // probably want to make smdata.simdFaceViews be a
                 // pointer/reference to smdata.faceViews[0] in some way...
                 copy_and_interleave(
-                  smdata.faceViews, smdata.numSimdFaces, smdata.simdFaceViews,
-                  interleaveMeViews);
+                  smdata.faceViews, smdata.numSimdFaces, smdata.simdFaceViews);
                 copy_and_interleave(
-                  smdata.elemViews, smdata.numSimdFaces, smdata.simdElemViews,
-                  interleaveMeViews);
+                  smdata.elemViews, smdata.numSimdFaces, smdata.simdElemViews);
 
                 fill_master_element_views(
                   faceDataNGP, smdata.simdFaceViews, smdata.elemFaceOrdinal);
@@ -174,7 +169,6 @@ public:
   unsigned nodesPerFace_;
   unsigned nodesPerElem_;
   int rhsSize_;
-  const bool interleaveMEViews_;
 };
 
 } // namespace nalu

--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -18,6 +18,7 @@ namespace sierra{
 namespace nalu{
 
 template<typename SimdViewType, typename ViewType>
+KOKKOS_FUNCTION
 void interleave(SimdViewType& dview, const ViewType& sview, int simdIndex)
 {
   int sz = dview.size();
@@ -29,6 +30,7 @@ void interleave(SimdViewType& dview, const ViewType& sview, int simdIndex)
 }
 
 template<typename SimdViewType>
+KOKKOS_FUNCTION
 void interleave(SimdViewType& dview, const double* sviews[], int simdElems)
 {
     int dim = dview.size();
@@ -42,7 +44,7 @@ void interleave(SimdViewType& dview, const double* sviews[], int simdElems)
 }
 
 template<typename MultiDimViewsType, typename SimdMultiDimViewsType>
-inline
+KOKKOS_INLINE_FUNCTION
 void copy_and_interleave(const MultiDimViewsType ** data,
                          int simdElems,
                          SimdMultiDimViewsType& simdData)
@@ -99,7 +101,7 @@ void copy_and_interleave(std::unique_ptr<ScratchViews<double>>* data,
 }
 #endif
 
-inline
+KOKKOS_INLINE_FUNCTION
 void extract_vector_lane(const SharedMemView<DoubleType*>& simdrhs, int simdIndex, SharedMemView<double*>& rhs)
 {
   int dim = simdrhs.extent(0);
@@ -110,7 +112,7 @@ void extract_vector_lane(const SharedMemView<DoubleType*>& simdrhs, int simdInde
   }
 }
 
-inline
+KOKKOS_INLINE_FUNCTION
 void extract_vector_lane(const SharedMemView<DoubleType**>& simdlhs, int simdIndex, SharedMemView<double**>& lhs)
 {
   int len = simdlhs.extent(0)*simdlhs.extent(1);

--- a/include/CopyAndInterleave.h
+++ b/include/CopyAndInterleave.h
@@ -41,26 +41,6 @@ void interleave(SimdViewType& dview, const double* sviews[], int simdElems)
     }
 }
 
-inline
-void interleave_me_views(MasterElementViews<DoubleType>& dest,
-                         const MasterElementViews<double>& src,
-                         int simdIndex)
-{
-  interleave(dest.scs_areav, src.scs_areav, simdIndex);
-  interleave(dest.dndx, src.dndx, simdIndex);
-  interleave(dest.dndx_scv, src.dndx_scv, simdIndex);
-  interleave(dest.dndx_shifted, src.dndx_shifted, simdIndex);
-  interleave(dest.dndx_fem, src.dndx_fem, simdIndex);
-  interleave(dest.deriv, src.deriv, simdIndex);
-  interleave(dest.deriv_fem, src.deriv_fem, simdIndex);
-  interleave(dest.det_j, src.det_j, simdIndex);
-  interleave(dest.det_j_fem, src.det_j_fem, simdIndex);
-  interleave(dest.scv_volume, src.scv_volume, simdIndex);
-  interleave(dest.gijUpper, src.gijUpper, simdIndex);
-  interleave(dest.gijLower, src.gijLower, simdIndex);
-  interleave(dest.metric, src.metric, simdIndex);
-}
-
 template<typename MultiDimViewsType, typename SimdMultiDimViewsType>
 inline
 void copy_and_interleave(const MultiDimViewsType ** data,
@@ -106,8 +86,7 @@ void copy_and_interleave(const MultiDimViewsType ** data,
 inline
 void copy_and_interleave(std::unique_ptr<ScratchViews<double>>* data,
                          int simdElems,
-                         ScratchViews<DoubleType>& simdData,
-                         bool copyMEViews = true)
+                         ScratchViews<DoubleType>& simdData)
 {
     MultiDimViews<DoubleType, TeamHandleType, HostShmem>& simdFieldViews = simdData.get_field_views();
     const MultiDimViews<double, TeamHandleType, HostShmem>* fViews[stk::simd::ndoubles] = {nullptr};
@@ -117,18 +96,6 @@ void copy_and_interleave(std::unique_ptr<ScratchViews<double>>* data,
     }
 
     copy_and_interleave(fViews, simdElems, simdFieldViews);
-
-    if (copyMEViews)
-    {
-      for(int simdIndex=0; simdIndex<simdElems; ++simdIndex) {
-        if (simdData.has_coord_field(CURRENT_COORDINATES)) {
-          interleave_me_views(simdData.get_me_views(CURRENT_COORDINATES), data[simdIndex]->get_me_views(CURRENT_COORDINATES), simdIndex);
-        }
-        if (simdData.has_coord_field(MODEL_COORDINATES)) {
-          interleave_me_views(simdData.get_me_views(MODEL_COORDINATES), data[simdIndex]->get_me_views(MODEL_COORDINATES), simdIndex);
-        }
-      }
-    }
 }
 #endif
 

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -103,7 +103,7 @@ public:
     int numFaceIp, int numScsIp, int numScvIp, int numFemIp);
 #endif
 
-  void fill_master_element_views(
+  void fill_master_element_views_new_me(
     const ElemDataRequestsGPU::DataEnumView& dataEnums,
     SharedMemView<double**, DeviceShmem>* coordsView,
     MasterElement* meFC,
@@ -658,7 +658,7 @@ int MasterElementViews<T>::create_master_element_views(
 #endif
 
 template<typename T>
-void MasterElementViews<T>::fill_master_element_views(
+void MasterElementViews<T>::fill_master_element_views_new_me(
   const ElemDataRequestsGPU::DataEnumView& dataEnums,
   SharedMemView<double**, DeviceShmem>* coordsView,
   MasterElement* /* meFC */,
@@ -902,8 +902,7 @@ void fill_pre_req_data(const ElemDataRequestsGPU& dataNeeded,
                        const ngp::Mesh& ngpMesh,
                        stk::mesh::EntityRank entityRank,
                        stk::mesh::Entity elem,
-                       ScratchViews<double,DeviceTeamHandleType,DeviceShmem>& prereqData,
-                       bool fillMEViews = true);
+                       ScratchViews<double,DeviceTeamHandleType,DeviceShmem>& prereqData);
 
 template<typename ELEMDATAREQUESTSTYPE,typename SCRATCHVIEWSTYPE>
 void fill_master_element_views(ELEMDATAREQUESTSTYPE& dataNeeded,

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -80,68 +80,65 @@ NumNeededViews count_needed_field_views(const ELEMDATAREQUESTSTYPE& dataNeeded)
   return numNeededViews;
 }
 
-template<typename T>
+template<typename T, typename TEAMHANDLETYPE, typename SHMEM>
 class MasterElementViews
 {
 public:
   typedef T value_type;
 
+  KOKKOS_FUNCTION
   MasterElementViews() = default;
+
+  KOKKOS_FUNCTION
   virtual ~MasterElementViews() = default;
 
+  KOKKOS_FUNCTION
   int create_master_element_views(
-    const TeamHandleType& team,
+    const TEAMHANDLETYPE& team,
     const ElemDataRequestsGPU::DataEnumView& dataEnums,
     int nDim, int nodesPerFace, int nodesPerElem,
     int numFaceIp, int numScsIp, int numScvIp, int numFemIp);
-
-#ifdef KOKKOS_ENABLE_CUDA
-  int create_master_element_views(
-    const DeviceTeamHandleType& team,
-    const ElemDataRequestsGPU::DataEnumView& dataEnums,
-    int nDim, int nodesPerFace, int nodesPerElem,
-    int numFaceIp, int numScsIp, int numScvIp, int numFemIp);
-#endif
 
   void fill_master_element_views_new_me(
     const ElemDataRequestsGPU::DataEnumView& dataEnums,
-    SharedMemView<double**, DeviceShmem>* coordsView,
+    SharedMemView<double**, SHMEM>* coordsView,
     MasterElement* meFC,
     MasterElement* meSCS,
     MasterElement* meSCV,
     MasterElement* meFEM,
     int faceOrdinal = 0);
 
+  KOKKOS_FUNCTION
   void fill_master_element_views_new_me(
     const ElemDataRequestsGPU::DataEnumView& dataEnums,
-    SharedMemView<DoubleType**, DeviceShmem>* coordsView,
+    SharedMemView<DoubleType**, SHMEM>* coordsView,
     MasterElement* meFC,
     MasterElement* meSCS,
     MasterElement* meSCV,
     MasterElement* meFEM,
     int faceOrdinal = 0);
 
-  SharedMemView<T**> fc_areav;
-  SharedMemView<T**> scs_areav;
-  SharedMemView<T***> dndx_fc_scs;
-  SharedMemView<T***> dndx_shifted_fc_scs;
-  SharedMemView<T***> dndx;
-  SharedMemView<T***> dndx_shifted;
-  SharedMemView<T***> dndx_scv;
-  SharedMemView<T***> dndx_scv_shifted;
-  SharedMemView<T***> dndx_fem;
-  SharedMemView<T***> deriv_fc_scs;
-  SharedMemView<T***> deriv;
-  SharedMemView<T***> deriv_scv;
-  SharedMemView<T***> deriv_fem;
-  SharedMemView<T*> det_j_fc_scs;
-  SharedMemView<T*> det_j;
-  SharedMemView<T*> det_j_scv;
-  SharedMemView<T*> det_j_fem;
-  SharedMemView<T*> scv_volume;
-  SharedMemView<T***> gijUpper;
-  SharedMemView<T***> gijLower;
-  SharedMemView<T***> metric;
+  SharedMemView<T**, SHMEM> fc_areav;
+  SharedMemView<T**, SHMEM> scs_areav;
+  SharedMemView<T***, SHMEM> dndx_fc_scs;
+  SharedMemView<T***, SHMEM> dndx_shifted_fc_scs;
+  SharedMemView<T***, SHMEM> dndx;
+  SharedMemView<T***, SHMEM> dndx_shifted;
+  SharedMemView<T***, SHMEM> dndx_scv;
+  SharedMemView<T***, SHMEM> dndx_scv_shifted;
+  SharedMemView<T***, SHMEM> dndx_fem;
+  SharedMemView<T***, SHMEM> deriv_fc_scs;
+  SharedMemView<T***, SHMEM> deriv;
+  SharedMemView<T***, SHMEM> deriv_scv;
+  SharedMemView<T***, SHMEM> deriv_fem;
+  SharedMemView<T*, SHMEM> det_j_fc_scs;
+  SharedMemView<T*, SHMEM> det_j;
+  SharedMemView<T*, SHMEM> det_j_scv;
+  SharedMemView<T*, SHMEM> det_j_fem;
+  SharedMemView<T*, SHMEM> scv_volume;
+  SharedMemView<T***, SHMEM> gijUpper;
+  SharedMemView<T***, SHMEM> gijLower;
+  SharedMemView<T***, SHMEM> metric;
 };
 
 template<typename T,typename SHMEM,typename TEAMHANDLETYPE,typename ELEMDATAREQUESTSTYPE, typename MULTIDIMVIEWSTYPE>
@@ -241,10 +238,10 @@ public:
   KOKKOS_INLINE_FUNCTION
   SharedMemView<T****,SHMEM>& get_scratch_view_4D(const unsigned fieldOrdinal);
 
-  inline
-  MasterElementViews<T>& get_me_views(const COORDS_TYPES cType)
+  KOKKOS_INLINE_FUNCTION
+  MasterElementViews<T, TEAMHANDLETYPE, SHMEM>& get_me_views(const COORDS_TYPES cType)
   {
-    ThrowRequire(hasCoordField[cType] == true);
+    NGP_ThrowRequire(hasCoordField[cType] == true);
     return meViews[cType];
   }
 
@@ -262,13 +259,14 @@ public:
   const MultiDimViews<T,TEAMHANDLETYPE,SHMEM>& get_field_views() const { return fieldViews; }
 
 private:
+  KOKKOS_FUNCTION
   void create_needed_master_element_views(const TEAMHANDLETYPE& team,
                                           const ElemDataRequestsGPU& dataNeeded,
                                           int nDim, int nodesPerFace, int nodesPerElem,
                                           int numFaceIp, int numScsIp, int numScvIp, int numFemIp);
 
   MultiDimViews<T,TEAMHANDLETYPE, SHMEM> fieldViews;
-  MasterElementViews<T> meViews[MAX_COORDS_TYPES];
+  MasterElementViews<T, TEAMHANDLETYPE, SHMEM> meViews[MAX_COORDS_TYPES];
   bool hasCoordField[MAX_COORDS_TYPES] = {false, false};
   int num_bytes_required{0};
 };
@@ -333,9 +331,9 @@ SharedMemView<T****,SHMEM>& ScratchViews<T,TEAMHANDLETYPE,SHMEM>::get_scratch_vi
   return fieldViews.get_scratch_view_4D(fieldOrdinal);
 }
 
-template<typename T>
-int MasterElementViews<T>::create_master_element_views(
-  const TeamHandleType& team,
+template<typename T, typename TEAMHANDLETYPE, typename SHMEM>
+int MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
+  const TEAMHANDLETYPE& team,
   const ElemDataRequestsGPU::DataEnumView& dataEnums,
   int nDim, int /* nodesPerFace */, int nodesPerElem,
   int numFaceIp, int numScsIp, int numScvIp, int numFemIp)
@@ -348,86 +346,86 @@ int MasterElementViews<T>::create_master_element_views(
     switch(dataEnums(i))
     {
       case FC_AREAV:
-          ThrowRequireMsg(numFaceIp > 0, "ERROR, meFC must be non-null if FC_AREAV is requested.");
-          fc_areav = get_shmem_view_2D<T>(team, numFaceIp, nDim);
+          NGP_ThrowRequireMsg(numFaceIp > 0, "ERROR, meFC must be non-null if FC_AREAV is requested.");
+          fc_areav = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(team, numFaceIp, nDim);
           numScalars += numFaceIp * nDim;
           break;
       case SCS_FACE_GRAD_OP:
-          ThrowRequireMsg(numFaceIp > 0, "ERROR, meSCS must be non-null if SCS_FACE_GRAD_OP is requested.");
-          dndx_fc_scs = get_shmem_view_3D<T>(team, numFaceIp, nodesPerElem, nDim);
+          NGP_ThrowRequireMsg(numFaceIp > 0, "ERROR, meSCS must be non-null if SCS_FACE_GRAD_OP is requested.");
+          dndx_fc_scs = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numFaceIp, nodesPerElem, nDim);
           numScalars += nodesPerElem * numFaceIp * nDim;
           needDerivFC = true;
           needDetjFC = true;
           break;
       case SCS_SHIFTED_FACE_GRAD_OP:
-          ThrowRequireMsg(numFaceIp > 0, "ERROR, meSCS must be non-null if SCS_SHIFTED_FACE_GRAD_OP is requested.");
-          dndx_shifted_fc_scs = get_shmem_view_3D<T>(team, numFaceIp, nodesPerElem, nDim);
+          NGP_ThrowRequireMsg(numFaceIp > 0, "ERROR, meSCS must be non-null if SCS_SHIFTED_FACE_GRAD_OP is requested.");
+          dndx_shifted_fc_scs = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numFaceIp, nodesPerElem, nDim);
           numScalars += nodesPerElem * numFaceIp * nDim;
           needDerivFC = true;
           needDetjFC = true;
           break;
       case SCS_AREAV:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_AREAV is requested.");
-         scs_areav = get_shmem_view_2D<T>(team, numScsIp, nDim);
+         NGP_ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_AREAV is requested.");
+         scs_areav = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(team, numScsIp, nDim);
          numScalars += numScsIp * nDim;
          break;
 
       case SCS_GRAD_OP:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GRAD_OP is requested.");
-         dndx = get_shmem_view_3D<T>(team, numScsIp, nodesPerElem, nDim);
+         NGP_ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GRAD_OP is requested.");
+         dndx = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScsIp, nodesPerElem, nDim);
          numScalars += nodesPerElem * numScsIp * nDim;
          needDeriv = true;
          needDetj = true;
          break;
 
       case SCS_SHIFTED_GRAD_OP:
-        ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_SHIFTED_GRAD_OP is requested.");
-        dndx_shifted = get_shmem_view_3D<T>(team, numScsIp, nodesPerElem, nDim);
+        NGP_ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_SHIFTED_GRAD_OP is requested.");
+        dndx_shifted = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScsIp, nodesPerElem, nDim);
         numScalars += nodesPerElem * numScsIp * nDim;
         needDeriv = true;
         needDetj = true;
         break;
 
       case SCS_GIJ:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GIJ is requested.");
-         gijUpper = get_shmem_view_3D<T>(team, numScsIp, nDim, nDim);
-         gijLower = get_shmem_view_3D<T>(team, numScsIp, nDim, nDim);
+         NGP_ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GIJ is requested.");
+         gijUpper = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScsIp, nDim, nDim);
+         gijLower = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScsIp, nDim, nDim);
          numScalars += 2 * numScsIp * nDim * nDim;
          needDeriv = true;
          break;
 
       case SCV_MIJ:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCV must be non-null if SCV_MIJ is requested.");
-         metric = get_shmem_view_3D<T>(team, numScvIp, nDim, nDim);
+         NGP_ThrowRequireMsg(numScsIp > 0, "ERROR, meSCV must be non-null if SCV_MIJ is requested.");
+         metric = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScvIp, nDim, nDim);
          numScalars += numScvIp * nDim * nDim;
          needDeriv = true;
          break;
 
       case SCV_VOLUME:
-         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_VOLUME is requested.");
-         scv_volume = get_shmem_view_1D<T>(team, numScvIp);
+         NGP_ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_VOLUME is requested.");
+         scv_volume = get_shmem_view_1D<T, TEAMHANDLETYPE, SHMEM>(team, numScvIp);
          numScalars += numScvIp;
          break;
 
       case SCV_GRAD_OP:
-         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_GRAD_OP is requested.");
-         dndx_scv = get_shmem_view_3D<T>(team, numScvIp, nodesPerElem, nDim);
+         NGP_ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_GRAD_OP is requested.");
+         dndx_scv = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScvIp, nodesPerElem, nDim);
          numScalars += nodesPerElem * numScvIp * nDim;
          needDerivScv = true;
          needDetjScv = true;
          break;
 
       case SCV_SHIFTED_GRAD_OP:
-         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_SHIFTED_GRAD_OP is requested.");
-         dndx_scv_shifted = get_shmem_view_3D<T>(team, numScvIp, nodesPerElem, nDim);
+         NGP_ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_SHIFTED_GRAD_OP is requested.");
+         dndx_scv_shifted = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScvIp, nodesPerElem, nDim);
          numScalars += nodesPerElem * numScvIp * nDim;
          needDerivScv = true;
          needDetjScv = true;
          break;
 
       case FEM_GRAD_OP:
-         ThrowRequireMsg(numFemIp > 0, "ERROR, meFEM must be non-null if FEM_GRAD_OP is requested.");
-         dndx_fem = get_shmem_view_3D<T>(team, numFemIp, nodesPerElem, nDim);
+         NGP_ThrowRequireMsg(numFemIp > 0, "ERROR, meFEM must be non-null if FEM_GRAD_OP is requested.");
+         dndx_fem = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numFemIp, nodesPerElem, nDim);
          numScalars += nodesPerElem * numFemIp * nDim;
          needDerivFem = true;
          needDetjFem = true;
@@ -435,8 +433,8 @@ int MasterElementViews<T>::create_master_element_views(
          break;
 
       case FEM_SHIFTED_GRAD_OP:
-         ThrowRequireMsg(numFemIp > 0, "ERROR, meFEM must be non-null if FEM_SHIFTED_GRAD_OP is requested.");
-         dndx_fem = get_shmem_view_3D<T>(team, numFemIp, nodesPerElem, nDim);
+         NGP_ThrowRequireMsg(numFemIp > 0, "ERROR, meFEM must be non-null if FEM_SHIFTED_GRAD_OP is requested.");
+         dndx_fem = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numFemIp, nodesPerElem, nDim);
          numScalars += nodesPerElem * numFemIp * nDim;
          needDerivFem = true;
          needDetjFem = true;
@@ -448,219 +446,56 @@ int MasterElementViews<T>::create_master_element_views(
   }
 
   if (needDerivFC) {
-    deriv_fc_scs = get_shmem_view_3D<T>(team, numFaceIp,nodesPerElem,nDim);
+    deriv_fc_scs = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numFaceIp,nodesPerElem,nDim);
     numScalars += numFaceIp * nodesPerElem * nDim;
   }
 
   if (needDeriv) {
-    deriv = get_shmem_view_3D<T>(team, numScsIp,nodesPerElem,nDim);
+    deriv = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScsIp,nodesPerElem,nDim);
     numScalars += numScsIp * nodesPerElem * nDim;
   }
 
   if (needDerivScv) {
-    deriv_scv = get_shmem_view_3D<T>(team, numScvIp,nodesPerElem,nDim);
+    deriv_scv = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScvIp,nodesPerElem,nDim);
     numScalars += numScvIp * nodesPerElem * nDim;
   }
 
   if (needDerivFem) {
-    deriv_fem = get_shmem_view_3D<T>(team, numFemIp,nodesPerElem,nDim);
+    deriv_fem = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numFemIp,nodesPerElem,nDim);
     numScalars += numFemIp * nodesPerElem * nDim;
   }
 
   if (needDetjFC) {
-    det_j_fc_scs = get_shmem_view_1D<T>(team, numFaceIp);
+    det_j_fc_scs = get_shmem_view_1D<T, TEAMHANDLETYPE, SHMEM>(team, numFaceIp);
     numScalars += numFaceIp;
   }
 
   if (needDetj) {
-    det_j = get_shmem_view_1D<T>(team, numScsIp);
+    det_j = get_shmem_view_1D<T, TEAMHANDLETYPE, SHMEM>(team, numScsIp);
     numScalars += numScsIp;
   }
 
   if (needDetjScv) {
-    det_j_scv = get_shmem_view_1D<T>(team, numScvIp);
+    det_j_scv = get_shmem_view_1D<T, TEAMHANDLETYPE, SHMEM>(team, numScvIp);
     numScalars += numScvIp;
   }
 
   if (needDetjFem) {
-    det_j_fem = get_shmem_view_1D<T>(team, numFemIp);
+    det_j_fem = get_shmem_view_1D<T, TEAMHANDLETYPE, SHMEM>(team, numFemIp);
     numScalars += numFemIp;
   }
 
   // error check
   if ( femGradOp && femShiftedGradOp )
-    ThrowRequireMsg(numFemIp > 0, "ERROR, femGradOp and femShiftedGradOp both requested.");
+    NGP_ThrowRequireMsg(numFemIp > 0, "ERROR, femGradOp and femShiftedGradOp both requested.");
 
   return numScalars;
 }
 
-#ifdef KOKKOS_ENABLE_CUDA
-template<typename T>
-int MasterElementViews<T>::create_master_element_views(
-  const DeviceTeamHandleType& team,
+template<typename T, typename TEAMHANDLETYPE, typename SHMEM>
+void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new_me(
   const ElemDataRequestsGPU::DataEnumView& dataEnums,
-  int nDim, int nodesPerFace, int nodesPerElem,
-  int numFaceIp, int numScsIp, int numScvIp, int numFemIp)
-{
-  int numScalars = 0;
-  bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false; bool needDerivFC = false;
-  bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false; bool needDetjFC = false;
-  bool femGradOp = false; bool femShiftedGradOp = false;
-  for(unsigned i=0; i<dataEnums.size(); ++i) {
-    switch(dataEnums(i))
-    {
-      case FC_AREAV:
-          ThrowRequireMsg(numFaceIp > 0, "ERROR, meFC must be non-null if FC_AREAV is requested.");
-          fc_areav = get_shmem_view_2D<T>(team, numFaceIp, nDim);
-          numScalars += numFaceIp * nDim;
-          break;
-      case SCS_FACE_GRAD_OP:
-          ThrowRequireMsg(numFaceIp > 0, "ERROR, meSCS must be non-null if SCS_FACE_GRAD_OP is requested.");
-          dndx_fc_scs = get_shmem_view_3D<T>(team, numFaceIp, nodesPerElem, nDim);
-          numScalars += nodesPerElem * numFaceIp * nDim;
-          needDerivFC = true;
-          needDetjFC = true;
-          break;
-      case SCS_SHIFTED_FACE_GRAD_OP:
-          ThrowRequireMsg(numFaceIp > 0, "ERROR, meSCS must be non-null if SCS_SHIFTED_FACE_GRAD_OP is requested.");
-          dndx_shifted_fc_scs = get_shmem_view_3D<T>(team, numFaceIp, nodesPerElem, nDim);
-          numScalars += nodesPerElem * numFaceIp * nDim;
-          needDerivFC = true;
-          needDetjFC = true;
-          break;
-      case SCS_AREAV:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_AREAV is requested.");
-         scs_areav = get_shmem_view_2D<T>(team, numScsIp, nDim);
-         numScalars += numScsIp * nDim;
-         break;
-
-      case SCS_GRAD_OP:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GRAD_OP is requested.");
-         dndx = get_shmem_view_3D<T>(team, numScsIp, nodesPerElem, nDim);
-         numScalars += nodesPerElem * numScsIp * nDim;
-         needDeriv = true;
-         needDetj = true;
-         break;
-
-      case SCS_SHIFTED_GRAD_OP:
-        ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_SHIFTED_GRAD_OP is requested.");
-        dndx_shifted = get_shmem_view_3D<T>(team, numScsIp, nodesPerElem, nDim);
-        numScalars += nodesPerElem * numScsIp * nDim;
-        needDeriv = true;
-        needDetj = true;
-        break;
-
-      case SCS_GIJ:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCS must be non-null if SCS_GIJ is requested.");
-         gijUpper = get_shmem_view_3D<T>(team, numScsIp, nDim, nDim);
-         gijLower = get_shmem_view_3D<T>(team, numScsIp, nDim, nDim);
-         numScalars += 2 * numScsIp * nDim * nDim;
-         needDeriv = true;
-         break;
-
-      case SCV_MIJ:
-         ThrowRequireMsg(numScsIp > 0, "ERROR, meSCV must be non-null if SCV_MIJ is requested.");
-         metric = get_shmem_view_3D<T>(team, numScvIp, nDim, nDim);
-         numScalars += numScvIp * nDim * nDim;
-         needDeriv = true;
-         break;
-
-      case SCV_VOLUME:
-         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_VOLUME is requested.");
-         scv_volume = get_shmem_view_1D<T>(team, numScvIp);
-         numScalars += numScvIp;
-         break;
-
-      case SCV_GRAD_OP:
-         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_GRAD_OP is requested.");
-         dndx_scv = get_shmem_view_3D<T>(team, numScvIp, nodesPerElem, nDim);
-         numScalars += nodesPerElem * numScvIp * nDim;
-         needDerivScv = true;
-         needDetjScv = true;
-         break;
-
-      case SCV_SHIFTED_GRAD_OP:
-         ThrowRequireMsg(numScvIp > 0, "ERROR, meSCV must be non-null if SCV_SHIFTED_GRAD_OP is requested.");
-         dndx_scv_shifted = get_shmem_view_3D<T>(team, numScvIp, nodesPerElem, nDim);
-         numScalars += nodesPerElem * numScvIp * nDim;
-         needDerivScv = true;
-         needDetjScv = true;
-         break;
-
-      case FEM_GRAD_OP:
-         ThrowRequireMsg(numFemIp > 0, "ERROR, meFEM must be non-null if FEM_GRAD_OP is requested.");
-         dndx_fem = get_shmem_view_3D<T>(team, numFemIp, nodesPerElem, nDim);
-         numScalars += nodesPerElem * numFemIp * nDim;
-         needDerivFem = true;
-         needDetjFem = true;
-         femGradOp = true;
-         break;
-
-      case FEM_SHIFTED_GRAD_OP:
-         ThrowRequireMsg(numFemIp > 0, "ERROR, meFEM must be non-null if FEM_SHIFTED_GRAD_OP is requested.");
-         dndx_fem = get_shmem_view_3D<T>(team, numFemIp, nodesPerElem, nDim);
-         numScalars += nodesPerElem * numFemIp * nDim;
-         needDerivFem = true;
-         needDetjFem = true;
-         femShiftedGradOp = true;
-         break;
-
-      default: break;
-    }
-  }
-
-  if (needDerivFC) {
-    deriv_fc_scs = get_shmem_view_3D<T>(team, numFaceIp,nodesPerElem,nDim);
-    numScalars += numFaceIp * nodesPerElem * nDim;
-  }
-
-  if (needDeriv) {
-    deriv = get_shmem_view_3D<T>(team, numScsIp,nodesPerElem,nDim);
-    numScalars += numScsIp * nodesPerElem * nDim;
-  }
-
-  if (needDerivScv) {
-    deriv_scv = get_shmem_view_3D<T>(team, numScvIp,nodesPerElem,nDim);
-    numScalars += numScvIp * nodesPerElem * nDim;
-  }
-
-  if (needDerivFem) {
-    deriv_fem = get_shmem_view_3D<T>(team, numFemIp,nodesPerElem,nDim);
-    numScalars += numFemIp * nodesPerElem * nDim;
-  }
-
-  if (needDetjFC) {
-    det_j_fc_scs = get_shmem_view_1D<T>(team, numFaceIp);
-    numScalars += numFaceIp;
-  }
-
-  if (needDetj) {
-    det_j = get_shmem_view_1D<T>(team, numScsIp);
-    numScalars += numScsIp;
-  }
-
-  if (needDetjScv) {
-    det_j_scv = get_shmem_view_1D<T>(team, numScvIp);
-    numScalars += numScvIp;
-  }
-
-  if (needDetjFem) {
-    det_j_fem = get_shmem_view_1D<T>(team, numFemIp);
-    numScalars += numFemIp;
-  }
-
-  // error check
-  if ( femGradOp && femShiftedGradOp )
-    ThrowRequireMsg(numFemIp > 0, "ERROR, femGradOp and femShiftedGradOp both requested.");
-
-  return numScalars;
-}
-#endif
-
-template<typename T>
-void MasterElementViews<T>::fill_master_element_views_new_me(
-  const ElemDataRequestsGPU::DataEnumView& dataEnums,
-  SharedMemView<double**, DeviceShmem>* coordsView,
+  SharedMemView<double**, SHMEM>* coordsView,
   MasterElement* /* meFC */,
   MasterElement* meSCS,
   MasterElement* meSCV,
@@ -741,10 +576,10 @@ void MasterElementViews<T>::fill_master_element_views_new_me(
   }
 }
 
-template<typename T>
-void MasterElementViews<T>::fill_master_element_views_new_me(
+template<typename T, typename TEAMHANDLETYPE, typename SHMEM>
+void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new_me(
   const ElemDataRequestsGPU::DataEnumView& dataEnums,
-  SharedMemView<DoubleType**, DeviceShmem>* coordsView,
+  SharedMemView<DoubleType**, SHMEM>* coordsView,
   MasterElement* /* meFC */,
   MasterElement* meSCS,
   MasterElement* meSCV,
@@ -755,73 +590,79 @@ void MasterElementViews<T>::fill_master_element_views_new_me(
     switch(dataEnums(i))
     {
       case FC_AREAV:
-        ThrowRequireMsg(false, "FC_AREAV not implemented yet.");
+        NGP_ThrowRequireMsg(false, "FC_AREAV not implemented yet.");
         break;
       case SCS_AREAV:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
+         NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
          meSCS->determinant(*coordsView, scs_areav);
          break;
+#ifndef KOKKOS_ENABLE_CUDA
       case SCS_FACE_GRAD_OP:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_FACE_GRAD_OP is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_FACE_GRAD_OP requested.");
+         NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_FACE_GRAD_OP is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_FACE_GRAD_OP requested.");
          meSCS->face_grad_op(faceOrdinal, *coordsView, dndx_fc_scs);
        break;
       case SCS_SHIFTED_FACE_GRAD_OP:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_SHIFTED_FACE_GRAD_OP is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_SHIFTED_FACE_GRAD_OP requested.");
+         NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_SHIFTED_FACE_GRAD_OP is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_SHIFTED_FACE_GRAD_OP requested.");
          meSCS->shifted_face_grad_op(faceOrdinal, *coordsView, dndx_shifted_fc_scs);
        break;
+#endif
       case SCS_GRAD_OP:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
+         NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
          meSCS->grad_op(*coordsView, dndx, deriv);
          break;
       case SCS_SHIFTED_GRAD_OP:
-        ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
-        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
+        NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
+        NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
         meSCS->shifted_grad_op(*coordsView, dndx_shifted, deriv);
         break;
+#ifndef KOKKOS_ENABLE_CUDA
       case SCS_GIJ:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GIJ is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GIJ requested.");
+         NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GIJ is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GIJ requested.");
          meSCS->gij(*coordsView, gijUpper, gijLower, deriv);
          break;
       case SCS_MIJ:
-         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCV needs to be non-null if SCS_MIJ is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_MIJ requested.");
+         NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCV needs to be non-null if SCS_MIJ is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_MIJ requested.");
          meSCS->Mij(*coordsView, metric, deriv);
          break;
       case SCV_MIJ:
-         ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_MIJ is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_MIJ requested.");
+         NGP_ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_MIJ is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_MIJ requested.");
          meSCV->Mij(*coordsView, metric, deriv_scv);
          break;
+#endif
       case SCV_VOLUME:
-         ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_VOLUME requested.");
+         NGP_ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_VOLUME requested.");
          meSCV->determinant(*coordsView, scv_volume);
          break;
       case SCV_GRAD_OP:
-        ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_GRAD_OP is requested.");
-        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_GRAD_OP requested.");
+        NGP_ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_GRAD_OP is requested.");
+        NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_GRAD_OP requested.");
         meSCV->grad_op(*coordsView, dndx_scv, deriv_scv);
         break;
       case SCV_SHIFTED_GRAD_OP:
-        ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_SHIFTED_GRAD_OP is requested.");
-        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_SHIFTED_GRAD_OP requested.");
+        NGP_ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_SHIFTED_GRAD_OP is requested.");
+        NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_SHIFTED_GRAD_OP requested.");
         meSCV->shifted_grad_op(*coordsView, dndx_scv_shifted, deriv_scv);
         break;
+#ifndef KOKKOS_ENABLE_CUDA
       case FEM_GRAD_OP:
-         ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_GRAD_OP is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
+         NGP_ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_GRAD_OP is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
          meFEM->grad_op_fem(*coordsView, dndx_fem, deriv_fem, det_j_fem);
          break;
       case FEM_SHIFTED_GRAD_OP:
-         ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_SHIFTED_GRAD_OP is requested.");
-         ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
+         NGP_ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_SHIFTED_GRAD_OP is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
          meFEM->shifted_grad_op_fem(*coordsView, dndx_fem, deriv_fem, det_j_fem);
          break;
+#endif
 
       default: break;
     }
@@ -837,7 +678,6 @@ ScratchViews<T,TEAMHANDLETYPE,SHMEM>::ScratchViews(const TEAMHANDLETYPE& team,
 {
   num_bytes_required = create_needed_field_views<T,SHMEM>(team, dataNeeded, nodalGatherSize, fieldViews) * sizeof(T);
 
-#ifndef KOKKOS_ENABLE_CUDA
   /* master elements are allowed to be null if they are not required */
   MasterElement *meFC = dataNeeded.get_cvfem_face_me();
   MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
@@ -855,7 +695,6 @@ ScratchViews<T,TEAMHANDLETYPE,SHMEM>::ScratchViews(const TEAMHANDLETYPE& team,
   int numFemIp = meFEM != nullptr ? meFEM->num_integration_points() : 0;
 
   create_needed_master_element_views(team, dataNeeded, nDim, nodesPerFace, nodesPerElem, numFaceIp, numScsIp, numScvIp, numFemIp);
-#endif
 }
 
 template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
@@ -866,9 +705,7 @@ ScratchViews<T,TEAMHANDLETYPE,SHMEM>::ScratchViews(const TEAMHANDLETYPE& team,
  : fieldViews(team, dataNeeded.get_total_num_fields(), count_needed_field_views(dataNeeded))
 {
   num_bytes_required = create_needed_field_views<T,SHMEM>(team, dataNeeded, meInfo.nodalGatherSize_, fieldViews) * sizeof(T);
-#ifndef KOKKOS_ENABLE_CUDA
   create_needed_master_element_views(team, dataNeeded, nDim, meInfo.nodesPerFace_, meInfo.nodesPerElement_, meInfo.numFaceIp_, meInfo.numScsIp_, meInfo.numScvIp_, meInfo.numFemIp_);
-#endif
 }
 
 template<typename T,typename TEAMHANDLETYPE,typename SHMEM>
@@ -879,8 +716,6 @@ void ScratchViews<T,TEAMHANDLETYPE,SHMEM>::create_needed_master_element_views(co
 {
   int numScalars = 0;
 
-//going to have to fix this for GPU !!!
-#ifndef KOKKOS_ENABLE_CUDA
   const ElemDataRequestsGPU::CoordsTypesView& coordsTypes = dataNeeded.get_coordinates_types();
 
   for(unsigned i=0; i<coordsTypes.size(); ++i) {
@@ -889,7 +724,6 @@ void ScratchViews<T,TEAMHANDLETYPE,SHMEM>::create_needed_master_element_views(co
       team, dataNeeded.get_data_enums(coordsTypes(i)),
       nDim, nodesPerFace, nodesPerElem, numFaceIp, numScsIp, numScvIp, numFemIp);
   }
-#endif
 
   num_bytes_required += numScalars * sizeof(T);
 }
@@ -905,11 +739,11 @@ void fill_pre_req_data(const ElemDataRequestsGPU& dataNeeded,
                        ScratchViews<double,DeviceTeamHandleType,DeviceShmem>& prereqData);
 
 template<typename ELEMDATAREQUESTSTYPE,typename SCRATCHVIEWSTYPE>
+KOKKOS_FUNCTION
 void fill_master_element_views(ELEMDATAREQUESTSTYPE& dataNeeded,
                                SCRATCHVIEWSTYPE& prereqData,
                                int faceOrdinal = 0)
 {
-#ifndef KOKKOS_ENABLE_CUDA
     MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
     MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
     MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
@@ -927,7 +761,6 @@ void fill_master_element_views(ELEMDATAREQUESTSTYPE& dataNeeded,
 
       meData.fill_master_element_views_new_me(dataEnums, coordsView, meFC, meSCS, meSCV, meFEM, faceOrdinal);
     }
-#endif
 }
 
 

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -731,12 +731,13 @@ void ScratchViews<T,TEAMHANDLETYPE,SHMEM>::create_needed_master_element_views(co
 int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeededBySuppAlgs, int nDim);
 int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeededBySuppAlgs, int nDim, const ScratchMeInfo &meInfo);
 
+template<typename T>
 KOKKOS_FUNCTION
 void fill_pre_req_data(const ElemDataRequestsGPU& dataNeeded,
                        const ngp::Mesh& ngpMesh,
                        stk::mesh::EntityRank entityRank,
                        stk::mesh::Entity elem,
-                       ScratchViews<double,DeviceTeamHandleType,DeviceShmem>& prereqData);
+                       ScratchViews<T,DeviceTeamHandleType,DeviceShmem>& prereqData);
 
 template<typename ELEMDATAREQUESTSTYPE,typename SCRATCHVIEWSTYPE>
 KOKKOS_FUNCTION

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -28,16 +28,13 @@ struct SharedMemData {
          unsigned nodesPerEntity,
          unsigned rhsSize)
      : simdPrereqData(team, nDim, nodesPerEntity, dataNeededByKernels)
-#ifdef KOKKOS_ENABLE_CUDA
-      ,prereqData_byValue(team, nDim, nodesPerEntity, dataNeededByKernels)
-#endif
     {
 #ifndef KOKKOS_ENABLE_CUDA
         for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
           prereqData[simdIndex] = std::unique_ptr<ScratchViews<double,TEAMHANDLETYPE,SHMEM> >(new ScratchViews<double,TEAMHANDLETYPE,SHMEM>(team, nDim, nodesPerEntity, dataNeededByKernels));
         }
 #else
-        prereqData[0] = &prereqData_byValue;
+        prereqData[0] = &simdPrereqData;
 #endif
         simdrhs = get_shmem_view_1D<DoubleType,TEAMHANDLETYPE,SHMEM>(team, rhsSize);
         simdlhs = get_shmem_view_2D<DoubleType,TEAMHANDLETYPE,SHMEM>(team, rhsSize, rhsSize);
@@ -54,8 +51,7 @@ struct SharedMemData {
     ngp::Mesh::ConnectedNodes ngpElemNodes[simdLen];
     int numSimdElems;
 #ifdef KOKKOS_ENABLE_CUDA
-    ScratchViews<double,TEAMHANDLETYPE,SHMEM> prereqData_byValue;
-    ScratchViews<double,TEAMHANDLETYPE,SHMEM>* prereqData[1];
+    ScratchViews<DoubleType,TEAMHANDLETYPE,SHMEM>* prereqData[1];
 #else
     std::unique_ptr<ScratchViews<double,TEAMHANDLETYPE,SHMEM>> prereqData[simdLen];
 #endif

--- a/include/kernel/Kernel.h
+++ b/include/kernel/Kernel.h
@@ -145,6 +145,15 @@ public:
     SharedMemView<DoubleType*, DeviceShmem>&,
     ScratchViews<double, DeviceTeamHandleType, DeviceShmem>&)
   {}
+
+#ifdef KOKKOS_ENABLE_CUDA
+  KOKKOS_FUNCTION
+  virtual void execute(
+    SharedMemView<DoubleType**, DeviceShmem>&,
+    SharedMemView<DoubleType*, DeviceShmem>&,
+    ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>&)
+  {}
+#endif
 };
 
 /** Kernel that can be transferred to a device

--- a/include/kernel/KernelBuilder.h
+++ b/include/kernel/KernelBuilder.h
@@ -95,11 +95,12 @@ namespace nalu{
                       topo == stk::topology::WEDGE_6 ||
                       topo == stk::topology::TETRAHEDRON_4 ||
                       topo == stk::topology::PYRAMID_5);
+    ThrowRequireMsg(!isNotNGP, "Consolidated algorithm called on non-NGP MasterElement");
 
     auto itc = solverAlgs.find(algName);
     bool createNewAlg = itc == solverAlgs.end();
     if (createNewAlg) {
-      auto* theSolverAlg = new AssembleElemSolverAlgorithm(eqSys.realm_, &part, &eqSys, stk::topology::ELEMENT_RANK, topo.num_nodes(), isNotNGP);
+      auto* theSolverAlg = new AssembleElemSolverAlgorithm(eqSys.realm_, &part, &eqSys, stk::topology::ELEMENT_RANK, topo.num_nodes());
       ThrowRequire(theSolverAlg != nullptr);
 
       NaluEnv::self().naluOutputP0() << "Created the following interior elem alg: " << algName << std::endl;
@@ -521,12 +522,13 @@ namespace nalu{
                       elemTopo == stk::topology::WEDGE_6 ||
                       elemTopo == stk::topology::TETRAHEDRON_4 ||
                       elemTopo == stk::topology::PYRAMID_5);
+    ThrowRequireMsg(!isNotNGP, "Consolidated algorithm called on non-NGP MasterElement");
 
     auto itc = solverAlgs.find(algName);
     bool createNewAlg = itc == solverAlgs.end();
     if (createNewAlg) {
-      auto* theSolverAlg = new AssembleFaceElemSolverAlgorithm(eqSys.realm_, &part, &eqSys,
-                                            topo.num_nodes(), elemTopo.num_nodes(), isNotNGP);
+      auto* theSolverAlg = new AssembleFaceElemSolverAlgorithm(
+        eqSys.realm_, &part, &eqSys, topo.num_nodes(), elemTopo.num_nodes());
       ThrowRequire(theSolverAlg != nullptr);
 
       NaluEnv::self().naluOutputP0() << "Created the following bc face/elem alg: " << algName << std::endl;
@@ -561,12 +563,14 @@ namespace nalu{
                       topo == stk::topology::TRI_3 ||
                       topo == stk::topology::LINE_2 ||
                       topo == stk::topology::LINE_3 );
+    ThrowRequireMsg(!isNotNGP, "Consolidated algorithm called on non-NGP MasterElement");
 
     auto itc = solverAlgs.find(algName);
     bool createNewAlg = itc == solverAlgs.end();
     if (createNewAlg) {
-      auto* theSolverAlg = new AssembleElemSolverAlgorithm(eqSys.realm_, &part, &eqSys, 
-                                                           eqSys.realm_.meta_data().side_rank(), topo.num_nodes(), isNotNGP);
+      auto* theSolverAlg = new AssembleElemSolverAlgorithm(
+        eqSys.realm_, &part, &eqSys, eqSys.realm_.meta_data().side_rank(),
+        topo.num_nodes());
       ThrowRequire(theSolverAlg != nullptr);
 
       NaluEnv::self().naluOutputP0() << "Created the following bc face alg: " << algName << std::endl;

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -262,7 +262,7 @@ public:
 
   virtual int ndim()                           const {return nDim_;} 
   virtual int nodes_per_element()              const {return nodesPerElement_;} 
-          int num_integration_points()         const {return numIntPoints_;} 
+  KOKKOS_FUNCTION int num_integration_points() const {return numIntPoints_;}
           double scal_to_standard_iso_factor() const {return scaleToStandardIsoFac_;} 
 
   virtual const int   * adjacentNodes()              const {throw std::runtime_error("adjacentNodes not implimented");}

--- a/reg_tests/test_files/cvfemHexHC_P3/cvfemHexHC_P3_R0.i
+++ b/reg_tests/test_files/cvfemHexHC_P3/cvfemHexHC_P3_R0.i
@@ -97,11 +97,11 @@ realms:
     solution_options:
       name: myOptions
 
-      use_consolidated_solver_algorithm: yes
+      use_consolidated_solver_algorithm: no
 
       options:
         - element_source_terms:
-            temperature: [steady_3d_thermal, CVFEM_DIFF]
+            temperature: [steady_3d_thermal]
 
     output:
       output_data_base_name: cvfemHexHC_P3_R0.e

--- a/reg_tests/test_files/cvfemHexHC_P3/cvfemHexHC_P3_R1.i
+++ b/reg_tests/test_files/cvfemHexHC_P3/cvfemHexHC_P3_R1.i
@@ -97,11 +97,11 @@ realms:
     solution_options:
       name: myOptions
 
-      use_consolidated_solver_algorithm: yes
+      use_consolidated_solver_algorithm: no
 
       options:
         - element_source_terms:
-            temperature: [steady_3d_thermal, CVFEM_DIFF]
+            temperature: [steady_3d_thermal]
 
     output:
       output_data_base_name: cvfemHexHC_P3_R1.e

--- a/reg_tests/test_files/cvfemHexHC_P3/cvfemHexHC_P3_R2.i
+++ b/reg_tests/test_files/cvfemHexHC_P3/cvfemHexHC_P3_R2.i
@@ -97,11 +97,11 @@ realms:
     solution_options:
       name: myOptions
 
-      use_consolidated_solver_algorithm: yes
+      use_consolidated_solver_algorithm: no
 
       options:
         - element_source_terms:
-            temperature: [steady_3d_thermal, CVFEM_DIFF]
+            temperature: [steady_3d_thermal]
 
     output:
       output_data_base_name: cvfemHexHC_P3_R2.e

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -51,14 +51,12 @@ AssembleElemSolverAlgorithm::AssembleElemSolverAlgorithm(
   stk::mesh::Part *part,
   EquationSystem *eqSystem,
   stk::mesh::EntityRank entityRank,
-  unsigned nodesPerEntity,
-  bool interleaveMEViews)
+  unsigned nodesPerEntity)
   : SolverAlgorithm(realm, part, eqSystem),
     dataNeededByKernels_(realm.meta_data()),
     entityRank_(entityRank),
     nodesPerEntity_(nodesPerEntity),
-    rhsSize_(nodesPerEntity*eqSystem->linsys_->numDof()),
-    interleaveMEViews_(interleaveMEViews)
+    rhsSize_(nodesPerEntity*eqSystem->linsys_->numDof())
 {
   if (eqSystem->dofName_ != "pressure") {
     diagRelaxFactor_ = realm.solutionOptions_->get_relaxation_factor(

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -106,11 +106,7 @@ AssembleElemSolverAlgorithm::execute()
 
       for (size_t i=0; i < numKernels; i++) {
         Kernel* kernel = ngpKernels(i);
-#ifdef KOKKOS_ENABLE_CUDA
-        kernel->execute(smdata.simdlhs, smdata.simdrhs, *smdata.prereqData[0]);
-#else
         kernel->execute(smdata.simdlhs, smdata.simdrhs, smdata.simdPrereqData);
-#endif
       }
 
 #ifndef KOKKOS_ENABLE_CUDA

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -53,16 +53,14 @@ AssembleFaceElemSolverAlgorithm::AssembleFaceElemSolverAlgorithm(
   stk::mesh::Part *part,
   EquationSystem *eqSystem,
   unsigned nodesPerFace,
-  unsigned nodesPerElem,
-  bool interleaveMEViews)
+  unsigned nodesPerElem)
   : SolverAlgorithm(realm, part, eqSystem),
     faceDataNeeded_(realm.meta_data()),
     elemDataNeeded_(realm.meta_data()),
     numDof_(eqSystem->linsys_->numDof()),
     nodesPerFace_(nodesPerFace),
     nodesPerElem_(nodesPerElem),
-    rhsSize_(nodesPerFace*eqSystem->linsys_->numDof()),
-    interleaveMEViews_(interleaveMEViews)
+    rhsSize_(nodesPerFace*eqSystem->linsys_->numDof())
 {
   if (eqSystem->dofName_ != "pressure") {
     diagRelaxFactor_ = realm.solutionOptions_->get_relaxation_factor(

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -415,13 +415,14 @@ int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeeded, int nDim
   return numScalars + 8;
 }
 
+template<typename T>
 KOKKOS_FUNCTION
 void fill_pre_req_data(
   const ElemDataRequestsGPU& dataNeeded,
   const ngp::Mesh& ngpMesh,
   stk::mesh::EntityRank entityRank,
   stk::mesh::Entity entity,
-  ScratchViews<double,DeviceTeamHandleType,DeviceShmem>& prereqData)
+  ScratchViews<T,DeviceTeamHandleType,DeviceShmem>& prereqData)
 {
   stk::mesh::FastMeshIndex entityIndex = ngpMesh.fast_mesh_index(entity);
   prereqData.elemNodes = ngpMesh.get_nodes(entityRank, entityIndex);
@@ -475,6 +476,21 @@ void fill_pre_req_data(
   }
 }
 
+template
+void fill_pre_req_data(
+  const ElemDataRequestsGPU& dataNeeded,
+  const ngp::Mesh& ngpMesh,
+  stk::mesh::EntityRank entityRank,
+  stk::mesh::Entity entity,
+  ScratchViews<double, DeviceTeamHandleType,DeviceShmem>& prereqData);
+
+template
+void fill_pre_req_data(
+  const ElemDataRequestsGPU& dataNeeded,
+  const ngp::Mesh& ngpMesh,
+  stk::mesh::EntityRank entityRank,
+  stk::mesh::Entity entity,
+  ScratchViews<DoubleType, DeviceTeamHandleType,DeviceShmem>& prereqData);
 }
 }
 

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -421,16 +421,8 @@ void fill_pre_req_data(
   const ngp::Mesh& ngpMesh,
   stk::mesh::EntityRank entityRank,
   stk::mesh::Entity entity,
-  ScratchViews<double,DeviceTeamHandleType,DeviceShmem>& prereqData,
-  bool fillMEViews)
+  ScratchViews<double,DeviceTeamHandleType,DeviceShmem>& prereqData)
 {
-#ifndef KOKKOS_ENABLE_CUDA
-  MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
-  MasterElement *meSCS = dataNeeded.get_cvfem_surface_me();
-  MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
-  MasterElement *meFEM = dataNeeded.get_fem_volume_me();
-#endif
-
   stk::mesh::FastMeshIndex entityIndex = ngpMesh.fast_mesh_index(entity);
   prereqData.elemNodes = ngpMesh.get_nodes(entityRank, entityIndex);
   int nodesPerElem = prereqData.elemNodes.size();
@@ -481,24 +473,6 @@ void fill_pre_req_data(
       NGP_ThrowRequireMsg(false,"Unknown stk-rank in ScratchViewsNGP.C::fill_pre_req_data" );
     }
   }
-
-#ifndef KOKKOS_ENABLE_CUDA
-  if (fillMEViews)
-  {
-    const ElemDataRequestsGPU::CoordsTypesView& coordsTypes = dataNeeded.get_coordinates_types();
-    const ElemDataRequestsGPU::FieldView& coordsFields = dataNeeded.get_coordinates_fields();
-    for(unsigned i=0; i<coordsTypes.size(); ++i) {
-      auto cType = coordsTypes(i);
-      auto& coordField = coordsFields(i);
-
-      const ElemDataRequestsGPU::DataEnumView& dataEnums = dataNeeded.get_data_enums(cType);
-      auto* coordsView = &prereqData.get_scratch_view_2D(coordField.get_ordinal());
-      auto& meData = prereqData.get_me_views(cType);
-
-      meData.fill_master_element_views(dataEnums, coordsView, meFC, meSCS, meSCV, meFEM);
-    }
-  }
-#endif
 }
 
 }

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -146,6 +146,7 @@ public:
           Kokkos::parallel_for(Kokkos::TeamThreadRange(team, bkt.size()), [&](const size_t& jj)
           {
             fill_pre_req_data(dataNeededNGP, ngpMesh, stk::topology::ELEMENT_RANK, bkt[jj], prereqData);
+            fill_master_element_views(dataNeededNGP, prereqData);
 
             for(SuppAlg* alg : suppAlgs_) {
               alg->elem_execute(topo, *meSCS, prereqData);

--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -27,7 +27,7 @@ struct HelperObjects {
     realm.metaData_ = &bulk.mesh_meta_data();
     realm.bulkData_ = &bulk;
     eqSystem.linsys_ = linsys;
-    assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, topo.rank(), topo.num_nodes(), false);
+    assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, topo.rank(), topo.num_nodes());
   }
 
   ~HelperObjects()
@@ -55,7 +55,7 @@ struct FaceElemHelperObjects : HelperObjects {
   FaceElemHelperObjects(stk::mesh::BulkData& bulk, stk::topology faceTopo, stk::topology elemTopo, int numDof, stk::mesh::Part* part)
   : HelperObjects(bulk, elemTopo, numDof, part)
   {
-    assembleFaceElemSolverAlg = new sierra::nalu::AssembleFaceElemSolverAlgorithm(realm, part, &eqSystem, faceTopo.num_nodes(), elemTopo.num_nodes(), false);
+    assembleFaceElemSolverAlg = new sierra::nalu::AssembleFaceElemSolverAlgorithm(realm, part, &eqSystem, faceTopo.num_nodes(), elemTopo.num_nodes());
   }
 
   ~FaceElemHelperObjects() {    delete assembleFaceElemSolverAlg;

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -91,8 +91,6 @@ void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* press
        lhsSize, rhsSize, rhsSize, meta.spatial_dimension(), dataNGP) +
      (rhsSize + lhsSize) * sizeof(double) * sierra::nalu::simdLen);
 
-  const bool interleaveMEViews = false;
-
   int numResults = 5;
   IntViewType result("result", numResults);
 
@@ -125,7 +123,7 @@ void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* press
     {
         stk::mesh::Entity element = b[bktIndex];
         sierra::nalu::fill_pre_req_data(dataNGP, ngpMesh, stk::topology::ELEM_RANK, element,
-                          scrviews, interleaveMEViews);
+                          scrviews);
         auto& velocityView = scrviews.get_scratch_view_2D(velocityOrdinal);
         auto& pressureView = scrviews.get_scratch_view_1D(pressureOrdinal);
 
@@ -219,8 +217,6 @@ void do_the_smdata_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType
        lhsSize, rhsSize, rhsSize, meta.spatial_dimension(), dataNGP) +
      (rhsSize + lhsSize) * sizeof(double) * sierra::nalu::simdLen);
 
-  const bool interleaveMEViews = false;
-
   int numResults = 5;
   IntViewType result("result", numResults);
 
@@ -248,11 +244,11 @@ void do_the_smdata_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType
     {
         stk::mesh::Entity element = b[bktIndex];
         sierra::nalu::fill_pre_req_data(dataNGP, ngpMesh, stk::topology::ELEM_RANK, element,
-                          *smdata.prereqData[0], interleaveMEViews);
+                          *smdata.prereqData[0]);
 
 #ifndef KOKKOS_ENABLE_CUDA
 //no copy-interleave needed on GPU since no simd.
-        sierra::nalu::copy_and_interleave(smdata.prereqData, 1, smdata.simdPrereqData, interleaveMEViews);
+        sierra::nalu::copy_and_interleave(smdata.prereqData, 1, smdata.simdPrereqData);
 #endif
 
         auto& velocityView = smdata.prereqData[0]->get_scratch_view_2D(velocityOrdinal);

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -266,15 +266,12 @@ void do_the_smdata_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, bucketLen), [&](const size_t& bktIndex)
     {
         stk::mesh::Entity element = b[bktIndex];
-
-#ifndef KOKKOS_ENABLE_CUDA
         sierra::nalu::fill_pre_req_data(
           dataNGP, ngpMesh, stk::topology::ELEM_RANK, element, *smdata.prereqData[0]);
-        sierra::nalu::copy_and_interleave(smdata.prereqData, 1, smdata.simdPrereqData);
-#else
+
+#ifndef KOKKOS_ENABLE_CUDA
         // no copy-interleave needed on GPU since no simd.
-        sierra::nalu::fill_pre_req_data(
-          dataNGP, ngpMesh, stk::topology::ELEM_RANK, element, smdata.simdPrereqData);
+        sierra::nalu::copy_and_interleave(smdata.prereqData, 1, smdata.simdPrereqData);
 #endif
         sierra::nalu::fill_master_element_views(dataNGP, smdata.simdPrereqData);
 

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -306,9 +306,11 @@ void do_the_smdata_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType
 
 TEST_F(Hex8MeshWithNSOFields, NGPSharedMemData)
 {
-  fill_mesh_and_initialize_test_fields("generated:2x2x2");
+  if (stk::parallel_machine_size(comm) == 1) {
+    fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  do_the_smdata_test(bulk, pressure, velocity);
+    do_the_smdata_test(bulk, pressure, velocity);
+  }
 }
 
 #ifdef KOKKOS_ENABLE_CUDA

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -65,13 +65,17 @@ void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* press
 {
   stk::topology elemTopo = stk::topology::HEX_8;
   sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
-  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
+  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
   dataReq.add_cvfem_volume_me(meSCV);
 
+  auto* coordsField = bulk.mesh_meta_data().coordinate_field();
+
+  dataReq.add_coordinates_field(*coordsField, 3, sierra::nalu::CURRENT_COORDINATES);
   dataReq.add_gathered_nodal_field(*velocity, 3);
   dataReq.add_gathered_nodal_field(*pressure, 1);
+  dataReq.add_master_element_call(sierra::nalu::SCV_VOLUME, sierra::nalu::CURRENT_COORDINATES);
 
-  EXPECT_EQ(2u, dataReq.get_fields().size());
+  EXPECT_EQ(3u, dataReq.get_fields().size());
 
   const stk::mesh::MetaData& meta = bulk.mesh_meta_data();
   ngp::FieldManager fieldMgr(bulk);
@@ -175,12 +179,15 @@ TEST_F(Hex8MeshWithNSOFields, NGPAssembleElemSolver)
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 
-  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(stk::topology::HEX_8);
+  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
   dataNeeded.add_cvfem_volume_me(meSCV);
+  auto* coordsField = bulk.mesh_meta_data().coordinate_field();
+
+  dataNeeded.add_coordinates_field(*coordsField, 3, sierra::nalu::CURRENT_COORDINATES);
   dataNeeded.add_gathered_nodal_field(*velocity, 3);
   dataNeeded.add_gathered_nodal_field(*pressure, 1);
 
-  EXPECT_EQ(2u, dataNeeded.get_fields().size());
+  EXPECT_EQ(3u, dataNeeded.get_fields().size());
 
   do_assemble_elem_solver_test(
     bulk, *assembleElemSolverAlg, velocity->mesh_meta_data_ordinal(),
@@ -191,13 +198,17 @@ void do_the_smdata_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType
 {
   stk::topology elemTopo = stk::topology::HEX_8;
   sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
-  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
+  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
   dataReq.add_cvfem_volume_me(meSCV);
 
+  auto* coordsField = bulk.mesh_meta_data().coordinate_field();
+
+  dataReq.add_coordinates_field(*coordsField, 3, sierra::nalu::CURRENT_COORDINATES);
   dataReq.add_gathered_nodal_field(*velocity, 3);
   dataReq.add_gathered_nodal_field(*pressure, 1);
+  dataReq.add_master_element_call(sierra::nalu::SCV_VOLUME, sierra::nalu::CURRENT_COORDINATES);
 
-  EXPECT_EQ(2u, dataReq.get_fields().size());
+  EXPECT_EQ(3u, dataReq.get_fields().size());
 
   const stk::mesh::MetaData& meta = bulk.mesh_meta_data();
   ngp::FieldManager fieldMgr(bulk);

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -609,6 +609,7 @@ void calc_mass_flow_rate_scs(
           sierra::nalu::fill_pre_req_data(
             dataNeededNGP, ngpMesh, stk::topology::ELEMENT_RANK, element,
             preReqData);
+          sierra::nalu::fill_master_element_views(dataNeededNGP, preReqData);
 
           std::vector<double> rhoU(ndim);
           std::vector<double> v_shape_function(
@@ -695,6 +696,7 @@ void calc_projected_nodal_gradient_interior(
       sierra::nalu::fill_pre_req_data(
         dataNeededNGP, ngpMesh, stk::topology::ELEMENT_RANK, element,
         preReqData);
+      sierra::nalu::fill_master_element_views(dataNeededNGP, preReqData);
 
       meSCS->shape_fcn(v_shape_function.data());
       auto v_dnv = preReqData.get_scratch_view_1D(dnv);
@@ -778,6 +780,7 @@ void calc_projected_nodal_gradient_interior(
       sierra::nalu::fill_pre_req_data(
         dataNeededNGP, ngpMesh, stk::topology::ELEMENT_RANK, element,
         preReqData);
+      sierra::nalu::fill_master_element_views(dataNeededNGP, preReqData);
 
       meSCS->shape_fcn(v_shape_function.data());
       auto v_dnv = preReqData.get_scratch_view_1D(dnv);
@@ -862,6 +865,7 @@ void calc_projected_nodal_gradient_boundary(
       stk::mesh::Entity face = b[k];
       sierra::nalu::fill_pre_req_data(
         dataNeededNGP, ngpMesh, meta.side_rank(), face, preReqData);
+      sierra::nalu::fill_master_element_views(dataNeededNGP, preReqData);
 
       meBC->shape_fcn(v_shape_function.data());
       auto v_dnv = preReqData.get_scratch_view_1D(dnv);
@@ -940,6 +944,7 @@ void calc_projected_nodal_gradient_boundary(
       stk::mesh::Entity face = b[k];
       sierra::nalu::fill_pre_req_data(
         dataNeededNGP, ngpMesh, meta.side_rank(), face, preReqData);
+      sierra::nalu::fill_master_element_views(dataNeededNGP, preReqData);
 
       meBC->shape_fcn(v_shape_function.data());
       auto v_dnv = preReqData.get_scratch_view_1D(dnv);
@@ -1015,6 +1020,7 @@ void calc_dual_nodal_volume(
       sierra::nalu::fill_pre_req_data(
         dataNeededNGP, ngpMesh, stk::topology::ELEMENT_RANK, element,
         preReqData);
+      sierra::nalu::fill_master_element_views(dataNeededNGP, preReqData);
 
       auto v_scv_vol = preReqData.get_me_views(sierra::nalu::CURRENT_COORDINATES).scv_volume;
       const ngp::Mesh::ConnectedNodes node_rels = preReqData.elemNodes;

--- a/unit_tests/ngp_kernels/UTNgpKernelUtils.h
+++ b/unit_tests/ngp_kernels/UTNgpKernelUtils.h
@@ -45,6 +45,7 @@ public:
                                   sierra::nalu::CURRENT_COORDINATES);
     dataReq.add_gathered_nodal_field(velocity_, AlgTraits::nDim_);
     dataReq.add_gathered_nodal_field(pressure_, 1);
+    dataReq.add_master_element_call(sierra::nalu::SCS_AREAV, sierra::nalu::CURRENT_COORDINATES);
   }
 
   using sierra::nalu::Kernel::execute;
@@ -76,8 +77,15 @@ TestContinuityKernel<AlgTraits>::execute(
   sierra::nalu::SharedMemView<DoubleType*, ShmemType>& rhs,
   sierra::nalu::ScratchViews<DoubleType, TeamType, ShmemType>& scratchViews)
 {
+  // Get the integration point to node mapping
+  const int* ipNodeMap = meSCS_->ipNodeMap(3);
+
   auto& v_velocity = scratchViews.get_scratch_view_2D(velocity_);
   auto& v_pressure = scratchViews.get_scratch_view_1D(pressure_);
+  auto& scs_areav = scratchViews.get_me_views(sierra::nalu::CURRENT_COORDINATES).scs_areav;
+
+  printf("ipNodeMap[2] = %d (7); SCS areav[2, 0] = %f\n", ipNodeMap[2],
+         stk::simd::get_data(scs_areav(2, 0), 0));
 
   rhs(0) = v_velocity(0, 0) + v_pressure(0);
 }

--- a/unit_tests/ngp_kernels/UTNgpKernelUtils.h
+++ b/unit_tests/ngp_kernels/UTNgpKernelUtils.h
@@ -48,10 +48,12 @@ public:
   }
 
   using sierra::nalu::Kernel::execute;
+
+  KOKKOS_FUNCTION
   void execute(
-    sierra::nalu::SharedMemView<DoubleType**>&,
-    sierra::nalu::SharedMemView<DoubleType*>&,
-    sierra::nalu::ScratchViews<DoubleType>&);
+    sierra::nalu::SharedMemView<DoubleType**, ShmemType>&,
+    sierra::nalu::SharedMemView<DoubleType*, ShmemType>&,
+    sierra::nalu::ScratchViews<DoubleType, TeamType, ShmemType>&);
 
   KOKKOS_FUNCTION
   virtual void execute(
@@ -70,9 +72,9 @@ private:
 template<typename AlgTraits>
 void
 TestContinuityKernel<AlgTraits>::execute(
-  sierra::nalu::SharedMemView<DoubleType**>&,
-  sierra::nalu::SharedMemView<DoubleType*>& rhs,
-  sierra::nalu::ScratchViews<DoubleType>& scratchViews)
+  sierra::nalu::SharedMemView<DoubleType**, ShmemType>&,
+  sierra::nalu::SharedMemView<DoubleType*, ShmemType>& rhs,
+  sierra::nalu::ScratchViews<DoubleType, TeamType, ShmemType>& scratchViews)
 {
   auto& v_velocity = scratchViews.get_scratch_view_2D(velocity_);
   auto& v_pressure = scratchViews.get_scratch_view_1D(pressure_);

--- a/unit_tests/ngp_kernels/UnitTestNgpKernel.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpKernel.C
@@ -53,7 +53,7 @@ void kernel_runalg_test(
   solverAlg.run_algorithm(
     bulk,
     KOKKOS_LAMBDA(sierra::nalu::SharedMemData<TeamType, ShmemType> & smdata) {
-      testKernel->execute(smdata.simdlhs, smdata.simdrhs, *smdata.prereqData[0]);
+      testKernel->execute(smdata.simdlhs, smdata.simdrhs, smdata.simdPrereqData);
     });
 }
 


### PR DESCRIPTION
This pull request demonstrates a full working prototype of ScratchViews + MasterElement + Kernel. The main changes are summarized below:

- Remove option to interleave MasterElement views. This part of code was only used to support transition on MasterElement classes in stages and is no longer necessary. The code in `KernelBuilder` will now throw if it encounters a MasterElement type that is not yet supported on NGP architectures. 

- Convert MasterElementViews to be templated on `TeamHandleType` and `ShmemType`

- Removed all `#ifndef KOKKOS_ENABLE_CUDA` guards in master element related methods in `ScratchViews`. 

- Converted `fill_pre_req_data` to be templated on `double` and `DoubleType`, added necessary logic in SharedMemData such that `prereqData` points to `simdPrereqData`. Update `NGPSharedMemData` unit test to test registration and access of MEViews (using `scv_volume`).

- Update `AssembleElemSolverAlgorithm::run_algorithm` and related `NGP*` unit tests.
