### PR TITLE
TpetraSegregatedLinearSystem: preparing the linear system/linear solver files (see issue #249)

### DIFF
--- a/include/LinearSolver.h
+++ b/include/LinearSolver.h
@@ -12,8 +12,6 @@
 #include <LinearSolverTypes.h>
 #include <LinearSolverConfig.h>
 
-#include <LinearSolverTypes.h>
-
 #include <Kokkos_DefaultNode.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
@@ -44,9 +42,10 @@ namespace nalu{
 
 /** Type of solvers available in Nalu simulation **/
   enum PetraType {
-    PT_TPETRA,       //!< Nalu Tpetra interface
-    PT_HYPRE,        //!< Direct HYPRE interface
-    PT_HYPRE_SEGREGATED, //!< Direct HYPRE Segregated momentum solver
+    PT_TPETRA,            //!< Nalu Tpetra interface
+    PT_TPETRA_SEGREGATED, //!< Nalu Tpetra interface Segregated solver
+    PT_HYPRE,             //!< Direct HYPRE interface
+    PT_HYPRE_SEGREGATED,  //!< Direct HYPRE Segregated momentum solver
     PT_END
   };
 
@@ -208,7 +207,7 @@ class TpetraLinearSolver : public LinearSolver
     const Teuchos::RCP<Teuchos::ParameterList> paramsPrecond,
     LinearSolvers *linearSolvers);
   virtual ~TpetraLinearSolver() ;
-  
+
     void setSystemObjects(
       Teuchos::RCP<LinSys::Matrix> matrix,
       Teuchos::RCP<LinSys::MultiVector> rhs);
@@ -245,7 +244,9 @@ class TpetraLinearSolver : public LinearSolver
       double & scaledResidual,
       bool isFinalOuterIter);
 
-    virtual PetraType getType() override { return PT_TPETRA; }
+    virtual PetraType getType() override {
+      return (config_->useSegregatedSolver() ? PT_TPETRA_SEGREGATED : PT_TPETRA);
+    }
 
   private:
   //! The solver parameters

--- a/include/LinearSolverConfig.h
+++ b/include/LinearSolverConfig.h
@@ -50,6 +50,9 @@ public:
   inline bool reusePreconditioner() const
   { return reusePreconditioner_; }
 
+  inline bool useSegregatedSolver() const
+  { return useSegregatedSolver_; }
+
   std::string get_method() const
   {return method_;}
 
@@ -77,6 +80,7 @@ protected:
 
   bool recomputePreconditioner_{true};
   bool reusePreconditioner_{false};
+  bool useSegregatedSolver_{false};
   bool writeMatrixFiles_{false};
 };
 

--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -18,7 +18,7 @@
 // Forward declare templates
 namespace Teuchos {
 
-template <typename T> 
+template <typename T>
 class ArrayRCP;
 
 template <typename T>
@@ -65,6 +65,8 @@ typedef int    LocalOrdinal;  // MUST be signed
 typedef double Scalar;
 
 typedef Kokkos::DualView<size_t*, DeviceSpace>                             RowLengths;
+typedef RowLengths::t_dev                                                  DeviceRowLengths;
+typedef RowLengths::t_host                                                 HostRowLengths;
 typedef Tpetra::Map<LocalOrdinal, GlobalOrdinal>::node_type                Node;
 typedef Tpetra::CrsGraph< LocalOrdinal, GlobalOrdinal, Node>               Graph;
 typedef typename Graph::local_graph_type                                   LocalGraph;
@@ -75,7 +77,6 @@ typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node>                       Map;
 typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>        MultiVector;
 typedef Teuchos::ArrayRCP<Scalar >                                         OneDVector;
 typedef Teuchos::ArrayRCP<const Scalar >                                   ConstOneDVector;
-/* typedef Tpetra::Vector<Scalar,LocalOrdinal,GlobalOrdinal,Node>             Vector; */
 typedef MultiVector::dual_view_type::t_host                                LocalVector;
 typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>       Matrix;
 typedef Matrix::local_matrix_type                                          LocalMatrix;

--- a/include/LinearSolvers.h
+++ b/include/LinearSolvers.h
@@ -39,7 +39,7 @@ class LinearSolvers {
 public:
   LinearSolvers(Simulation& sim);
   ~LinearSolvers();
-  
+
   /** Parse the `linear_solvers` section from Nalu input file
    */
   void load(const YAML::Node & node);
@@ -52,10 +52,10 @@ public:
   LinearSolver *create_solver(
     std::string solverBlockName,
     EquationType theEQ);
-  
+
   Simulation *root();
   Simulation *parent();
-  
+
   typedef std::map<EquationType, LinearSolver *> SolverMap;
   typedef std::map<std::string, TpetraLinearSolverConfig *> SolverTpetraConfigMap;
   typedef std::map<std::string, HypreLinearSolverConfig*> HypreSolverConfigMap;
@@ -70,7 +70,7 @@ public:
   //! A lookup table of solver configurations against the names provided in the
   //! input file when `type` is `hypre` or `tpetra_hypre`
   HypreSolverConfigMap solverHypreConfig_;
-  
+
   //! Reference to the sierra::nalu::Simulation instance
   Simulation& sim_;
 

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -109,10 +109,10 @@ public:
     DefaultHostOnlyCoeffApplier(LinearSystem& linSys)
     : linSys_(linSys)
     {}
-  
+
     KOKKOS_FUNCTION
     ~DefaultHostOnlyCoeffApplier() {}
-  
+
     KOKKOS_FUNCTION
     virtual void operator()(unsigned numEntities,
                             const ngp::Mesh::ConnectedNodes& entities,
@@ -124,7 +124,7 @@ public:
     {
       linSys_.sumInto(numEntities, entities, rhs, lhs, localIds, sortPermutation, trace_tag);
     }
-  
+
     void free_device_pointer() {}
 
     CoeffApplier* device_pointer() { return this; }

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -43,13 +43,6 @@ typedef std::unordered_map<stk::mesh::EntityId, size_t>  MyLIDMapType;
 
 typedef std::pair<stk::mesh::Entity, stk::mesh::Entity> Connection;
 
-  enum DOFStatus {
-    DS_NotSet           = 0,
-    DS_SkippedDOF       = 1 << 1,
-    DS_OwnedDOF         = 1 << 2,
-    DS_SharedNotOwnedDOF = 1 << 3,
-    DS_GhostedDOF       = 1 << 4
-  };
 
 class TpetraLinearSystem : public LinearSystem
 {

--- a/include/TpetraLinearSystemHelpers.h
+++ b/include/TpetraLinearSystemHelpers.h
@@ -1,0 +1,107 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef TpetraLinearSystemHelpers_h
+#define TpetraLinearSystemHelpers_h
+
+#include <stdio.h>
+
+#include <Realm.h>
+#include <PeriodicManager.h>
+#include <NonConformalManager.h>
+#include <utils/StkHelpers.h>
+#include <LinearSolverTypes.h>
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_topology/topology.hpp>
+
+namespace stk {
+class CommNeighbors;
+}
+
+namespace sierra {
+namespace nalu {
+
+class LocalGraphArrays;
+
+#define GID_(gid, ndof, idof)  ((ndof)*((gid)-1)+(idof)+1)
+#define LID_(lid, ndof, idof)  ((ndof)*((lid))+(idof))
+
+#define GLOBAL_ENTITY_ID(gid, ndof) ((gid-1)/ndof + 1)
+#define GLOBAL_ENTITY_ID_IDOF(gid, ndof) ((gid-1) % ndof)
+
+enum DOFStatus {
+  DS_NotSet            = 0,
+  DS_SkippedDOF        = 1 << 1,
+  DS_OwnedDOF          = 1 << 2,
+  DS_SharedNotOwnedDOF = 1 << 3,
+  DS_GhostedDOF        = 1 << 4
+};
+
+void add_procs_to_neighbors(const std::vector<int>& procs, std::vector<int>& neighbors);
+
+void fill_neighbor_procs(std::vector<int>& neighborProcs,
+                         const stk::mesh::BulkData& bulk,
+                         const Realm& realm);
+
+void fill_owned_and_shared_then_nonowned_ordered_by_proc(std::vector<LinSys::GlobalOrdinal>& totalGids,
+                                                         std::vector<int>& srcPids,
+                                                         int localProc,
+                                                         const Teuchos::RCP<LinSys::Map>& ownedRowsMap,
+                                                         const Teuchos::RCP<LinSys::Map>& sharedNotOwnedRowsMap,
+                                                         const std::set<std::pair<int, LinSys::GlobalOrdinal> >& ownersAndGids,
+                                                         const std::vector<int>& sharedPids);
+
+stk::mesh::Entity get_entity_master(const stk::mesh::BulkData& bulk,
+                                    stk::mesh::Entity entity,
+                                    stk::mesh::EntityId naluId);
+
+size_t get_neighbor_index(const std::vector<int>& neighborProcs, int proc);
+
+void sort_connections(std::vector<std::vector<stk::mesh::Entity> >& connections);
+
+void add_to_length(LinSys::DeviceRowLengths& v_owned, LinSys::DeviceRowLengths& v_shared,
+                   unsigned numDof, LinSys::LocalOrdinal lid_a, LinSys::LocalOrdinal maxOwnedRowId,
+                   bool a_owned, unsigned numColEntities);
+
+void add_lengths_to_comm(const stk::mesh::BulkData&  /* bulk */,
+                         stk::CommNeighbors& commNeighbors,
+                         int entity_a_owner,
+                         stk::mesh::EntityId entityId_a,
+                         unsigned numDof,
+                         unsigned numColEntities,
+                         const stk::mesh::EntityId* colEntityIds,
+                         const int* colOwners);
+
+void communicate_remote_columns(const stk::mesh::BulkData& bulk,
+                                const std::vector<int>& neighborProcs,
+                                stk::CommNeighbors& commNeighbors,
+                                unsigned numDof,
+                                const Teuchos::RCP<LinSys::Map>& ownedRowsMap,
+                                LinSys::DeviceRowLengths& deviceLocallyOwnedRowLengths,
+                                std::set<std::pair<int, LinSys::GlobalOrdinal> >& communicatedColIndices);
+
+void insert_single_dof_row_into_graph(LocalGraphArrays& crsGraph, LinSys::LocalOrdinal rowLid,
+                                      LinSys::LocalOrdinal maxOwnedRowId, unsigned numDof,
+                                      unsigned numCols, const std::vector<LinSys::LocalOrdinal>& colLids);
+
+void insert_communicated_col_indices(const std::vector<int>& neighborProcs,
+                                     stk::CommNeighbors& commNeighbors,
+                                     unsigned numDof,
+                                     LocalGraphArrays& ownedGraph,
+                                     const LinSys::Map& rowMap,
+                                     const LinSys::Map& colMap);
+
+void fill_in_extra_dof_rows_per_node(LocalGraphArrays& csg, int numDof);
+
+void remove_invalid_indices(LocalGraphArrays& csg, LinSys::DeviceRowLengths& rowLengths);
+
+} // nalu
+} // sierra
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,6 +167,7 @@ add_sources(GlobalSourceList
    SurfaceForceAndMomentWallFunctionAlgorithm.C
    TimeIntegrator.C
    TpetraLinearSystem.C
+   TpetraLinearSystemHelpers.C
    TurbKineticEnergyEquationSystem.C
    TurbKineticEnergyKsgsBuoyantElemSuppAlg.C
    TurbKineticEnergyKsgsNodeSourceSuppAlg.C

--- a/src/LinearSolverConfig.C
+++ b/src/LinearSolverConfig.C
@@ -56,7 +56,7 @@ TpetraLinearSolverConfig::load(const YAML::Node & node)
   if (output_level > 0)
   {
     params_->set("Verbosity", Belos::Errors + Belos::Warnings + Belos::StatusTestDetails);
-    params_->set("Output Style",Belos::Brief); 
+    params_->set("Output Style",Belos::Brief);
   }
 
   params_->set("Output Frequency", output_level);
@@ -99,11 +99,12 @@ TpetraLinearSolverConfig::load(const YAML::Node & node)
     throw std::runtime_error("invalid linear solver preconditioner specified ");
   }
 
-  get_if_present(node, "write_matrix_files", writeMatrixFiles_, writeMatrixFiles_);
-  get_if_present(node, "summarize_muelu_timer", summarizeMueluTimer_, summarizeMueluTimer_);
+  get_if_present(node, "write_matrix_files",       writeMatrixFiles_,        writeMatrixFiles_);
+  get_if_present(node, "summarize_muelu_timer",    summarizeMueluTimer_,     summarizeMueluTimer_);
 
   get_if_present(node, "recompute_preconditioner", recomputePreconditioner_, recomputePreconditioner_);
   get_if_present(node, "reuse_preconditioner",     reusePreconditioner_,     reusePreconditioner_);
+  get_if_present(node, "segregated_solver",        useSegregatedSolver_,     useSegregatedSolver_);
 
 }
 

--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -72,10 +72,10 @@ LinearSystem::LinearSystem(
 
 void LinearSystem::zero_timer_precond()
 {
-  linearSolver_->zero_timer_precond();  
+  linearSolver_->zero_timer_precond();
 }
 
-double LinearSystem::get_timer_precond() 
+double LinearSystem::get_timer_precond()
 {
   return linearSolver_->get_timer_precond();
 }
@@ -91,6 +91,10 @@ LinearSystem *LinearSystem::create(Realm& realm, const unsigned numDof, Equation
 {
   switch(solver->getType()) {
   case PT_TPETRA:
+    return new TpetraLinearSystem(realm, numDof, eqSys, solver);
+    break;
+
+  case PT_TPETRA_SEGREGATED:
     return new TpetraLinearSystem(realm, numDof, eqSys, solver);
     break;
 

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -7,6 +7,7 @@
 
 
 #include <TpetraLinearSystem.h>
+#include <TpetraLinearSystemHelpers.h>
 #include <NonConformalInfo.h>
 #include <NonConformalManager.h>
 #include <FieldTypeDef.h>
@@ -72,11 +73,6 @@
 namespace sierra{
 namespace nalu{
 
-#define GID_(gid, ndof, idof)  ((ndof)*((gid)-1)+(idof)+1)
-#define LID_(lid, ndof, idof)  ((ndof)*((lid))+(idof))
-
-#define GLOBAL_ENTITY_ID(gid, ndof) ((gid-1)/ndof + 1)
-#define GLOBAL_ENTITY_ID_IDOF(gid, ndof) ((gid-1) % ndof)
 
 ///====================================================================================================================================
 ///======== T P E T R A ===============================================================================================================
@@ -163,37 +159,7 @@ int TpetraLinearSystem::getDofStatus(stk::mesh::Entity node)
     return getDofStatus_impl(node, realm_);
 }
 
-stk::mesh::Entity get_entity_master(const stk::mesh::BulkData& bulk,
-                             stk::mesh::Entity entity,
-                             stk::mesh::EntityId naluId)
-{
-  bool thisEntityIsMaster = (bulk.identifier(entity) == naluId);
-  if (thisEntityIsMaster) {
-    return entity;
-  }
-  stk::mesh::Entity master = bulk.get_entity(stk::topology::NODE_RANK, naluId);
-  if (!bulk.is_valid(master)) {
-    std::ostringstream os;
-    const stk::mesh::Entity* elems = bulk.begin_elements(entity);
-    unsigned numElems = bulk.num_elements(entity);
-    os<<" elems: ";
-    for(unsigned i=0; i<numElems; ++i) {
-       os<<"{"<<bulk.identifier(elems[i])<<","<<bulk.bucket(elems[i]).topology()
-         <<",owned="<<bulk.bucket(elems[i]).owned()<<"}";
-    }
-    ThrowRequireMsg(bulk.is_valid(master),
-                    "get_entity_master, P"<<bulk.parallel_rank()
-                    <<" failed to get entity for naluId="<<naluId
-                    <<", from entity with stkId="<<bulk.identifier(entity)
-                    <<", owned="<<bulk.bucket(entity).owned()
-                    <<", shared="<<bulk.bucket(entity).shared()
-                    <<", "<<os.str());
-  }
-  return master;
-}
-
-void
-TpetraLinearSystem::beginLinearSystemConstruction()
+void TpetraLinearSystem::beginLinearSystemConstruction()
 {
   if(inConstruction_) return;
   inConstruction_ = true;
@@ -372,8 +338,7 @@ void TpetraLinearSystem::addConnections(const stk::mesh::Entity* entities, const
   }
 }
 
-void
-TpetraLinearSystem::buildNodeGraph(const stk::mesh::PartVector & parts)
+void TpetraLinearSystem::buildNodeGraph(const stk::mesh::PartVector & parts)
 {
   beginLinearSystemConstruction();
   stk::mesh::MetaData & metaData = realm_.meta_data();
@@ -419,30 +384,26 @@ void TpetraLinearSystem::buildConnectedNodeGraph(stk::mesh::EntityRank rank,
   }
 }
 
-void
-TpetraLinearSystem::buildEdgeToNodeGraph(const stk::mesh::PartVector & parts)
+void TpetraLinearSystem::buildEdgeToNodeGraph(const stk::mesh::PartVector & parts)
 {
   beginLinearSystemConstruction();
   buildConnectedNodeGraph(stk::topology::EDGE_RANK, parts);
 }
 
-void
-TpetraLinearSystem::buildFaceToNodeGraph(const stk::mesh::PartVector & parts)
+void TpetraLinearSystem::buildFaceToNodeGraph(const stk::mesh::PartVector & parts)
 {
   beginLinearSystemConstruction();
   stk::mesh::MetaData & metaData = realm_.meta_data();
   buildConnectedNodeGraph(metaData.side_rank(), parts);
 }
 
-void
-TpetraLinearSystem::buildElemToNodeGraph(const stk::mesh::PartVector & parts)
+void TpetraLinearSystem::buildElemToNodeGraph(const stk::mesh::PartVector & parts)
 {
   beginLinearSystemConstruction();
   buildConnectedNodeGraph(stk::topology::ELEM_RANK, parts);
 }
 
-void
-TpetraLinearSystem::buildReducedElemToNodeGraph(const stk::mesh::PartVector & parts)
+void TpetraLinearSystem::buildReducedElemToNodeGraph(const stk::mesh::PartVector & parts)
 {
   beginLinearSystemConstruction();
   stk::mesh::MetaData & metaData = realm_.meta_data();
@@ -483,8 +444,7 @@ TpetraLinearSystem::buildReducedElemToNodeGraph(const stk::mesh::PartVector & pa
   }
 }
 
-void
-TpetraLinearSystem::buildFaceElemToNodeGraph(const stk::mesh::PartVector & parts)
+void TpetraLinearSystem::buildFaceElemToNodeGraph(const stk::mesh::PartVector & parts)
 {
   beginLinearSystemConstruction();
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
@@ -518,8 +478,7 @@ TpetraLinearSystem::buildFaceElemToNodeGraph(const stk::mesh::PartVector & parts
   }
 }
 
-void
-TpetraLinearSystem::buildNonConformalNodeGraph(const stk::mesh::PartVector & /* parts */)
+void TpetraLinearSystem::buildNonConformalNodeGraph(const stk::mesh::PartVector & /* parts */)
 {
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
   beginLinearSystemConstruction();
@@ -572,8 +531,7 @@ TpetraLinearSystem::buildNonConformalNodeGraph(const stk::mesh::PartVector & /* 
   }
 }
 
-void
-TpetraLinearSystem::buildOversetNodeGraph(const stk::mesh::PartVector & /* parts */)
+void TpetraLinearSystem::buildOversetNodeGraph(const stk::mesh::PartVector & /* parts */)
 {
   // extract the rank
   const int theRank = NaluEnv::self().parallel_rank();
@@ -610,10 +568,8 @@ TpetraLinearSystem::buildOversetNodeGraph(const stk::mesh::PartVector & /* parts
   }
 }
 
-void
-TpetraLinearSystem::copy_stk_to_tpetra(
-  stk::mesh::FieldBase * stkField,
-  const Teuchos::RCP<LinSys::MultiVector> tpetraField)
+void TpetraLinearSystem::copy_stk_to_tpetra(stk::mesh::FieldBase * stkField,
+                                            const Teuchos::RCP<LinSys::MultiVector> tpetraField)
 {
   ThrowAssert(!tpetraField.is_null());
   ThrowAssert(stkField);
@@ -658,102 +614,10 @@ TpetraLinearSystem::copy_stk_to_tpetra(
   }
 }
 
-void sort_connections(std::vector<std::vector<stk::mesh::Entity> >& connections)
-{
-  for(std::vector<stk::mesh::Entity>& vec : connections) {
-    std::sort(vec.begin(), vec.end());
-  }
-}
-
-template<typename ViewType, typename LocalOrdinal>
-void add_to_length(ViewType& v_owned, ViewType& v_shared, unsigned numDof,
-                   LocalOrdinal lid_a, LocalOrdinal maxOwnedRowId, bool a_owned, unsigned numColEntities)
-{
-    ViewType& v_a = a_owned ? v_owned : v_shared;
-    LocalOrdinal lid = a_owned ? lid_a : lid_a - maxOwnedRowId;
-
-    for (unsigned d=0; d < numDof; ++d) {
-      v_a(lid+d) += numDof*numColEntities;
-    }
-}
-
-void add_lengths_to_comm(const stk::mesh::BulkData&  /* bulk */,
-                         stk::CommNeighbors& commNeighbors,
-                         int entity_a_owner,
-                         stk::mesh::EntityId entityId_a,
-                         unsigned numDof,
-                         unsigned numColEntities,
-                         const stk::mesh::EntityId* colEntityIds,
-                         const int* colOwners)
-{
-    int owner = entity_a_owner;
-    stk::CommBufferV& sbuf = commNeighbors.send_buffer(owner);
-    GlobalOrdinal rowGid = GID_(entityId_a, numDof , 0);
-
-    sbuf.pack(rowGid);
-    sbuf.pack(numColEntities*2);
-    for(unsigned c=0; c<numColEntities; ++c) {
-        GlobalOrdinal colGid0 = GID_(colEntityIds[c], numDof , 0);
-        sbuf.pack(colGid0);
-        sbuf.pack(colOwners[c]);
-    }
-}
-
-template<typename ViewType>
-void communicate_remote_columns(const stk::mesh::BulkData& bulk,
-                                const std::vector<int>& neighborProcs,
-                                stk::CommNeighbors& commNeighbors,
-                                unsigned numDof,
-                                const Teuchos::RCP<LinSys::Map>& ownedRowsMap,
-                                ViewType& deviceLocallyOwnedRowLengths,
-                                std::set<std::pair<int,GlobalOrdinal> >& communicatedColIndices)
-{
-    commNeighbors.communicate();
-
-    for(int p : neighborProcs) {
-        stk::CommBufferV& rbuf = commNeighbors.recv_buffer(p);
-        size_t bufSize = rbuf.size_in_bytes();
-        while(rbuf.size_in_bytes() > 0) {
-            GlobalOrdinal rowGid = 0;
-            rbuf.unpack(rowGid);
-            unsigned len = 0;
-            rbuf.unpack(len);
-            unsigned numCols = len/2;
-            LocalOrdinal lid = ownedRowsMap->getLocalElement(rowGid);
-            if (lid < 0) {
-                std::cerr<<"P"<<bulk.parallel_rank()<<" lid="<<lid<<" for rowGid="<<rowGid<<" sent from proc "<<p<<std::endl;
-            }
-            for(unsigned d=0; d<numDof; ++d) {
-                deviceLocallyOwnedRowLengths(lid++) += numCols*numDof;
-            }
-            for(unsigned i=0; i<numCols; ++i) {
-                GlobalOrdinal colGid = 0;
-                rbuf.unpack(colGid);
-                int owner = 0;
-                rbuf.unpack(owner);
-                for(unsigned dd=0; dd<numDof; ++dd) {
-                    communicatedColIndices.insert(std::make_pair(owner,colGid++));
-                }
-            }
-        }
-        rbuf.resize(bufSize);
-    }
-}
-
-size_t get_neighbor_index(const std::vector<int>& neighborProcs, int proc)
-{
-    std::vector<int>::const_iterator neighbor = std::find(neighborProcs.begin(), neighborProcs.end(), proc);
-    ThrowRequireMsg(neighbor != neighborProcs.end(),"Error, failed to find p="<<proc<<" in neighborProcs.");
-
-    size_t neighborIndex = neighbor-neighborProcs.begin();
-    return neighborIndex;
-}
-
-void
-TpetraLinearSystem::compute_send_lengths(const std::vector<stk::mesh::Entity>& rowEntities,
-        const std::vector<std::vector<stk::mesh::Entity> >& connections,
-                          const std::vector<int>& neighborProcs,
-                          stk::CommNeighbors& commNeighbors)
+void TpetraLinearSystem::compute_send_lengths(const std::vector<stk::mesh::Entity>& rowEntities,
+                                              const std::vector<std::vector<stk::mesh::Entity> >& connections,
+                                              const std::vector<int>& neighborProcs,
+                                              stk::CommNeighbors& commNeighbors)
 {
   const stk::mesh::BulkData& bulk = realm_.bulk_data();
   std::vector<int> sendLengths(neighborProcs.size(), 0);
@@ -802,15 +666,14 @@ TpetraLinearSystem::compute_send_lengths(const std::vector<stk::mesh::Entity>& r
   }
 }
 
-void
-TpetraLinearSystem::compute_graph_row_lengths(const std::vector<stk::mesh::Entity>& rowEntities,
-        const std::vector<std::vector<stk::mesh::Entity> >& connections,
-                                              LinSys::RowLengths& sharedNotOwnedRowLengths,
-                                              LinSys::RowLengths& locallyOwnedRowLengths,
-                                              stk::CommNeighbors& commNeighbors)
+void TpetraLinearSystem::compute_graph_row_lengths(const std::vector<stk::mesh::Entity>& rowEntities,
+                                                   const std::vector<std::vector<stk::mesh::Entity> >& connections,
+                                                   LinSys::RowLengths& sharedNotOwnedRowLengths,
+                                                   LinSys::RowLengths& locallyOwnedRowLengths,
+                                                   stk::CommNeighbors& commNeighbors)
 {
-  auto deviceSharedNotOwnedRowLengths = sharedNotOwnedRowLengths.view<DeviceSpace>();
-  auto deviceLocallyOwnedRowLengths = locallyOwnedRowLengths.view<DeviceSpace>();
+  LinSys::DeviceRowLengths deviceSharedNotOwnedRowLengths = sharedNotOwnedRowLengths.view<DeviceSpace>();
+  LinSys::DeviceRowLengths deviceLocallyOwnedRowLengths = locallyOwnedRowLengths.view<DeviceSpace>();
 
   const stk::mesh::BulkData& bulk = realm_.bulk_data();
 
@@ -867,21 +730,10 @@ TpetraLinearSystem::compute_graph_row_lengths(const std::vector<stk::mesh::Entit
   }
 }
 
-void
-insert_single_dof_row_into_graph(LocalGraphArrays& crsGraph, LocalOrdinal rowLid, LocalOrdinal maxOwnedRowId,
-                unsigned numDof, unsigned numCols, const std::vector<LocalOrdinal>& colLids)
-{
-    if (rowLid >= maxOwnedRowId) {
-      rowLid -= maxOwnedRowId;
-    }
-    crsGraph.insertIndices(rowLid++, numCols, colLids.data(), numDof);
-}
-
-void
-TpetraLinearSystem::insert_graph_connections(const std::vector<stk::mesh::Entity>& rowEntities,
-         const std::vector<std::vector<stk::mesh::Entity> >& connections,
-                                             LocalGraphArrays& locallyOwnedGraph,
-                                             LocalGraphArrays& sharedNotOwnedGraph)
+void TpetraLinearSystem::insert_graph_connections(const std::vector<stk::mesh::Entity>& rowEntities,
+                                                  const std::vector<std::vector<stk::mesh::Entity> >& connections,
+                                                  LocalGraphArrays& locallyOwnedGraph,
+                                                  LocalGraphArrays& sharedNotOwnedGraph)
 {
   std::vector<LocalOrdinal> localDofs_a(1);
   unsigned max = 128;
@@ -919,38 +771,7 @@ TpetraLinearSystem::insert_graph_connections(const std::vector<stk::mesh::Entity
   }
 }
 
-void insert_communicated_col_indices(const std::vector<int>& neighborProcs,
-                                     stk::CommNeighbors& commNeighbors,
-                                     unsigned numDof,
-                                     LocalGraphArrays& ownedGraph,
-                                     const LinSys::Map& rowMap,
-                                     const LinSys::Map& colMap)
-{
-    std::vector<LocalOrdinal> colLids;
-    for(int p : neighborProcs) {
-        stk::CommBufferV& rbuf = commNeighbors.recv_buffer(p);
-        while(rbuf.size_in_bytes() > 0) {
-            stk::mesh::EntityId rowGid = 0;
-            rbuf.unpack(rowGid);
-            unsigned len = 0;
-            rbuf.unpack(len);
-            unsigned numCols = len/2;
-            colLids.resize(numCols);
-            LocalOrdinal rowLid = rowMap.getLocalElement(rowGid);
-            for(unsigned i=0; i<numCols; ++i) {
-                GlobalOrdinal colGid = 0;
-                rbuf.unpack(colGid);
-                int owner = 0;
-                rbuf.unpack(owner);
-                colLids[i] = colMap.getLocalElement(colGid);
-            }
-            ownedGraph.insertIndices(rowLid++,numCols,colLids.data(), numDof);
-        }
-    }
-}
-
-void
-TpetraLinearSystem::fill_entity_to_row_LID_mapping()
+void TpetraLinearSystem::fill_entity_to_row_LID_mapping()
 {
   const stk::mesh::BulkData& bulk = realm_.bulk_data();
   stk::mesh::Selector selector = bulk.mesh_meta_data().universal_part() & !(realm_.get_inactive_selector());
@@ -976,8 +797,7 @@ TpetraLinearSystem::fill_entity_to_row_LID_mapping()
   }
 }
 
-void
-TpetraLinearSystem::fill_entity_to_col_LID_mapping()
+void TpetraLinearSystem::fill_entity_to_col_LID_mapping()
 {
     const stk::mesh::BulkData& bulk = realm_.bulk_data();
     entityToColLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
@@ -993,8 +813,7 @@ TpetraLinearSystem::fill_entity_to_col_LID_mapping()
     }
 }
 
-void
-TpetraLinearSystem::storeOwnersForShared()
+void TpetraLinearSystem::storeOwnersForShared()
 {
   const stk::mesh::BulkData & bulkData = realm_.bulk_data();
   const stk::mesh::MetaData & metaData = realm_.meta_data();
@@ -1017,239 +836,7 @@ TpetraLinearSystem::storeOwnersForShared()
   }
 }
 
-void add_procs_to_neighbors(const std::vector<int>& procs, std::vector<int>& neighbors)
-{
-  neighbors.insert(neighbors.end(), procs.begin(), procs.end());
-  stk::util::sort_and_unique(neighbors);
-}
-
-void fill_neighbor_procs(std::vector<int>& neighborProcs,
-                         const stk::mesh::BulkData& bulk,
-                         const Realm& realm)
-{
-  if (bulk.parallel_size() > 1) {
-    neighborProcs = bulk.all_sharing_procs(stk::topology::NODE_RANK);
-    if (bulk.is_automatic_aura_on()) {
-      std::vector<int> ghostCommProcs;
-      populate_ghost_comm_procs(bulk, bulk.aura_ghosting(), ghostCommProcs);
-      add_procs_to_neighbors(ghostCommProcs, neighborProcs);
-    }
-    if (realm.hasPeriodic_) {
-      add_procs_to_neighbors(realm.periodicManager_->ghostCommProcs_, neighborProcs);
-    }
-    if (realm.nonConformalManager_) {
-      add_procs_to_neighbors(realm.nonConformalManager_->ghostCommProcs_, neighborProcs);
-    }
-    if (realm.oversetManager_) {
-      add_procs_to_neighbors(realm.oversetManager_->ghostCommProcs_, neighborProcs);
-    }
-  }
-}
-
-void fill_owned_and_shared_then_nonowned_ordered_by_proc(std::vector<GlobalOrdinal>& totalGids,
-                                    std::vector<int>& srcPids,
-                                    int localProc,
-                                    const Teuchos::RCP<LinSys::Map>& ownedRowsMap,
-                                    const Teuchos::RCP<LinSys::Map>& sharedNotOwnedRowsMap,
-                                    const std::set<std::pair<int,GlobalOrdinal> >& ownersAndGids,
-                                    const std::vector<int>& sharedPids)
-{
-  auto ownedIndices = ownedRowsMap->getMyGlobalIndices();
-  totalGids.clear();
-  totalGids.reserve(ownedIndices.size() + ownersAndGids.size());
-
-  srcPids.clear();
-  srcPids.reserve(ownersAndGids.size());
-
-  for(unsigned i=0; i<ownedIndices.size(); ++i) {
-    totalGids.push_back(ownedIndices[i]);
-  }
-
-  auto sharedIndices = sharedNotOwnedRowsMap->getMyGlobalIndices();
-  for(unsigned i=0; i<sharedIndices.size(); ++i) {
-    totalGids.push_back(sharedIndices[i]);
-    srcPids.push_back(sharedPids[i]);
-    ThrowRequireMsg(sharedPids[i] != localProc && sharedPids[i] >= 0,
-                    "Error, bad sharedPid = "<<sharedPids[i]<<
-                    ", localProc = "<<localProc<<", gid = "<<sharedIndices[i]);
-  }
-
-  for(const std::pair<int,GlobalOrdinal>& procAndGid : ownersAndGids) {
-    int proc = procAndGid.first;
-    GlobalOrdinal gid = procAndGid.second;
-    if (proc != localProc &&
-        !ownedRowsMap->isNodeGlobalElement(gid) &&
-        !sharedNotOwnedRowsMap->isNodeGlobalElement(gid)) {
-      totalGids.push_back(gid);
-      srcPids.push_back(procAndGid.first);
-      ThrowRequireMsg(procAndGid.first != localProc && procAndGid.first >= 0,
-                      "Error, bad remote proc = "<<procAndGid.first);
-    }
-  }
-
-  ThrowRequireMsg(srcPids.size() == (totalGids.size() - ownedIndices.size()),
-                  "Error, bad srcPids.size() = "<<srcPids.size());
-}
-
-void verify_same_except_sort_order(const std::vector<GlobalOrdinal>& vec1, const std::string& vec1name,
-                                   const std::vector<GlobalOrdinal>& vec2, const std::string& vec2name,
-                                   int localProc)
-{
-  std::vector<GlobalOrdinal> svec1(vec1);
-  std::vector<GlobalOrdinal> svec2(vec2);
-
-  std::sort(svec1.begin(), svec1.end());
-  std::sort(svec2.begin(), svec2.end());
-
-  std::vector<GlobalOrdinal> vec1NotInVec2;
-  std::vector<GlobalOrdinal> vec2NotInVec1;
-
-  for(GlobalOrdinal gid : vec1) {
-    if (!std::binary_search(svec2.begin(), svec2.end(), gid)) {
-      vec1NotInVec2.push_back(gid);
-    }
-  }
-  for(GlobalOrdinal gid : vec2) {
-    if (!std::binary_search(svec1.begin(), svec1.end(), gid)) {
-      vec2NotInVec1.push_back(gid);
-    }
-  }
-  std::vector<GlobalOrdinal>::iterator uniq1 = std::unique(svec1.begin(), svec1.end());
-  std::vector<GlobalOrdinal>::iterator uniq2 = std::unique(svec2.begin(), svec2.end());
-  unsigned idx1 = uniq1-svec1.begin();
-  unsigned idx2 = uniq2-svec2.begin();
-  bool foundDuplicates = ((svec1.size()-idx1)!=0) || ((svec2.size()-idx2)!=0);
-  if (foundDuplicates) {
-    std::ostringstream oss;
-    oss<<"P"<<localProc<<" "<<(svec1.size()-idx1) << " duplicates in "<<vec1name<<std::endl;
-    oss<<"P"<<localProc<<" "<<(svec2.size()-idx2) << " duplicates in "<<vec2name<<std::endl;
-    oss<<"P"<<localProc<<" in "<<vec1name<<" but not in "<<vec2name<<":";
-    for(GlobalOrdinal gid : vec1NotInVec2) { oss << gid << ","; }
-    oss << ";; in "<<vec2name<<" but not in "<<vec1name<<":";
-    for(GlobalOrdinal gid : vec2NotInVec1) { oss << gid << ","; }
-    oss<<std::endl;
-    std::cerr<<oss.str();
-  }
-
-  ThrowRequireMsg(vec1.size() == vec1.size() && vec1NotInVec2.empty() && vec2NotInVec1.empty() && !foundDuplicates,
-                  "P"<<localProc<<", failed to verify "<<vec1name<<" against "<<vec2name);
-}
-
-void verify_row_lengths(const LinSys::Graph& graph,
-                        const Kokkos::View<size_t*,DeviceSpace>& rowLengths, int localProc)
-{
-  ThrowRequireMsg(graph.getNodeNumRows() == rowLengths.size(),
-                  "Error, graph.getNodeNumRows="<<graph.getNodeNumRows()<<" must equal "
-                  <<"rowLengths.size="<<rowLengths.size());
-
-  for(size_t i=0; i<rowLengths.size(); ++i) {
-    if (rowLengths(i) < graph.getNumEntriesInLocalRow(i)) {
-      std::ostringstream os;
-      os<<"Error, P"<<localProc<<" expected global row "<<graph.getRowMap()->getGlobalElement(i)
-         <<" to have "<<rowLengths(i)<<" entries, graph row has "<<graph.getNumEntriesInLocalRow(i)
-         <<" entries: ";
-      GlobalOrdinal rowGID = graph.getRowMap()->getGlobalElement(i);
-      std::vector<GlobalOrdinal> vIndices(graph.getNumEntriesInGlobalRow(rowGID));
-      Teuchos::ArrayView<GlobalOrdinal> colIndices(vIndices);
-      size_t rowLen = 0;
-      graph.getGlobalRowCopy(rowGID, colIndices, rowLen);
-
-      for(unsigned j=0; j<graph.getNumEntriesInLocalRow(i); ++j) {
-        os<<colIndices[j]<<",";
-      }
-      ThrowRequireMsg(rowLengths(i) >= graph.getNumEntriesInLocalRow(i),os.str());
-    }
-  }
-}
-
-void dump_graph(const std::string& name, int counter, int proc, LinSys::Graph& graph)
-{
-  std::string fullname(name+"."+std::to_string(counter)+"."+std::to_string(proc));
-  std::ofstream ofs(fullname);
-  Teuchos::RCP<const LinSys::Map> rowMap = graph.getRowMap();
-  const auto myGlobalIndices = rowMap->getMyGlobalIndices();
-  for(size_t i=0; i<myGlobalIndices.size(); ++i) {
-    GlobalOrdinal rowGID = myGlobalIndices[i];
-    std::vector<GlobalOrdinal> vIndices(graph.getNumEntriesInGlobalRow(rowGID));
-    Teuchos::ArrayView<GlobalOrdinal> colIndices(vIndices);
-    size_t rowLen = 0;
-    graph.getGlobalRowCopy(rowGID, colIndices, rowLen);
-    std::ostringstream os;
-    os<<rowGID<<": ";
-    for(size_t j=0; j<rowLen; ++j) {
-        os<<colIndices[j]<<", ";
-    }
-    os<<std::endl;
-    ofs<<os.str();
-  }
-}
-
-template<typename ViewType>
-void remove_invalid_indices(LocalGraphArrays& csg, ViewType& rowLengths)
-{
-  size_t nnz = csg.rowPointers(rowLengths.size());
-  auto cols = csg.colIndices.data();
-  auto rowPtrs = csg.rowPointers.data();
-  size_t newNnz = 0;
-  for(int i=0, ie=csg.rowPointers.size()-1; i<ie; ++i) {
-    const LocalOrdinal* row = cols+rowPtrs[i];
-    int rowLen = csg.get_row_length(i);
-    for(int j=rowLen-1; j>=0; --j) {
-      if (row[j] != INVALID) {
-        rowLengths(i) = j+1;
-        break;
-      }
-    }
-    newNnz += rowLengths(i);
-  }
-
-  if (newNnz < nnz) {
-    Kokkos::View<LocalOrdinal*,DeviceSpace> newColIndices(Kokkos::ViewAllocateWithoutInitializing("colInds"),newNnz);
-    LocalOrdinal* newCols = newColIndices.data();
-    auto rowLens = rowLengths.data();
-    int index = 0;
-    for(int i=0, ie=csg.rowPointers.size()-1; i<ie; ++i) {
-      auto row = cols+rowPtrs[i];
-      for(size_t j=0; j<rowLens[i]; ++j) {
-        newCols[index++] = row[j];
-      }
-    }
-    csg.colIndices = newColIndices;
-    LocalGraphArrays::compute_row_pointers(csg.rowPointers, rowLengths);
-  }
-}
-
-void fill_in_extra_dof_rows_per_node(LocalGraphArrays& csg, int numDof)
-{
-  if (numDof == 1) {
-    return;
-  }
-
-  auto rowPtrs = csg.rowPointers.data();
-  LocalOrdinal* cols = csg.colIndices.data();
-  for(int i=0, ie=csg.rowPointers.size()-1; i<ie;) {
-    const LocalOrdinal* row = cols+rowPtrs[i];
-    int rowLen = csg.get_row_length(i);
-    for(int d=1; d<numDof; ++d) {
-      LocalOrdinal* row_d = cols + rowPtrs[i] + rowLen*d;
-      for(int j=0; j<rowLen; ++j) {
-        row_d[j] = row[j];
-      }
-    }
-    i += numDof;
-  }
-}
-
-void verify_no_empty_connections(const std::vector<stk::mesh::Entity>&  /* rowEntities */,
-        const std::vector<std::vector<stk::mesh::Entity> >& connections)
-{
-  for(const std::vector<stk::mesh::Entity>& vec : connections) {
-    ThrowRequireMsg(!vec.empty(), "Error, empty connections vec.");
-  }
-}
-
-void
-TpetraLinearSystem::finalizeLinearSystem()
+void TpetraLinearSystem::finalizeLinearSystem()
 {
   ThrowRequire(inConstruction_);
   inConstruction_ = false;
@@ -1263,8 +850,8 @@ TpetraLinearSystem::finalizeLinearSystem()
   size_t numLocallyOwned = ownedRowsMap_->getMyGlobalIndices().extent(0);
   LinSys::RowLengths sharedNotOwnedRowLengths("rowLengths", numSharedNotOwned);
   LinSys::RowLengths locallyOwnedRowLengths("rowLengths", numLocallyOwned);
-  auto ownedRowLengths = locallyOwnedRowLengths.view<DeviceSpace>();
-  auto globalRowLengths = sharedNotOwnedRowLengths.view<DeviceSpace>();
+  LinSys::DeviceRowLengths ownedRowLengths = locallyOwnedRowLengths.view<DeviceSpace>();
+  LinSys::DeviceRowLengths globalRowLengths = sharedNotOwnedRowLengths.view<DeviceSpace>();
 
   std::vector<int> neighborProcs;
   fill_neighbor_procs(neighborProcs, bulkData, realm_);
@@ -1349,8 +936,7 @@ TpetraLinearSystem::finalizeLinearSystem()
   }
 }
 
-void
-TpetraLinearSystem::zeroSystem()
+void TpetraLinearSystem::zeroSystem()
 {
   ThrowRequire(!ownedMatrix_.is_null());
   ThrowRequire(!sharedNotOwnedMatrix_.is_null());
@@ -1526,15 +1112,13 @@ void sum_into(
   }
 }
 
-void
-TpetraLinearSystem::sumInto(
-      unsigned numEntities,
-      const stk::mesh::Entity* entities,
-      const SharedMemView<const double*> & rhs,
-      const SharedMemView<const double**> & lhs,
-      const SharedMemView<int*> & localIds,
-      const SharedMemView<int*> & sortPermutation,
-      const char *  /* trace_tag */)
+void TpetraLinearSystem::sumInto(unsigned numEntities,
+                                 const stk::mesh::Entity* entities,
+                                 const SharedMemView<const double*> & rhs,
+                                 const SharedMemView<const double**> & lhs,
+                                 const SharedMemView<int*> & localIds,
+                                 const SharedMemView<int*> & sortPermutation,
+                                 const char *  /* trace_tag */)
 {
   constexpr bool forceAtomic = !std::is_same<sierra::nalu::DeviceSpace, Kokkos::Serial>::value;
 
@@ -1602,14 +1186,13 @@ sierra::nalu::CoeffApplier* TpetraLinearSystem::get_coeff_applier()
 }
 
 KOKKOS_FUNCTION
-void
-TpetraLinearSystem::TpetraLinSysCoeffApplier::operator()(unsigned numEntities,
-                            const ngp::Mesh::ConnectedNodes& entities,
-                            const SharedMemView<int*,DeviceShmem> & localIds,
-                            const SharedMemView<int*,DeviceShmem> & sortPermutation,
-                            const SharedMemView<const double*,DeviceShmem> & rhs,
-                            const SharedMemView<const double**,DeviceShmem> & lhs,
-                            const char * /*trace_tag*/)
+void TpetraLinearSystem::TpetraLinSysCoeffApplier::operator()(unsigned numEntities,
+                                                              const ngp::Mesh::ConnectedNodes& entities,
+                                                              const SharedMemView<int*,DeviceShmem> & localIds,
+                                                              const SharedMemView<int*,DeviceShmem> & sortPermutation,
+                                                              const SharedMemView<const double*,DeviceShmem> & rhs,
+                                                              const SharedMemView<const double**,DeviceShmem> & lhs,
+                                                              const char * /*trace_tag*/)
 {
   sum_into(
       ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
@@ -1640,15 +1223,13 @@ sierra::nalu::CoeffApplier* TpetraLinearSystem::TpetraLinSysCoeffApplier::device
   return devicePointer_;
 }
 
-void
-TpetraLinearSystem::sumInto(
-  unsigned numEntities,
-  const ngp::Mesh::ConnectedNodes& entities,
-  const SharedMemView<const double*,DeviceShmem> & rhs,
-  const SharedMemView<const double**,DeviceShmem> & lhs,
-  const SharedMemView<int*,DeviceShmem> & localIds,
-  const SharedMemView<int*,DeviceShmem> & sortPermutation,
-  const char *  /* trace_tag */)
+void TpetraLinearSystem::sumInto(unsigned numEntities,
+                                 const ngp::Mesh::ConnectedNodes& entities,
+                                 const SharedMemView<const double*,DeviceShmem> & rhs,
+                                 const SharedMemView<const double**,DeviceShmem> & lhs,
+                                 const SharedMemView<int*,DeviceShmem> & localIds,
+                                 const SharedMemView<int*,DeviceShmem> & sortPermutation,
+                                 const char *  /* trace_tag */)
 {
   ThrowAssertMsg(lhs.span_is_contiguous(), "LHS assumed contiguous");
   ThrowAssertMsg(rhs.span_is_contiguous(), "RHS assumed contiguous");
@@ -1666,15 +1247,12 @@ TpetraLinearSystem::sumInto(
       numDof_);
 }
 
-void
-TpetraLinearSystem::sumInto(
-  const std::vector<stk::mesh::Entity> & entities,
-  std::vector<int> &scratchIds,
-  std::vector<double> & /* scratchVals */,
-  const std::vector<double> & rhs,
-  const std::vector<double> & lhs,
-  const char * /* trace_tag */
-  )
+void TpetraLinearSystem::sumInto(const std::vector<stk::mesh::Entity> & entities,
+                                 std::vector<int> &scratchIds,
+                                 std::vector<double> & /* scratchVals */,
+                                 const std::vector<double> & rhs,
+                                 const std::vector<double> & lhs,
+                                 const char * /* trace_tag */)
 {
   const size_t n_obj = entities.size();
   const unsigned numRows = n_obj * numDof_;
@@ -1721,13 +1299,11 @@ TpetraLinearSystem::sumInto(
   }
 }
 
-void
-TpetraLinearSystem::applyDirichletBCs(
-  stk::mesh::FieldBase * solutionField,
-  stk::mesh::FieldBase * bcValuesField,
-  const stk::mesh::PartVector & parts,
-  const unsigned beginPos,
-  const unsigned endPos)
+void TpetraLinearSystem::applyDirichletBCs(stk::mesh::FieldBase * solutionField,
+                                           stk::mesh::FieldBase * bcValuesField,
+                                           const stk::mesh::PartVector & parts,
+                                           const unsigned beginPos,
+                                           const unsigned endPos)
 {
   stk::mesh::MetaData & metaData = realm_.meta_data();
 
@@ -1800,10 +1376,8 @@ TpetraLinearSystem::applyDirichletBCs(
   adbc_time += NaluEnv::self().nalu_time();
 }
 
-void
-TpetraLinearSystem::prepareConstraints(
-  const unsigned beginPos,
-  const unsigned endPos)
+void TpetraLinearSystem::prepareConstraints(const unsigned beginPos,
+                                            const unsigned endPos)
 {
   Teuchos::ArrayView<const LocalOrdinal> indices;
   Teuchos::ArrayView<const double> values;
@@ -1850,13 +1424,11 @@ TpetraLinearSystem::prepareConstraints(
   }
 }
 
-void
-TpetraLinearSystem::resetRows(
-  const std::vector<stk::mesh::Entity>& nodeList,
-  const unsigned beginPos,
-  const unsigned endPos,
-  const double diag_value,
-  const double rhs_residual)
+void TpetraLinearSystem::resetRows(const std::vector<stk::mesh::Entity>& nodeList,
+                                   const unsigned beginPos,
+                                   const unsigned endPos,
+                                   const double diag_value,
+                                   const double rhs_residual)
 {
   Teuchos::ArrayView<const LocalOrdinal> indices;
   Teuchos::ArrayView<const double> values;
@@ -1900,8 +1472,7 @@ TpetraLinearSystem::resetRows(
   }
 }
 
-void
-TpetraLinearSystem::loadComplete()
+void TpetraLinearSystem::loadComplete()
 {
   // LHS
   Teuchos::RCP<Teuchos::ParameterList> params = Teuchos::parameterList ();
@@ -1923,9 +1494,7 @@ TpetraLinearSystem::loadComplete()
   ownedRhs_->doExport(*sharedNotOwnedRhs_, *exporter_, Tpetra::ADD);
 }
 
-int
-TpetraLinearSystem::solve(
-  stk::mesh::FieldBase * linearSolutionField)
+int TpetraLinearSystem::solve(stk::mesh::FieldBase * linearSolutionField)
 {
 
   TpetraLinearSolver *linearSolver = reinterpret_cast<TpetraLinearSolver *>(linearSolver_);
@@ -1998,8 +1567,7 @@ TpetraLinearSystem::solve(
   return status;
 }
 
-void
-TpetraLinearSystem::checkForNaN(bool useOwned)
+void TpetraLinearSystem::checkForNaN(bool useOwned)
 {
   Teuchos::RCP<LinSys::Matrix> matrix = useOwned ? ownedMatrix_ : sharedNotOwnedMatrix_;
   Teuchos::RCP<LinSys::MultiVector> rhs = useOwned ? ownedRhs_ : sharedNotOwnedRhs_;
@@ -2030,8 +1598,7 @@ TpetraLinearSystem::checkForNaN(bool useOwned)
   }
 }
 
-bool
-TpetraLinearSystem::checkForZeroRow(bool useOwned, bool doThrow, bool doPrint)
+bool TpetraLinearSystem::checkForZeroRow(bool useOwned, bool doThrow, bool doPrint)
 {
   Teuchos::RCP<LinSys::Matrix> matrix = useOwned ? ownedMatrix_ : sharedNotOwnedMatrix_;
   Teuchos::RCP<LinSys::MultiVector> rhs = useOwned ? ownedRhs_ : sharedNotOwnedRhs_;
@@ -2117,8 +1684,7 @@ TpetraLinearSystem::checkForZeroRow(bool useOwned, bool doThrow, bool doPrint)
   return found;
 }
 
-void
-TpetraLinearSystem::writeToFile(const char * base_filename, bool useOwned)
+void TpetraLinearSystem::writeToFile(const char * base_filename, bool useOwned)
 {
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
   const unsigned p_rank = bulkData.parallel_rank();
@@ -2193,8 +1759,7 @@ TpetraLinearSystem::writeToFile(const char * base_filename, bool useOwned)
 
 }
 
-void
-TpetraLinearSystem::printInfo(bool useOwned)
+void TpetraLinearSystem::printInfo(bool useOwned)
 {
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
   const unsigned p_rank = bulkData.parallel_rank();
@@ -2218,8 +1783,7 @@ TpetraLinearSystem::printInfo(bool useOwned)
   }
 }
 
-void
-TpetraLinearSystem::writeSolutionToFile(const char * base_filename, bool useOwned)
+void TpetraLinearSystem::writeSolutionToFile(const char * base_filename, bool useOwned)
 {
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
   const unsigned p_rank = bulkData.parallel_rank();
@@ -2267,8 +1831,7 @@ TpetraLinearSystem::writeSolutionToFile(const char * base_filename, bool useOwne
 
 }
 
-void
-TpetraLinearSystem::copy_tpetra_to_stk(
+void TpetraLinearSystem::copy_tpetra_to_stk(
   const Teuchos::RCP<LinSys::MultiVector> tpetraField,
   stk::mesh::FieldBase * stkField)
 {

--- a/src/TpetraLinearSystemHelpers.C
+++ b/src/TpetraLinearSystemHelpers.C
@@ -1,0 +1,315 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <TpetraLinearSystemHelpers.h>
+
+#include <Realm.h>
+#include <PeriodicManager.h>
+#include <NonConformalManager.h>
+#include <utils/StkHelpers.h>
+#include <LinearSolver.h>
+
+#include <stk_util/parallel/CommNeighbors.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_topology/topology.hpp>
+
+#include <stdio.h>
+
+namespace sierra {
+namespace nalu {
+
+void add_procs_to_neighbors(const std::vector<int>& procs, std::vector<int>& neighbors)
+{
+  neighbors.insert(neighbors.end(), procs.begin(), procs.end());
+  stk::util::sort_and_unique(neighbors);
+}
+
+void fill_neighbor_procs(std::vector<int>& neighborProcs,
+                         const stk::mesh::BulkData& bulk,
+                         const Realm& realm)
+{
+  if (bulk.parallel_size() > 1) {
+    neighborProcs = bulk.all_sharing_procs(stk::topology::NODE_RANK);
+    if (bulk.is_automatic_aura_on()) {
+      std::vector<int> ghostCommProcs;
+      populate_ghost_comm_procs(bulk, bulk.aura_ghosting(), ghostCommProcs);
+      add_procs_to_neighbors(ghostCommProcs, neighborProcs);
+    }
+    if (realm.hasPeriodic_) {
+      add_procs_to_neighbors(realm.periodicManager_->ghostCommProcs_, neighborProcs);
+    }
+    if (realm.nonConformalManager_) {
+      add_procs_to_neighbors(realm.nonConformalManager_->ghostCommProcs_, neighborProcs);
+    }
+    if (realm.oversetManager_) {
+      add_procs_to_neighbors(realm.oversetManager_->ghostCommProcs_, neighborProcs);
+    }
+  }
+}
+
+void fill_owned_and_shared_then_nonowned_ordered_by_proc(std::vector<LinSys::GlobalOrdinal>& totalGids,
+                                                         std::vector<int>& srcPids,
+                                                         int localProc,
+                                                         const Teuchos::RCP<LinSys::Map>& ownedRowsMap,
+                                                         const Teuchos::RCP<LinSys::Map>& sharedNotOwnedRowsMap,
+                                                         const std::set<std::pair<int, LinSys::GlobalOrdinal> >& ownersAndGids,
+                                                         const std::vector<int>& sharedPids)
+{
+  auto ownedIndices = ownedRowsMap->getMyGlobalIndices();
+  totalGids.clear();
+  totalGids.reserve(ownedIndices.size() + ownersAndGids.size());
+
+  srcPids.clear();
+  srcPids.reserve(ownersAndGids.size());
+
+  for(unsigned i=0; i<ownedIndices.size(); ++i) {
+    totalGids.push_back(ownedIndices[i]);
+  }
+
+  auto sharedIndices = sharedNotOwnedRowsMap->getMyGlobalIndices();
+  for(unsigned i=0; i<sharedIndices.size(); ++i) {
+    totalGids.push_back(sharedIndices[i]);
+    srcPids.push_back(sharedPids[i]);
+    ThrowRequireMsg(sharedPids[i] != localProc && sharedPids[i] >= 0,
+                    "Error, bad sharedPid = "<<sharedPids[i]<<
+                    ", localProc = "<<localProc<<", gid = "<<sharedIndices[i]);
+  }
+
+  for(const std::pair<int, LinSys::GlobalOrdinal>& procAndGid : ownersAndGids) {
+    int proc = procAndGid.first;
+    LinSys::GlobalOrdinal gid = procAndGid.second;
+    if (proc != localProc &&
+        !ownedRowsMap->isNodeGlobalElement(gid) &&
+        !sharedNotOwnedRowsMap->isNodeGlobalElement(gid)) {
+      totalGids.push_back(gid);
+      srcPids.push_back(procAndGid.first);
+      ThrowRequireMsg(procAndGid.first != localProc && procAndGid.first >= 0,
+                      "Error, bad remote proc = "<<procAndGid.first);
+    }
+  }
+
+  ThrowRequireMsg(srcPids.size() == (totalGids.size() - ownedIndices.size()),
+                  "Error, bad srcPids.size() = "<<srcPids.size());
+}
+
+stk::mesh::Entity get_entity_master(const stk::mesh::BulkData& bulk,
+                                    stk::mesh::Entity entity,
+                                    stk::mesh::EntityId naluId)
+{
+  bool thisEntityIsMaster = (bulk.identifier(entity) == naluId);
+  if (thisEntityIsMaster) {
+    return entity;
+  }
+  stk::mesh::Entity master = bulk.get_entity(stk::topology::NODE_RANK, naluId);
+  if (!bulk.is_valid(master)) {
+    std::ostringstream os;
+    const stk::mesh::Entity* elems = bulk.begin_elements(entity);
+    unsigned numElems = bulk.num_elements(entity);
+    os<<" elems: ";
+    for(unsigned i=0; i<numElems; ++i) {
+       os<<"{"<<bulk.identifier(elems[i])<<","<<bulk.bucket(elems[i]).topology()
+         <<",owned="<<bulk.bucket(elems[i]).owned()<<"}";
+    }
+    ThrowRequireMsg(bulk.is_valid(master),
+                    "get_entity_master, P"<<bulk.parallel_rank()
+                    <<" failed to get entity for naluId="<<naluId
+                    <<", from entity with stkId="<<bulk.identifier(entity)
+                    <<", owned="<<bulk.bucket(entity).owned()
+                    <<", shared="<<bulk.bucket(entity).shared()
+                    <<", "<<os.str());
+  }
+  return master;
+}
+
+size_t get_neighbor_index(const std::vector<int>& neighborProcs, int proc)
+{
+    std::vector<int>::const_iterator neighbor = std::find(neighborProcs.begin(), neighborProcs.end(), proc);
+    ThrowRequireMsg(neighbor != neighborProcs.end(),"Error, failed to find p="<<proc<<" in neighborProcs.");
+
+    size_t neighborIndex = neighbor-neighborProcs.begin();
+    return neighborIndex;
+}
+
+void sort_connections(std::vector<std::vector<stk::mesh::Entity> >& connections)
+{
+  for(std::vector<stk::mesh::Entity>& vec : connections) {
+    std::sort(vec.begin(), vec.end());
+  }
+}
+
+void add_to_length(LinSys::DeviceRowLengths& v_owned, LinSys::DeviceRowLengths& v_shared,
+                   unsigned numDof, LinSys::LocalOrdinal lid_a, LinSys::LocalOrdinal maxOwnedRowId,
+                   bool a_owned, unsigned numColEntities)
+{
+    LinSys::DeviceRowLengths& v_a = a_owned ? v_owned : v_shared;
+    LinSys::LocalOrdinal lid = a_owned ? lid_a : lid_a - maxOwnedRowId;
+
+    for (unsigned d=0; d < numDof; ++d) {
+      v_a(lid+d) += numDof*numColEntities;
+    }
+}
+
+void add_lengths_to_comm(const stk::mesh::BulkData&  /* bulk */,
+                         stk::CommNeighbors& commNeighbors,
+                         int entity_a_owner,
+                         stk::mesh::EntityId entityId_a,
+                         unsigned numDof,
+                         unsigned numColEntities,
+                         const stk::mesh::EntityId* colEntityIds,
+                         const int* colOwners)
+{
+    int owner = entity_a_owner;
+    stk::CommBufferV& sbuf = commNeighbors.send_buffer(owner);
+    LinSys::GlobalOrdinal rowGid = GID_(entityId_a, numDof , 0);
+
+    sbuf.pack(rowGid);
+    sbuf.pack(numColEntities*2);
+    for(unsigned c=0; c<numColEntities; ++c) {
+        LinSys::GlobalOrdinal colGid0 = GID_(colEntityIds[c], numDof , 0);
+        sbuf.pack(colGid0);
+        sbuf.pack(colOwners[c]);
+    }
+}
+
+void communicate_remote_columns(const stk::mesh::BulkData& bulk,
+                                const std::vector<int>& neighborProcs,
+                                stk::CommNeighbors& commNeighbors,
+                                unsigned numDof,
+                                const Teuchos::RCP<LinSys::Map>& ownedRowsMap,
+                                LinSys::DeviceRowLengths& deviceLocallyOwnedRowLengths,
+                                std::set<std::pair<int, LinSys::GlobalOrdinal> >& communicatedColIndices)
+{
+    commNeighbors.communicate();
+
+    for(int p : neighborProcs) {
+        stk::CommBufferV& rbuf = commNeighbors.recv_buffer(p);
+        size_t bufSize = rbuf.size_in_bytes();
+        while(rbuf.size_in_bytes() > 0) {
+            LinSys::GlobalOrdinal rowGid = 0;
+            rbuf.unpack(rowGid);
+            unsigned len = 0;
+            rbuf.unpack(len);
+            unsigned numCols = len/2;
+            LinSys::LocalOrdinal lid = ownedRowsMap->getLocalElement(rowGid);
+            if (lid < 0) {
+                std::cerr<<"P"<<bulk.parallel_rank()<<" lid="<<lid<<" for rowGid="<<rowGid<<" sent from proc "<<p<<std::endl;
+            }
+            for(unsigned d=0; d<numDof; ++d) {
+                deviceLocallyOwnedRowLengths(lid++) += numCols*numDof;
+            }
+            for(unsigned i=0; i<numCols; ++i) {
+                LinSys::GlobalOrdinal colGid = 0;
+                rbuf.unpack(colGid);
+                int owner = 0;
+                rbuf.unpack(owner);
+                for(unsigned dd=0; dd<numDof; ++dd) {
+                    communicatedColIndices.insert(std::make_pair(owner,colGid++));
+                }
+            }
+        }
+        rbuf.resize(bufSize);
+    }
+}
+
+void insert_single_dof_row_into_graph(LocalGraphArrays& crsGraph, LinSys::LocalOrdinal rowLid,
+                                      LinSys::LocalOrdinal maxOwnedRowId, unsigned numDof,
+                                      unsigned numCols, const std::vector<LinSys::LocalOrdinal>& colLids)
+{
+    if (rowLid >= maxOwnedRowId) {
+      rowLid -= maxOwnedRowId;
+    }
+    crsGraph.insertIndices(rowLid++, numCols, colLids.data(), numDof);
+}
+
+void insert_communicated_col_indices(const std::vector<int>& neighborProcs,
+                                     stk::CommNeighbors& commNeighbors,
+                                     unsigned numDof,
+                                     LocalGraphArrays& ownedGraph,
+                                     const LinSys::Map& rowMap,
+                                     const LinSys::Map& colMap)
+{
+    std::vector<LocalOrdinal> colLids;
+    for(int p : neighborProcs) {
+        stk::CommBufferV& rbuf = commNeighbors.recv_buffer(p);
+        while(rbuf.size_in_bytes() > 0) {
+            stk::mesh::EntityId rowGid = 0;
+            rbuf.unpack(rowGid);
+            unsigned len = 0;
+            rbuf.unpack(len);
+            unsigned numCols = len/2;
+            colLids.resize(numCols);
+            LocalOrdinal rowLid = rowMap.getLocalElement(rowGid);
+            for(unsigned i=0; i<numCols; ++i) {
+                GlobalOrdinal colGid = 0;
+                rbuf.unpack(colGid);
+                int owner = 0;
+                rbuf.unpack(owner);
+                colLids[i] = colMap.getLocalElement(colGid);
+            }
+            ownedGraph.insertIndices(rowLid++,numCols,colLids.data(), numDof);
+        }
+    }
+}
+
+void fill_in_extra_dof_rows_per_node(LocalGraphArrays& csg, int numDof)
+{
+  if (numDof == 1) {
+    return;
+  }
+
+  auto rowPtrs = csg.rowPointers.data();
+  LocalOrdinal* cols = csg.colIndices.data();
+  for(int i=0, ie=csg.rowPointers.size()-1; i<ie;) {
+    const LocalOrdinal* row = cols+rowPtrs[i];
+    int rowLen = csg.get_row_length(i);
+    for(int d=1; d<numDof; ++d) {
+      LocalOrdinal* row_d = cols + rowPtrs[i] + rowLen*d;
+      for(int j=0; j<rowLen; ++j) {
+        row_d[j] = row[j];
+      }
+    }
+    i += numDof;
+  }
+}
+
+void remove_invalid_indices(LocalGraphArrays& csg, LinSys::DeviceRowLengths& rowLengths)
+{
+  size_t nnz = csg.rowPointers(rowLengths.size());
+  auto cols = csg.colIndices.data();
+  auto rowPtrs = csg.rowPointers.data();
+  size_t newNnz = 0;
+  for(int i=0, ie=csg.rowPointers.size()-1; i<ie; ++i) {
+    const LocalOrdinal* row = cols+rowPtrs[i];
+    int rowLen = csg.get_row_length(i);
+    for(int j=rowLen-1; j>=0; --j) {
+      if (row[j] != INVALID) {
+        rowLengths(i) = j+1;
+        break;
+      }
+    }
+    newNnz += rowLengths(i);
+  }
+
+  if (newNnz < nnz) {
+    Kokkos::View<LocalOrdinal*, DeviceSpace> newColIndices(Kokkos::ViewAllocateWithoutInitializing("colInds"),newNnz);
+    LocalOrdinal* newCols = newColIndices.data();
+    auto rowLens = rowLengths.data();
+    int index = 0;
+    for(int i=0, ie=csg.rowPointers.size()-1; i<ie; ++i) {
+      auto row = cols+rowPtrs[i];
+      for(size_t j=0; j<rowLens[i]; ++j) {
+        newCols[index++] = row[j];
+      }
+    }
+    csg.colIndices = newColIndices;
+    LocalGraphArrays::compute_row_pointers(csg.rowPointers, rowLengths);
+  }
+}
+
+} // nalu
+} // sierra

--- a/unit_tests/UnitTestGetDofStatus.C
+++ b/unit_tests/UnitTestGetDofStatus.C
@@ -6,6 +6,7 @@
 #include "UnitTestUtils.h"
 
 #include <TpetraLinearSystem.h>
+#include <TpetraLinearSystemHelpers.h>
 
 #ifndef KOKKOS_ENABLE_CUDA
 
@@ -33,7 +34,7 @@ TEST_F(DofStatusHex8Mesh, getDofStatus_shared)
 
   stk::mesh::Selector shared = bulk.mesh_meta_data().globally_shared_part();
   const stk::mesh::BucketVector& sharedBuckets = bulk.get_buckets(stk::topology::NODE_RANK, shared);
-  
+
   for(const stk::mesh::Bucket* bptr : sharedBuckets) {
       const stk::mesh::Bucket& bucket = *bptr;
       for(stk::mesh::Entity node : bucket) {
@@ -50,4 +51,3 @@ TEST_F(DofStatusHex8Mesh, getDofStatus_shared)
 }
 
 #endif
-


### PR DESCRIPTION
There are a reasonable amount of changes in this PR, here is a quick summary:

1. I am adding the `PT_TPETRA_SEGREGATED` in LinearSolver.h and changing the logic in `TpetraLinearSystem::getType()` to prepare it for my next PR.
2. I am creating `TpetraLinearSystemHelpers` that gathers all the helper functions from `TpetraLinearSystem`, the idea it to then reuse them in `TpetraSegregatedLinearSystem` without code duplication.
3. As the helper functions are instantiated in their `.C` file I am removing unnecessary template arguments and replacing them with `typedef` (see LinearSolverTypes.h) to actually use the concrete type of parameters in function signatures.
4. I removed functions that were not called anywhere in Nalu.

I also strongly debated whether I should remove the following macros:
```
#define LID_(lid, ndof, idof)  ((ndof)*((lid))+(idof))

#define GLOBAL_ENTITY_ID(gid, ndof) ((gid-1)/ndof + 1)
#define GLOBAL_ENTITY_ID_IDOF(gid, ndof) ((gid-1) % ndof)
```
The 1st one does not appear to be used in the code and the 2nd and 3rd ones are used only once which makes them a little superfluous. Any opinion on that?

I already have the start of the next PR for issue #249 with the actual `TpetraSegregatedLinearSystem.{h/C}` but I would rather not introduce them here to compartmentalize changes in different commits/PRs.