### PR TITLE
reduce number of time steps in oversetRotCylinder test case

### DIFF
--- a/reg_tests/test_files/oversetRotCylinder/oversetRotCylinder.i
+++ b/reg_tests/test_files/oversetRotCylinder/oversetRotCylinder.i
@@ -199,7 +199,7 @@ Time_Integrators:
   - StandardTimeIntegrator:
       name: ti_1
       start_time: 0
-      termination_step_count: 50
+      termination_step_count: 15
       time_step: 0.0001
       time_stepping_type: adaptive
       time_step_count: 0

--- a/reg_tests/test_files/oversetRotCylinder/oversetRotCylinder.i
+++ b/reg_tests/test_files/oversetRotCylinder/oversetRotCylinder.i
@@ -200,8 +200,8 @@ Time_Integrators:
       name: ti_1
       start_time: 0
       termination_step_count: 15
-      time_step: 0.0001
-      time_stepping_type: adaptive
+      time_step: 0.003
+      time_stepping_type: fixed
       time_step_count: 0
       second_order_accuracy: yes
 


### PR DESCRIPTION
Based on diffs for `oversetRotCylinder` test case plotted over the past couple of months, I am reducing the number of time steps to 15 to ensure consistent passing of this test with a tolerance of `1e-15` on a regular basis. 

<img width="956" alt="Screen Shot 2019-05-19 at 6 02 09 PM" src="https://user-images.githubusercontent.com/36968394/58281524-97e1c980-7d60-11e9-8dc0-1199f04c14c1.png">