### PR TITLE
Somehow omitted the HelperObjects change (deep_copy in execute) from

### DIFF
--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -100,8 +100,10 @@ TpetraLinearSystem::TpetraLinearSystem(
 TpetraLinearSystem::~TpetraLinearSystem()
 {
   // dereference linear solver in safe manner
-  TpetraLinearSolver *linearSolver = reinterpret_cast<TpetraLinearSolver *>(linearSolver_);
-  linearSolver->destroyLinearSolver();
+  if (linearSolver_ != nullptr) {
+    TpetraLinearSolver *linearSolver = reinterpret_cast<TpetraLinearSolver *>(linearSolver_);
+    linearSolver->destroyLinearSolver();
+  }
 }
 
 struct CompareEntityEqualById

--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -46,6 +46,9 @@ struct HelperObjects {
     for (auto kern: assembleElemSolverAlg->activeKernels_)
       kern->free_on_device();
     assembleElemSolverAlg->activeKernels_.clear();
+
+    Kokkos::deep_copy(linsys->hostlhs_, linsys->lhs_);
+    Kokkos::deep_copy(linsys->hostrhs_, linsys->rhs_);
   }
 
   void print_lhs_and_rhs() const


### PR DESCRIPTION
previous commit.

The gpu test in UnitTestScalarAdvDiffElem.C won't pass without this.
