### PR TITLE
NGP implementation of Edge algorithm

### DIFF
--- a/include/AssembleEdgeSolverAlgorithm.h
+++ b/include/AssembleEdgeSolverAlgorithm.h
@@ -1,0 +1,109 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef ASSEMBLEEDGESOLVERALGORITHM_H
+#define ASSEMBLEEDGESOLVERALGORITHM_H
+
+#include "SolverAlgorithm.h"
+#include "ElemDataRequests.h"
+#include "ElemDataRequestsGPU.h"
+#include "Realm.h"
+#include "ScratchViews.h"
+#include "SharedMemData.h"
+
+namespace stk {
+namespace mesh {
+class Part;
+}
+}
+
+namespace sierra {
+namespace nalu {
+
+class AssembleEdgeSolverAlgorithm : public SolverAlgorithm
+{
+public:
+  using DblType = double;
+  using ShmemDataType = SharedMemData_Edge<DeviceTeamHandleType, DeviceShmem>;
+
+  AssembleEdgeSolverAlgorithm(
+    Realm& realm,
+    stk::mesh::Part* part,
+    EquationSystem* eqSystem);
+
+  AssembleEdgeSolverAlgorithm() = delete;
+  AssembleEdgeSolverAlgorithm(const AssembleEdgeSolverAlgorithm&) = delete;
+
+  virtual ~AssembleEdgeSolverAlgorithm() = default;
+
+  virtual void initialize_connectivity();
+
+  template<typename LambdaFunction>
+  void run_algorithm(stk::mesh::BulkData& bulk, LambdaFunction lambdaFunc)
+  {
+    const auto& meta = bulk.mesh_meta_data();
+    const auto& ngpMesh = realm_.ngp_mesh();
+
+    const int bytes_per_team = 0;
+    const int bytes_per_thread = calc_shmem_bytes_per_thread_edge(rhsSize_);
+
+    stk::mesh::Selector sel = meta.locally_owned_part() &
+                              stk::mesh::selectUnion(partVec_) &
+                              !(realm_.get_inactive_selector());
+
+    const auto& buckets = ngp::get_bucket_ids(bulk, entityRank_, sel);
+    auto team_exec = get_device_team_policy(buckets.size(), bytes_per_team, bytes_per_thread);
+
+    // Create local copies of class data for device capture
+    const auto entityRank = entityRank_;
+    const auto nodesPerEntity = nodesPerEntity_;
+    const auto rhsSize = rhsSize_;
+
+    Kokkos::parallel_for(
+      team_exec, KOKKOS_LAMBDA(const DeviceTeamHandleType& team) {
+        auto bktId = buckets.device_get(team.league_rank());
+        auto& b = ngpMesh.get_bucket(entityRank, bktId);
+
+        ShmemDataType smdata(team, rhsSize);
+
+        const size_t bktLen = b.size();
+        Kokkos::parallel_for(
+          Kokkos::TeamThreadRange(team, bktLen),
+          [&](const size_t& bktIndex) {
+            auto edge = b[bktIndex];
+            const auto edgeIndex = ngpMesh.fast_mesh_index(edge);
+            smdata.ngpElemNodes = ngpMesh.get_nodes(entityRank, edgeIndex);
+
+            const auto nodeL = ngpMesh.fast_mesh_index(smdata.ngpElemNodes[0]);
+            const auto nodeR = ngpMesh.fast_mesh_index(smdata.ngpElemNodes[1]);
+
+            lambdaFunc(smdata, edgeIndex, nodeL, nodeR);
+
+#ifndef KOKKOS_ENABLE_CUDA
+            // TODO: scratchIds and sort permutations could be optimized away for edge based
+            apply_coeff(
+              nodesPerEntity, smdata.ngpElemNodes, smdata.scratchIds,
+              smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
+#endif
+          });
+      });
+  }
+
+protected:
+  ElemDataRequests dataNeeded_;
+
+  static constexpr stk::mesh::EntityRank entityRank_{stk::topology::EDGE_RANK};
+  static constexpr int nodesPerEntity_{2};
+  static constexpr int nDimMax_{3};
+  const int rhsSize_;
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* ASSEMBLEEDGESOLVERALGORITHM_H */

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -932,6 +932,17 @@ int calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchI
     return bytes_per_thread;
 }
 
+inline
+int calc_shmem_bytes_per_thread_edge(int rhsSize)
+{
+  // LHS (RHS^2) + RHS
+  const int matSize = rhsSize * (1 + rhsSize) * sizeof(double);
+  // Scratch IDs and search permutations (will be optimized later)
+  const int idSize = 2 * rhsSize * sizeof(int);
+
+  return (matSize + idSize);
+}
+
 template<typename ELEMDATAREQUESTSTYPE>
 inline
 int calculate_shared_mem_bytes_per_thread(int lhsSize, int rhsSize, int scratchIdsSize, int nDim,

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -124,6 +124,26 @@ struct SharedMemData_FaceElem {
     SharedMemView<int*,SHMEM> sortPermutation;
 };
 
+template<typename TEAMHANDLETYPE, typename SHMEM>
+struct SharedMemData_Edge {
+  KOKKOS_FUNCTION
+  SharedMemData_Edge(
+    const TEAMHANDLETYPE& team,
+    unsigned rhsSize)
+  {
+    rhs = get_shmem_view_1D<double, TEAMHANDLETYPE, SHMEM>(team, rhsSize);
+    lhs = get_shmem_view_2D<double, TEAMHANDLETYPE, SHMEM>(team, rhsSize, rhsSize);
+    scratchIds = get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team, rhsSize);
+    sortPermutation = get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team, rhsSize);
+  }
+
+  ngp::Mesh::ConnectedNodes ngpElemNodes;
+  SharedMemView<double*,SHMEM> rhs;
+  SharedMemView<double**,SHMEM> lhs;
+
+  SharedMemView<int*,SHMEM> scratchIds;
+  SharedMemView<int*,SHMEM> sortPermutation;
+};
 } // namespace nalu
 } // namespace Sierra
 

--- a/include/edge_kernels/ContinuityEdgeSolverAlg.h
+++ b/include/edge_kernels/ContinuityEdgeSolverAlg.h
@@ -1,0 +1,42 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef CONTINUITYEDGESOLVERALG_H
+#define CONTINUITYEDGESOLVERALG_H
+
+#include "AssembleEdgeSolverAlgorithm.h"
+
+namespace sierra {
+namespace nalu {
+
+class ContinuityEdgeSolverAlg : public AssembleEdgeSolverAlgorithm
+{
+public:
+  ContinuityEdgeSolverAlg(
+    Realm&,
+    stk::mesh::Part*,
+    EquationSystem*);
+
+  virtual ~ContinuityEdgeSolverAlg() = default;
+
+  virtual void execute();
+
+private:
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned velocityRTM_ {stk::mesh::InvalidOrdinal};
+  unsigned pressure_ {stk::mesh::InvalidOrdinal};
+  unsigned densityNp1_ {stk::mesh::InvalidOrdinal};
+  unsigned Gpdx_ {stk::mesh::InvalidOrdinal};
+  unsigned edgeAreaVec_ {stk::mesh::InvalidOrdinal};
+  unsigned Udiag_ {stk::mesh::InvalidOrdinal};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* CONTINUITYEDGESOLVERALG_H */

--- a/src/AssembleEdgeSolverAlgorithm.C
+++ b/src/AssembleEdgeSolverAlgorithm.C
@@ -1,0 +1,32 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "AssembleEdgeSolverAlgorithm.h"
+#include "EquationSystem.h"
+#include "LinearSystem.h"
+#include "Realm.h"
+
+namespace sierra {
+namespace nalu {
+
+AssembleEdgeSolverAlgorithm::AssembleEdgeSolverAlgorithm(
+  Realm& realm,
+  stk::mesh::Part* part,
+  EquationSystem* eqSystem
+) : SolverAlgorithm(realm, part, eqSystem),
+    dataNeeded_(realm.meta_data()),
+    rhsSize_(nodesPerEntity_ * eqSystem->linsys_->numDof())
+{}
+
+void
+AssembleEdgeSolverAlgorithm::initialize_connectivity()
+{
+  eqSystem_->linsys_->buildEdgeToNodeGraph(partVec_);
+}
+
+}  // nalu
+}  // sierra

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ add_sources(GlobalSourceList
    AssembleElemSolverAlgorithm.C
    AssembleElemSolverAlgorithmHO.C
    AssembleFaceElemSolverAlgorithm.C
+   AssembleEdgeSolverAlgorithm.C
    AssembleHeatCondIrradWallSolverAlgorithm.C
    AssembleHeatCondWallSolverAlgorithm.C
    AssembleMomentumEdgeABLWallFunctionSolverAlgorithm.C
@@ -214,6 +215,7 @@ endif()
 
 add_subdirectory(element_promotion)
 add_subdirectory(kernel)
+add_subdirectory(edge_kernels)
 add_subdirectory(master_element)
 add_subdirectory(mesh_motion)
 add_subdirectory(nso)

--- a/src/edge_kernels/CMakeLists.txt
+++ b/src/edge_kernels/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_sources(GlobalSourceList
+  ContinuityEdgeSolverAlg.C
+  )

--- a/src/edge_kernels/ContinuityEdgeSolverAlg.C
+++ b/src/edge_kernels/ContinuityEdgeSolverAlg.C
@@ -1,0 +1,127 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "edge_kernels/ContinuityEdgeSolverAlg.h"
+#include "utils/StkHelpers.h"
+
+namespace sierra {
+namespace nalu {
+
+ContinuityEdgeSolverAlg::ContinuityEdgeSolverAlg(
+  Realm& realm,
+  stk::mesh::Part* part,
+  EquationSystem* eqSystem
+) : AssembleEdgeSolverAlgorithm(realm, part, eqSystem)
+{
+  const auto& meta = realm.meta_data();
+
+  coordinates_ = get_field_ordinal(meta, realm.get_coordinates_name());
+  const std::string velField = realm.does_mesh_move()? "velocity_rtm" : "velocity";
+  velocityRTM_ = get_field_ordinal(meta, velField);
+  densityNp1_ = get_field_ordinal(meta, "density", stk::mesh::StateNP1);
+  pressure_ = get_field_ordinal(meta, "pressure");
+  Gpdx_ = get_field_ordinal(meta, "dpdx");
+  edgeAreaVec_ = get_field_ordinal(meta, "edge_area_vector", stk::topology::EDGE_RANK);
+  Udiag_ = get_field_ordinal(meta, "momentum_diag");
+}
+
+void
+ContinuityEdgeSolverAlg::execute()
+{
+  const int ndim = realm_.meta_data().spatial_dimension();
+
+  // Non-orthogonal correction factor for continuity equation system
+  const std::string dofName = "pressure";
+  const DblType nocFac
+    = (realm_.get_noc_usage(dofName) == true) ? 1.0 : 0.0;
+
+  // Classic Nalu projection timescale
+  const DblType dt = realm_.get_time_step();
+  const DblType gamma1 = realm_.get_gamma1();
+  const DblType tauScale = dt / gamma1;
+
+  // Interpolation option for rho*U
+  const DblType interpTogether = realm_.get_mdot_interp();
+  const DblType om_interpTogether = (1.0 - interpTogether);
+
+  // STK ngp::Field instances for capture by lambda
+  const auto& fieldMgr = realm_.ngp_field_manager();
+  const auto coordinates = fieldMgr.get_field<double>(coordinates_);
+  const auto velocity = fieldMgr.get_field<double>(velocityRTM_);
+  const auto Gpdx = fieldMgr.get_field<double>(Gpdx_);
+  const auto density = fieldMgr.get_field<double>(densityNp1_);
+  const auto pressure = fieldMgr.get_field<double>(pressure_);
+  const auto udiag = fieldMgr.get_field<double>(Udiag_);
+  const auto edgeAreaVec = fieldMgr.get_field<double>(edgeAreaVec_);
+
+  run_algorithm(
+    realm_.bulk_data(),
+    KOKKOS_LAMBDA(
+      ShmemDataType& smdata,
+      const stk::mesh::FastMeshIndex& edge,
+      const stk::mesh::FastMeshIndex& nodeL,
+      const stk::mesh::FastMeshIndex& nodeR)
+    {
+      // Scratch work array for edgeAreaVector
+      NALU_ALIGNED DblType av[nDimMax_];
+      // Populate area vector work array
+      for (int d=0; d < ndim; ++d)
+        av[d] = edgeAreaVec.get(edge, d);
+
+      const DblType pressureL = pressure.get(nodeL, 0);
+      const DblType pressureR = pressure.get(nodeR, 0);
+
+      const DblType densityL = density.get(nodeL, 0);
+      const DblType densityR = density.get(nodeR, 0);
+
+      const DblType udiagL = udiag.get(nodeL, 0);
+      const DblType udiagR = udiag.get(nodeR, 0);
+
+      const DblType projTimeScale = 0.5 * (1.0/udiagL + 1.0/udiagR);
+      const DblType rhoIp = 0.5 * (densityL + densityR);
+
+      DblType axdx = 0.0;
+      DblType asq = 0.0;
+      for (int d=0; d < ndim; ++d) {
+        const DblType dxj = coordinates.get(nodeR, d) - coordinates.get(nodeL, d);
+        asq += av[d] * av[d];
+        axdx += av[d] * dxj;
+      }
+      const DblType inv_axdx = 1.0 / axdx;
+
+      DblType tmdot = -projTimeScale * (pressureR - pressureL) * asq * inv_axdx;
+      for (int d = 0; d < ndim; ++d) {
+        const DblType dxj =
+          coordinates.get(nodeR, d) - coordinates.get(nodeL, d);
+        // non-orthogonal correction
+        const DblType kxj = av[d] - asq * inv_axdx * dxj;
+        const DblType rhoUjIp = 0.5 * (densityR * velocity.get(nodeR, d) +
+                                       densityL * velocity.get(nodeL, d));
+        const DblType ujIp = 0.5 * (velocity.get(nodeR, d) + velocity.get(nodeL, d));
+        const DblType GjIp = 0.5 * (Gpdx.get(nodeR, d) / udiagR +
+                                    Gpdx.get(nodeL, d) / udiagL);
+        tmdot += (interpTogether * rhoUjIp +
+                  om_interpTogether * rhoIp * ujIp + GjIp) * av[d]
+          - kxj * GjIp * nocFac;
+      }
+      tmdot /= tauScale;
+      const DblType lhsfac = -asq * inv_axdx * projTimeScale / tauScale;
+
+      // Left node entries
+      smdata.lhs(0, 0) = -lhsfac;
+      smdata.lhs(0, 1) = +lhsfac;
+      smdata.rhs(0) = -tmdot;
+
+      // Right node entries
+      smdata.lhs(1, 0) = +lhsfac;
+      smdata.lhs(1, 1) = -lhsfac;
+      smdata.rhs(1) = tmdot;
+    });
+}
+
+}  // nalu
+}  // sierra

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 
 add_subdirectory(algorithms)
 add_subdirectory(kernels)
+add_subdirectory(edge_kernels)
 add_subdirectory(ho_kernels)
 add_subdirectory(ngp_kernels)
 add_subdirectory(mesh_motion)

--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -161,7 +161,6 @@ struct EdgeHelperObjects : public HelperObjectsBase
     ThrowRequire(edgeAlg != nullptr);
     edgeAlg->execute();
 
-    EXPECT_EQ(linsys->numSumIntoCalls_, 12);
     Kokkos::deep_copy(linsys->hostlhs_, linsys->lhs_);
     Kokkos::deep_copy(linsys->hostrhs_, linsys->rhs_);
   }

--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -4,6 +4,7 @@
 #include "UnitTestRealm.h"
 #include "UnitTestLinearSystem.h"
 
+#include "AssembleEdgeSolverAlgorithm.h"
 #include "AssembleElemSolverAlgorithm.h"
 #include "AssembleFaceElemSolverAlgorithm.h"
 #include "EquationSystem.h"
@@ -14,19 +15,70 @@
 
 namespace unit_test_utils {
 
-struct HelperObjects {
-  HelperObjects(stk::mesh::BulkData& bulk, stk::topology topo, int numDof, stk::mesh::Part* part)
-  : yamlNode(unit_test_utils::get_default_inputs()),
-    realmDefaultNode(unit_test_utils::get_realm_default_node()),
-    naluObj(new unit_test_utils::NaluTest(yamlNode)),
-    realm(naluObj->create_realm(realmDefaultNode, "multi_physics", false)),
-    eqSystems(realm),
-    eqSystem(eqSystems),
-    linsys(new unit_test_utils::TestLinearSystem(realm, numDof, &eqSystem, topo)),
-    assembleElemSolverAlg(nullptr)
+struct HelperObjectsBase
+{
+  HelperObjectsBase(
+    stk::mesh::BulkData& bulk
+  ) : yamlNode(unit_test_utils::get_default_inputs()),
+      realmDefaultNode(unit_test_utils::get_realm_default_node()),
+      naluObj(new unit_test_utils::NaluTest(yamlNode)),
+      realm(naluObj->create_realm(realmDefaultNode, "multi_physics", false)),
+      eqSystems(realm),
+      eqSystem(eqSystems)
   {
     realm.metaData_ = &bulk.mesh_meta_data();
     realm.bulkData_ = &bulk;
+  }
+
+  virtual ~HelperObjectsBase()
+  {
+    realm.metaData_ = nullptr;
+    realm.bulkData_ = nullptr;
+
+    delete naluObj;
+  }
+
+  virtual void execute() = 0;
+
+  void print_lhs_and_rhs(const TestLinearSystem* linsys) const
+  {
+    auto oldPrec = std::cerr.precision();
+    std::cerr.precision(14);
+    std::cerr << "lhs:\n{" << std::endl;
+    for(unsigned i=0; i<linsys->lhs_.extent(0); ++i) {
+      std::cerr<<"{";
+      for(unsigned j=0; j<linsys->lhs_.extent(1); ++j) {
+        std::cerr<< linsys->lhs_(i,j)<<", ";
+      }
+      std::cerr<<"};"<<std::endl;
+    }
+    std::cerr << "};" << std::endl;
+    std::cerr<<"rhs:\n{";
+    for(unsigned i=0; i<linsys->lhs_.extent(0); ++i) {
+      std::cerr<< linsys->rhs_(i)<<", ";
+    }
+    std::cerr<<"};"<<std::endl;
+    std::cerr.precision(oldPrec);
+  }
+
+  YAML::Node yamlNode;
+  YAML::Node realmDefaultNode;
+  unit_test_utils::NaluTest* naluObj;
+  sierra::nalu::Realm& realm;
+  sierra::nalu::EquationSystems eqSystems;
+  sierra::nalu::EquationSystem eqSystem;
+};
+
+struct HelperObjects : public HelperObjectsBase
+{
+  HelperObjects(
+    stk::mesh::BulkData& bulk,
+    stk::topology topo,
+    int numDof,
+    stk::mesh::Part* part
+  ) : HelperObjectsBase(bulk),
+      linsys(new unit_test_utils::TestLinearSystem(realm, numDof, &eqSystem, topo))
+  {
     eqSystem.linsys_ = linsys;
     assembleElemSolverAlg = new sierra::nalu::AssembleElemSolverAlgorithm(realm, part, &eqSystem, topo.rank(), topo.num_nodes());
   }
@@ -34,13 +86,9 @@ struct HelperObjects {
   virtual ~HelperObjects()
   {
     delete assembleElemSolverAlg;
-    realm.metaData_ = nullptr;
-    realm.bulkData_ = nullptr;
-
-    delete naluObj;
   }
 
-  virtual void execute()
+  virtual void execute() override
   {
     assembleElemSolverAlg->execute();
     for (auto kern: assembleElemSolverAlg->activeKernels_)
@@ -53,37 +101,17 @@ struct HelperObjects {
 
   void print_lhs_and_rhs() const
   {
-    auto oldPrec = std::cerr.precision();
-    std::cerr.precision(14);
-    for(unsigned i=0; i<linsys->lhs_.extent(0); ++i) {
-      std::cerr<<"{";
-      for(unsigned j=0; j<linsys->lhs_.extent(1); ++j) {
-        std::cerr<< linsys->lhs_(i,j)<<", ";
-      }
-      std::cerr<<"}"<<std::endl;
-    }
-    std::cerr<<"rhs: {";
-    for(unsigned i=0; i<linsys->lhs_.extent(0); ++i) {
-      std::cerr<< linsys->rhs_(i)<<", ";
-    }
-    std::cerr<<"}"<<std::endl;
-    std::cerr.precision(oldPrec);
+    HelperObjectsBase::print_lhs_and_rhs(linsys);
   }
 
-  YAML::Node yamlNode;
-  YAML::Node realmDefaultNode;
-  unit_test_utils::NaluTest* naluObj;
-  sierra::nalu::Realm& realm;
-  sierra::nalu::EquationSystems eqSystems;
-  sierra::nalu::EquationSystem eqSystem;
-  unit_test_utils::TestLinearSystem* linsys;
-  sierra::nalu::AssembleElemSolverAlgorithm* assembleElemSolverAlg;
+  unit_test_utils::TestLinearSystem* linsys{nullptr};
+  sierra::nalu::AssembleElemSolverAlgorithm* assembleElemSolverAlg{nullptr};
 };
 
 
 struct FaceElemHelperObjects : HelperObjects {
   FaceElemHelperObjects(stk::mesh::BulkData& bulk, stk::topology faceTopo, stk::topology elemTopo, int numDof, stk::mesh::Part* part)
-  : HelperObjects(bulk, elemTopo, numDof, part)
+    : HelperObjects(bulk, elemTopo, numDof, part)
   {
     assembleFaceElemSolverAlg = new sierra::nalu::AssembleFaceElemSolverAlgorithm(realm, part, &eqSystem, faceTopo.num_nodes(), elemTopo.num_nodes());
   }
@@ -102,6 +130,49 @@ struct FaceElemHelperObjects : HelperObjects {
   }
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm* assembleFaceElemSolverAlg;
+};
+
+struct EdgeHelperObjects : public HelperObjectsBase
+{
+  EdgeHelperObjects(
+    stk::mesh::BulkData& bulk,
+    stk::topology topo,
+    int numDof
+  ) : HelperObjectsBase(bulk),
+      linsys(new TestEdgeLinearSystem(realm, numDof, &eqSystem, topo))
+  {
+    eqSystem.linsys_ = linsys;
+  }
+
+  virtual ~EdgeHelperObjects()
+  {
+    if (edgeAlg != nullptr) delete edgeAlg;
+  }
+
+  template<typename T>
+  void create(stk::mesh::Part* part)
+  {
+    ThrowRequire(edgeAlg == nullptr);
+    edgeAlg = new T(realm, part, &eqSystem);
+  }
+
+  virtual void execute() override
+  {
+    ThrowRequire(edgeAlg != nullptr);
+    edgeAlg->execute();
+
+    EXPECT_EQ(linsys->numSumIntoCalls_, 12);
+    Kokkos::deep_copy(linsys->hostlhs_, linsys->lhs_);
+    Kokkos::deep_copy(linsys->hostrhs_, linsys->rhs_);
+  }
+
+  void print_lhs_and_rhs() const
+  {
+    HelperObjectsBase::print_lhs_and_rhs(linsys);
+  }
+
+  unit_test_utils::TestEdgeLinearSystem* linsys{nullptr};
+  sierra::nalu::AssembleEdgeSolverAlgorithm* edgeAlg{nullptr};
 };
 
 }

--- a/unit_tests/UnitTestLinearSystem.h
+++ b/unit_tests/UnitTestLinearSystem.h
@@ -235,6 +235,7 @@ public:
   ) : TestLinearSystem(realm, numDof, eqSys, topo)
   {}
 
+  using TestLinearSystem::sumInto;
   virtual void sumInto(
     unsigned  /* numEntities */,
     const ngp::Mesh::ConnectedNodes&  entities,

--- a/unit_tests/edge_kernels/CMakeLists.txt
+++ b/unit_tests/edge_kernels/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_sources(GlobalUnitSourceList
+  UnitTestContinuityAdvEdge.C
+  )

--- a/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
@@ -1,0 +1,70 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "edge_kernels/ContinuityEdgeSolverAlg.h"
+
+#ifndef KOKKOS_ENABLE_CUDA
+namespace {
+namespace hex8_golds {
+static constexpr double rhs[8] = {
+  0.05158341811906, -0.16056815656532, 0.16056815656532, -0.05158341811906,
+  0.05158341811906, -0.16056815656532, 0.16056815656532, -0.05158341811906,
+};
+
+static constexpr double lhs[8][8] =
+{
+  {0.75, -0.25, -0.25, 0, -0.25, 0, 0, 0, },
+  {-0.25, 0.75, 0, -0.25, 0, -0.25, 0, 0, },
+  {-0.25, 0, 0.75, -0.25, 0, 0, -0.25, 0, },
+  {0, -0.25, -0.25, 0.75, 0, 0, 0, -0.25, },
+  {-0.25, 0, 0, 0, 0.75, -0.25, -0.25, 0, },
+  {0, -0.25, 0, 0, -0.25, 0.75, 0, -0.25, },
+  {0, 0, -0.25, 0, -0.25, 0, 0.75, -0.25, },
+  {0, 0, 0, -0.25, 0, -0.25, -0.25, 0.75, },
+};
+
+} // hex8_golds
+} // anonymous namespace
+#endif
+
+TEST_F(ContinuityEdgeHex8Mesh, NGP_advection)
+{
+  fill_mesh_and_init_fields();
+
+  // Setup solution options for default advection kernel
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.mdotInterpRhoUTogether_ = true;
+
+  unit_test_utils::EdgeHelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 1);
+
+  sierra::nalu::TimeIntegrator timeIntegrator;
+  timeIntegrator.gamma1_ = 1.0;
+  timeIntegrator.timeStepN_ = 1.0;
+  timeIntegrator.timeStepNm1_ = 1.0;
+  helperObjs.realm.timeIntegrator_ = &timeIntegrator;
+
+  helperObjs.create<sierra::nalu::ContinuityEdgeSolverAlg>(partVec_[0]);
+
+  helperObjs.execute();
+
+#ifndef KOKKOS_ENABLE_CUDA
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
+  EXPECT_EQ(helperObjs.linsys->numSumIntoCalls_, 12);
+
+  unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
+  unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, hex8_golds::lhs);
+#endif
+}

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -131,12 +131,24 @@ void dhdx_test_function(
   const VectorFieldType& coordinates,
   VectorFieldType& dhdx);
 
+void calc_edge_area_vec(
+  const stk::mesh::BulkData& bulk,
+  const stk::topology& topo,
+  const VectorFieldType& coordinates,
+  const VectorFieldType& edgeAreaVec);
+
 void calc_exposed_area_vec(
   const stk::mesh::BulkData& bulk,
   const stk::topology& topo,
   const VectorFieldType& coordinates,
-  GenericFieldType& exposedAreaVec
-);
+  GenericFieldType& exposedAreaVec);
+
+void calc_mass_flow_rate(
+  const stk::mesh::BulkData&,
+  const VectorFieldType&,
+  const ScalarFieldType&,
+  const VectorFieldType&,
+  ScalarFieldType&);
 
 void calc_mass_flow_rate_scs(
   stk::mesh::BulkData&,

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -21,6 +21,8 @@
 
 #include <gtest/gtest.h>
 
+#include "stk_mesh/base/CreateEdges.hpp"
+
 #include <mpi.h>
 #include <vector>
 #include <memory>
@@ -263,6 +265,7 @@ public:
     if (doPerturb) {
       unit_test_utils::perturb_coord_hex_8(bulk_, 0.125);
     }
+    stk::mesh::create_edges(bulk_, meta_.universal_part());
 
     partVec_ = {meta_.get_part("block_1")};
 
@@ -315,7 +318,10 @@ public:
           meta_.side_rank(), "exposed_area_vector")),
       velocityBC_(
         &meta_.declare_field<VectorFieldType>(
-          stk::topology::NODE_RANK, "velocity_bc"))
+          stk::topology::NODE_RANK, "velocity_bc")),
+      edgeAreaVec_(
+        &meta_.declare_field<VectorFieldType>(
+          stk::topology::EDGE_RANK, "edge_area_vector"))
   {
     stk::mesh::put_field_on_mesh(*velocity_, meta_.universal_part(), spatialDim_, nullptr);
     stk::mesh::put_field_on_mesh(*dpdx_, meta_.universal_part(), spatialDim_, nullptr);
@@ -325,6 +331,7 @@ public:
     stk::mesh::put_field_on_mesh(
       *exposedAreaVec_, meta_.universal_part(),
       spatialDim_ * sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
+    stk::mesh::put_field_on_mesh(*edgeAreaVec_, meta_.universal_part(), spatialDim_, nullptr);
     stk::mesh::put_field_on_mesh(*velocityBC_, meta_.universal_part(), spatialDim_, nullptr);
   }
 
@@ -344,6 +351,8 @@ public:
       bulk_, sierra::nalu::AlgTraitsQuad4::topo_, *coordinates_,
       *exposedAreaVec_);
     unit_test_kernel_utils::velocity_test_function(bulk_, *coordinates_, *velocityBC_);
+    unit_test_kernel_utils::calc_edge_area_vec(
+      bulk_, sierra::nalu::AlgTraitsHex8::topo_, *coordinates_, *edgeAreaVec_);
   }
 
   VectorFieldType* velocity_{nullptr};
@@ -353,6 +362,7 @@ public:
   ScalarFieldType* Udiag_{nullptr};
   GenericFieldType* exposedAreaVec_{nullptr};
   VectorFieldType* velocityBC_{nullptr};
+  VectorFieldType* edgeAreaVec_{nullptr};
 };
 
 class ContinuityKernelHex8Mesh : public LowMachKernelHex8Mesh
@@ -379,6 +389,10 @@ public:
 private:
   ScalarFieldType* pressureBC_{nullptr};
 };
+
+// Provide separate namespace for Edge kernel tests
+class ContinuityEdgeHex8Mesh : public ContinuityKernelHex8Mesh
+{};
 
 class MomentumKernelHex8Mesh : public LowMachKernelHex8Mesh
 {


### PR DESCRIPTION
Implement `AssembleEdgeSolverAlgorithm` capable of executing on GPUs and demonstrate using `ContinuityEdgeSolverAlg`, an NGP-ready replacement for `AssembleContinuityEdgeSolverAlgorithm`.

Details on other changes:

- Added `TestEdgeLinearSystem` class to handle `sumInto` for edge based algorithms over a single element
- Added `EdgeHelperObjects` that deals with `AssembleEdgeSolverAlgorithm` and `TestEdgeLinearSystem`, created a `HelperObjectsBase` class to consolidate common code
- Updated `UnitTestKernelUtils` to create and initialize edge based fields
- Introduced a dummy `ContinuityEdgeHex8Mesh` class for easy filtering
- Added unit test for `ContinuityEdgeSolverAlg` class and demonstrated execution on GPUs. 

See #225 and #226 for discussion related to these changes. 