### PR TITLE
New GPU kernel Turb Kinetic Energy Rodi

### DIFF
--- a/include/node_kernels/MomentumBoussinesqNodeKernel.h
+++ b/include/node_kernels/MomentumBoussinesqNodeKernel.h
@@ -44,9 +44,9 @@ private:
   ngp::Field<double> dualNodalVolume_;
   ngp::Field<double> temperature_;
   const int nDim_;
-  double tRef_;
-  double rhoRef_;
-  double beta_;
+  NodeKernelTraits::DblType tRef_;
+  NodeKernelTraits::DblType rhoRef_;
+  NodeKernelTraits::DblType beta_;
 
   NALU_ALIGNED NodeKernelTraits::DblType forceVector_[NodeKernelTraits::NDimMax];
 

--- a/include/node_kernels/TurbKineticEnergyRodiNodeKernel.h
+++ b/include/node_kernels/TurbKineticEnergyRodiNodeKernel.h
@@ -1,0 +1,67 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef TURBKINETICENERGYRODINODEKERNEL_H          
+#define TURBKINETICENERGYRODINODEKERNEL_H          
+
+#include "node_kernels/NodeKernel.h"
+#include "stk_ngp/Ngp.hpp"
+
+namespace stk{
+namespace mesh{
+class MetaData;
+}
+}
+
+namespace sierra{
+namespace nalu{
+
+class Realm;
+class SolutionOptions;
+
+class TurbKineticEnergyRodiNodeKernel : public NGPNodeKernel<TurbKineticEnergyRodiNodeKernel>
+{
+public:
+  TurbKineticEnergyRodiNodeKernel(const stk::mesh::MetaData&, const SolutionOptions&);
+
+  KOKKOS_FUNCTION
+  TurbKineticEnergyRodiNodeKernel() = default;
+  
+  KOKKOS_FUNCTION
+  virtual ~TurbKineticEnergyRodiNodeKernel() = default;
+
+  virtual void setup(Realm &) override;
+
+  KOKKOS_FUNCTION
+  virtual void execute(
+    NodeKernelTraits::LhsType&,
+    NodeKernelTraits::RhsType&,
+    const stk::mesh::FastMeshIndex&) override;
+
+private:
+
+  ngp::Field<double> dhdx_;
+  ngp::Field<double> specificHeat_;
+  ngp::Field<double> tvisc_;
+  ngp::Field<double> dualNodalVolume_;
+
+  const unsigned dhdxID_           {stk::mesh::InvalidOrdinal};
+  const unsigned specificHeatID_   {stk::mesh::InvalidOrdinal};
+  const unsigned tviscID_          {stk::mesh::InvalidOrdinal};
+  const unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
+
+  NALU_ALIGNED NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType       turbPr_;
+  const NodeKernelTraits::DblType beta_;
+  const int    nDim_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/src/node_kernels/CMakeLists.txt
+++ b/src/node_kernels/CMakeLists.txt
@@ -6,5 +6,6 @@ add_sources(GlobalSourceList
   MomentumActuatorNodeKernel.C
   MomentumCoriolisNodeKernel.C
   ScalarMassBDFNodeKernel.C
+  TurbKineticEnergyRodiNodeKernel.C
   WallDistNodeKernel.C
   )

--- a/src/node_kernels/TurbKineticEnergyRodiNodeKernel.C
+++ b/src/node_kernels/TurbKineticEnergyRodiNodeKernel.C
@@ -1,0 +1,88 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include "node_kernels/TurbKineticEnergyRodiNodeKernel.h"
+#include "node_kernels/NodeKernel.h"
+#include "Realm.h"
+#include "SolutionOptions.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/MetaData.hpp>
+#include "utils/StkHelpers.h"
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// TurbKineticEnergyRodiNodeKernel Pb = beta*mu^t/Pr^t gi/Cp dh/dxi
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+TurbKineticEnergyRodiNodeKernel::TurbKineticEnergyRodiNodeKernel(
+    const stk::mesh::MetaData& meta,
+    const SolutionOptions& solnOpts) 
+  : NGPNodeKernel<TurbKineticEnergyRodiNodeKernel>(),
+
+    dhdxID_             (get_field_ordinal(meta, "dhdx")),
+    specificHeatID_     (get_field_ordinal(meta, "specific_heat")),
+    tviscID_            (get_field_ordinal(meta, "turbulent_viscosity")),
+    dualNodalVolumeID_  (get_field_ordinal(meta, "dual_nodal_volume")),
+
+    turbPr_             (0), // Set in setup()
+    beta_               (solnOpts.thermalExpansionCoeff_),
+    nDim_               (meta.spatial_dimension()) 
+{
+  const std::vector<double>& solnOptsGravity = solnOpts.get_gravity_vector(nDim_);
+  for (int i = 0; i < nDim_; i++)
+    gravity_[i] = solnOptsGravity[i];
+}
+
+//--------------------------------------------------------------------------
+//-------- setup -----------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+TurbKineticEnergyRodiNodeKernel::setup(Realm &realm)
+{
+  const auto& fieldMgr = realm.ngp_field_manager();
+  dhdx_            = fieldMgr.get_field<double>(dhdxID_);
+  specificHeat_    = fieldMgr.get_field<double>(specificHeatID_);
+  tvisc_           = fieldMgr.get_field<double>(tviscID_);
+  dualNodalVolume_ = fieldMgr.get_field<double>(dualNodalVolumeID_);
+
+  turbPr_ = realm.get_turb_prandtl("enthalpy");
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+TurbKineticEnergyRodiNodeKernel::execute(
+  NodeKernelTraits::LhsType& /*lhs*/,
+  NodeKernelTraits::RhsType& rhs,
+  const stk::mesh::FastMeshIndex& node)
+{
+  typedef NodeKernelTraits::DblType Dbl;
+  const Dbl dualVolume   = dualNodalVolume_.get(node, 0);
+  const Dbl specificHeat = specificHeat_.   get(node, 0);
+  const Dbl tvisc        = tvisc_.          get(node, 0);
+
+  Dbl sum = 0.0;
+  for ( int i = 0; i < nDim_; ++i ) {
+    const Dbl dhdx = dhdx_.get(node, i);
+    sum += gravity_[i]*dhdx;
+  }
+  // no lhs contribution; all rhs source term
+  rhs(0) += beta_*tvisc/turbPr_*sum/specificHeat*dualVolume;
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/unit_tests/algorithms/UnitTestRodiAlgorithm.C
+++ b/unit_tests/algorithms/UnitTestRodiAlgorithm.C
@@ -19,7 +19,9 @@ TEST_F(TestTurbulenceAlgorithm, turbkineticenergyrodinodesourcesuppalg)
 {
   sierra::nalu::Realm& realm = this->create_realm();
   
-  fill_mesh_and_init_fields();
+  const int nprocs = this->bulk().parallel_size();
+  std::string meshSpec = "generated:1x1x"+std::to_string(nprocs);
+  fill_mesh_and_init_fields(meshSpec);
 
   // set solution options
   realm.solutionOptions_->gravity_.resize(3);
@@ -42,7 +44,7 @@ TEST_F(TestTurbulenceAlgorithm, turbkineticenergyrodinodesourcesuppalg)
   const double lhs_norm = assembleSuppAlgs.get_lhs_norm();
   const double rhs_norm = assembleSuppAlgs.get_rhs_norm();
   const double lhs_gold_norm = 0.0;
-  const double rhs_gold_norm = 0.000244820116732111;
+  const double rhs_gold_norm = nprocs==1 ? 0.00030133929246584567 : 0.0002760523778561557 ;
   EXPECT_NEAR(lhs_norm, lhs_gold_norm, tol);
   EXPECT_NEAR(rhs_norm, rhs_gold_norm, tol);
 }

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -268,9 +268,9 @@ public:
 
   virtual ~TestKernelHex8Mesh() {}
 
-  void fill_mesh_and_init_fields(bool doPerturb = false, bool generateSidesets = false)
+  virtual void fill_mesh_and_init_fields(bool doPerturb = false, bool generateSidesets = false)
   {
-    const std::string baseMeshSpec =
+    const std::string baseMeshSpec = 
       "generated:1x1x" + std::to_string(bulk_.parallel_size());
     const std::string meshSpec =
       generateSidesets ? (baseMeshSpec + "|sideset:xXyYzZ") : baseMeshSpec;
@@ -354,7 +354,7 @@ public:
   virtual ~LowMachKernelHex8Mesh() {}
 
   virtual void fill_mesh_and_init_fields(
-    bool doPerturb = false, bool generateSidesets = false)
+    bool doPerturb = false, bool generateSidesets = false) override
   {
     TestKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
@@ -393,7 +393,7 @@ public:
   virtual ~ContinuityKernelHex8Mesh() {}
 
   virtual void fill_mesh_and_init_fields(
-    bool doPerturb = false, bool generateSidesets = false)
+    bool doPerturb = false, bool generateSidesets = false) override
   {
     LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
     stk::mesh::field_fill(0.0, *pressureBC_);
@@ -442,7 +442,7 @@ public:
   virtual ~MomentumKernelHex8Mesh() {}
 
   virtual void fill_mesh_and_init_fields(
-    bool doPerturb = false, bool generateSidesets = false)
+    bool doPerturb = false, bool generateSidesets = false) override
   {
     LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
     unit_test_kernel_utils::calc_mass_flow_rate_scs(
@@ -493,7 +493,7 @@ public:
   virtual ~KsgsKernelHex8Mesh() {}
 
   virtual void fill_mesh_and_init_fields(
-    bool doPerturb = false, bool generateSidesets = false)
+    bool doPerturb = false, bool generateSidesets = false) override
   {
     LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
     stk::mesh::field_fill(0.3, *tvisc_);
@@ -537,7 +537,7 @@ public:
   virtual ~SSTKernelHex8Mesh() {}
 
   virtual void fill_mesh_and_init_fields(
-    bool doPerturb = false, bool generateSidesets = false)
+    bool doPerturb = false, bool generateSidesets = false) override
   {
     LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
     stk::mesh::field_fill(0.3, *tvisc_);
@@ -555,6 +555,84 @@ public:
   ScalarFieldType* tvisc_{nullptr};
   ScalarFieldType* maxLengthScale_{nullptr};
   ScalarFieldType* fOneBlend_{nullptr};
+};
+
+/** Test Fixture for the Turbulence Kernels
+ *
+ */
+class TurbulenceKernelHex8Mesh : public LowMachKernelHex8Mesh
+{
+public:
+  TurbulenceKernelHex8Mesh()
+    : LowMachKernelHex8Mesh(),
+      viscosity_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "viscosity")),
+      tke_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "turbulent_ke")),
+      sdr_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "specific_dissipation_rate")),
+      minDistance_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "minimum_distance_to_wall")),
+      dudx_(&meta_.declare_field<GenericFieldType>( stk::topology::NODE_RANK, "dudx")),
+      tvisc_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "turbulent_viscosity")),
+      maxLengthScale_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "sst_max_length_scale")),
+      fOneBlend_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "sst_f_one_blending")),
+      evisc_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "effective_viscosity")),
+      dualNodalVolume_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "dual_nodal_volume")),
+      dkdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dkdx")),
+      dwdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dwdx")),
+      dhdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dhdx")),
+      specificHeat_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "specific_heat"))
+  {
+    stk::mesh::put_field_on_mesh(*viscosity_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*tke_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*sdr_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*minDistance_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*dudx_, meta_.universal_part(), spatialDim_*spatialDim_, nullptr);
+    stk::mesh::put_field_on_mesh(*tvisc_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*maxLengthScale_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*fOneBlend_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*evisc_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*dualNodalVolume_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*dkdx_, meta_.universal_part(),  spatialDim_, nullptr);
+    stk::mesh::put_field_on_mesh(*dwdx_, meta_.universal_part(),  spatialDim_, nullptr);
+    stk::mesh::put_field_on_mesh(*dhdx_, meta_.universal_part(),  spatialDim_, nullptr);
+    stk::mesh::put_field_on_mesh(*specificHeat_, meta_.universal_part(),  1, nullptr);
+  }
+
+  virtual ~TurbulenceKernelHex8Mesh() {}; 
+
+  virtual void fill_mesh_and_init_fields(
+    bool doPerturb = false, bool generateSidesets = false) override
+  {
+    LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
+    unit_test_kernel_utils::density_test_function(bulk_, *coordinates_, *density_);
+    stk::mesh::field_fill(0.2, *viscosity_);
+    unit_test_kernel_utils::tke_test_function(bulk_, *coordinates_, *tke_);
+    unit_test_kernel_utils::sdr_test_function(bulk_, *coordinates_, *sdr_);
+    unit_test_kernel_utils::minimum_distance_to_wall_test_function(bulk_, *coordinates_, *minDistance_);
+    unit_test_kernel_utils::dudx_test_function(bulk_, *coordinates_, *dudx_);
+    unit_test_kernel_utils::turbulent_viscosity_test_function(bulk_, *coordinates_, *tvisc_);
+    stk::mesh::field_fill(0.5, *maxLengthScale_);
+    unit_test_kernel_utils::sst_f_one_blending_test_function(bulk_, *coordinates_, *fOneBlend_);
+    stk::mesh::field_fill(0.0, *evisc_);
+    stk::mesh::field_fill(0.2, *dualNodalVolume_);
+    unit_test_kernel_utils::dkdx_test_function(bulk_, *coordinates_, *dkdx_);
+    unit_test_kernel_utils::dwdx_test_function(bulk_, *coordinates_, *dwdx_);
+    unit_test_kernel_utils::dhdx_test_function(bulk_, *coordinates_, *dhdx_);
+    stk::mesh::field_fill(1000.0, *specificHeat_);
+  }
+
+  ScalarFieldType*    viscosity_{nullptr};
+  ScalarFieldType*    tke_{nullptr};
+  ScalarFieldType*    sdr_{nullptr};
+  ScalarFieldType*    minDistance_{nullptr};
+  GenericFieldType*   dudx_{nullptr};
+  ScalarFieldType*    tvisc_{nullptr};
+  ScalarFieldType*    maxLengthScale_{nullptr};
+  ScalarFieldType*    fOneBlend_{nullptr};
+  ScalarFieldType*    evisc_{nullptr};
+  ScalarFieldType*    dualNodalVolume_{nullptr};
+  VectorFieldType*    dkdx_{nullptr};
+  VectorFieldType*    dwdx_{nullptr};
+  VectorFieldType*    dhdx_{nullptr};
+  ScalarFieldType*    specificHeat_{nullptr};
 };
 
 /** Test Fixture for the hybrid turbulence Kernels
@@ -581,7 +659,7 @@ public:
   virtual ~HybridTurbKernelHex8Mesh() {}
 
   virtual void fill_mesh_and_init_fields(
-    bool doPerturb = false, bool generateSidesets = false)
+    bool doPerturb = false, bool generateSidesets = false) override
   {
     LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
     stk::mesh::field_fill(0.0, *tke_);
@@ -620,9 +698,10 @@ public:
     stk::mesh::put_field_on_mesh(*thermalCond_, meta_.universal_part(), 1, nullptr);
   }
 
-  void fill_mesh_and_init_fields(bool doPerturb = false)
+  void fill_mesh_and_init_fields(
+    bool doPerturb = false, bool generateSidesets = false) override
   {
-    TestKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb);
+    TestKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
     unit_test_kernel_utils::temperature_test_function(bulk_, *coordinates_, *temperature_);
     stk::mesh::field_fill(1.0, *thermalCond_);
@@ -689,7 +768,7 @@ public:
   virtual ~MixtureFractionKernelHex8Mesh() {}
 
   virtual void fill_mesh_and_init_fields(
-    bool doPerturb = false, bool generateSidesets = false)
+    bool doPerturb = false, bool generateSidesets = false) override
   {
     TestKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
@@ -753,9 +832,10 @@ public:
 
   virtual ~ActuatorSourceKernelHex8Mesh() {}
 
-  virtual void fill_mesh_and_init_fields(bool doPerturb = false)
+  virtual void fill_mesh_and_init_fields(
+    bool doPerturb = false, bool generateSidesets = false) override
   {
-    TestKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb);
+    TestKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
     std::vector<double> act_source(spatialDim_,0.0);
     for(size_t j=0;j<spatialDim_;j++) act_source[j] = j+1;

--- a/unit_tests/node_kernels/CMakeLists.txt
+++ b/unit_tests/node_kernels/CMakeLists.txt
@@ -6,5 +6,6 @@ add_sources(GlobalUnitSourceList
   UnitTestMomentumCoriolisNode.C
   UnitTestScalarMassBDFNodeKernel.C
   UnitTestMomentumActuatorNodeKernel.C
+  UnitTestTurbKineticEnergyRodiNodeKernel.C
   UnitTestWallDistNode.C
 )

--- a/unit_tests/node_kernels/UnitTestTurbKineticEnergyRodiNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestTurbKineticEnergyRodiNodeKernel.C
@@ -1,0 +1,74 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "SolutionOptions.h"
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "node_kernels/TurbKineticEnergyRodiNodeKernel.h"
+
+TEST_F(TurbulenceKernelHex8Mesh, NGP_turb_kenetic_energy_Rodi)
+{
+  // Only execute for 1 processor runs
+  if (bulk_.parallel_size() > 1) return;
+
+  const int nprocs = bulk_.parallel_size();
+  
+  std::mt19937 rng;
+  rng.seed(0); // fixed seed
+
+  fill_mesh_and_init_fields(false,false);
+
+  unit_test_utils::NodeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+
+  // set solution options
+  sierra::nalu::SolutionOptions *solnOpts=helperObjs.nodeAlg->realm_.solutionOptions_;
+  solnOpts->gravity_.resize(3);
+  solnOpts->gravity_[0] = 10.0;
+  solnOpts->gravity_[1] = -10.0;
+  solnOpts->gravity_[2] = 5.0;
+  solnOpts->turbPrMap_["enthalpy"] = 0.60;
+  solnOpts->thermalExpansionCoeff_ = 3.0e-3;
+
+  solnOpts_.gravity_.resize(3);
+  solnOpts_.gravity_[0] = 10.0;
+  solnOpts_.gravity_[1] = -10.0;
+  solnOpts_.gravity_[2] = 5.0;
+  solnOpts_.turbPrMap_["enthalpy"] = 0.60;
+  solnOpts_.thermalExpansionCoeff_ = 3.0e-3;
+
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::TurbKineticEnergyRodiNodeKernel>
+   (bulk_.mesh_meta_data(), *solnOpts);
+
+  helperObjs.execute();
+
+#ifndef KOKKOS_ENABLE_CUDA
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
+
+  const Kokkos::View<double**>lhs = helperObjs.linsys->lhs_;
+  const Kokkos::View<double*> rhs = helperObjs.linsys->rhs_;
+  double lhs_norm = 0, rhs_norm=0;
+  for (unsigned i=0; i < rhs.extent(0); ++i)
+     rhs_norm += rhs(i)*rhs(i);
+  for (unsigned i=0; i < lhs.extent(0); ++i)
+     for (unsigned j=0; j < lhs.extent(1); ++j)
+        lhs_norm += lhs(i,j)*lhs(i,j);
+
+  lhs_norm = std::sqrt(lhs_norm/(lhs.extent(0)*lhs.extent(1)/3));
+  rhs_norm = std::sqrt(rhs_norm/(rhs.extent(0)/3));
+
+  const double tol = 1e-14;
+  const double lhs_gold_norm = 0.0;
+  const double rhs_gold_norm = nprocs==1 ? 0.00030133929246584567 : 0.0002760523778561557;
+  EXPECT_NEAR(lhs_norm, lhs_gold_norm, tol);
+  EXPECT_NEAR(rhs_norm, rhs_gold_norm, tol);
+#endif
+
+}

--- a/unit_tests/node_kernels/UnitTestTurbKineticEnergyRodiNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestTurbKineticEnergyRodiNodeKernel.C
@@ -12,7 +12,7 @@
 
 #include "node_kernels/TurbKineticEnergyRodiNodeKernel.h"
 
-TEST_F(TurbulenceKernelHex8Mesh, NGP_turb_kenetic_energy_Rodi)
+TEST_F(KsgsKernelHex8Mesh, NGP_turb_kenetic_energy_Rodi)
 {
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
@@ -22,7 +22,7 @@ TEST_F(TurbulenceKernelHex8Mesh, NGP_turb_kenetic_energy_Rodi)
   std::mt19937 rng;
   rng.seed(0); // fixed seed
 
-  fill_mesh_and_init_fields(false,false);
+  fill_mesh_and_init_fields(false,false,true);
 
   unit_test_utils::NodeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 


### PR DESCRIPTION
Second try. Since the test is over one
element change the old non-GPU test to
be over one element so the reference
solution can be the same between the
two.