### PR TITLE
WIP: Prototype NGP Edge algorithm accessing ngp::Field directly

### DIFF
--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -932,19 +932,15 @@ int calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchI
     return bytes_per_thread;
 }
 
-template<typename DATAREQUESTSTYPE>
 inline
-int calc_shmem_bytes_per_thread_edge(int rhsSize, const DATAREQUESTSTYPE& dataNeeded)
+int calc_shmem_bytes_per_thread_edge(int rhsSize)
 {
   // LHS (RHS^2) + RHS
   const int matSize = rhsSize * (1 + rhsSize) * sizeof(double);
   // Scratch IDs and search permutations (will be optimized later)
   const int idSize = 2 * rhsSize * sizeof(int);
-  const int mdvSize = MultiDimViews<double>::bytes_needed(
-    dataNeeded.get_total_num_fields(),
-    count_needed_field_views(dataNeeded));
 
-  return (matSize + idSize + mdvSize);
+  return (matSize + idSize);
 }
 
 template<typename ELEMDATAREQUESTSTYPE>

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -932,6 +932,21 @@ int calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchI
     return bytes_per_thread;
 }
 
+template<typename DATAREQUESTSTYPE>
+inline
+int calc_shmem_bytes_per_thread_edge(int rhsSize, const DATAREQUESTSTYPE& dataNeeded)
+{
+  // LHS (RHS^2) + RHS
+  const int matSize = rhsSize * (1 + rhsSize) * sizeof(double);
+  // Scratch IDs and search permutations (will be optimized later)
+  const int idSize = 2 * rhsSize * sizeof(int);
+  const int mdvSize = MultiDimViews<double>::bytes_needed(
+    dataNeeded.get_total_num_fields(),
+    count_needed_field_views(dataNeeded));
+
+  return (matSize + idSize + mdvSize);
+}
+
 template<typename ELEMDATAREQUESTSTYPE>
 inline
 int calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchIdsSize, int nDim,

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -124,6 +124,31 @@ struct SharedMemData_FaceElem {
     SharedMemView<int*,SHMEM> sortPermutation;
 };
 
+template<typename TEAMHANDLETYPE, typename SHMEM>
+struct SharedMemData_Edge {
+  KOKKOS_FUNCTION
+  SharedMemData_Edge(
+    const TEAMHANDLETYPE& team,
+    unsigned nDim,
+    const ElemDataRequestsGPU& dataNeededByKernels,
+    unsigned nodesPerEntity,
+    unsigned rhsSize
+  ) : preReqData(team, nDim, nodesPerEntity, dataNeededByKernels)
+  {
+    rhs = get_shmem_view_1D<double, TEAMHANDLETYPE, SHMEM>(team, rhsSize);
+    lhs = get_shmem_view_2D<double, TEAMHANDLETYPE, SHMEM>(team, rhsSize, rhsSize);
+    scratchIds = get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team, rhsSize);
+    sortPermutation = get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team, rhsSize);
+  }
+
+  ngp::Mesh::ConnectedNodes ngpElemNodes;
+  ScratchViews<double, TEAMHANDLETYPE, SHMEM> preReqData;
+  SharedMemView<double*,SHMEM> rhs;
+  SharedMemView<double**,SHMEM> lhs;
+
+  SharedMemView<int*,SHMEM> scratchIds;
+  SharedMemView<int*,SHMEM> sortPermutation;
+};
 } // namespace nalu
 } // namespace Sierra
 

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -129,11 +129,7 @@ struct SharedMemData_Edge {
   KOKKOS_FUNCTION
   SharedMemData_Edge(
     const TEAMHANDLETYPE& team,
-    unsigned nDim,
-    const ElemDataRequestsGPU& dataNeededByKernels,
-    unsigned nodesPerEntity,
-    unsigned rhsSize
-  ) : preReqData(team, nDim, nodesPerEntity, dataNeededByKernels)
+    unsigned rhsSize)
   {
     rhs = get_shmem_view_1D<double, TEAMHANDLETYPE, SHMEM>(team, rhsSize);
     lhs = get_shmem_view_2D<double, TEAMHANDLETYPE, SHMEM>(team, rhsSize, rhsSize);
@@ -142,7 +138,6 @@ struct SharedMemData_Edge {
   }
 
   ngp::Mesh::ConnectedNodes ngpElemNodes;
-  ScratchViews<double, TEAMHANDLETYPE, SHMEM> preReqData;
   SharedMemView<double*,SHMEM> rhs;
   SharedMemView<double**,SHMEM> lhs;
 

--- a/include/edge_kernels/ContinuityEdgeSolverAlg.h
+++ b/include/edge_kernels/ContinuityEdgeSolverAlg.h
@@ -1,0 +1,42 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef CONTINUITYEDGESOLVERALG_H
+#define CONTINUITYEDGESOLVERALG_H
+
+#include "AssembleEdgeSolverAlgorithm.h"
+
+namespace sierra {
+namespace nalu {
+
+class ContinuityEdgeSolverAlg : public AssembleEdgeSolverAlgorithm
+{
+public:
+  ContinuityEdgeSolverAlg(
+    Realm&,
+    stk::mesh::Part*,
+    EquationSystem*);
+
+  virtual ~ContinuityEdgeSolverAlg() = default;
+
+  virtual void execute();
+
+private:
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityRTM_ {stk::mesh::InvalidOrdinal};
+  unsigned pressure_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned Gpdx_ {stk::mesh::InvalidOrdinal};
+  unsigned edgeAreaVec_ {stk::mesh::InvalidOrdinal};
+  unsigned Udiag_ {stk::mesh::InvalidOrdinal};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* CONTINUITYEDGESOLVERALG_H */

--- a/src/AssembleEdgeSolverAlgorithm.C
+++ b/src/AssembleEdgeSolverAlgorithm.C
@@ -1,0 +1,32 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "AssembleEdgeSolverAlgorithm.h"
+#include "EquationSystem.h"
+#include "LinearSystem.h"
+#include "Realm.h"
+
+namespace sierra {
+namespace nalu {
+
+AssembleEdgeSolverAlgorithm::AssembleEdgeSolverAlgorithm(
+  Realm& realm,
+  stk::mesh::Part* part,
+  EquationSystem* eqSystem
+) : SolverAlgorithm(realm, part, eqSystem),
+    dataNeeded_(realm.meta_data()),
+    rhsSize_(nodesPerEntity_ * eqSystem->linsys_->numDof())
+{}
+
+void
+AssembleEdgeSolverAlgorithm::initialize_connectivity()
+{
+  eqSystem_->linsys_->buildEdgeToNodeGraph(partVec_);
+}
+
+}  // nalu
+}  // sierra

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_sources(GlobalSourceList
    AssembleElemSolverAlgorithm.C
    AssembleElemSolverAlgorithmHO.C
    AssembleFaceElemSolverAlgorithm.C
+   AssembleEdgeSolverAlgorithm.C
    AssembleHeatCondIrradWallSolverAlgorithm.C
    AssembleHeatCondWallSolverAlgorithm.C
    AssembleMomentumEdgeABLWallFunctionSolverAlgorithm.C
@@ -214,6 +215,7 @@ endif()
 
 add_subdirectory(element_promotion)
 add_subdirectory(kernel)
+add_subdirectory(edge_kernels)
 add_subdirectory(master_element)
 add_subdirectory(mesh_motion)
 add_subdirectory(nso)

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -130,6 +130,8 @@
 #include <kernel/PressurePoissonHOElemKernel.h>
 #include <kernel/ContinuityMassHOElemKernel.h>
 
+#include <edge_kernels/ContinuityEdgeSolverAlg.h>
+
 //mms kernels
 #include <user_functions/TGMMSHOElemKernel.h>
 
@@ -2797,8 +2799,9 @@ ContinuityEquationSystem::register_interior_algorithm(
     std::map<AlgorithmType, SolverAlgorithm *>::iterator its =
       solverAlgDriver_->solverAlgMap_.find(algType);
     if ( its == solverAlgDriver_->solverAlgMap_.end() ) {
-      AssembleContinuityEdgeSolverAlgorithm *theAlg
-        = new AssembleContinuityEdgeSolverAlgorithm(realm_, part, this);
+      // AssembleContinuityEdgeSolverAlgorithm *theAlg
+      //   = new AssembleContinuityEdgeSolverAlgorithm(realm_, part, this);
+      auto* theAlg = new ContinuityEdgeSolverAlg(realm_, part, this);
       solverAlgDriver_->solverAlgMap_[algType] = theAlg;
     }
     else {

--- a/src/edge_kernels/CMakeLists.txt
+++ b/src/edge_kernels/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_sources(GlobalSourceList
+  ContinuityEdgeSolverAlg.C
+  )

--- a/src/edge_kernels/ContinuityEdgeSolverAlg.C
+++ b/src/edge_kernels/ContinuityEdgeSolverAlg.C
@@ -1,0 +1,131 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "edge_kernels/ContinuityEdgeSolverAlg.h"
+#include "utils/StkHelpers.h"
+
+namespace sierra {
+namespace nalu {
+
+ContinuityEdgeSolverAlg::ContinuityEdgeSolverAlg(
+  Realm& realm,
+  stk::mesh::Part* part,
+  EquationSystem* eqSystem
+) : AssembleEdgeSolverAlgorithm(realm, part, eqSystem)
+{
+  const auto& meta = realm.meta_data();
+  const int ndim = meta.spatial_dimension();
+
+  coordinates_ = get_field_ordinal(meta, realm.get_coordinates_name());
+  const std::string velField = realm.does_mesh_move()? "velocity_rtm" : "velocity";
+  velocityRTM_ = get_field_ordinal(meta, velField);
+  densityNp1_ = get_field_ordinal(meta, "density", stk::mesh::StateNP1);
+  pressure_ = get_field_ordinal(meta, "pressure");
+  Gpdx_ = get_field_ordinal(meta, "dpdx");
+  edgeAreaVec_ = get_field_ordinal(meta, "edge_area_vector", stk::topology::EDGE_RANK);
+  Udiag_ = get_field_ordinal(meta, "momentum_diag");
+
+  dataNeeded_.add_coordinates_field(coordinates_, ndim, CURRENT_COORDINATES);
+  dataNeeded_.add_gathered_nodal_field(velocityRTM_, ndim);
+  dataNeeded_.add_gathered_nodal_field(densityNp1_, 1);
+  dataNeeded_.add_gathered_nodal_field(pressure_, 1);
+  dataNeeded_.add_gathered_nodal_field(Udiag_, 1);
+  dataNeeded_.add_gathered_nodal_field(Gpdx_, ndim);
+}
+
+void
+ContinuityEdgeSolverAlg::execute()
+{
+  const int ndim = realm_.meta_data().spatial_dimension();
+
+  // Non-orthogonal correction factor for continuity equation system
+  const std::string dofName = "pressure";
+  const DblType nocFac
+    = (realm_.get_noc_usage(dofName) == true) ? 1.0 : 0.0;
+
+  // Classic Nalu projection timescale
+  const DblType dt = realm_.get_time_step();
+  const DblType gamma1 = realm_.get_gamma1();
+  const DblType tauScale = dt / gamma1;
+
+  // Interpolation option for rho*U
+  const DblType interpTogether = realm_.get_mdot_interp();
+  const DblType om_interpTogether = (1.0 - interpTogether);
+
+  const auto& fieldMgr = realm_.ngp_field_manager();
+  const auto edgeAreaVec = fieldMgr.get_field<double>(edgeAreaVec_);
+
+  run_algorithm(
+    realm_.bulk_data(),
+    KOKKOS_LAMBDA(ShmemDataType& smdata, const stk::mesh::FastMeshIndex & edge)
+    {
+      auto& scrViews = smdata.preReqData;
+      const auto& v_coords = scrViews.get_scratch_view_2D(coordinates_);
+      const auto& v_velocity = scrViews.get_scratch_view_2D(velocityRTM_);
+      const auto& v_Gpdx = scrViews.get_scratch_view_2D(Gpdx_);
+      const auto& v_density = scrViews.get_scratch_view_1D(densityNp1_);
+      const auto& v_pressure = scrViews.get_scratch_view_1D(pressure_);
+      const auto& v_udiag = scrViews.get_scratch_view_1D(Udiag_);
+
+      // Scratch work array for edgeAreaVector
+      NALU_ALIGNED DblType av[nDimMax_];
+      for (int d=0; d < ndim; ++d)
+        av[d] = edgeAreaVec.get(edge, d);
+
+      const DblType projTimeScale = 0.5 * (1.0 / v_udiag(nodeL) + 1.0 / v_udiag(nodeR));
+      const DblType rhoIp = 0.5 * (v_density(nodeL) + v_density(nodeR));
+
+      // Compute geometry
+      DblType axdx = 0.0;
+      DblType asq = 0.0;
+      for (int d=0; d < ndim; ++d) {
+        const DblType dxj = v_coords(nodeR, d) - v_coords(nodeL, d);
+        asq += av[d] * av[d];
+        axdx += av[d] * dxj;
+      }
+      const DblType inv_axdx = 1.0 / axdx;
+
+      DblType tmdot = -projTimeScale * (v_pressure(nodeR) - v_pressure(nodeL)) *
+                      asq * inv_axdx;
+      for (int d = 0; d < ndim; ++d) {
+        const DblType dxj = v_coords(nodeR, d) - v_coords(nodeL, d);
+        // non-orthogonal correction
+        const DblType kxj = av[d] - asq * inv_axdx * dxj;
+        const DblType rhoUjIp = 0.5 * (v_density(nodeR) * v_velocity(nodeR, d) +
+                                       v_density(nodeL) * v_velocity(nodeL, d));
+        const DblType ujIp = 0.5 * (v_velocity(nodeL, d) + v_velocity(nodeR, d));
+        const DblType GjIp = 0.5 * (v_Gpdx(nodeR, d) / v_udiag(nodeR) +
+                                    v_Gpdx(nodeL, d) / v_udiag(nodeL));
+
+        tmdot += (interpTogether * rhoUjIp +
+                  om_interpTogether * rhoIp * ujIp + GjIp) * av[d]
+          - kxj * GjIp * nocFac;
+      }
+
+      tmdot /= tauScale;
+      const DblType lhsfac = -asq * inv_axdx * projTimeScale / tauScale;
+
+      // Left node entries
+      smdata.lhs(nodeL, nodeL) = -lhsfac;
+      smdata.lhs(nodeL, nodeR) = +lhsfac;
+      smdata.rhs(nodeL) = -tmdot;
+
+      // Right node entries
+      smdata.lhs(nodeR, nodeL) = +lhsfac;
+      smdata.lhs(nodeR, nodeR) = -lhsfac;
+      smdata.rhs(nodeR) = tmdot;
+
+#ifndef KOKKOS_ENABLE_CUDA
+      apply_coeff(
+        nodesPerEntity_, smdata.ngpElemNodes, smdata.scratchIds,
+        smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
+#endif
+    });
+}
+
+}  // nalu
+}  // sierra


### PR DESCRIPTION
Modify the NGP edge algorithm implemented in #225 to eliminate the intermediate ScratchViews and directly access the `ngp::Field` within the `lambda` of the algorithm. On CPU executions, with regression tests, this recovers the performance of the original implementation whereas #225 approach incurs >15% overhead in my preliminary tests. 

- I am unsure if the performance penalty of #225 might be overcome with SIMD, considering it would require copying overhead + interleave/de-interleave overhead. I feel this design implemented in this pull request will be difficult to implement with SIMD.
- I haven't explored if copying the vector data into local arrays will have any performance benefits.
- While the `VectorFieldType` accesses are a bit more verbose compared to the non-NGP and ScratchViews implementations, I feel it is not a huge barrier now that I look at it. 
- All the bucket looping and `sumInto` logic is encapsulated within `AssembleEdgeAlgorithm::run_algorithm` and the _edge kernels_ themselves still look very similar to the _element kernels_. 