### PR TITLE
Converting TurbKineticEnergyKsgsSrcElemKernel to NGP

### DIFF
--- a/unit_tests/kernels/CMakeLists.txt
+++ b/unit_tests/kernels/CMakeLists.txt
@@ -18,6 +18,7 @@ add_sources(GlobalUnitSourceList
    UnitTestScalarMassElem.C
    UnitTestScalarDiffElem.C
    UnitTestSteadyThermal3dContactSrcElem.C
+   UnitTestTurbKineticEnergyKsgsSrcElemKernel.C
    UnitTestWallDistElem.C
 )
 

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -131,12 +131,6 @@ void dhdx_test_function(
   const VectorFieldType& coordinates,
   VectorFieldType& dhdx);
 
-void calc_dual_nodal_volume(
-  stk::mesh::BulkData& bulk,
-  const stk::topology& topo,
-  const VectorFieldType& coordinates,
-  const ScalarFieldType& dnvField);
-
 void calc_mass_flow_rate_scs(
   stk::mesh::BulkData&,
   const stk::topology&,
@@ -394,7 +388,7 @@ public:
     unit_test_kernel_utils::density_test_function(
       bulk_, *coordinates_, *density_);
     unit_test_kernel_utils::tke_test_function(bulk_, *coordinates_, *tke_);
-    unit_test_kernel_utils::calc_dual_nodal_volume(bulk_, stk::topology::HEX_8, *coordinates_, *dnvField_);
+    stk::mesh::field_fill(0.125, *dnvField_);
     unit_test_kernel_utils::dudx_test_function(bulk_, *coordinates_, *dudx_);
   }
 

--- a/unit_tests/kernels/UnitTestTurbKineticEnergyKsgsSrcElemKernel.C
+++ b/unit_tests/kernels/UnitTestTurbKineticEnergyKsgsSrcElemKernel.C
@@ -1,0 +1,92 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "kernel/TurbKineticEnergyKsgsSrcElemKernel.h"
+
+#ifndef KOKKOS_ENABLE_CUDA
+
+namespace {
+namespace hex8_golds {
+namespace TurbKineticEnergyKsgsSrcElemKernel {
+
+static constexpr double lhs[8][8] = {
+  {0.44812892257697001, 0, 0, 0, 0, 0, 0, 0, },
+  {0, 0.26340357181646001, 0, 0, 0, 0, 0, 0, },
+  {0, 0, 0.17225002410293999, 0, 0, 0, 0, 0, },
+  {0, 0, 0, 0.31216473910173997, 0, 0, 0, 0, },
+  {0, 0, 0, 0, 0.26340357181646001, 0, 0, 0, },
+  {0, 0, 0, 0, 0, 0.15482473491488, 0, 0, },
+  {0, 0, 0, 0, 0, 0, 0.097154884604998,0, },
+  {0, 0, 0, 0, 0, 0, 0, 0.17225002410293999, }
+};
+
+static constexpr double rhs[8] = {
+   -0.59750523010263001,
+   -0.35120476242194998,
+   -0.22719581319873999,
+   -0.58458403812094994,
+   -0.35120476242194998,
+   -0.2064329798865,
+   -0.090566201776693,
+   -0.28427320142228002
+};
+
+} // namespace TurbKineticEnergyKsgsSrcElemKernel
+} // namespace hex8_golds
+} // anonymous namespace
+
+#endif
+
+TEST_F(KsgsKernelHex8Mesh, NGP_turb_kinetic_energy_ksgs_src_elem_kernel)
+{
+
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
+    return;
+
+  fill_mesh_and_init_fields();
+
+  // Setup solution options
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.initialize_turbulence_constants();
+
+  unit_test_utils::HelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+
+  // Initialize the kernel
+  std::unique_ptr<sierra::nalu::Kernel> kernel(
+    new sierra::nalu::TurbKineticEnergyKsgsSrcElemKernel<
+      sierra::nalu::AlgTraitsHex8>(
+      bulk_, solnOpts_, helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
+
+  // Add to kernels to be tested
+  helperObjs.assembleElemSolverAlg->activeKernels_.push_back(kernel.get());
+
+  helperObjs.assembleElemSolverAlg->execute();
+
+#ifndef KOKKOS_ENABLE_CUDA
+
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
+
+  namespace gold_values = hex8_golds::TurbKineticEnergyKsgsSrcElemKernel;
+  // Why do these need 1.0e-14 while others seem to be fine with 1.0e-15 default?
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, gold_values::rhs, 1.0e-14);
+  unit_test_kernel_utils::expect_all_near<8>(
+    helperObjs.linsys->lhs_, gold_values::lhs, 1.0e-14);
+
+#endif
+}
+
+


### PR DESCRIPTION
This is still a WIP.

This one was a bit more involved than the others I did. I had to add a unit test. It appears everything works on the CPU. I have two small questions regarding my implementation:
 1. I am curious if I implemented `KsgsKernelHex8Mesh` correctly?
 2. Why did I need `1.0e-14` `tol` when I used `print_lhs_and_rhs()` and used the values it emitted, when the other SST kernels I did used the `1.0e-15` default?

Also, what makes this a WIP is that at the moment it doesn't build with CUDA because when I put `calc_dual_nodal_volume` in `UnitTestKernelUtils.C` outside of the CUDA ifdefs (so it is live when CUDA is enabled) I can't get it to link with CUDA enabled because of:
```
unit_tests/kernels/UnitTestKernelUtils.C(599): error: no instance of function template "sierra::nalu::fill_pre_req_data" matches the argument list
            argument types are: (sierra::nalu::ElemDataRequestsGPU, ngp::Mesh, stk::topology::rank_t, stk::mesh::Entity, sierra::nalu::ScratchViews<double, sierra::nalu::TeamHandleType, sierra::nalu::HostShmem>)
```
Is this a known problem since `calc_dual_nodal_volume` is currently ifdef'd out? I'm guessing I'm just missing something.