### PR TITLE
Switch Edge/Node algorithms to the NGP versions in equation systems

### DIFF
--- a/include/node_kernels/NodeKernelUtils.h
+++ b/include/node_kernels/NodeKernelUtils.h
@@ -1,0 +1,58 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef NODEKERNELUTILS_H
+#define NODEKERNELUTILS_H
+
+#include "AssembleNGPNodeSolverAlgorithm.h"
+#include "Enums.h"
+#include "EquationSystem.h"
+#include "Realm.h"
+#include "SolutionOptions.h"
+
+#include <map>
+
+namespace sierra {
+namespace nalu {
+
+template<typename LambdaGeneral, typename LambdaUserSrc>
+void process_ngp_node_kernels(
+  std::map<AlgorithmType, SolverAlgorithm*>& solverAlgMap,
+  Realm& realm,
+  stk::mesh::Part* part,
+  EquationSystem* eqSystem,
+  LambdaGeneral lambdaGeneral,
+  LambdaUserSrc lambdaUsrSrc)
+{
+  const auto algMass = AlgorithmType::MASS;
+  const auto it = solverAlgMap.find(algMass);
+
+  if (it == solverAlgMap.end()) {
+    auto* nodeAlg = new AssembleNGPNodeSolverAlgorithm(realm, part, eqSystem);
+    solverAlgMap[algMass] = nodeAlg;
+
+    // Custom node src kernels for this equation system
+    lambdaGeneral(*nodeAlg);
+
+    const auto it = realm.solutionOptions_->srcTermsMap_.find(eqSystem->eqnTypeName_);
+    if (it != realm.solutionOptions_->srcTermsMap_.end()) {
+      NaluEnv::self().naluOutputP0()
+        << "Processing user source terms for "
+        << eqSystem->eqnTypeName_ << std::endl;
+      for (auto& srcName : it->second) {
+        lambdaUsrSrc(*nodeAlg, srcName);
+      }
+    }
+  } else {
+    it->second->partVec_.push_back(part);
+  }
+}
+
+}  // nalu
+}  // sierra
+
+#endif /* NODEKERNELUTILS_H */

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -71,7 +71,10 @@ AssembleElemSolverAlgorithm::AssembleElemSolverAlgorithm(
 void
 AssembleElemSolverAlgorithm::initialize_connectivity()
 {
-  eqSystem_->linsys_->buildElemToNodeGraph(partVec_);
+  if (entityRank_ == stk::topology::ELEM_RANK)
+    eqSystem_->linsys_->buildElemToNodeGraph(partVec_);
+  else if (entityRank_ == realm_.meta_data().side_rank())
+    eqSystem_->linsys_->buildFaceToNodeGraph(partVec_);
 }
 
 //--------------------------------------------------------------------------

--- a/src/AssembleNGPNodeSolverAlgorithm.C
+++ b/src/AssembleNGPNodeSolverAlgorithm.C
@@ -79,6 +79,8 @@ AssembleNGPNodeSolverAlgorithm::execute()
   using ShmemDataType = SharedMemData_Node<DeviceTeamHandleType, DeviceShmem>;
 
   const size_t numKernels = nodeKernels_.size();
+  if (numKernels < 1) return;
+
   for (auto& kern: nodeKernels_)
     kern->setup(realm_);
 

--- a/src/AssembleNodeSolverAlgorithm.C
+++ b/src/AssembleNodeSolverAlgorithm.C
@@ -57,6 +57,11 @@ AssembleNodeSolverAlgorithm::initialize_connectivity()
 void
 AssembleNodeSolverAlgorithm::execute()
 {
+  // Handle transition period, it is likely that most of the user-requested
+  // source terms were handled by the NGP version of nodal algorithm
+  const size_t supplementalAlgSize = supplementalAlg_.size();
+  if (supplementalAlgSize < 1) return;
+
   stk::mesh::MetaData & meta_data = realm_.meta_data();
 
   // space for LHS/RHS
@@ -73,7 +78,6 @@ AssembleNodeSolverAlgorithm::execute()
   double *p_rhs = &rhs[0];
 
   // supplemental algorithm size and setup
-  const size_t supplementalAlgSize = supplementalAlg_.size();
   for ( size_t i = 0; i < supplementalAlgSize; ++i )
     supplementalAlg_[i]->setup();
 

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -11,7 +11,6 @@
 #include <AlgorithmDriver.h>
 #include <AssembleScalarFluxBCSolverAlgorithm.h>
 #include <AssembleScalarEdgeOpenSolverAlgorithm.h>
-#include <AssembleScalarEdgeSolverAlgorithm.h>
 #include <AssembleScalarEigenEdgeSolverAlgorithm.h>
 #include <AssembleScalarElemSolverAlgorithm.h>
 #include <AssembleScalarElemOpenSolverAlgorithm.h>
@@ -48,8 +47,6 @@
 #include <Realm.h>
 #include <Realms.h>
 #include <ScalarGclNodeSuppAlg.h>
-#include <ScalarMassBackwardEulerNodeSuppAlg.h>
-#include <ScalarMassBDF2NodeSuppAlg.h>
 #include <ScalarMassElemSuppAlgDep.h>
 #include <Simulation.h>
 #include <TimeIntegrator.h>
@@ -402,7 +399,6 @@ EnthalpyEquationSystem::register_interior_algorithm(
       SolverAlgorithm *theAlg = NULL;
       if ( realm_.realmUsesEdges_ ) {
         if ( !realm_.solutionOptions_->eigenvaluePerturb_ )
-          // theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, enthalpy_, dhdx_, evisc_);
           theAlg = new ScalarEdgeSolverAlg(realm_, part, this, enthalpy_, dhdx_, evisc_);
         else
           theAlg = new AssembleScalarEigenEdgeSolverAlgorithm(realm_, part, this, enthalpy_, dhdx_, thermalCond_, specHeat_,

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -75,6 +75,9 @@
 // bc kernels
 #include <kernel/ScalarOpenAdvElemKernel.h>
 
+// edge kernels
+#include <edge_kernels/ScalarEdgeSolverAlg.h>
+
 // nso
 #include <nso/ScalarNSOElemKernel.h>
 #include <nso/ScalarNSOKeElemKernel.h>
@@ -395,7 +398,8 @@ EnthalpyEquationSystem::register_interior_algorithm(
       SolverAlgorithm *theAlg = NULL;
       if ( realm_.realmUsesEdges_ ) {
         if ( !realm_.solutionOptions_->eigenvaluePerturb_ )
-          theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, enthalpy_, dhdx_, evisc_);
+          // theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, enthalpy_, dhdx_, evisc_);
+          theAlg = new ScalarEdgeSolverAlg(realm_, part, this, enthalpy_, dhdx_, evisc_);
         else
           theAlg = new AssembleScalarEigenEdgeSolverAlgorithm(realm_, part, this, enthalpy_, dhdx_, thermalCond_, specHeat_,
             tvisc_, realm_.get_turb_prandtl(enthalpy_->name()));

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -141,6 +141,11 @@
 #include <kernel/MomentumSymmetryElemKernel.h>
 #include <kernel/MomentumWallFunctionElemKernel.h>
 
+// edge kernels
+#include <edge_kernels/ContinuityEdgeSolverAlg.h>
+#include <edge_kernels/MomentumEdgeSolverAlg.h>
+#include <edge_kernels/MomentumSymmetryEdgeKernel.h>
+
 // nso
 #include <nso/MomentumNSOElemKernel.h>
 #include <nso/MomentumNSOKeElemKernel.h>
@@ -1182,7 +1187,8 @@ MomentumEquationSystem::register_interior_algorithm(
     if ( itsi == solverAlgDriver_->solverAlgMap_.end() ) {
       SolverAlgorithm *theSolverAlg = NULL;
       if ( realm_.realmUsesEdges_ ) {
-        theSolverAlg = new AssembleMomentumEdgeSolverAlgorithm(realm_, part, this);
+        // theSolverAlg = new AssembleMomentumEdgeSolverAlgorithm(realm_, part, this);
+        theSolverAlg = new MomentumEdgeSolverAlg(realm_, part, this);
       }
       else {
         theSolverAlg = new AssembleMomentumElemSolverAlgorithm(realm_, part, this);
@@ -2793,17 +2799,24 @@ ContinuityEquationSystem::register_interior_algorithm(
       itc->second->partVec_.push_back(part);
     }
 
-    // solver
-    std::map<AlgorithmType, SolverAlgorithm *>::iterator its =
-      solverAlgDriver_->solverAlgMap_.find(algType);
-    if ( its == solverAlgDriver_->solverAlgMap_.end() ) {
-      AssembleContinuityEdgeSolverAlgorithm *theAlg
-        = new AssembleContinuityEdgeSolverAlgorithm(realm_, part, this);
-      solverAlgDriver_->solverAlgMap_[algType] = theAlg;
+    auto& solverAlgMap =  solverAlgDriver_->solverAlgMap_;
+    const auto it = solverAlgMap.find(algType);
+    if (it == solverAlgMap.end()) {
+      solverAlgMap[algType] = new ContinuityEdgeSolverAlg(realm_, part, this);
+    } else {
+      it->second->partVec_.push_back(part);
     }
-    else {
-      its->second->partVec_.push_back(part);
-    }
+    // // solver
+    // std::map<AlgorithmType, SolverAlgorithm *>::iterator its =
+    //   solverAlgDriver_->solverAlgMap_.find(algType);
+    // if ( its == solverAlgDriver_->solverAlgMap_.end() ) {
+    //   AssembleContinuityEdgeSolverAlgorithm *theAlg
+    //     = new AssembleContinuityEdgeSolverAlgorithm(realm_, part, this);
+    //   solverAlgDriver_->solverAlgMap_[algType] = theAlg;
+    // }
+    // else {
+    //   its->second->partVec_.push_back(part);
+    // }
   }
   else {
 

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -10,13 +10,11 @@
 #include <wind_energy/ABLForcingAlgorithm.h>
 #include <AlgorithmDriver.h>
 #include <AssembleCourantReynoldsElemAlgorithm.h>
-#include <AssembleContinuityEdgeSolverAlgorithm.h>
 #include <AssembleContinuityElemSolverAlgorithm.h>
 #include <AssembleContinuityInflowSolverAlgorithm.h>
 #include <AssembleContinuityEdgeOpenSolverAlgorithm.h>
 #include <AssembleContinuityElemOpenSolverAlgorithm.h>
 #include <AssembleContinuityNonConformalSolverAlgorithm.h>
-#include <AssembleMomentumEdgeSolverAlgorithm.h>
 #include <AssembleMomentumElemSolverAlgorithm.h>
 #include <AssembleMomentumEdgeOpenSolverAlgorithm.h>
 #include <AssembleMomentumElemOpenSolverAlgorithm.h>
@@ -1190,7 +1188,6 @@ MomentumEquationSystem::register_interior_algorithm(
     if ( itsi == solverAlgDriver_->solverAlgMap_.end() ) {
       SolverAlgorithm *theSolverAlg = NULL;
       if ( realm_.realmUsesEdges_ ) {
-        // theSolverAlg = new AssembleMomentumEdgeSolverAlgorithm(realm_, part, this);
         theSolverAlg = new MomentumEdgeSolverAlg(realm_, part, this);
       }
       else {
@@ -2849,17 +2846,6 @@ ContinuityEquationSystem::register_interior_algorithm(
     } else {
       it->second->partVec_.push_back(part);
     }
-    // // solver
-    // std::map<AlgorithmType, SolverAlgorithm *>::iterator its =
-    //   solverAlgDriver_->solverAlgMap_.find(algType);
-    // if ( its == solverAlgDriver_->solverAlgMap_.end() ) {
-    //   AssembleContinuityEdgeSolverAlgorithm *theAlg
-    //     = new AssembleContinuityEdgeSolverAlgorithm(realm_, part, this);
-    //   solverAlgDriver_->solverAlgMap_[algType] = theAlg;
-    // }
-    // else {
-    //   its->second->partVec_.push_back(part);
-    // }
   }
   else {
 

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -9,7 +9,6 @@
 #include <SpecificDissipationRateEquationSystem.h>
 #include <AlgorithmDriver.h>
 #include <AssembleScalarEdgeOpenSolverAlgorithm.h>
-#include <AssembleScalarEdgeSolverAlgorithm.h>
 #include <AssembleScalarElemSolverAlgorithm.h>
 #include <AssembleScalarElemOpenSolverAlgorithm.h>
 #include <AssembleScalarNonConformalSolverAlgorithm.h>
@@ -237,7 +236,6 @@ SpecificDissipationRateEquationSystem::register_interior_algorithm(
     if (itsi == solverAlgDriver_->solverAlgMap_.end()) {
       SolverAlgorithm* theAlg = NULL;
       if (realm_.realmUsesEdges_) {
-        // theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, sdr_, dwdx_, evisc_);
         theAlg = new ScalarEdgeSolverAlg(realm_, part, this, sdr_, dwdx_, evisc_);
       }
       else {

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -38,8 +38,6 @@
 #include <Realm.h>
 #include <Realms.h>
 #include <ScalarGclNodeSuppAlg.h>
-#include <ScalarMassBackwardEulerNodeSuppAlg.h>
-#include <ScalarMassBDF2NodeSuppAlg.h>
 #include <ScalarMassElemSuppAlgDep.h>
 #include <Simulation.h>
 #include <SolutionOptions.h>
@@ -61,6 +59,10 @@
 
 // edge kernels
 #include <edge_kernels/ScalarEdgeSolverAlg.h>
+
+// node kernels
+#include <node_kernels/NodeKernelUtils.h>
+#include <node_kernels/ScalarMassBDFNodeKernel.h>
 
 // nso
 #include <nso/ScalarNSOElemKernel.h>
@@ -288,13 +290,26 @@ SpecificDissipationRateEquationSystem::register_interior_algorithm(
     }
 
     // time term; src; both nodally lumped
-    const AlgorithmType algMass = MASS;
+    const AlgorithmType algMass = SRC;
     // Check if the user has requested CMM or LMM algorithms; if so, do not
     // include Nodal Mass algorithms
     std::vector<std::string> checkAlgNames = {
       "specific_dissipation_rate_time_derivative",
       "lumped_specific_dissipation_rate_time_derivative"};
     bool elementMassAlg = supp_alg_is_requested(checkAlgNames);
+    auto& solverAlgMap = solverAlgDriver_->solverAlgMap_;
+    process_ngp_node_kernels(
+      solverAlgMap, realm_, part, this,
+      [&](AssembleNGPNodeSolverAlgorithm& nodeAlg) {
+        if (!elementMassAlg)
+          nodeAlg.add_kernel<ScalarMassBDFNodeKernel>(realm_.bulk_data(), sdr_);
+
+        // TODO: Add SST source terms here
+      },
+      [&](AssembleNGPNodeSolverAlgorithm& /* nodeAlg */, std::string& /* srcName */) {
+        // No source terms available yet
+      });
+
     std::map<AlgorithmType, SolverAlgorithm*>::iterator itsm =
       solverAlgDriver_->solverAlgMap_.find(algMass);
     if (itsm == solverAlgDriver_->solverAlgMap_.end()) {
@@ -302,20 +317,6 @@ SpecificDissipationRateEquationSystem::register_interior_algorithm(
       AssembleNodeSolverAlgorithm *theAlg
         = new AssembleNodeSolverAlgorithm(realm_, part, this);
       solverAlgDriver_->solverAlgMap_[algMass] = theAlg;
-
-      // now create the supplemental alg for mass term
-      if (!elementMassAlg) {
-        if (realm_.number_of_states() == 2) {
-          ScalarMassBackwardEulerNodeSuppAlg *theMass
-            = new ScalarMassBackwardEulerNodeSuppAlg(realm_, sdr_);
-          theAlg->supplementalAlg_.push_back(theMass);
-        }
-        else {
-          ScalarMassBDF2NodeSuppAlg *theMass
-            = new ScalarMassBDF2NodeSuppAlg(realm_, sdr_);
-          theAlg->supplementalAlg_.push_back(theMass);
-        }
-      }
 
       // now create the src alg for sdr source
       SpecificDissipationRateSSTNodeSourceSuppAlg *theSrc

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -59,6 +59,9 @@
 #include <kernel/ScalarUpwAdvDiffElemKernel.h>
 #include <kernel/SpecificDissipationRateSSTSrcElemKernel.h>
 
+// edge kernels
+#include <edge_kernels/ScalarEdgeSolverAlg.h>
+
 // nso
 #include <nso/ScalarNSOElemKernel.h>
 #include <nso/ScalarNSOKeElemSuppAlg.h>
@@ -232,7 +235,8 @@ SpecificDissipationRateEquationSystem::register_interior_algorithm(
     if (itsi == solverAlgDriver_->solverAlgMap_.end()) {
       SolverAlgorithm* theAlg = NULL;
       if (realm_.realmUsesEdges_) {
-        theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, sdr_, dwdx_, evisc_);
+        // theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, sdr_, dwdx_, evisc_);
+        theAlg = new ScalarEdgeSolverAlg(realm_, part, this, sdr_, dwdx_, evisc_);
       }
       else {
         theAlg = new AssembleScalarElemSolverAlgorithm(realm_, part, this, sdr_, dwdx_, evisc_);

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -39,8 +39,6 @@
 #include <Realm.h>
 #include <Realms.h>
 #include <ScalarGclNodeSuppAlg.h>
-#include <ScalarMassBackwardEulerNodeSuppAlg.h>
-#include <ScalarMassBDF2NodeSuppAlg.h>
 #include <Simulation.h>
 #include <SolutionOptions.h>
 #include <TimeIntegrator.h>
@@ -72,6 +70,10 @@
 
 // edge kernels
 #include <edge_kernels/ScalarEdgeSolverAlg.h>
+
+// node kernels
+#include <node_kernels/NodeKernelUtils.h>
+#include <node_kernels/ScalarMassBDFNodeKernel.h>
 
 // nso
 #include <nso/ScalarNSOElemKernel.h>
@@ -318,12 +320,25 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
     }
     
     // time term; (Pk-Dk); both nodally lumped
-    const AlgorithmType algMass = MASS;
+    const AlgorithmType algMass = SRC;
     // Check if the user has requested CMM or LMM algorithms; if so, do not
     // include Nodal Mass algorithms
     std::vector<std::string> checkAlgNames = {"turbulent_ke_time_derivative",
                                               "lumped_turbulent_ke_time_derivative"};
     bool elementMassAlg = supp_alg_is_requested(checkAlgNames);
+    auto& solverAlgMap = solverAlgDriver_->solverAlgMap_;
+    process_ngp_node_kernels(
+      solverAlgMap, realm_, part, this,
+      [&](AssembleNGPNodeSolverAlgorithm& nodeAlg) {
+        if (!elementMassAlg)
+          nodeAlg.add_kernel<ScalarMassBDFNodeKernel>(realm_.bulk_data(), tke_);
+
+        // TODO: Add kSGS/SST/SST_DES source terms here
+      },
+      [&](AssembleNGPNodeSolverAlgorithm& /* nodeAlg */, std::string& /* srcName */) {
+        // No source terms available yet
+      });
+
     std::map<AlgorithmType, SolverAlgorithm *>::iterator itsm =
       solverAlgDriver_->solverAlgMap_.find(algMass);
     if ( itsm == solverAlgDriver_->solverAlgMap_.end() ) {
@@ -331,21 +346,7 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
       AssembleNodeSolverAlgorithm *theAlg
         = new AssembleNodeSolverAlgorithm(realm_, part, this);
       solverAlgDriver_->solverAlgMap_[algMass] = theAlg;
-      
-      // now create the supplemental alg for mass term
-      if ( !elementMassAlg ) {
-        if ( realm_.number_of_states() == 2 ) {
-          ScalarMassBackwardEulerNodeSuppAlg *theMass
-            = new ScalarMassBackwardEulerNodeSuppAlg(realm_, tke_);
-          theAlg->supplementalAlg_.push_back(theMass);
-        }
-        else {
-          ScalarMassBDF2NodeSuppAlg *theMass
-            = new ScalarMassBDF2NodeSuppAlg(realm_, tke_);
-          theAlg->supplementalAlg_.push_back(theMass);
-        }
-      }
-      
+
       // now create the src alg for tke source
       SupplementalAlgorithm *theSrc = NULL;
       switch(turbulenceModel_) {

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -9,7 +9,6 @@
 #include <TurbKineticEnergyEquationSystem.h>
 #include <AlgorithmDriver.h>
 #include <AssembleScalarEdgeOpenSolverAlgorithm.h>
-#include <AssembleScalarEdgeSolverAlgorithm.h>
 #include <AssembleScalarElemSolverAlgorithm.h>
 #include <AssembleScalarElemOpenSolverAlgorithm.h>
 #include <AssembleScalarNonConformalSolverAlgorithm.h>
@@ -262,7 +261,6 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
     if ( itsi == solverAlgDriver_->solverAlgMap_.end() ) {
       SolverAlgorithm *theAlg = NULL;
       if ( realm_.realmUsesEdges_ ) {
-        // theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, tke_, dkdx_, evisc_);
         theAlg = new ScalarEdgeSolverAlg(realm_, part, this, tke_, dkdx_, evisc_);
       }
       else {

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -70,6 +70,9 @@
 // bc kernels
 #include <kernel/ScalarOpenAdvElemKernel.h>
 
+// edge kernels
+#include <edge_kernels/ScalarEdgeSolverAlg.h>
+
 // nso
 #include <nso/ScalarNSOElemKernel.h>
 #include <nso/ScalarNSOKeElemSuppAlg.h>
@@ -257,7 +260,8 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
     if ( itsi == solverAlgDriver_->solverAlgMap_.end() ) {
       SolverAlgorithm *theAlg = NULL;
       if ( realm_.realmUsesEdges_ ) {
-        theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, tke_, dkdx_, evisc_);
+        // theAlg = new AssembleScalarEdgeSolverAlgorithm(realm_, part, this, tke_, dkdx_, evisc_);
+        theAlg = new ScalarEdgeSolverAlg(realm_, part, this, tke_, dkdx_, evisc_);
       }
       else {
         theAlg = new AssembleScalarElemSolverAlgorithm(realm_, part, this, tke_, dkdx_, evisc_);


### PR DESCRIPTION
This pull request replaces the current non-NGP versions of Edge and nodal source algorithms in the following equation systems with their NGP counterparts (see #238):

- Momentum
- Continuity
- Enthalpy
- TurbKineticEnergy
- SpecificDissipationRate
- WallDistance

Other comments:

- `AssembleElemSolverAlgorithm::initialize_connectivity()` calls `TpetraLinearSystem::buildFaceToNodeGraph()` when dealing with a boundary kernel. Without this, edge flavor of BC kernel (e.g., `MomentumABLWallFuncEdgeKernel`) segfaults. 
- The changes introduce some diffs in the regression tests due to order of operation changes, but all appear to be within expected range. 