### PR TITLE
Transition ContinuityAdvElemKernel to run on GPUs

### DIFF
--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -733,7 +733,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
         meSCS->shifted_grad_op(*coordsView, dndx_shifted, deriv);
         break;
-#ifndef KOKKOS_ENABLE_CUDA
       case SCS_GIJ:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GIJ is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GIJ requested.");
@@ -749,7 +748,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_MIJ requested.");
          meSCV->Mij(*coordsView, metric, deriv_scv);
          break;
-#endif
       case SCV_VOLUME:
          NGP_ThrowRequireMsg(meSCV != nullptr, "ERROR, meSCV needs to be non-null if SCV_VOLUME is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_VOLUME requested.");

--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -429,7 +429,7 @@ public:
     const double *side_pcoords,
     double *elem_pcoords);
 
-  virtual const int * adjacentNodes() final;
+  KOKKOS_FUNCTION virtual const int * adjacentNodes() final;
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -288,7 +288,7 @@ public:
     double *metric,
     double *deriv);
 
-  virtual const int * adjacentNodes() final;
+  KOKKOS_FUNCTION virtual const int * adjacentNodes() final;
 
   const int * scsIpEdgeOrd();
 

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -194,8 +194,12 @@ public:
      double * /* error  */) {
      throw std::runtime_error("shifted_face_grad_op not implemented");}
 
-  virtual const int * adjacentNodes() {
+  KOKKOS_FUNCTION virtual const int * adjacentNodes() {
+#ifndef KOKKOS_ENABLE_CUDA
     throw std::runtime_error("adjacentNodes not implemented");
+#else
+    return nullptr;
+#endif
     }
 
   virtual const int * scsIpEdgeOrd() {
@@ -279,7 +283,13 @@ public:
   KOKKOS_FUNCTION int num_integration_points() const {return numIntPoints_;}
           double scal_to_standard_iso_factor() const {return scaleToStandardIsoFac_;} 
 
-  virtual const int   * adjacentNodes()              const {throw std::runtime_error("adjacentNodes not implimented");}
+  KOKKOS_FUNCTION virtual const int   * adjacentNodes()              const {
+#ifndef KOKKOS_ENABLE_CUDA
+    throw std::runtime_error("adjacentNodes not implimented");
+#else
+    return nullptr;
+#endif
+  }
   virtual const double* integration_locations()      const {throw std::runtime_error("integration_locations not implemented");}
   virtual const double* integration_location_shift() const {throw std::runtime_error("adjacentNodes not implimented");}
   virtual const double* integration_exp_face_shift() const {throw std::runtime_error("integration_exp_face_shift not implimented");}

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -195,25 +195,18 @@ public:
      throw std::runtime_error("shifted_face_grad_op not implemented");}
 
   KOKKOS_FUNCTION virtual const int * adjacentNodes() {
-#ifndef KOKKOS_ENABLE_CUDA
-    throw std::runtime_error("adjacentNodes not implemented");
-#else
+    NGP_ThrowErrorMsg("MasterElement::adjacentNodes not implemented");
     return nullptr;
-#endif
-    }
+  }
 
   virtual const int * scsIpEdgeOrd() {
     throw std::runtime_error("scsIpEdgeOrd not implemented");
-    }
+  }
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int /* ordinal */ = 0) const {
-#ifndef KOKKOS_ENABLE_CUDA
-      throw std::runtime_error("ipNodeMap not implemented");
-#else
-      printf("Invalid ipNodeMap call on GPUs");
-      return nullptr;
-#endif
-     }
+    NGP_ThrowErrorMsg("MasterElement::ipNodeMap not implemented");
+    return nullptr;
+  }
 
   virtual void shape_fcn(
     double * /* shpfc */) {

--- a/include/master_element/MasterElementHO.h
+++ b/include/master_element/MasterElementHO.h
@@ -163,7 +163,7 @@ public:
       const double *field,
       double *result) final;
 
-  const int * adjacentNodes() final;
+  KOKKOS_FUNCTION const int * adjacentNodes() final;
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
@@ -412,7 +412,7 @@ public:
       const double *field,
       double *result) final;
 
-  const int * adjacentNodes() final;
+  KOKKOS_FUNCTION const int * adjacentNodes() final;
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -40,8 +40,6 @@ public:
   using MasterElement::determinant;
   using MasterElement::grad_op;
   using MasterElement::shifted_grad_op;
-  using MasterElement::shape_fcn;
-  using MasterElement::shifted_shape_fcn;
 
   KOKKOS_FUNCTION
   PyrSCV();
@@ -49,6 +47,11 @@ public:
   virtual ~PyrSCV() = default;
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
+
+  KOKKOS_FUNCTION void shape_fcn(SharedMemView<DoubleType**, DeviceShmem> &shpfc);
+
+  KOKKOS_FUNCTION void shifted_shape_fcn(
+    SharedMemView<DoubleType**, DeviceShmem> &shpfc);
 
   KOKKOS_FUNCTION void determinant(
     SharedMemView<DoubleType**, DeviceShmem>& coords,
@@ -139,8 +142,6 @@ class PyrSCS : public MasterElement
 public:
   using AlgTraits = AlgTraitsPyr5;
   using MasterElement::determinant;
-  using MasterElement::shape_fcn;
-  using MasterElement::shifted_shape_fcn;
   using MasterElement::adjacentNodes;
 
   KOKKOS_FUNCTION
@@ -149,6 +150,11 @@ public:
   virtual ~PyrSCS() = default;
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
+
+  KOKKOS_FUNCTION void shape_fcn(SharedMemView<DoubleType**, DeviceShmem> &shpfc);
+
+  KOKKOS_FUNCTION void shifted_shape_fcn(
+    SharedMemView<DoubleType**, DeviceShmem> &shpfc);
 
   KOKKOS_FUNCTION void determinant(
     SharedMemView<DoubleType**, DeviceShmem>& coords,

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -218,7 +218,7 @@ public:
     double *metric,
     double *deriv);
 
-  virtual const int * adjacentNodes() final;
+  KOKKOS_FUNCTION virtual const int * adjacentNodes() final;
 
   const int * scsIpEdgeOrd();
 

--- a/include/master_element/Quad42DCVFEM.h
+++ b/include/master_element/Quad42DCVFEM.h
@@ -220,7 +220,7 @@ public:
      double *metric,
      double *deriv) override ;
 
-  virtual const int * adjacentNodes() final;
+  KOKKOS_FUNCTION virtual const int * adjacentNodes() final;
 
   const int * scsIpEdgeOrd() override;
 

--- a/include/master_element/Quad92DCVFEM.h
+++ b/include/master_element/Quad92DCVFEM.h
@@ -313,7 +313,7 @@ public:
     double *metric,
     double *deriv) override ;
 
-  virtual const int * adjacentNodes() final ;
+  KOKKOS_FUNCTION virtual const int * adjacentNodes() final ;
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final ;
 

--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -214,7 +214,7 @@ public:
     double *metric,
     double *deriv);
 
-  virtual const int * adjacentNodes() final;
+  KOKKOS_FUNCTION virtual const int * adjacentNodes() final;
 
   const int * scsIpEdgeOrd();
 

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -215,7 +215,7 @@ public:
     double *metric,
     double *deriv) override;
 
-  const int * adjacentNodes() final;
+  KOKKOS_FUNCTION const int * adjacentNodes() final;
 
   const int * scsIpEdgeOrd() override;
 

--- a/include/master_element/Wed6CVFEM.h
+++ b/include/master_element/Wed6CVFEM.h
@@ -222,7 +222,7 @@ public:
     double *metric,
     double *deriv);
 
-  virtual const int * adjacentNodes() final;
+  KOKKOS_FUNCTION virtual const int * adjacentNodes() final;
   
   const int * scsIpEdgeOrd();
 

--- a/unit_tests/kernels/UnitTestContinuityAdvElem.C
+++ b/unit_tests/kernels/UnitTestContinuityAdvElem.C
@@ -11,6 +11,7 @@
 
 #include "kernel/ContinuityAdvElemKernel.h"
 
+#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 namespace advection_default {
@@ -58,10 +59,10 @@ static constexpr double lhs[8][8] = {
 } // hex8_golds
 } // anonymous namespace
 
-#ifndef KOKKOS_ENABLE_CUDA
+#endif
 
 /// Continuity advection with default Solution options
-TEST_F(ContinuityKernelHex8Mesh, advection_default)
+TEST_F(ContinuityKernelHex8Mesh, NGP_advection_default)
 {
   fill_mesh_and_init_fields();
 
@@ -93,6 +94,7 @@ TEST_F(ContinuityKernelHex8Mesh, advection_default)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
+#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -101,13 +103,14 @@ TEST_F(ContinuityKernelHex8Mesh, advection_default)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, gold_values::lhs);
+#endif
 }
 
 /// Continuity advection kernel
 ///
 /// `reduced_sens_cvfem_poisson: true`
 ///
-TEST_F(ContinuityKernelHex8Mesh, advection_reduced_sens_cvfem_poisson)
+TEST_F(ContinuityKernelHex8Mesh, NGP_advection_reduced_sens_cvfem_poisson)
 {
   fill_mesh_and_init_fields();
 
@@ -139,6 +142,7 @@ TEST_F(ContinuityKernelHex8Mesh, advection_reduced_sens_cvfem_poisson)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
+#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -147,13 +151,14 @@ TEST_F(ContinuityKernelHex8Mesh, advection_reduced_sens_cvfem_poisson)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, gold_values::lhs);
+#endif
 }
 
 /// Continuity advection kernel
 ///
 /// `shift_cvfem_poisson: true`
 ///
-TEST_F(ContinuityKernelHex8Mesh, advection_reduced_shift_cvfem_poisson)
+TEST_F(ContinuityKernelHex8Mesh, NGP_advection_reduced_shift_cvfem_poisson)
 {
   fill_mesh_and_init_fields();
 
@@ -185,6 +190,7 @@ TEST_F(ContinuityKernelHex8Mesh, advection_reduced_shift_cvfem_poisson)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
+#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -193,7 +199,5 @@ TEST_F(ContinuityKernelHex8Mesh, advection_reduced_shift_cvfem_poisson)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, gold_values::lhs);
-}
-
 #endif
-
+}


### PR DESCRIPTION
Convert an SCS based Kernel to make sure that there is coverage on GPUs for surface element.