### PR TITLE
Transition Momentum Mass and AdvDiff Kernels to GPU

### DIFF
--- a/unit_tests/kernels/UnitTestMomentumAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestMomentumAdvDiffElem.C
@@ -11,6 +11,7 @@
 
 #include "kernel/MomentumAdvDiffElemKernel.h"
 
+#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 namespace advection_diffusion {
@@ -270,10 +271,9 @@ static constexpr double lhs[24][24] = {
 } // advection_diffusion
 } // hex8_golds
 } // anonymous namespace
+#endif
 
-#ifndef KOKKOS_ENABLE_CUDA
-
-TEST_F(MomentumKernelHex8Mesh, advection_diffusion)
+TEST_F(MomentumKernelHex8Mesh, NGP_advection_diffusion)
 {
   fill_mesh_and_init_fields();
 
@@ -297,6 +297,7 @@ TEST_F(MomentumKernelHex8Mesh, advection_diffusion)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
+#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -304,7 +305,5 @@ TEST_F(MomentumKernelHex8Mesh, advection_diffusion)
   namespace gold_values = ::hex8_golds::advection_diffusion;
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->lhs_, gold_values::lhs);
-}
-
 #endif
-
+}

--- a/unit_tests/kernels/UnitTestMomentumMassElem.C
+++ b/unit_tests/kernels/UnitTestMomentumMassElem.C
@@ -11,6 +11,8 @@
 
 #include "kernel/MomentumMassElemKernel.h"
 
+#ifndef KOKKOS_ENABLE_CUDA
+
 namespace {
 namespace hex8_golds {
 namespace momentum_time_derivative {
@@ -141,9 +143,9 @@ static constexpr double rhs[24] = {
 } // hex8_golds
 } // anonymous namespace
 
-#ifndef KOKKOS_ENABLE_CUDA
+#endif
 
-TEST_F(MomentumKernelHex8Mesh, momentum_time_derivative)
+TEST_F(MomentumKernelHex8Mesh, NGP_momentum_time_derivative)
 {
   fill_mesh_and_init_fields();
 
@@ -177,6 +179,7 @@ TEST_F(MomentumKernelHex8Mesh, momentum_time_derivative)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
+#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -184,9 +187,10 @@ TEST_F(MomentumKernelHex8Mesh, momentum_time_derivative)
   namespace gold_values = ::hex8_golds::momentum_time_derivative;
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<24>(helperObjs.linsys->lhs_, gold_values::lhs);
+#endif
 }
 
-TEST_F(MomentumKernelHex8Mesh, momentum_time_derivative_lumped)
+TEST_F(MomentumKernelHex8Mesh, NGP_momentum_time_derivative_lumped)
 {
   fill_mesh_and_init_fields();
 
@@ -220,6 +224,7 @@ TEST_F(MomentumKernelHex8Mesh, momentum_time_derivative_lumped)
   // Populate LHS and RHS
   helperObjs.assembleElemSolverAlg->execute();
 
+#ifndef KOKKOS_ENABLE_CUDA
   namespace gold_values = ::hex8_golds::momentum_time_derivative_lumped;
   // Exact LHS expected
   std::vector<double> lhsExact(576, 0.0);
@@ -231,7 +236,5 @@ TEST_F(MomentumKernelHex8Mesh, momentum_time_derivative_lumped)
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->lhs_, lhsExact.data());
-}
-
 #endif
-
+}


### PR DESCRIPTION
Follows the same formula used to convert Continuity interior kernels for two Momentum Kernels.