### PR TITLE
Fix the crashing master-element GPU test from James' branch.

### DIFF
--- a/include/MultiDimViews.h
+++ b/include/MultiDimViews.h
@@ -42,14 +42,18 @@ public:
   static constexpr unsigned bytesPerUnsigned = sizeof(unsigned);
 
   KOKKOS_FUNCTION
-  MultiDimViews(const TEAMHANDLETYPE& team,
+  MultiDimViews(const TEAMHANDLETYPE& /*team*/,
                 unsigned maxOrdinal,
                 const NumNeededViews& numNeededViews)
-  : indices(get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team,
-            adjust_up_to_alignment_boundary((maxOrdinal+1)*bytesPerUnsigned, KOKKOS_MEMORY_ALIGNMENT)/bytesPerUnsigned)),
+  : indices(),
     views_1D(), views_2D(), views_3D(), views_4D(), 
     views_1D_size(0), views_2D_size(0), views_3D_size(0), views_4D_size(0)
   {
+    if (maxOrdinal > maxFieldOrdinals)
+    {
+        printf("Too many fields (%u), current limit in internal arrays is %u. Code will crash...\n", maxOrdinal, maxFieldOrdinals);
+    }
+
     if (numNeededViews.num1DViews > maxViewsPerDim ||
         numNeededViews.num2DViews > maxViewsPerDim ||
         numNeededViews.num3DViews > maxViewsPerDim ||
@@ -237,8 +241,9 @@ public:
 
 public:
   static const unsigned maxViewsPerDim = 25;
+  static const unsigned maxFieldOrdinals = 64;
 
-  SharedMemView<int*,SHMEM> indices;
+  int indices[maxFieldOrdinals];
 #ifndef KOKKOS_ENABLE_CUDA
   SharedMemView1D* views_1D[maxViewsPerDim];
   SharedMemView2D* views_2D[maxViewsPerDim];


### PR DESCRIPTION
The MultiDimViews object was calling get_shmem_view for the indices
array, and switching indices to a stack array solves the problem.
I'm not sure if it was a problem with alignment, or something else...