### PR TITLE
Remove the gtest_shuffle flag since it occasionally runs tests in a

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -46,7 +46,7 @@ endfunction(add_test_r_np)
 
 # Standard unit test
 function(add_test_u testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${utest_ex_name} --gtest_shuffle")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${utest_ex_name}")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 1000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "unit")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_u)

--- a/unit_tests/UnitTestBasicKokkos.C
+++ b/unit_tests/UnitTestBasicKokkos.C
@@ -10,23 +10,23 @@ TEST(BasicKokkos, discover_execution_space)
     int proc = stk::parallel_machine_rank(comm);
 
     if (proc == 0) {
-        std::cout << std::endl;
+        std::cerr << std::endl;
 
-#ifdef KOKKOS_HAVE_SERIAL
-        std::cout << "Kokkos::Serial is available." << std::endl;
+#ifdef KOKKOS_ENABLE_SERIAL
+        std::cerr << "Kokkos::Serial is available." << std::endl;
 #endif
 
-#ifdef KOKKOS_HAVE_OPENMP
-        std::cout << "Kokkos::OpenMP is available. (Control num-threads via env-var OMP_NUM_THREADS)" << std::endl;
+#ifdef KOKKOS_ENABLE_OPENMP
+        std::cerr << "Kokkos::OpenMP is available. (Control num-threads via env-var OMP_NUM_THREADS)" << std::endl;
 #endif
 
 #ifdef KOKKOS_ENABLE_CUDA
-        std::cout << "Kokkos::Cuda is available." << std::endl;
+        std::cerr << "Kokkos::Cuda is available." << std::endl;
 #endif
-        std::cout << "Default execution space info: ";
-        Kokkos::DefaultExecutionSpace::print_configuration(std::cout);
+        std::cerr << "Default execution space info: ";
+        Kokkos::DefaultExecutionSpace::print_configuration(std::cerr);
 
-        std::cout << std::endl;
+        std::cerr << std::endl;
     }
 }
 


### PR DESCRIPTION
different order on different mpi procs. They need to be in lock-step
across mpi procs.

Also changed some unit-test output to use cerr instead of cout, it seems
like some of the cout output wasn't coming out due to weird buffering or
something.