### PR TITLE
NGP implementation of Edge BC algorithms

### DIFF
--- a/include/edge_kernels/MomentumSymmetryEdgeKernel.h
+++ b/include/edge_kernels/MomentumSymmetryEdgeKernel.h
@@ -1,0 +1,70 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef MOMENTUMSYMMETRYEDGEKERNEL_H
+#define MOMENTUMSYMMETRYEDGEKERNEL_H
+
+#include "kernel/Kernel.h"
+#include "KokkosInterface.h"
+#include "FieldTypeDef.h"
+
+#include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Entity.hpp"
+
+namespace sierra {
+namespace nalu {
+
+class SolutionOptions;
+class ElemDataRequests;
+class MasterElement;
+
+template<typename BcAlgTraits>
+class MomentumSymmetryEdgeKernel: public NGPKernel<MomentumSymmetryEdgeKernel<BcAlgTraits>>
+{
+public:
+  MomentumSymmetryEdgeKernel(
+    const stk::mesh::MetaData&,
+    const SolutionOptions&,
+    VectorFieldType*,
+    ScalarFieldType*,
+    ElemDataRequests&,
+    ElemDataRequests&);
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  MomentumSymmetryEdgeKernel() = default;
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  virtual ~MomentumSymmetryEdgeKernel() = default;
+
+  using Kernel::execute;
+
+  KOKKOS_FUNCTION
+  virtual void execute(
+    SharedMemView<DoubleType**, DeviceShmem>&,
+    SharedMemView<DoubleType*, DeviceShmem>&,
+    ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>&,
+    ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>&,
+    int);
+
+private:
+  unsigned coordinates_    {stk::mesh::InvalidOrdinal};
+  unsigned velocityNp1_    {stk::mesh::InvalidOrdinal};
+  unsigned viscosity_      {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
+  unsigned dudx_           {stk::mesh::InvalidOrdinal};
+
+  const DoubleType includeDivU_;
+
+  MasterElement* meFC_{nullptr};
+  MasterElement* meSCS_{nullptr};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* MOMENTUMSYMMETRYEDGEKERNEL_H */

--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -433,10 +433,10 @@ public:
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node);
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node);
 
   const int* side_node_ordinals(int sideOrdinal) const final;

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -298,10 +298,10 @@ public:
   void shifted_shape_fcn(
     double *shpfc);
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node);
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node);
 
   double isInElement(

--- a/include/master_element/HexPCVFEM.h
+++ b/include/master_element/HexPCVFEM.h
@@ -151,10 +151,10 @@ public:
 
   const int * side_node_ordinals(int ordinal = 0) const final;
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node) final;
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node) final;
 
   KOKKOS_FUNCTION void face_grad_op(
@@ -173,7 +173,7 @@ private:
   void set_interior_info();
   void set_boundary_info();
 
-  int opposing_face_map(int k, int l, int i, int j, int face_index);
+  KOKKOS_FUNCTION int opposing_face_map(int k, int l, int i, int j, int face_index);
 
   template <Jacobian::Direction direction> void
   area_vector(

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -216,9 +216,11 @@ public:
     double * /* shpfc */) {
     throw std::runtime_error("shifted_shape_fcn not implemented"); }
 
-  virtual int opposingNodes(
+  KOKKOS_FUNCTION virtual int opposingNodes(
     const int /* ordinal */, const int /* node */) {
-    throw std::runtime_error("opposingNodes not implemented"); }
+    NGP_ThrowErrorMsg("opposingNodes not implemented");
+    return -1;
+  }
 
   virtual int opposingFace(
     const int /* ordinal */, const int /* node */) {

--- a/include/master_element/MasterElementHO.h
+++ b/include/master_element/MasterElementHO.h
@@ -203,10 +203,10 @@ public:
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node) final;
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node) final;
 
   const int * side_node_ordinals(int ordinal = 0) const final;

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -256,10 +256,10 @@ public:
     const double *side_pcoords,
     double *elem_pcoords);
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node);
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node);
 
   void face_grad_op(

--- a/include/master_element/Quad42DCVFEM.h
+++ b/include/master_element/Quad42DCVFEM.h
@@ -224,10 +224,10 @@ public:
 
   const int * scsIpEdgeOrd() override;
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node) override;
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node) override;
 
   KOKKOS_FUNCTION virtual void shape_fcn(

--- a/include/master_element/Quad92DCVFEM.h
+++ b/include/master_element/Quad92DCVFEM.h
@@ -317,10 +317,10 @@ public:
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final ;
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node) override ;
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node) override ;
 
   const int* side_node_ordinals(int sideOrdinal) const final;

--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -236,9 +236,9 @@ public:
     const double *par_coord,
     double* shape_fcn);
 
-  int opposingNodes(const int ordinal, const int node) override;
+  KOKKOS_FUNCTION int opposingNodes(const int ordinal, const int node) override;
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node) override;
 
   double isInElement(

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -236,10 +236,10 @@ public:
     tri_shape_fcn(numIp, isoParCoord, shpfc);
   }
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node) override;
   
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node) override;
 
   double isInElement(

--- a/include/master_element/Wed6CVFEM.h
+++ b/include/master_element/Wed6CVFEM.h
@@ -226,10 +226,10 @@ public:
   
   const int * scsIpEdgeOrd();
 
-  int opposingNodes(
+  KOKKOS_FUNCTION int opposingNodes(
     const int ordinal, const int node);
 
-  int opposingFace(
+  KOKKOS_FUNCTION int opposingFace(
     const int ordinal, const int node);
 
   void shape_fcn(

--- a/src/edge_kernels/CMakeLists.txt
+++ b/src/edge_kernels/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_sources(GlobalSourceList
+  # Edge kernels
   ContinuityEdgeSolverAlg.C
   MomentumEdgeSolverAlg.C
   WallDistEdgeSolverAlg.C
+
+  # Face/edge BC kernels
+  MomentumSymmetryEdgeKernel.C
   )

--- a/src/edge_kernels/MomentumSymmetryEdgeKernel.C
+++ b/src/edge_kernels/MomentumSymmetryEdgeKernel.C
@@ -1,0 +1,185 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "edge_kernels/MomentumSymmetryEdgeKernel.h"
+#include "master_element/MasterElement.h"
+#include "master_element/MasterElementFactory.h"
+#include "SolutionOptions.h"
+
+#include "BuildTemplates.h"
+#include "ScratchViews.h"
+#include "utils/StkHelpers.h"
+
+#include "stk_mesh/base/Field.hpp"
+
+namespace sierra {
+namespace nalu {
+
+template <typename BcAlgTraits>
+MomentumSymmetryEdgeKernel<BcAlgTraits>::MomentumSymmetryEdgeKernel(
+  const stk::mesh::MetaData& meta,
+  const SolutionOptions& solnOpts,
+  VectorFieldType* velocity,
+  ScalarFieldType* viscosity,
+  ElemDataRequests& faceDataPreReqs,
+  ElemDataRequests& elemDataPreReqs)
+  : NGPKernel<MomentumSymmetryEdgeKernel<BcAlgTraits>>(),
+    coordinates_(get_field_ordinal(meta, solnOpts.get_coordinates_name())),
+    velocityNp1_(
+      velocity->field_of_state(stk::mesh::StateNP1).mesh_meta_data_ordinal()),
+    viscosity_(viscosity->mesh_meta_data_ordinal()),
+    exposedAreaVec_(
+      get_field_ordinal(meta, "exposed_area_vector", meta.side_rank())),
+    dudx_(get_field_ordinal(meta, "dudx")),
+    includeDivU_(solnOpts.includeDivU_),
+    meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element<
+           typename BcAlgTraits::FaceTraits>()),
+    meSCS_(sierra::nalu::MasterElementRepo::get_surface_master_element<
+           typename BcAlgTraits::ElemTraits>())
+{
+  faceDataPreReqs.add_cvfem_face_me(meFC_);
+  elemDataPreReqs.add_cvfem_surface_me(meSCS_);
+
+  faceDataPreReqs.add_gathered_nodal_field(viscosity_, 1);
+  faceDataPreReqs.add_gathered_nodal_field(dudx_, BcAlgTraits::nDim_, BcAlgTraits::nDim_);
+  faceDataPreReqs.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  elemDataPreReqs.add_coordinates_field(coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  elemDataPreReqs.add_gathered_nodal_field(velocityNp1_, BcAlgTraits::nDim_);
+}
+
+template <typename BcAlgTraits>
+void
+MomentumSymmetryEdgeKernel<BcAlgTraits>::execute(
+  SharedMemView<DoubleType**, DeviceShmem>& lhs,
+  SharedMemView<DoubleType*, DeviceShmem>& rhs,
+  ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>& faceScratchViews,
+  ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>& elemScratchViews,
+  int elemFaceOrdinal)
+{
+  // Work arrays
+  NALU_ALIGNED DoubleType nx[BcAlgTraits::nDim_];
+  NALU_ALIGNED DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
+
+  // Field variables on the boundary face
+  auto& v_visc = faceScratchViews.get_scratch_view_1D(viscosity_);
+  auto& v_dudx = faceScratchViews.get_scratch_view_3D(dudx_);
+  auto& v_areavec = faceScratchViews.get_scratch_view_2D(exposedAreaVec_);
+
+  // Field variables on element connected to the boundary face
+  auto& v_uNp1 = elemScratchViews.get_scratch_view_2D(velocityNp1_);
+  auto& v_coords = elemScratchViews.get_scratch_view_2D(coordinates_);
+
+  // Mapping of face nodes into element indices
+  const int* ipNodeMap = meSCS_->ipNodeMap(elemFaceOrdinal);
+
+  for (int ip = 0; ip < BcAlgTraits::nodesPerFace_; ++ip) {
+    // ip is the index of the node in the face array, nodeL and nodeR are the
+    // indices for the face node and opposing node in the element arrays
+    const int nodeR = ipNodeMap[ip];
+    const int nodeL = meSCS_->opposingNodes(elemFaceOrdinal, ip);
+
+    // Extract viscosity for this node from face data
+    const auto visc = v_visc(ip);
+
+    // Compute area vector related quantities
+    DoubleType axdx = 0.0;
+    DoubleType asq = 0.0;
+    for (int d=0; d < BcAlgTraits::nDim_; ++d) {
+      const DoubleType dxj = v_coords(nodeR, d) - v_coords(nodeL, d);
+      asq += v_areavec(ip, d) * v_areavec(ip, d);
+      axdx += v_areavec(ip, d) * dxj;
+    }
+    const DoubleType inv_axdx = 1.0 / axdx;
+
+    // Populate unit vector for later use
+    const DoubleType amag = stk::math::sqrt(asq);
+    for (int d=0; d < BcAlgTraits::nDim_; ++d)
+      nx[d] = v_areavec(ip, d) / amag;
+
+    // Computation of duidxj term, reproduce original comment by S. P. Domino
+    /*
+      form duidxj with over-relaxed procedure of Jasak:
+
+      dui/dxj = GjUi +[(uiR - uiL) - GlUi*dxl]*Aj/AxDx
+      where Gp is the interpolated pth nodal gradient for ui
+    */
+    for (int i=0; i < BcAlgTraits::nDim_; i++) {
+      const auto dui = v_uNp1(nodeR, i) - v_uNp1(nodeL, i);
+
+      // Non-orthogonal correction
+      DoubleType gjuidx = 0.0;
+      for (int j=0; j < BcAlgTraits::nDim_; j++) {
+        const DoubleType dxj = v_coords(nodeR, j) - v_coords(nodeL, j);
+        gjuidx += v_dudx(ip, i, j) * dxj;
+      }
+
+      // final dui/dxj with non-orthogonal contributions
+      for (int j=0; j < BcAlgTraits::nDim_; j++) {
+        duidxj[i][j] = v_dudx(ip, i, j) + (dui - gjuidx) * v_areavec(ip, j) * inv_axdx;
+      }
+    }
+
+    // div(U) terms
+    DoubleType divU = 0.0;
+    for (int d=0; d < BcAlgTraits::nDim_; ++d)
+      divU += duidxj[d][d];
+
+    // Viscous flux terms
+    DoubleType fxnx = 0.0;
+    for (int i=0; i < BcAlgTraits::nDim_; ++i) {
+      DoubleType fxi = 2.0 / 3.0 * visc * divU * v_areavec(ip, i) * includeDivU_;
+
+      for (int j=0; j < BcAlgTraits::nDim_; ++j) {
+        fxi += -visc * (duidxj[i][j] + duidxj[j][i]) * v_areavec(ip, j);
+      }
+
+      fxnx += nx[i] * fxi;
+    }
+
+    for (int i=0; i < BcAlgTraits::nDim_; i++) {
+      const int rowL = nodeL * BcAlgTraits::nDim_ + i;
+      const int rowR = nodeR * BcAlgTraits::nDim_ + i;
+
+      rhs(rowR) -= fxnx * nx[i];
+      DoubleType lhsfac = -visc * asq * inv_axdx * nx[i] * nx[i];
+      lhs(rowR, rowL) -= lhsfac;
+      lhs(rowR, rowR) += lhsfac;
+
+      const DoubleType axi = v_areavec(ip, i);
+      const DoubleType nxnx = nx[i] * nx[i];
+
+      for (int j=0; j < BcAlgTraits::nDim_; ++j) {
+        const int colL = nodeL * BcAlgTraits::nDim_ + j;
+        const int colR = nodeR * BcAlgTraits::nDim_ + j;
+
+        const DoubleType axj = v_areavec(ip, j);
+        lhsfac = -visc * axi * axj * inv_axdx * nxnx;
+        lhs(rowR, colL) -= lhsfac;
+        lhs(rowR, colR) += lhsfac;
+
+        if (i == j ) continue;
+
+        lhsfac = -visc * asq * inv_axdx * nx[i] * nx[j];
+        lhs(rowR, colL) -= lhsfac;
+        lhs(rowR, colR) += lhsfac;
+
+        lhsfac = -visc * axj * axj * nx[i] * nx[j];
+        lhs(rowR, colL) -= lhsfac;
+        lhs(rowR, colR) += lhsfac;
+
+        lhsfac = -visc * axj * axi * nx[i] * nx[j];
+        lhs(rowR, rowL) -= lhsfac;
+        lhs(rowR, rowR) += lhsfac;
+      }
+    }
+  }
+}
+
+INSTANTIATE_KERNEL_FACE_ELEMENT(MomentumSymmetryEdgeKernel)
+
+}  // nalu
+}  // sierra

--- a/unit_tests/edge_kernels/CMakeLists.txt
+++ b/unit_tests/edge_kernels/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_sources(GlobalUnitSourceList
+  # Edge interior kernels
   UnitTestContinuityAdvEdge.C
   UnitTestMomentumAdvDiffEdge.C
   UnitTestWallDistEdgeSolver.C
+
+  # Face/elem edge BC kernels
+  UnitTestMomentumSymmetryEdge.C
   )

--- a/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
@@ -1,0 +1,91 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "edge_kernels/MomentumSymmetryEdgeKernel.h"
+
+#ifndef KOKKOS_ENABLE_CUDA
+namespace {
+namespace hex8_golds  {
+static constexpr double rhs[24] = {
+  0, 0, 0, 0, 0, 0, 0.016674436811369,
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0.016674436811369, 0, 0, 0, 0, 0,
+};
+
+static constexpr double lhs[24][24] = {
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0.05, 0, 0, -0.05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, -0.05, 0, 0, 0.05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.05, 0, 0, -0.05, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, -0.05, 0, 0, 0.05, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, },
+};
+}
+}
+#endif
+
+TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge)
+{
+  if (bulk_.parallel_size() > 1) return;
+
+  const bool doPerturb = false;
+  const bool generateSidesets = true;
+  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+
+  // Setup solution options for default advection kernel
+  solnOpts_.meshMotion_ = false;
+  solnOpts_.meshDeformation_ = false;
+  solnOpts_.externalMeshDeformation_ = false;
+
+  auto* part = meta_.get_part("surface_2");
+  unit_test_utils::FaceElemHelperObjects helperObjs(
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part);
+
+  std::unique_ptr<sierra::nalu::Kernel> kernel(
+    new sierra::nalu::MomentumSymmetryEdgeKernel<
+      sierra::nalu::AlgTraitsQuad4Hex8>(
+      meta_, solnOpts_, velocity_, viscosity_,
+      helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
+      helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_));
+
+  helperObjs.assembleFaceElemSolverAlg->activeKernels_.push_back(kernel.get());
+
+  helperObjs.execute();
+
+#ifndef KOKKOS_ENABLE_CUDA
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
+  EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
+  EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
+
+  unit_test_kernel_utils::expect_all_near(
+    helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
+  unit_test_kernel_utils::expect_all_near<24>(
+    helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
+#endif
+}


### PR DESCRIPTION
Use MomentumSymmetry BC as an example to demonstrate conversion of edge BC
algorithms.

Add necessary KOKKOS_FUNCTION decorators to MasterElement methods.