### PR TITLE
Convert MomentumBuoyancyBoussinesqSrcElemKernel to NGP

### DIFF
--- a/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
+++ b/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
@@ -56,7 +56,7 @@ private:
   double rhoRef_;
   double tRef_;
   double beta_;
-  AlignedViewType<DoubleType[AlgTraits::nDim_]> gravity_{ "v_gravity"};
+  NALU_ALIGNED DoubleType gravity_[3];
 
   MasterElement* meSCV_{nullptr};
 };

--- a/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
+++ b/include/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.h
@@ -26,7 +26,7 @@ class ElemDataRequests;
 /** CMM buoyancy term for momentum equation (velocity DOF)
  */
 template<typename AlgTraits>
-class MomentumBuoyancyBoussinesqSrcElemKernel: public Kernel
+class MomentumBuoyancyBoussinesqSrcElemKernel: public NGPKernel<MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>>
 {
 public:
   MomentumBuoyancyBoussinesqSrcElemKernel(
@@ -34,20 +34,22 @@ public:
     const SolutionOptions&,
     ElemDataRequests&);
 
-  virtual ~MomentumBuoyancyBoussinesqSrcElemKernel();
+  KOKKOS_FUNCTION MomentumBuoyancyBoussinesqSrcElemKernel() = default;
+
+  KOKKOS_FUNCTION virtual ~MomentumBuoyancyBoussinesqSrcElemKernel() = default;
 
   /** Execute the kernel within a Kokkos loop and populate the LHS and RHS for
    *  the linear solve
    */
   using Kernel::execute;
+
+  KOKKOS_FUNCTION
   virtual void execute(
-    SharedMemView<DoubleType**>&,
-    SharedMemView<DoubleType*>&,
-    ScratchViews<DoubleType>&);
+    SharedMemView<DoubleType**, DeviceShmem>&,
+    SharedMemView<DoubleType*, DeviceShmem>&,
+    ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>&);
 
 private:
-  MomentumBuoyancyBoussinesqSrcElemKernel() = delete;
-
   unsigned temperatureNp1_ {stk::mesh::InvalidOrdinal};
   unsigned coordinates_ {stk::mesh::InvalidOrdinal};
 
@@ -56,10 +58,7 @@ private:
   double beta_;
   AlignedViewType<DoubleType[AlgTraits::nDim_]> gravity_{ "v_gravity"};
 
-  const int* ipNodeMap_;
-
-  // scratch space
-  AlignedViewType<DoubleType[AlgTraits::numScvIp_][AlgTraits::nodesPerElement_]> v_shape_function_ { "v_shape_func" };
+  MasterElement* meSCV_{nullptr};
 };
 
 }  // nalu

--- a/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
+++ b/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
@@ -30,9 +30,7 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::MomentumBuoyancyBoussinesqSr
   const stk::mesh::BulkData& bulkData,
   const SolutionOptions& solnOpts,
   ElemDataRequests& dataPreReqs)
-  : Kernel(),
-    rhoRef_(solnOpts.referenceDensity_),
-    ipNodeMap_(sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_)->ipNodeMap())
+  : rhoRef_(solnOpts.referenceDensity_)
 {
   const stk::mesh::MetaData& metaData = bulkData.mesh_meta_data();
 
@@ -47,38 +45,36 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::MomentumBuoyancyBoussinesqSr
   rhoRef_ = solnOpts.referenceDensity_;
   beta_ = solnOpts.thermalExpansionCoeff_;
 
-  MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(AlgTraits::topo_);
-  get_scv_shape_fn_data<AlgTraits>([&](double* ptr){meSCV->shape_fcn(ptr);}, v_shape_function_);
+  meSCV_ = MasterElementRepo::get_volume_master_element<AlgTraits>();
 
   // add master elements
-  dataPreReqs.add_cvfem_volume_me(meSCV);
+  dataPreReqs.add_cvfem_volume_me(meSCV_);
 
   // fields and data
   dataPreReqs.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_gathered_nodal_field(temperatureNp1_, 1);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+  dataPreReqs.add_master_element_call(SCV_SHAPE_FCN, CURRENT_COORDINATES);
 }
-
-template<typename AlgTraits>
-MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::~MomentumBuoyancyBoussinesqSrcElemKernel()
-{}
 
 template<typename AlgTraits>
 void
 MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::execute(
-  SharedMemView<DoubleType**>& /* lhs */,
-  SharedMemView<DoubleType*>& rhs,
-  ScratchViews<DoubleType>& scratchViews)
+  SharedMemView<DoubleType**, DeviceShmem>& /* lhs */,
+  SharedMemView<DoubleType*, DeviceShmem>& rhs,
+  ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>& scratchViews)
 {
-  SharedMemView<DoubleType*>& v_temperatureNp1 = scratchViews.get_scratch_view_1D(temperatureNp1_);
-  SharedMemView<DoubleType*>& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+  const auto& v_temperatureNp1 = scratchViews.get_scratch_view_1D(temperatureNp1_);
+  const auto& v_scv_volume = scratchViews.get_me_views(CURRENT_COORDINATES).scv_volume;
+  const auto& v_shape_function = scratchViews.get_me_views(CURRENT_COORDINATES).scv_shape_fcn;
+  const auto* ipNodeMap = meSCV_->ipNodeMap();
 
   for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
-    const int nearestNode = ipNodeMap_[ip];
+    const int nearestNode = ipNodeMap[ip];
     DoubleType temperatureIp = 0.0;
 
     for (int ic=0; ic < AlgTraits::nodesPerElement_; ++ic) {
-      const DoubleType r = v_shape_function_(ip, ic);
+      const DoubleType r = v_shape_function(ip, ic);
       temperatureIp += r * v_temperatureNp1(ic);
     }
 

--- a/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
+++ b/src/kernel/MomentumBuoyancyBoussinesqSrcElemKernel.C
@@ -36,10 +36,11 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::MomentumBuoyancyBoussinesqSr
 
   temperatureNp1_ = get_field_ordinal(metaData, "temperature", stk::mesh::StateNP1);
   coordinates_ = get_field_ordinal(metaData, solnOpts.get_coordinates_name());
-  
+
   const std::vector<double>& solnOptsGravity = solnOpts.get_gravity_vector(AlgTraits::nDim_);
+
   for (int i = 0; i < AlgTraits::nDim_; i++)
-    gravity_(i) = solnOptsGravity[i];
+    gravity_[i] = solnOptsGravity[i];
 
   tRef_ = solnOpts.referenceTemperature_;
   rhoRef_ = solnOpts.referenceDensity_;
@@ -83,7 +84,7 @@ MomentumBuoyancyBoussinesqSrcElemKernel<AlgTraits>::execute(
     const int nnNdim = nearestNode * AlgTraits::nDim_;
     const DoubleType fac = -rhoRef_ * beta_ * (temperatureIp - tRef_) * scV;
     for (int j=0; j < AlgTraits::nDim_; ++j) {
-      rhs(nnNdim + j) += fac * gravity_(j);
+      rhs(nnNdim + j) += fac * gravity_[j];
     }
 
     // No LHS contributions

--- a/unit_tests/kernels/UnitTestMomentumBuoyancyBoussinesqSrcElem.C
+++ b/unit_tests/kernels/UnitTestMomentumBuoyancyBoussinesqSrcElem.C
@@ -13,9 +13,7 @@
 
 #include <random>
 
-#ifndef KOKKOS_ENABLE_CUDA
-
-TEST_F(MomentumKernelHex8Mesh, buoyancy_boussinesq)
+TEST_F(MomentumKernelHex8Mesh, NGP_buoyancy_boussinesq)
 {
   std::mt19937 rng;
   rng.seed(0); // fixed seed
@@ -45,6 +43,7 @@ TEST_F(MomentumKernelHex8Mesh, buoyancy_boussinesq)
 
   helperObjs.assembleElemSolverAlg->execute();
 
+#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -57,7 +56,6 @@ TEST_F(MomentumKernelHex8Mesh, buoyancy_boussinesq)
     rhsExact[i] = -0.125 * solnOpts_.gravity_[2] * expFac * (300.0 - solnOpts_.referenceTemperature_);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,rhsExact.data());
-}
-
 #endif
+}
 


### PR DESCRIPTION
I feel like I should have to replace `AlignedViewType<DoubleType[AlgTraits::nDim_]> gravity_{ "v_gravity"};` with something else here like we do with the shape functions, but this seems to run on the GPU. Let me know if that looks like a problem.