### PR TITLE
Support selection of input and output mesh format in YAML configuration file

### DIFF
--- a/include/OutputInfo.h
+++ b/include/OutputInfo.h
@@ -38,7 +38,8 @@ public:
   bool get_restart_shuffle();
   
   std::string outputDBName_;
-  
+  std::string outputMeshDBType_;
+
   // catalyst options
   std::string catalystFileName_;
   std::string catalystParseJson_;

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -385,6 +385,7 @@ class Realm {
 
   std::string name_;
   std::string type_;
+  std::string meshDBType_;
   std::string inputDBName_;
   unsigned spatialDimension_;
 

--- a/reg_tests/test_files/ablUnstableEdge/ablUnstableEdge.i.in
+++ b/reg_tests/test_files/ablUnstableEdge/ablUnstableEdge.i.in
@@ -244,7 +244,8 @@ realms:
           field_type: node_rank
 
     output:
-      output_data_base_name: abl_io_results.e
+      output_data_base_name: abl_io_results.@test_mesh_db_extension@
+      output_mesh_db_type: @test_mesh_db_type@
       output_frequency: 1
       output_node_set: no
       output_variables:

--- a/reg_tests/test_files/ablUnstableEdge/ablUnstableEdge_rst.i.in
+++ b/reg_tests/test_files/ablUnstableEdge/ablUnstableEdge_rst.i.in
@@ -207,7 +207,8 @@ realms:
        - viscosity
 
   - name: ioRealm
-    mesh: abl_io_results.e
+    mesh: abl_io_results.@test_mesh_db_extension@
+    mesh_db_type: @test_mesh_db_type@
     type: external_field_provider
 
     field_registration:

--- a/reg_tests/test_files/ductWedge/ductWedge.i.in
+++ b/reg_tests/test_files/ductWedge/ductWedge.i.in
@@ -106,7 +106,8 @@ realms:
             pressure: element
           
     output:
-      output_data_base_name: ductWedge.e
+      output_data_base_name: ductWedge.@test_mesh_db_extension@
+      output_mesh_db_type: @test_mesh_db_type@
       output_frequency: 2 
       output_node_set: no 
       output_variables:

--- a/reg_tests/test_files/ductWedge/ductWedge_Input.i.in
+++ b/reg_tests/test_files/ductWedge/ductWedge_Input.i.in
@@ -128,7 +128,8 @@ realms:
        - turbulent_viscosity
 
   - name: ioRealm
-    mesh:  ductWedge.e
+    mesh:  ductWedge.@test_mesh_db_extension@
+    mesh_db_type: @test_mesh_db_type@
     type: initialization
 
     field_registration:

--- a/reg_tests/test_files/elemBackStepLRSST/elemBackStepLRSST.i.in
+++ b/reg_tests/test_files/elemBackStepLRSST/elemBackStepLRSST.i.in
@@ -178,7 +178,8 @@ realms:
             minimum_distance_to_wall: ndtw
 
     output:
-      output_data_base_name: elemBackStepLRSST.e
+      output_data_base_name: elemBackStepLRSST.@test_mesh_db_extension@
+      output_mesh_db_type: @test_mesh_db_type@
       output_frequency: 5
       output_node_set: no 
       output_variables:

--- a/reg_tests/test_files/elemBackStepLRSST/elemBackStepLRSST_Input.i.in
+++ b/reg_tests/test_files/elemBackStepLRSST/elemBackStepLRSST_Input.i.in
@@ -194,7 +194,8 @@ realms:
       target_name: [surface_4, surface_5, surface_6]
 
   - name: ioRealm
-    mesh:  elemBackStepLRSST.e
+    mesh:  elemBackStepLRSST.@test_mesh_db_extension@
+    mesh_db_type: @test_mesh_db_type@
     type: initialization
 
     field_registration:

--- a/src/OutputInfo.C
+++ b/src/OutputInfo.C
@@ -30,6 +30,7 @@ namespace nalu{
 //--------------------------------------------------------------------------
 OutputInfo::OutputInfo() 
   : outputDBName_("output.e"),
+    outputMeshDBType_("exodus"),
     catalystFileName_(""),
     catalystParseJson_(""),
     paraviewScriptName_(""),
@@ -84,6 +85,9 @@ OutputInfo::load(
 
     // output data base name
     get_if_present(y_output, "output_data_base_name", outputDBName_, outputDBName_);
+
+    // output data base type
+    get_if_present(y_output, "output_mesh_db_type", outputMeshDBType_, outputMeshDBType_);
 
     // catalyst file name
     get_if_present(y_output, "catalyst_file_name", catalystFileName_, catalystFileName_);

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -171,6 +171,7 @@ namespace nalu{
   : realms_(realms),
     name_("na"),
     type_("multi_physics"),
+    meshDBType_("exodus"),
     inputDBName_("input_unknown"),
     spatialDimension_(3u),  // for convenience; can always get it from meta data
     realmUsesEdges_(false),
@@ -667,6 +668,7 @@ Realm::load(const YAML::Node & node)
   name_ = node["name"].as<std::string>() ;
   inputDBName_ = node["mesh"].as<std::string>() ;
   get_if_present(node, "type", type_, type_);
+  get_if_present(node, "mesh_db_type", meshDBType_, meshDBType_);
 
   // provide a high level banner
   NaluEnv::self().naluOutputP0() << std::endl;
@@ -2086,7 +2088,7 @@ Realm::create_mesh()
 
   // Initialize meta data (from exodus file); can possibly be a restart file..
   inputMeshIdx_ = ioBroker_->add_mesh_database( 
-   inputDBName_, restarted_simulation() ? stk::io::READ_RESTART : stk::io::READ_MESH );
+   inputDBName_, meshDBType_, restarted_simulation() ? stk::io::READ_RESTART : stk::io::READ_MESH );
   ioBroker_->create_input_mesh();
 
   // declare an exposed part for later bc coverage check
@@ -2152,7 +2154,7 @@ Realm::create_output_mesh()
       resultsFileIndex_ = ioBroker_->create_output_mesh( oname, stk::io::WRITE_RESULTS, *outputInfo_->outputPropertyManager_, "catalyst" );
    }
    else {
-      resultsFileIndex_ = ioBroker_->create_output_mesh( oname, stk::io::WRITE_RESULTS, *outputInfo_->outputPropertyManager_);
+      resultsFileIndex_ = ioBroker_->create_output_mesh( oname, stk::io::WRITE_RESULTS, *outputInfo_->outputPropertyManager_, outputInfo_->outputMeshDBType_.c_str());
    }
 
 #if defined (NALU_USES_PERCEPT)


### PR DESCRIPTION
Now that the SEACAS package of Trilinos has a factory for the ADIOS2 BP format, nalu-wind can read inputs and write outputs in that format. In this pull-request, these inputs and outputs are recognized based on the extension of the file. To test that this new format saves all the necessary information, the tests have been updated to use this format.