### PR TITLE
Add unit tests for BC kernels 

### DIFF
--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -77,7 +77,10 @@ struct FaceElemHelperObjects : HelperObjects {
     assembleFaceElemSolverAlg = new sierra::nalu::AssembleFaceElemSolverAlgorithm(realm, part, &eqSystem, faceTopo.num_nodes(), elemTopo.num_nodes());
   }
 
-  ~FaceElemHelperObjects() {    delete assembleFaceElemSolverAlg;
+  ~FaceElemHelperObjects()
+  {
+    assembleFaceElemSolverAlg->activeKernels_.clear();
+    delete assembleFaceElemSolverAlg;
   }
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm* assembleFaceElemSolverAlg;

--- a/unit_tests/kernels/CMakeLists.txt
+++ b/unit_tests/kernels/CMakeLists.txt
@@ -20,6 +20,7 @@ add_sources(GlobalUnitSourceList
    UnitTestScalarMassElem.C
    UnitTestScalarDiffElem.C
    UnitTestScalarUpwAdvDiffElem.C
+   UnitTestScalarOpenElem.C
    UnitTestSteadyThermal3dContactSrcElem.C
    UnitTestTurbKineticEnergyKsgsSrcElem.C
    UnitTestTurbKineticEnergyKsgsDesignOrderSrcElem.C

--- a/unit_tests/kernels/CMakeLists.txt
+++ b/unit_tests/kernels/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_sources(GlobalUnitSourceList
    UnitTestContinuityAdvElem.C
    UnitTestContinuityMassElem.C
+   UnitTestContinuityInflowElem.C
    UnitTestContinuityOpenElem.C
    UnitTestFaceBasic.C
    UnitTestFaceElemBasic.C

--- a/unit_tests/kernels/CMakeLists.txt
+++ b/unit_tests/kernels/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_sources(GlobalUnitSourceList
    UnitTestContinuityAdvElem.C
    UnitTestContinuityMassElem.C
+   UnitTestContinuityOpenElem.C
    UnitTestFaceBasic.C
    UnitTestFaceElemBasic.C
    UnitTestKernelUtils.C

--- a/unit_tests/kernels/UnitTestContinuityInflowElem.C
+++ b/unit_tests/kernels/UnitTestContinuityInflowElem.C
@@ -1,0 +1,71 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "kernel/ContinuityInflowElemKernel.h"
+
+#ifndef KOKKOS_ENABLE_CUDA
+namespace {
+namespace hex8_golds {
+
+static constexpr double rhs[4] = {
+  0, 0, -0.20225424859374, -0.20225424859374,
+};
+
+}
+} // anonymous namespace
+#endif
+
+TEST_F(ContinuityKernelHex8Mesh, inflow)
+{
+  const bool doPerturb = false;
+  const bool generateSidesets = true;
+  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+
+  // Setup solution options for default advection kernel
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.cvfemShiftMdot_ = true;
+  solnOpts_.shiftedGradOpMap_["pressure"] = true;
+  solnOpts_.cvfemReducedSensPoisson_ = true;
+  solnOpts_.mdotInterpRhoUTogether_ = true;
+  solnOpts_.activateOpenMdotCorrection_ = true;
+
+  auto* part = meta_.get_part("surface_1");
+  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::QUAD_4, 1, part);
+
+  sierra::nalu::TimeIntegrator timeIntegrator;
+  timeIntegrator.gamma1_ = 1.0;
+  timeIntegrator.timeStepN_ = 1.0;
+  timeIntegrator.timeStepNm1_ = 1.0;
+  helperObjs.realm.timeIntegrator_ = &timeIntegrator;
+
+  std::unique_ptr<sierra::nalu::Kernel> inflowKernel(
+    new sierra::nalu::ContinuityInflowElemKernel<sierra::nalu::AlgTraitsQuad4>(
+      bulk_, solnOpts_, true,
+      helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
+
+  // Register the kernel for execution
+  helperObjs.assembleElemSolverAlg->activeKernels_.push_back(inflowKernel.get());
+
+  // Populate LHS and RHS
+  helperObjs.assembleElemSolverAlg->execute();
+
+#ifndef KOKKOS_ENABLE_CUDA
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 4u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 4u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 4u);
+
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
+  unit_test_kernel_utils::expect_all_near<4>(helperObjs.linsys->lhs_, 0.0);
+#endif
+}

--- a/unit_tests/kernels/UnitTestContinuityOpenElem.C
+++ b/unit_tests/kernels/UnitTestContinuityOpenElem.C
@@ -1,0 +1,71 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "kernel/ContinuityOpenElemKernel.h"
+
+#ifndef KOKKOS_ENABLE_CUDA
+namespace {
+namespace hex8_golds {
+
+static constexpr double rhs[8] = {
+  0, 0, 0.11888206453689, 0, 0, 0, 0.11888206453689, 0,
+};
+}
+} // anonymous namespacek
+#endif
+
+TEST_F(ContinuityKernelHex8Mesh, open)
+{
+  const bool doPerturb = false;
+  const bool generateSidesets = true;
+  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+
+  // Setup solution options for default advection kernel
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.cvfemShiftMdot_ = true;
+  solnOpts_.shiftedGradOpMap_["pressure"] = true;
+  solnOpts_.cvfemReducedSensPoisson_ = true;
+  solnOpts_.mdotInterpRhoUTogether_ = true;
+  solnOpts_.activateOpenMdotCorrection_ = true;
+
+  auto* part = meta_.get_part("surface_2");
+  unit_test_utils::FaceElemHelperObjects helperObjs(
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
+
+  sierra::nalu::TimeIntegrator timeIntegrator;
+  timeIntegrator.gamma1_ = 1.0;
+  timeIntegrator.timeStepN_ = 1.0;
+  timeIntegrator.timeStepNm1_ = 1.0;
+  helperObjs.realm.timeIntegrator_ = &timeIntegrator;
+
+  std::unique_ptr<sierra::nalu::Kernel> openKernel(
+    new sierra::nalu::ContinuityOpenElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(
+      meta_, solnOpts_, helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
+      helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_));
+
+  // Register the kernel for execution
+  helperObjs.assembleFaceElemSolverAlg->activeKernels_.push_back(openKernel.get());
+
+  // Populate LHS and RHS
+  helperObjs.assembleFaceElemSolverAlg->execute();
+
+#ifndef KOKKOS_ENABLE_CUDA
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
+
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
+  unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, 0.0);
+#endif
+}

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -290,7 +290,7 @@ void init_trigonometric_field(
   const auto fieldName = qField.name();
   FieldInitFunction funcPtr = nullptr;
 
-  if (fieldName == "velocity")
+  if ((fieldName == "velocity") || (fieldName == "velocity_bc"))
     funcPtr = &TrigFieldFunction::velocity;
   else if (fieldName == "dudx")
     funcPtr = &TrigFieldFunction::dudx;

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -627,6 +627,125 @@ void calc_mass_flow_rate_scs(
   }
 }
 
+void calc_open_mass_flow_rate(
+  stk::mesh::BulkData& bulk,
+  const stk::topology& topo,
+  const VectorFieldType& coordinates,
+  const ScalarFieldType& density,
+  const VectorFieldType& velocity,
+  const GenericFieldType& exposedAreaVec,
+  const GenericFieldType& massFlowRate)
+{
+  const auto& meta = bulk.mesh_meta_data();
+  const int ndim = meta.spatial_dimension();
+  EXPECT_EQ(ndim, 3);
+
+  const ScalarFieldType& densityNp1 = density.field_of_state(stk::mesh::StateNP1);
+  const VectorFieldType& velocityNp1 = velocity.field_of_state(stk::mesh::StateNP1);
+  auto meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
+
+  std::vector<double> v_shape_fcn(meFC->num_integration_points() * meFC->nodesPerElement_);
+  meFC->shape_fcn(v_shape_fcn.data());
+
+  const int numScsIp = meFC->num_integration_points();
+  const int nodesPerElem = meFC->nodesPerElement_;
+  std::vector<double> w_rho(nodesPerElem);
+  std::vector<double> w_vel(ndim * nodesPerElem);
+  std::vector<double> w_coords(ndim * nodesPerElem);
+
+  const stk::mesh::Selector selector =
+    meta.locally_owned_part() | meta.globally_shared_part();
+  const auto& buckets = bulk.get_buckets(meta.side_rank(), selector);
+
+  for (auto b: buckets) {
+    const auto bktlen = b->size();
+
+    for (size_t ie = 0; ie < bktlen; ++ie) {
+      double* mdot = stk::mesh::field_data(massFlowRate, *b, ie);
+      const double* areaVec = stk::mesh::field_data(exposedAreaVec, *b, ie);
+
+      auto* elem_nodes = b->begin_nodes(ie);
+      const auto num_nodes = b->num_nodes(ie);
+
+      for (size_t in = 0; in < num_nodes; ++in) {
+        const auto node = elem_nodes[in];
+        w_rho[in] = *stk::mesh::field_data(densityNp1, node);
+        const double* vel = stk::mesh::field_data(velocityNp1, node);
+        const double* coords = stk::mesh::field_data(coordinates, node);
+
+        for (int d=0; d < ndim; ++d) {
+          w_vel[in * ndim + d] = vel[d];
+          w_coords[in * ndim + d] = coords[d];
+        }
+      }
+
+      for (int ip = 0; ip < numScsIp; ++ip) {
+        std::vector<double> rhoU(ndim, 0.0);
+
+        const int offset = ip * nodesPerElem;
+        for (int ic=0; ic < nodesPerElem; ++ic) {
+          const double r = v_shape_fcn[offset + ic];
+          for (int d = 0; d < ndim; d++)
+            rhoU[d] += r * w_rho[ic] * w_vel[ic * ndim + d];
+        }
+
+        double tmdot = 0.0;
+        for (int d = 0; d < ndim; d++)
+          tmdot += rhoU[d] * areaVec[ip * ndim + d];
+
+        mdot[ip] = tmdot;
+      }
+    }
+  }
+}
+
+void calc_exposed_area_vec(
+  const stk::mesh::BulkData& bulk,
+  const stk::topology& topo,
+  const VectorFieldType& coordinates,
+  GenericFieldType& exposedAreaVec)
+{
+  const auto& meta = bulk.mesh_meta_data();
+  const int ndim = meta.spatial_dimension();
+  EXPECT_EQ(ndim, 3);
+
+  auto meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
+  const auto npe = meFC->nodesPerElement_;
+  const auto numScsIp = meFC->num_integration_points();
+  std::vector<double> w_coords(ndim * npe);
+  std::vector<double> w_scs_areav(ndim * numScsIp);
+
+  const stk::mesh::Selector sel = meta.locally_owned_part() | meta.globally_shared_part();
+  const auto& buckets = bulk.get_buckets(meta.side_rank(), sel);
+
+  for (auto b: buckets) {
+    ThrowRequire(b->topology() == topo);
+
+    const auto bktlen = b->size();
+    for (size_t ie = 0; ie < bktlen; ++ie) {
+      double* areaVec = stk::mesh::field_data(exposedAreaVec, *b, ie);
+
+      const auto* face_nodes = b->begin_nodes(ie);
+      const auto num_nodes = b->num_nodes(ie);
+
+      for (size_t in = 0; in < num_nodes; ++in) {
+        const auto node = face_nodes[in];
+        const double* coords = stk::mesh::field_data(coordinates, node);
+        for (int d=0; d < ndim; ++d) {
+          w_coords[in * ndim + d] = coords[d];
+        }
+      }
+
+      double scs_error = 0.0;
+      meFC->determinant(1, w_coords.data(), w_scs_areav.data(), &scs_error);
+
+      for (int ip = 0; ip < numScsIp; ++ip)
+        for (int d=0; d < ndim; ++d)
+          areaVec[ip * ndim + d] = w_scs_areav[ip * ndim + d];
+    }
+  }
+}
+
 #ifndef KOKKOS_ENABLE_CUDA
 
 #if 0

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -298,7 +298,10 @@ public:
           stk::topology::NODE_RANK, "momentum_diag", 2)),
       exposedAreaVec_(
         &meta_.declare_field<GenericFieldType>(
-          meta_.side_rank(), "exposed_area_vector"))
+          meta_.side_rank(), "exposed_area_vector")),
+      velocityBC_(
+        &meta_.declare_field<VectorFieldType>(
+          stk::topology::NODE_RANK, "velocity_bc"))
   {
     stk::mesh::put_field_on_mesh(*velocity_, meta_.universal_part(), spatialDim_, nullptr);
     stk::mesh::put_field_on_mesh(*dpdx_, meta_.universal_part(), spatialDim_, nullptr);
@@ -308,6 +311,7 @@ public:
     stk::mesh::put_field_on_mesh(
       *exposedAreaVec_, meta_.universal_part(),
       spatialDim_ * sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
+    stk::mesh::put_field_on_mesh(*velocityBC_, meta_.universal_part(), spatialDim_, nullptr);
   }
 
   virtual ~LowMachKernelHex8Mesh() {}
@@ -325,6 +329,7 @@ public:
     unit_test_kernel_utils::calc_exposed_area_vec(
       bulk_, sierra::nalu::AlgTraitsQuad4::topo_, *coordinates_,
       *exposedAreaVec_);
+    unit_test_kernel_utils::velocity_test_function(bulk_, *coordinates_, *velocityBC_);
   }
 
   VectorFieldType* velocity_{nullptr};
@@ -333,6 +338,7 @@ public:
   ScalarFieldType* pressure_{nullptr};
   ScalarFieldType* Udiag_{nullptr};
   GenericFieldType* exposedAreaVec_{nullptr};
+  VectorFieldType* velocityBC_{nullptr};
 };
 
 class ContinuityKernelHex8Mesh : public LowMachKernelHex8Mesh

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -602,7 +602,10 @@ public:
     massFlowRate_(&meta_.declare_field<GenericFieldType>(stk::topology::ELEM_RANK,
                                                          "mass_flow_rate_scs")),
     dzdx_(&meta_.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dzdx")),
-
+    exposedAreaVec_(&meta_.declare_field<GenericFieldType>(
+                      meta_.side_rank(), "exposed_area_vector")),
+    openMassFlowRate_(&meta_.declare_field<GenericFieldType>(meta_.side_rank(),
+                                                         "open_mass_flow_rate")),
     znot_(1.0),
     amf_(2.0),
     lamSc_(0.9),
@@ -619,6 +622,12 @@ public:
     stk::mesh::put_field_on_mesh(*viscosity_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*massFlowRate_, meta_.universal_part(), meSCS->num_integration_points(), nullptr);
     stk::mesh::put_field_on_mesh(*dzdx_, meta_.universal_part(), spatialDim_, nullptr);
+    stk::mesh::put_field_on_mesh(
+      *exposedAreaVec_, meta_.universal_part(),
+      spatialDim_ * sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
+    stk::mesh::put_field_on_mesh(
+      *openMassFlowRate_, meta_.universal_part(),
+      sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
   }
   virtual ~MixtureFractionKernelHex8Mesh() {}
 
@@ -635,6 +644,12 @@ public:
                                                                          viscPrimary_, viscSecondary_);
     unit_test_kernel_utils::calc_mass_flow_rate_scs(
       bulk_, stk::topology::HEX_8, *coordinates_, *density_, *velocity_, *massFlowRate_);
+    unit_test_kernel_utils::calc_exposed_area_vec(
+      bulk_, sierra::nalu::AlgTraitsQuad4::topo_, *coordinates_,
+      *exposedAreaVec_);
+    unit_test_kernel_utils::calc_open_mass_flow_rate(
+      bulk_, stk::topology::QUAD_4, *coordinates_, *density_, *velocity_,
+      *exposedAreaVec_, *openMassFlowRate_);
   }
 
   ScalarFieldType* mixFraction_{nullptr};
@@ -644,6 +659,8 @@ public:
   ScalarFieldType* effectiveViscosity_{nullptr};
   GenericFieldType* massFlowRate_{nullptr};
   VectorFieldType* dzdx_{nullptr};
+  GenericFieldType* exposedAreaVec_{nullptr};
+  GenericFieldType* openMassFlowRate_{nullptr};
 
   const double znot_;
   const double amf_;

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -131,6 +131,13 @@ void dhdx_test_function(
   const VectorFieldType& coordinates,
   VectorFieldType& dhdx);
 
+void calc_exposed_area_vec(
+  const stk::mesh::BulkData& bulk,
+  const stk::topology& topo,
+  const VectorFieldType& coordinates,
+  GenericFieldType& exposedAreaVec
+);
+
 void calc_mass_flow_rate_scs(
   stk::mesh::BulkData&,
   const stk::topology&,
@@ -138,6 +145,15 @@ void calc_mass_flow_rate_scs(
   const ScalarFieldType&,
   const VectorFieldType&,
   const GenericFieldType&);
+
+void calc_open_mass_flow_rate(
+  stk::mesh::BulkData& bulk,
+  const stk::topology& topo,
+  const VectorFieldType& coordinates,
+  const ScalarFieldType& density,
+  const VectorFieldType& velocity,
+  const GenericFieldType& exposedAreaVec,
+  const GenericFieldType& massFlowRate);
 
 void calc_projected_nodal_gradient(
   stk::mesh::BulkData& bulk,

--- a/unit_tests/kernels/UnitTestScalarOpenElem.C
+++ b/unit_tests/kernels/UnitTestScalarOpenElem.C
@@ -1,0 +1,86 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "kernel/ScalarOpenAdvElemKernel.h"
+
+#ifndef KOKKOS_ENABLE_CUDA
+namespace {
+namespace hex8_golds {
+static constexpr double rhs[8] = {
+  0, -0.0023752535774385, 0.0071257607323155, 0, 0, -0.0032819663013787, 0.0098458989041362, 0,
+};
+
+static constexpr double lhs[8][8] = {
+  {0, 0, 0, 0, 0, 0, 0, 0, },
+  {0, 0, 0, 0, 0, 0, 0, 0, },
+  {0, 0, 0, 0, 0, 0, 0, 0, },
+  {0, 0, 0, 0, 0, 0, 0, 0, },
+  {0, 0, 0, 0, 0, 0, 0, 0, },
+  {0, 0, 0, 0, 0, 0.0016409831506894, 0, 0, },
+  {0, 0, 0, 0, 0, 0, 0.0049229494520681, 0, },
+  {0, 0, 0, 0, 0, 0, 0, 0, },
+};
+}
+}
+#endif
+
+TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
+{
+  const bool doPerturb = false;
+  const bool generateSidesets = true;
+  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+
+  // Setup solution options for default advection kernel
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.cvfemShiftMdot_ = true;
+  solnOpts_.cvfemReducedSensPoisson_ = true;
+  solnOpts_.activateOpenMdotCorrection_ = true;
+  solnOpts_.alphaMap_["mixture_fraction"] = 1.0;
+  solnOpts_.alphaUpwMap_["mixture_fraction"] = 1.0;
+  solnOpts_.upwMap_["mixture_fraction"] = 0.0;
+  solnOpts_.shiftedGradOpMap_["mixture_fraction"] = true;
+  solnOpts_.skewSymmetricMap_["mixture_fraction"] = true;
+
+  auto* part = meta_.get_part("surface_2");
+  unit_test_utils::FaceElemHelperObjects helperObjs(
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
+
+  sierra::nalu::TimeIntegrator timeIntegrator;
+  timeIntegrator.gamma1_ = 1.0;
+  timeIntegrator.timeStepN_ = 1.0;
+  timeIntegrator.timeStepNm1_ = 1.0;
+  helperObjs.realm.timeIntegrator_ = &timeIntegrator;
+
+  std::unique_ptr<sierra::nalu::Kernel> openKernel(
+    new sierra::nalu::ScalarOpenAdvElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(
+      meta_, solnOpts_, &helperObjs.eqSystem, mixFraction_, mixFraction_, dzdx_,
+      viscosity_, helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
+      helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_));
+
+  // Register the kernel for execution
+  helperObjs.assembleFaceElemSolverAlg->activeKernels_.push_back(openKernel.get());
+
+  // Populate LHS and RHS
+  helperObjs.assembleFaceElemSolverAlg->execute();
+
+#ifndef KOKKOS_ENABLE_CUDA
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
+
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
+  unit_test_kernel_utils::expect_all_near<8>(
+    helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
+#endif
+}


### PR DESCRIPTION
In anticipation of NGP transition of BC kernels (#202), this pull request does the following:

- Update kernel unit test infrastructure with the necessary fields used in BC kernels
- Update FaceElem helper object to fix segfaults
- Add unit tests for Continuity Inflow/Open, and Scalar Open kernels

Doesn't address Momentum Open kernel, but implements all necessary infrastructure to add the unit tests. 