### PR TITLE
Removing macros from TpetraLinearSystemHelpers see comment in PR #258

### DIFF
--- a/include/TpetraLinearSystemHelpers.h
+++ b/include/TpetraLinearSystemHelpers.h
@@ -30,10 +30,6 @@ namespace nalu {
 class LocalGraphArrays;
 
 #define GID_(gid, ndof, idof)  ((ndof)*((gid)-1)+(idof)+1)
-#define LID_(lid, ndof, idof)  ((ndof)*((lid))+(idof))
-
-#define GLOBAL_ENTITY_ID(gid, ndof) ((gid-1)/ndof + 1)
-#define GLOBAL_ENTITY_ID_IDOF(gid, ndof) ((gid-1) % ndof)
 
 enum DOFStatus {
   DS_NotSet            = 0,

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1649,12 +1649,12 @@ bool TpetraLinearSystem::checkForZeroRow(bool useOwned, bool doThrow, bool doPri
     if (global_row_exists[ii] && bulkData.parallel_rank() == 0 && row_sum < 1.e-10) {
       found = true;
       GlobalOrdinal gid = ii+1;
-      stk::mesh::EntityId nid = GLOBAL_ENTITY_ID(gid, numDof_);
+      stk::mesh::EntityId nid = (gid - 1) / numDof_ + 1;
       stk::mesh::Entity node = bulkData.get_entity(stk::topology::NODE_RANK, nid);
       stk::mesh::EntityId naluGlobalId;
       if (bulkData.is_valid(node)) naluGlobalId = *stk::mesh::field_data(*realm_.naluGlobalId_, node);
 
-      int idof = GLOBAL_ENTITY_ID_IDOF(gid, numDof_);
+      int idof = (gid - 1) % numDof_;
       GlobalOrdinal GID_check = GID_(nid, numDof_, idof);
       if (doPrint) {
 


### PR DESCRIPTION
@sayerhs @alanw0 @rcknaus 
Three macros are removed:
      1) LID_(), since it was actually not used anymore
      2) GLOBAL_ENTITY_ID() and GLOBAL_ENTITY_ID_IDOF() are replaced by direct implementation

This mainly cleans the code and macros always have a small potential for unexpected side effect...