### PR TITLE
NGP looping abstractions

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -26,6 +26,8 @@
 
 #include <stk_ngp/NgpFieldManager.hpp>
 
+#include "ngp_utils/NgpMeshInfo.h"
+
 // standard c++
 #include <map>
 #include <string>
@@ -90,6 +92,7 @@ struct ElementDescription;
  */
 class Realm {
  public:
+  using NgpMeshInfo = nalu_ngp::MeshInfo<ngp::Mesh, ngp::FieldManager>;
 
   Realm(Realms&, const YAML::Node & node);
   virtual ~Realm();
@@ -354,20 +357,22 @@ class Realm {
   stk::mesh::MetaData & meta_data();
   const stk::mesh::MetaData & meta_data() const;
 
-  inline ngp::Mesh& ngp_mesh()
+  inline NgpMeshInfo& mesh_info()
   {
-    if (!ngpMesh_) {
-      ngpMesh_.reset(new ngp::Mesh(*bulkData_));
+    if (!meshInfo_) {
+      meshInfo_.reset(new NgpMeshInfo(*bulkData_));
     }
-    return *ngpMesh_;
+    return *meshInfo_;
   }
 
-  inline ngp::FieldManager& ngp_field_manager()
+  inline const ngp::Mesh& ngp_mesh()
   {
-    if (!ngpFieldMgr_) {
-      ngpFieldMgr_.reset(new ngp::FieldManager(*bulkData_));
-    }
-    return *ngpFieldMgr_;
+    return mesh_info().ngp_mesh();
+  }
+
+  inline const ngp::FieldManager& ngp_field_manager()
+  {
+    return mesh_info().ngp_field_manager();
   }
 
   // inactive part
@@ -659,9 +664,7 @@ class Realm {
   bool hypreIsActive_{false};
 
 protected:
-  std::unique_ptr<ngp::Mesh> ngpMesh_;
-
-  std::unique_ptr<ngp::FieldManager> ngpFieldMgr_;
+  std::unique_ptr<NgpMeshInfo> meshInfo_;
 
 };
 

--- a/include/ngp_utils/NgpFieldOps.h
+++ b/include/ngp_utils/NgpFieldOps.h
@@ -220,11 +220,13 @@ struct ElemFieldOp
     {
       const auto& fld = obj_.ngpField_;
       const auto* einfo = obj_.edata_.elemInfo;
+
+      // No atomic_add here as only one element active per thread
 #ifdef STK_SIMD_NONE
-      Kokkos::atomic_add(fld.get(einfo[0].meshIdx, ic), stk::simd::get_data(val, 0));
+      fld.get(einfo[0].meshIdx, ic) += stk::simd::get_data(val, 0);
 #else
       for (int is=0; is < obj_.edata_.numSimdElems; ++is) {
-        Kokkos::atomic_add(fld.get(einfo[is].meshIdx, ic), stk::simd::get_data(val, is));
+        fld.get(einfo[is].meshIdx, ic) += stk::simd::get_data(val, is);
       }
 #endif
     }
@@ -249,10 +251,10 @@ struct ElemFieldOp
       const auto& fld = obj_.ngpField_;
       const auto* einfo = obj_.edata_.elemInfo;
 #ifdef STK_SIMD_NONE
-      Kokkos::atomic_add(fld.get(einfo[0].meshIdx, ic), val);
+      fld.get(einfo[0].meshIdx, ic) += val;
 #else
       for (int is=0; is < obj_.edata_.numSimdElems; ++is) {
-        Kokkos::atomic_add(fld.get(einfo[is].meshIdx, ic), val);
+        fld.get(einfo[is].meshIdx, ic) += val;
       }
 #endif
     }

--- a/include/ngp_utils/NgpFieldOps.h
+++ b/include/ngp_utils/NgpFieldOps.h
@@ -1,0 +1,180 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef NGPFIELDOPS_H
+#define NGPFIELDOPS_H
+
+/** \file
+ *  \brief Helper objects for field updates when using SIMD datatypes
+ */
+
+#include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpScratchData.h"
+#include "SimdInterface.h"
+
+#include "stk_ngp/Ngp.hpp"
+
+namespace sierra {
+namespace nalu {
+namespace nalu_ngp {
+
+/** Helper object to perform operations between SIMD data and non-SIMD
+ *  ngp::Field objects.
+ *
+ *  This updater is used when looping over the elements of a mesh
+ */
+template<typename Mesh, typename FieldDataType>
+struct ElemFieldOp
+{
+  /**
+   *  @param ngpMesh Instance of the ngp::Mesh
+   *  @param ngpField Field to be updated
+   *  @param elemData Element connectivity data structure
+   */
+  KOKKOS_FORCEINLINE_FUNCTION
+  ElemFieldOp(
+    const Mesh& ngpMesh,
+    const ngp::Field<FieldDataType>& ngpField,
+    const ElemSimdData<Mesh>& elemData
+  ) : ngpMesh_(ngpMesh),
+      ngpField_(ngpField),
+      edata_(elemData)
+  {}
+
+  KOKKOS_FUNCTION ~ElemFieldOp() = default;
+
+  /** Set an ELEM_RANK quantity
+   *
+   *  This method sets an element quantity for the desired component (e.g.,
+   *  integration point for a scalar) by scattering the contents of the SIMD
+   *  group. On non-SIMD architectures, it just simply copies the value.
+   *
+   *  @param component The array index to be set
+   *  @param value The SIMD data to be scattered
+   */
+  KOKKOS_FORCEINLINE_FUNCTION
+  void ip_set(const int component, const DoubleType& value) const
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    for (int is=0; is < edata_.numSimdElems; ++is) {
+      ngpField_.get(edata_.elemInfo[is].meshIdx, component) =
+        stk::simd::get_data(value, is);
+    }
+#else
+    ngpField_.get(edata_.elemInfo[0].meshIdx, component) =
+      stk::simd::get_data(value, 0);
+#endif
+  }
+
+  /** Add to an ELEM_RANK quantity
+   *
+   *  This method atomically adds to an element quantity for the desired
+   *  component (e.g., integration point for a scalar) by scattering the
+   *  contents of the SIMD group.
+   *
+   *  @param component The array index to be set
+   *  @param value The SIMD data to be added to various elements
+   */
+  KOKKOS_FORCEINLINE_FUNCTION
+  void ip_add(const int component, const DoubleType& value) const
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    for (int is=0; is < edata_.numSimdElems; ++is) {
+      Kokkos::atomic_add(
+        &ngpField_.get(edata_.elemInfo[is].meshIdx, component),
+        stk::simd::get_data(value, is));
+    }
+#else
+    Kokkos::atomic_add(
+      &ngpField_.get(edata_.elemInfo[0].meshIdx, component),
+      stk::simd::get_data(value, 0));
+#endif
+  }
+
+  /** Set value for a NODE_RANK field from within an element loop
+   *
+   *  This method sets the i-th component of a nodal quantity belonging to the
+   *  n-th node connected to an element from within an element loop.
+   *
+   *  @param n The node index into the element connectivity array
+   *  @param ic The component index for the field data array
+   *  @param value The SIMD data to to be scattered
+   */
+  KOKKOS_FORCEINLINE_FUNCTION
+  void set(const int n, const int ic, const DoubleType& value) const
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    for (int is=0; is < edata_.numSimdElems; ++is) {
+      ngpField_.get(ngpMesh_, edata_.elemInfo[is].entityNodes[n], ic) =
+        stk::simd::get_data(value, is);
+    }
+#else
+    ngpField_.get(ngpMesh_, edata_.elemInfo[0].entityNodes[n], ic) =
+      stk::simd::get_data(value, 0);
+#endif
+  }
+
+  /** Add to the value of a NODE_RANK field from within an element loop
+   *
+   *  This method adds to the i-th component of a nodal quantity belonging to
+   *  the n-th node connected to an element from within an element loop.
+   *
+   *  @param n The node index into the element connectivity array
+   *  @param ic The component index for the field data array
+   *  @param value The SIMD data to to be atomically added
+   */
+  KOKKOS_FORCEINLINE_FUNCTION
+  void add(const int n, const int ic, const DoubleType& value) const
+  {
+#ifndef KOKKOS_ENABLE_CUDA
+    for (int is=0; is < edata_.numSimdElems; ++is) {
+      Kokkos::atomic_add(
+        &ngpField_.get(ngpMesh_, edata_.elemInfo[is].entityNodes[n], ic),
+        stk::simd::get_data(value, is));
+    }
+#else
+    Kokkos::atomic_add(
+      &ngpField_.get(ngpMesh_, edata_.elemInfo[0].entityNodes[n], ic),
+      stk::simd::get_data(value, 0));
+#endif
+  }
+
+  //! NGP Mesh instance
+  const Mesh& ngpMesh_;
+
+  //! NGP element field to be updated
+  const ngp::Field<FieldDataType>& ngpField_;
+
+  //! Connectivity data for SIMD group
+  const ElemSimdData<Mesh>& edata_;
+};
+
+/** Create a field updater instance for modifying fields within an NGP loop
+ *
+ *  @param mesh The NGP-mesh instance
+ *  @param field The NGP-field that is being modified
+ *  @param edata The element scratch data within a SIMD loop
+ */
+template<typename Mesh, typename FieldDataType>
+KOKKOS_FORCEINLINE_FUNCTION
+ElemFieldOp<Mesh, FieldDataType>
+simd_field_updater(
+  const Mesh& mesh,
+  const ngp::Field<FieldDataType>& field,
+  const ElemSimdData<Mesh>& edata)
+{
+  return ElemFieldOp<Mesh, FieldDataType>(mesh, field, edata);
+}
+
+
+}  // nalu_ngp
+}  // nalu
+}  // sierra
+
+
+
+#endif /* NGPFIELDOPS_H */

--- a/include/ngp_utils/NgpFieldOps.h
+++ b/include/ngp_utils/NgpFieldOps.h
@@ -62,6 +62,8 @@ struct NodeFieldOp
     Ops(NodeFieldOp<Mesh, Field>& obj) : obj_(obj)
     {}
 
+    KOKKOS_FUNCTION ~Ops() = default;
+
     KOKKOS_INLINE_FUNCTION
     void operator= (const DoubleType& val) const
     {
@@ -161,10 +163,10 @@ struct NodeFieldOp
   }
 
   //! NGP Mesh instance
-  const Mesh& ngpMesh_;
+  const Mesh ngpMesh_;
 
   //! NGP element field to be updated
-  const Field& ngpField_;
+  const Field ngpField_;
 
   //! Connectivity data for SIMD group
   const ElemSimdData<Mesh>& edata_;
@@ -200,6 +202,8 @@ struct ElemFieldOp
     KOKKOS_INLINE_FUNCTION
     Ops(ElemFieldOp<Mesh, Field>& obj) : obj_(obj)
     {}
+
+    KOKKOS_FUNCTION ~Ops() = default;
 
     KOKKOS_INLINE_FUNCTION
     void operator= (const DoubleType& val) const
@@ -286,10 +290,10 @@ struct ElemFieldOp
   }
 
   //! NGP Mesh instance
-  const Mesh& ngpMesh_;
+  const Mesh ngpMesh_;
 
   //! NGP element field to be updated
-  const Field& ngpField_;
+  const Field ngpField_;
 
   //! Connectivity data for SIMD group
   const ElemSimdData<Mesh>& edata_;

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -1,0 +1,401 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef NGPLOOPUTILS_H
+#define NGPLOOPUTILS_H
+
+#include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpScratchData.h"
+#include "CopyAndInterleave.h"
+#include "ElemDataRequests.h"
+#include "ElemDataRequestsGPU.h"
+#include "ScratchViews.h"
+
+#include "stk_mesh/base/Selector.hpp"
+#include "stk_ngp/Ngp.hpp"
+
+namespace sierra {
+namespace nalu {
+
+namespace nalu_ngp {
+namespace impl {
+
+/** Return a Kokkos TeamPolicy object after setting the appropriate scratch
+ * memory sizes
+ *
+ * @param sz The number of STK buckets we are looping over
+ * @param bytes_per_team Bytes to be allocated at team parallelism level
+ * @param bytes_per_thread Bytes to be allocated at thread level
+ * @return Kokkos TeamPolicy instance for use with Kokkos::parallel_for
+ */
+template <typename TeamPolicy>
+inline TeamPolicy
+ngp_mesh_team_policy(
+  const size_t sz,
+  const size_t bytes_per_team,
+  const size_t bytes_per_thread)
+{
+  TeamPolicy policy(sz, Kokkos::AUTO);
+  return policy.set_scratch_size(
+    1, Kokkos::PerTeam(bytes_per_team), Kokkos::PerThread(bytes_per_thread));
+}
+
+/** Estimate the bytes required per thread to store ScratchViews for
+ *  element data.
+ *
+ *  @param ndim Spatial dimension
+ *  @param dataReq Element data requests object
+ *  @return bytes_per_thread
+ */
+template<typename T, typename DataReqType>
+inline int ngp_calc_thread_shmem_size(int ndim, const DataReqType& dataReq)
+{
+  int preReqSize = get_num_bytes_pre_req_data<T>(dataReq, ndim);
+  int mdvSize = MultiDimViews<T>::bytes_needed(
+    dataReq.get_total_num_fields(), count_needed_field_views(dataReq));
+
+#ifndef KOKKOS_ENABLE_CUDA
+  // On host account for extra data to store the SIMD and non-SIMD versions of
+  // the ScratchViews
+  return (preReqSize + mdvSize) * 2 * simdLen;
+#else
+  return (preReqSize + mdvSize);
+#endif
+}
+
+/** Estimate the bytes required per thread for face/element ScratchViews
+ *
+ *  @param ndim Spatial dimension
+ *  @param Face data requests object
+ *  @param Element data requests object (this is the parent element of the face)
+ *  @param MasterElementInfo object that contains nodesPerElem/nodesPerFace etc.
+ *  @return bytes_per_thread
+ */
+template<typename T, typename DataReqType>
+inline int ngp_calc_thread_shmem_size(
+  int ndim,
+  const DataReqType& faceDataReq,
+  const DataReqType& elemDataReq)
+{
+  const int faceMemSize = ngp_calc_thread_shmem_size<T>(ndim, faceDataReq);
+  const int elemMemSize = ngp_calc_thread_shmem_size<T>(ndim, elemDataReq);
+
+  return (faceMemSize + elemMemSize);
+}
+
+/** Get the nodes per element from the MasterElement registered
+ *
+ *  We need a convenience function because the ME instance is created on the device.
+ */
+template<typename DataReqType>
+inline int nodes_per_element(const DataReqType& dataReqIn)
+{
+  int npe = 0;
+  DataReqType dataReq(dataReqIn);
+  Kokkos::parallel_reduce(
+    1, KOKKOS_LAMBDA(int, int& n) {
+      auto* meSCS = dataReq.get_cvfem_surface_me();
+      auto* meSCV = dataReq.get_cvfem_volume_me();
+      n = ((meSCS != nullptr) ? meSCS->nodesPerElement_ :
+           (meSCV != nullptr) ? meSCV->nodesPerElement_ : 0);
+    }, npe);
+
+  NGP_ThrowRequire(npe != 0);
+  return npe;
+}
+
+/** Get the nodes per face from the MasterElement registered
+ *
+ *  We need a convenience function because the ME instance is created on the device.
+ */
+template<typename DataReqType>
+inline int nodes_per_face(const DataReqType& dataReqIn)
+{
+  int npe = 0;
+  DataReqType dataReq(dataReqIn);
+  Kokkos::parallel_reduce(
+    1, KOKKOS_LAMBDA(int, int& n) {
+      auto* meFC = dataReq.get_cvfem_face_me();
+      n = (meFC != nullptr) ? meFC->nodesPerElement_ : 0;
+    }, npe);
+
+  NGP_ThrowRequire(npe != 0);
+  return npe;
+}
+
+} // impl
+
+/** Execute the given functor for all entities in a Kokkos parallel loop
+ *
+ *  The functor is called with one argument MeshIndex, a struct containing a
+ *  pointer to the NGP bucket and the index into the bucket array for this
+ *  entity.
+ *
+ *  @param mesh A STK NGP mesh instance
+ *  @param rank Rank for the loop (node, elem, face, etc.)
+ *  @param sel  STK mesh selector to choose buckets for looping
+ *  @param algorithm A functor that will be executed for each entity
+ */
+template<typename Mesh, typename AlgFunctor>
+void run_entity_algorithm(
+  Mesh& mesh,
+  const stk::topology::rank_t rank,
+  const stk::mesh::Selector& sel,
+  const AlgFunctor algorithm)
+{
+  using Traits         = NGPMeshTraits<Mesh>;
+  using TeamPolicy     = typename Traits::TeamPolicy;
+  using TeamHandleType = typename Traits::TeamHandleType;
+  using MeshIndex      = typename Traits::MeshIndex;
+
+  const auto& buckets = mesh.get_bucket_ids(rank, sel);
+  auto team_exec = TeamPolicy(buckets.size(), Kokkos::AUTO);
+
+  Kokkos::parallel_for(
+    team_exec, KOKKOS_LAMBDA(const TeamHandleType& team) {
+      auto bktId = buckets.device_get(team.league_rank());
+      auto& bkt = mesh.get_bucket(rank, bktId);
+
+      const size_t bktLen = bkt.size();
+      Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team, bktLen),
+        [&](const size_t& bktIndex) {
+          MeshIndex meshIdx{&bkt, static_cast<unsigned>(bktIndex)};
+          algorithm(meshIdx);
+        });
+    });
+}
+
+/** Execute the given functor for all edges in a Kokkos parallel loop
+ *
+ *  The functor is called with one argument MeshIndex, a struct containing a
+ *  pointer to the NGP bucket and the index into the bucket array for this
+ *  entity.
+ *
+ *  @param mesh A STK NGP mesh instance
+ *  @param sel  STK mesh selector to choose buckets for looping
+ *  @param algorithm A functor that will be executed for each entity
+ */
+template<typename Mesh, typename AlgFunctor>
+void run_edge_algorithm(
+  Mesh& mesh,
+  const stk::mesh::Selector& sel,
+  const AlgFunctor algorithm)
+{
+  static constexpr stk::topology::rank_t rank = stk::topology::EDGE_RANK;
+  using Traits    = NGPMeshTraits<Mesh>;
+  using MeshIndex = typename Traits::MeshIndex;
+
+  run_entity_algorithm(
+    mesh, rank, sel,
+    KOKKOS_LAMBDA(MeshIndex& meshIdx) {
+      algorithm(
+        EntityInfo<Mesh>{meshIdx, (*meshIdx.bucket)[meshIdx.bucketOrd],
+            mesh.get_nodes(meshIdx)});
+  });
+}
+
+/** Execute the given functor for all elements in a Kokkos parallel loop
+ *
+ *  The functor is called with one argument MeshIndex, a struct containing a
+ *  pointer to the NGP bucket and the index into the bucket array for this
+ *  entity.
+ *
+ *  Note that a rank is still passed as an argument to allow looping over both
+ *  element and side/face ranks with the same function.
+ *
+ *  @param mesh A STK NGP mesh instance
+ *  @param sel  STK mesh selector to choose buckets for looping
+ *  @param algorithm A functor that will be executed for each entity
+ */
+template<typename Mesh, typename AlgFunctor>
+void run_elem_algorithm(
+  Mesh& mesh,
+  const stk::topology::rank_t rank,
+  const stk::mesh::Selector& sel,
+  const AlgFunctor algorithm)
+{
+  using Traits    = NGPMeshTraits<Mesh>;
+  using MeshIndex = typename Traits::MeshIndex;
+
+  run_entity_algorithm(
+    mesh, rank, sel,
+    KOKKOS_LAMBDA(MeshIndex& meshIdx) {
+      algorithm(
+        EntityInfo<Mesh>{meshIdx, (*meshIdx.bucket)[meshIdx.bucketOrd],
+            mesh.get_nodes(meshIdx)});
+    });
+}
+
+/** Gather element data in ScratchViews and execute functor over elements
+ *
+ *  The functor is called with an instance of ElemSimdData<Mesh> that contains
+ *  an EntityInfo describing the element connectivity data, and a ScratchViews
+ *  instance populated with all the data requested for a particular element
+ *  through ElemDataRequests.
+ *
+ *  In addition to gather of element data, this function also handles the
+ *  appropriate interleaving for SIMD data structures where appropriate.
+ *
+ *  @param meshInfo The MeshInfo object containing STK and NGP instances
+ *  @param rank ELEM or side_rank()
+ *  @param dataReqs Instance contaning element data to be added to ScratchViews
+ *  @param sel STK mesh selector to choose buckets for looping
+ *  @param algorithm The functor to be executed on each element
+ */
+template<
+  typename Mesh,
+  typename FieldManager,
+  typename DataReqType,
+  typename AlgFunctor>
+void run_elem_algorithm(
+  MeshInfo<Mesh, FieldManager>& meshInfo,
+  const stk::topology::rank_t rank,
+  const DataReqType& dataReqs,
+  const stk::mesh::Selector& sel,
+  const AlgFunctor algorithm)
+{
+  using Traits         = NGPMeshTraits<Mesh>;
+  using TeamPolicy     = typename Traits::TeamPolicy;
+  using TeamHandleType = typename Traits::TeamHandleType;
+  using MeshIndex      = typename Traits::MeshIndex;
+
+  const auto& ndim = meshInfo.ndim();
+  const auto& ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+
+  ElemDataRequestsGPU dataReqNGP(fieldMgr, dataReqs, meshInfo.num_fields());
+
+  const int nodesPerElement = impl::nodes_per_element(dataReqNGP);
+  const int bytes_per_team = 0;
+  const int bytes_per_thread = impl::ngp_calc_thread_shmem_size<sierra::nalu::DoubleType>(
+    ndim, dataReqNGP);
+
+  const auto& buckets = ngpMesh.get_bucket_ids(rank, sel);
+  auto team_exec = impl::ngp_mesh_team_policy<TeamPolicy>(
+    buckets.size(), bytes_per_team, bytes_per_thread);
+
+  Kokkos::parallel_for(team_exec, KOKKOS_LAMBDA(const TeamHandleType& team) {
+    auto bktId = buckets.device_get(team.league_rank());
+    auto& bkt = ngpMesh.get_bucket(rank, bktId);
+
+    ElemSimdData<Mesh> elemData(team, ndim, nodesPerElement, dataReqNGP);
+
+    const size_t bktLen = bkt.size();
+    const size_t simdBktLen = get_num_simd_groups(bktLen);
+
+    Kokkos::parallel_for(
+      Kokkos::TeamThreadRange(team, simdBktLen),
+      [&](const size_t& bktIndex) {
+        int nSimdElems = get_length_of_next_simd_group(bktIndex, bktLen);
+        elemData.numSimdElems = nSimdElems;
+
+        for (int is=0; is < nSimdElems; ++is) {
+          const unsigned bktOrd = bktIndex * simdLen + is;
+          MeshIndex meshIdx{&bkt, bktOrd};
+          const auto& elem = bkt[bktOrd];
+          elemData.elemInfo[is] =
+            EntityInfo<Mesh>{meshIdx, elem, ngpMesh.get_nodes(meshIdx)};
+
+          fill_pre_req_data(dataReqNGP, ngpMesh, rank, elem,
+                            *elemData.scrView[is]);
+        }
+
+#ifndef KOKKOS_ENABLE_CUDA
+        copy_and_interleave(elemData.scrView, nSimdElems, elemData.simdScrView);
+#endif
+
+        fill_master_element_views(dataReqNGP, elemData.simdScrView);
+        algorithm(elemData);
+      });
+  });
+}
+
+template<
+  typename Mesh,
+  typename FieldManager,
+  typename DataReqType,
+  typename AlgFunctor>
+void run_face_elem_algorithm_nosimd(
+  MeshInfo<Mesh, FieldManager>& meshInfo,
+  const DataReqType& faceDataReqs,
+  const DataReqType& elemDataReqs,
+  const stk::mesh::Selector& sel,
+  const AlgFunctor algorithm)
+{
+  static constexpr stk::topology::rank_t sideRank = meshInfo.meta().side_rank();
+  static constexpr stk::topology::rank_t elemRank = stk::topology::ELEMENT_RANK;
+  using Traits         = NGPMeshTraits<Mesh>;
+  using TeamPolicy     = typename Traits::TeamPolicy;
+  using TeamHandleType = typename Traits::TeamHandleType;
+  using MeshIndex      = typename Traits::MeshIndex;
+
+  const auto& ndim = meshInfo.ndim();
+  const auto& ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  const auto& numFields = meshInfo.num_fields();
+
+  ElemDataRequestsGPU faceDataNGP(fieldMgr, faceDataReqs, numFields);
+  ElemDataRequestsGPU elemDataNGP(fieldMgr, elemDataReqs, numFields);
+
+  const int nodesPerElement = impl::nodes_per_element(elemDataNGP);
+  const int nodesPerFace = impl::nodes_per_face(faceDataNGP);
+  const int bytes_per_team = 0;
+  const int bytes_per_thread = impl::ngp_calc_thread_shmem_size<double>(
+    ndim, faceDataNGP, elemDataNGP);
+
+  const auto& buckets = ngpMesh.get_bucket_ids(sideRank, sel);
+  auto team_exec = impl::ngp_mesh_team_policy<TeamPolicy>(
+    buckets.size(), bytes_per_team, bytes_per_thread);
+
+  Kokkos::parallel_for(team_exec, KOKKOS_LAMBDA(const TeamHandleType& team) {
+      auto bktId = buckets.device_get(team.league_rank());
+      auto& bkt = ngpMesh.get_bucket(sideRank, bktId);
+
+      typename Traits::ScratchViewsType faceViews(
+        team, ndim, nodesPerFace, faceDataNGP);
+      typename Traits::ScratchViewsType elemViews(
+        team, ndim, nodesPerElement, elemDataNGP);
+      faceViews.fill_static_meviews(faceDataNGP);
+      elemViews.fill_static_meviews(elemDataNGP);
+
+      const size_t bktLen = bkt.size();
+      Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team, bktLen),
+        [&](const size_t& bktIndex) {
+          MeshIndex meshIdx{&bkt, static_cast<unsigned>(bktIndex)};
+          const auto face = bkt[bktIndex];
+          const auto faceIdx = ngpMesh.fast_mesh_index(face);
+          const auto elements = ngpMesh.get_elements(sideRank, faceIdx);
+
+          NGP_ThrowAssert(elements.size() == 1);
+          const auto faceOrd = ngpMesh.get_element_ordinals(sideRank, faceIdx)[0];
+          const auto elem = elements[0];
+          const auto elemIdx = ngpMesh.fast_mesh_index(elem);
+
+          // Fill up face data
+          fill_pre_req_data(faceDataNGP, ngpMesh, sideRank, face, faceViews);
+          fill_master_element_views(faceDataNGP, faceViews);
+          // Fill up element data
+          fill_pre_req_data(elemDataNGP, ngpMesh, elemRank, elem, elemViews);
+          fill_master_element_views(elemDataNGP, elemViews);
+
+          const BcFaceElemInfo<Mesh> faceinfo{
+            meshIdx, face, elem, ngpMesh.get_nodes(elemRank, elemIdx), faceOrd};
+
+          algorithm(faceinfo, elemViews, faceViews);
+        });
+    });
+}
+
+}  // nalu_ngp
+}  // nalu
+}  // sierra
+
+
+
+#endif /* NGPLOOPUTILS_H */

--- a/include/ngp_utils/NgpMeshInfo.h
+++ b/include/ngp_utils/NgpMeshInfo.h
@@ -1,0 +1,76 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef NGPMESHINFO_H
+#define NGPMESHINFO_H
+
+/** \file
+ *  \brief NGP mesh information objects
+ */
+
+#include "stk_ngp/Ngp.hpp"
+#include "stk_ngp/NgpFieldManager.hpp"
+
+namespace sierra {
+namespace nalu {
+namespace nalu_ngp {
+
+/** STK mesh object holder
+ *
+ *  This lightweight class carries information regarding the STK meshes both the
+ *  non-NGP versions (MetaData/BulkData) as well as the `ngp::Mesh` and
+ *  `ngp::FieldManager` instances.
+ */
+template <typename Mesh = ngp::Mesh, typename FieldManager = ngp::FieldManager>
+class MeshInfo
+{
+public:
+  using NgpMeshType = Mesh;
+  using NgpFieldManagerType = FieldManager;
+
+  MeshInfo(
+    const stk::mesh::BulkData& bulk
+  ) : bulk_(bulk),
+      meta_(bulk.mesh_meta_data()),
+      ngpMesh_(bulk),
+      ngpFieldMgr_(bulk)
+  {}
+
+  ~MeshInfo() = default;
+
+  inline const stk::mesh::BulkData& bulk() const { return bulk_; }
+
+  inline const stk::mesh::MetaData& meta() const { return meta_; }
+
+  inline const Mesh& ngp_mesh() const { return ngpMesh_; }
+
+  inline const FieldManager& ngp_field_manager() const { return ngpFieldMgr_; }
+
+  inline int ndim() const { return meta_.spatial_dimension(); }
+
+  inline size_t num_fields() const { return meta_.get_fields().size(); }
+
+private:
+  //! Reference to the bulk data for the STK mesh
+  const stk::mesh::BulkData& bulk_;
+
+  //! Reference to the mesh meta data
+  const stk::mesh::MetaData& meta_;
+
+  //! NGP mesh instance
+  const Mesh ngpMesh_;
+
+  //! NGP field manager instance
+  const FieldManager ngpFieldMgr_;
+};
+
+}  // nalu_ngp
+}  // nalu
+}  // sierra
+
+
+#endif /* NGPMESHINFO_H */

--- a/include/ngp_utils/NgpScratchData.h
+++ b/include/ngp_utils/NgpScratchData.h
@@ -1,0 +1,88 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef NGPSCRATCHDATA_H
+#define NGPSCRATCHDATA_H
+
+/** \file
+ *  \brief Element connectivity and ScratchData holders
+ */
+
+#include "ngp_utils/NgpTypes.h"
+#include "SimdInterface.h"
+#include "ElemDataRequestsGPU.h"
+#include <memory>
+
+namespace sierra {
+namespace nalu {
+
+namespace nalu_ngp {
+
+/** Element connectivity and gathered scratch data for element
+ *
+ *  This class holds the element connectivity information and the gathered
+ *  element data (ScratchViews) within element loops.
+ *
+ */
+template<typename Mesh>
+struct ElemSimdData
+{
+  using MeshTraits = NGPMeshTraits<Mesh>;
+  using TeamHandleType = typename MeshTraits::TeamHandleType;
+  using ShmemType = typename MeshTraits::ShmemType;
+  using EntityInfo = EntityInfo<Mesh>;
+
+  KOKKOS_INLINE_FUNCTION
+  ElemSimdData(
+    const TeamHandleType& team,
+    unsigned ndim,
+    unsigned nodesPerElem,
+    const ElemDataRequestsGPU& dataReq)
+    : simdScrView(team, ndim, nodesPerElem, dataReq)
+  {
+#ifdef KOKKOS_ENABLE_CUDA
+    scrView[0] = &simdScrView;
+#else
+    for (int si=0; si < simdLen; ++si) {
+      scrView[si].reset(
+        new ScratchViews<double, TeamHandleType, ShmemType>(
+          team, ndim, nodesPerElem, dataReq));
+    }
+#endif
+
+    simdScrView.fill_static_meviews(dataReq);
+  }
+
+  KOKKOS_FUNCTION ~ElemSimdData() = default;
+
+  //! Gathered element data (always in SIMD datatype)
+  ScratchViews<DoubleType, TeamHandleType, ShmemType> simdScrView;
+
+  /** Non-SIMD gathered element data
+   *
+   *  When executing on GPUs we dont
+   */
+#ifdef KOKKOS_ENABLE_CUDA
+  ScratchViews<DoubleType, TeamHandleType, ShmemType>* scrView[1];
+#else
+  std::unique_ptr<ScratchViews<double, TeamHandleType, ShmemType>> scrView[simdLen];
+#endif
+
+  //! Element connectivity info for each element within the SIMD group
+  EntityInfo elemInfo[simdLen];
+
+  //! Number of SIMD elements in this batch
+  int numSimdElems;
+};
+
+}  // nalu_ngp
+}  // nalu
+}  // sierra
+
+
+
+#endif /* NGPSCRATCHDATA_H */

--- a/include/ngp_utils/NgpTypes.h
+++ b/include/ngp_utils/NgpTypes.h
@@ -1,0 +1,103 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef NGPTYPES_H
+#define NGPTYPES_H
+
+/** \file
+ *  \brief Nalu-Wind custom types for NGP execution
+ */
+
+#include "ngp_utils/NgpMeshInfo.h"
+#include "SimdInterface.h"
+
+#include <memory>
+
+namespace sierra {
+namespace nalu {
+
+template<typename T1, typename T2, typename T3>
+class ScratchViews;
+
+namespace nalu_ngp {
+
+/** Lightweight data structure holding information of the entity in mesh loops
+ *
+ *  The bucket loop wrappers provide this object to the lambda function for use
+ *  during iterations.
+ *
+ *  Depending on the bucket-loop, entity could be one of elem, edge, or face.
+ */
+template<typename Mesh = ngp::Mesh>
+struct EntityInfo
+{
+  //! Bucket information
+  typename Mesh::MeshIndex meshIdx;
+
+  //! The entity being handled
+  stk::mesh::Entity entity;
+
+  //! Nodes comprising the entity
+  typename Mesh::ConnectedNodes entityNodes;
+};
+
+/** Lightweight data structure for face/elem pair information in mesh loops
+ *
+ *  The bucket loop wrappers provide this object to the lambda function. The
+ *  connected nodes are always for the parent element that owns the boundary
+ *  face.
+ */
+template<typename Mesh = ngp::Mesh>
+struct BcFaceElemInfo
+{
+  typename Mesh::MeshIndex meshIdx;
+
+  //! The face being handled
+  stk::mesh::Entity face;
+
+  //! The element connected to the face
+  stk::mesh::Entity elem;
+
+  typename Mesh::ConnectedNodes faceNodes;
+
+  //! Nodes connected to the parent element (elem)
+  typename Mesh::ConnectedNodes elemNodes;
+
+  //! Index of the face within the element
+  int faceOrdinal;
+};
+
+
+/** Traits for dealing with STK NGP meshes
+ */
+template<typename Mesh=ngp::Mesh>
+struct NGPMeshTraits
+{
+  //! SIMD data type used in element data structures
+  using DblType = ::sierra::nalu::DoubleType;
+
+  //! Default scalar type for field data
+  using FieldScalarType = double;
+
+  using TeamPolicy =
+    Kokkos::TeamPolicy<typename Mesh::MeshExecSpace, ngp::ScheduleType>;
+  using TeamHandleType = typename TeamPolicy::member_type;
+  using ShmemType = typename Mesh::MeshExecSpace::scratch_memory_space;
+  using MeshIndex = typename Mesh::MeshIndex;
+
+  using ScratchViewsType = ScratchViews<DblType, TeamHandleType, ShmemType>;
+  using EntityInfo = EntityInfo<Mesh>;
+  using BcFaceElemInfo = BcFaceElemInfo<Mesh>;
+};
+
+
+}  // nalu_ngp
+}  // nalu
+}  // sierra
+
+
+#endif /* NGPTYPES_H */

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -266,8 +266,7 @@ namespace nalu{
 //--------------------------------------------------------------------------
 Realm::~Realm()
 {
-  ngpFieldMgr_.reset();
-  ngpMesh_.reset();
+  meshInfo_.reset();
 
   delete bulkData_;
   delete metaData_;
@@ -1902,8 +1901,7 @@ Realm::pre_timestep_work()
       initialize_overset();
 
     // Reset the ngp::Mesh instance
-    ngpMesh_.reset(new ngp::Mesh(*bulkData_));
-    ngpFieldMgr_.reset(new ngp::FieldManager(*bulkData_));
+    meshInfo_.reset(new typename Realm::NgpMeshInfo(*bulkData_));
 
     // now re-initialize linear system
     equationSystems_.reinitialize_linear_system();
@@ -2099,6 +2097,7 @@ Realm::create_mesh()
     edgesPart_ = &metaData_->declare_part("create_edges_part", stk::topology::EDGE_RANK);
   }
 
+  meshInfo_.reset(new typename Realm::NgpMeshInfo(*bulkData_));
   // set mesh creation
   const double end_time = NaluEnv::self().nalu_time();
   timerCreateMesh_ = (end_time - start_time);

--- a/unit_tests/UnitTestNgpMesh1.C
+++ b/unit_tests/UnitTestNgpMesh1.C
@@ -12,7 +12,7 @@
 
 #include "stk_ngp/Ngp.hpp"
 
-void test_ngp_mesh_1(const stk::mesh::BulkData& bulk, ngp::Mesh& ngpMesh)
+void test_ngp_mesh_1(const stk::mesh::BulkData& bulk, const ngp::Mesh& ngpMesh)
 {
   stk::topology elemTopo = stk::topology::HEX_8;
 

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -642,8 +642,9 @@ void calc_mass_flow_rate_scs(
   sierra::nalu::nalu_ngp::run_elem_algorithm(
     meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdData& edata) {
-      const auto mdotOps = sierra::nalu::nalu_ngp::simd_field_updater(
+      const auto mdotOps = sierra::nalu::nalu_ngp::simd_elem_field_updater(
         ngpMesh, ngpMdot, edata);
+
       NALU_ALIGNED Traits::DblType rhoU[Hex8Traits::nDim_];
 
       auto& scrViews = edata.simdScrView;
@@ -668,7 +669,7 @@ void calc_mass_flow_rate_scs(
           tmdot += rhoU[d] * v_area(ip, d);
 
         // Scatter to all elements in this SIMD group
-        mdotOps.ip_set(ip, tmdot);
+        mdotOps(ip) = tmdot;
       }
     });
 

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -7,6 +7,8 @@
 
 #include "kernels/UnitTestKernelUtils.h"
 #include "UnitTestKokkosUtils.h"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpFieldOps.h"
 
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
@@ -603,70 +605,75 @@ void calc_mass_flow_rate_scs(
   const VectorFieldType& velocity,
   const GenericFieldType& massFlowRate)
 {
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Hex8Traits = sierra::nalu::AlgTraitsHex8;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+
   const auto& meta = bulk.mesh_meta_data();
   const int ndim = meta.spatial_dimension();
+  const int npe = Hex8Traits::nodesPerElement_;
   EXPECT_EQ(ndim, 3);
+  EXPECT_EQ(topo.num_nodes(), npe);
 
-  const ScalarFieldType& densityNp1 = density.field_of_state(stk::mesh::StateNP1);
-  const VectorFieldType& velocityNp1 = velocity.field_of_state(stk::mesh::StateNP1);
-  auto meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
+  // Register necessary data for element gathers
+  sierra::nalu::ElemDataRequests dataReq(meta);
+  auto meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element<Hex8Traits>();
+  dataReq.add_cvfem_surface_me(meSCS);
 
-  std::vector<double> v_shape_fcn(meSCS->num_integration_points() * meSCS->nodesPerElement_);
-  meSCS->shape_fcn(v_shape_fcn.data());
+  dataReq.add_coordinates_field(coordinates, ndim, sierra::nalu::CURRENT_COORDINATES);
+  dataReq.add_gathered_nodal_field(velocity, ndim);
+  dataReq.add_gathered_nodal_field(density, 1);
+  dataReq.add_master_element_call(
+    sierra::nalu::SCS_AREAV, sierra::nalu::CURRENT_COORDINATES);
+  dataReq.add_master_element_call(
+    sierra::nalu::SCS_SHAPE_FCN, sierra::nalu::CURRENT_COORDINATES);
 
-  const int numScsIp = meSCS->num_integration_points();
-  const int nodesPerElem = meSCS->nodesPerElement_;
-  std::vector<double> w_rho(nodesPerElem);
-  std::vector<double> w_vel(ndim * nodesPerElem);
-  std::vector<double> w_coords(ndim * nodesPerElem);
-  std::vector<double> w_scs_areav(numScsIp * ndim);
-
-  const stk::mesh::Selector selector =
+  sierra::nalu::nalu_ngp::MeshInfo<> meshInfo(bulk);
+  const stk::mesh::Selector sel =
     meta.locally_owned_part() | meta.globally_shared_part();
-  const auto& buckets = bulk.get_buckets(stk::topology::ELEM_RANK, selector);
 
-  for (auto b: buckets) {
-    const auto bktlen = b->size();
+  const auto velID = velocity.mesh_meta_data_ordinal();
+  const auto rhoID = density.mesh_meta_data_ordinal();
+  const auto mdotID = massFlowRate.mesh_meta_data_ordinal();
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  auto ngpMdot = fieldMgr.get_field<double>(mdotID);
 
-    for (size_t ie = 0; ie < bktlen; ++ie) {
-      double* mdot = stk::mesh::field_data(massFlowRate, *b, ie);
+  sierra::nalu::nalu_ngp::run_elem_algorithm(
+    meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
+    KOKKOS_LAMBDA(ElemSimdData& edata) {
+      const auto mdotOps = sierra::nalu::nalu_ngp::simd_field_updater(
+        ngpMesh, ngpMdot, edata);
+      NALU_ALIGNED Traits::DblType rhoU[Hex8Traits::nDim_];
 
-      auto* elem_nodes = b->begin_nodes(ie);
-      const auto num_nodes = b->num_nodes(ie);
+      auto& scrViews = edata.simdScrView;
+      auto& v_rho = scrViews.get_scratch_view_1D(rhoID);
+      auto& v_vel = scrViews.get_scratch_view_2D(velID);
+      auto& meViews = scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
+      auto& v_area = meViews.scs_areav;
+      auto& v_shape_fcn = meViews.scs_shape_fcn;
 
-      for (size_t in = 0; in < num_nodes; ++in) {
-        const auto node = elem_nodes[in];
-        w_rho[in] = *stk::mesh::field_data(densityNp1, node);
-        const double* vel = stk::mesh::field_data(velocityNp1, node);
-        const double* coords = stk::mesh::field_data(coordinates, node);
+      for (int ip = 0; ip < Hex8Traits::numScsIp_; ++ip) {
+        for (int d=0; d < Hex8Traits::nDim_; ++d)
+          rhoU[d] = 0.0;
 
-        for (int d=0; d < ndim; ++d) {
-          w_vel[in * ndim + d] = vel[d];
-          w_coords[in * ndim + d] = coords[d];
-        }
-      }
-
-      double scs_error = 0;
-      meSCS->determinant(1, w_coords.data(), w_scs_areav.data(), &scs_error);
-
-      for (int ip = 0; ip < numScsIp; ++ip) {
-        std::vector<double> rhoU(ndim, 0.0);
-
-        const int offset = ip * nodesPerElem;
-        for (int ic=0; ic < nodesPerElem; ++ic) {
-          const double r = v_shape_fcn[offset + ic];
-          for (int d = 0; d < ndim; d++)
-            rhoU[d] += r * w_rho[ic] * w_vel[ic * ndim + d];
+        for (int ic=0; ic < Hex8Traits::nodesPerElement_; ++ic) {
+          const auto r = v_shape_fcn(ip, ic);
+          for (int d=0; d < Hex8Traits::nDim_; ++d)
+            rhoU[d] += r * v_rho(ic) * v_vel(ic, d);
         }
 
-        double tmdot = 0.0;
-        for (int d = 0; d < ndim; d++)
-          tmdot += rhoU[d] * w_scs_areav[ip * ndim + d];
+        Traits::DblType tmdot = 0.0;
+        for (int d=0; d < Hex8Traits::nDim_; ++d)
+          tmdot += rhoU[d] * v_area(ip, d);
 
-        mdot[ip] = tmdot;
+        // Scatter to all elements in this SIMD group
+        mdotOps.ip_set(ip, tmdot);
       }
-    }
-  }
+    });
+
+  ngpMdot.modify_on_device();
+  ngpMdot.sync_to_host();
 }
 
 void calc_open_mass_flow_rate(
@@ -863,98 +870,6 @@ void calc_exposed_area_vec(
 }
 
 #ifndef KOKKOS_ENABLE_CUDA
-
-#if 0
-void calc_mass_flow_rate_scs(
-  stk::mesh::BulkData& bulk,
-  const stk::topology& topo,
-  const VectorFieldType& coordinates,
-  const ScalarFieldType& density,
-  const VectorFieldType& velocity,
-  const GenericFieldType& massFlowRate)
-{
-  const auto& meta = bulk.mesh_meta_data();
-  const int ndim = meta.spatial_dimension();
-  EXPECT_EQ(ndim, 3);
-
-  sierra::nalu::ElemDataRequests dataNeeded(meta);
-
-  const ScalarFieldType& densityNp1 = density.field_of_state(stk::mesh::StateNP1);
-  const VectorFieldType& velocityNp1 = velocity.field_of_state(stk::mesh::StateNP1);
-  auto meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
-
-  dataNeeded.add_cvfem_surface_me(meSCS);
-  dataNeeded.add_coordinates_field(coordinates, ndim, sierra::nalu::CURRENT_COORDINATES);
-  dataNeeded.add_gathered_nodal_field(densityNp1, 1);
-  dataNeeded.add_gathered_nodal_field(velocityNp1, ndim);
-  dataNeeded.add_master_element_call(sierra::nalu::SCS_AREAV,
-                                     sierra::nalu::CURRENT_COORDINATES);
-
-  const stk::mesh::Selector selector =
-    meta.locally_owned_part() | meta.globally_shared_part();
-  const auto& buckets = bulk.get_buckets(stk::topology::ELEM_RANK, selector);
-
-  ngp::Mesh ngpMesh(bulk);
-  ngp::FieldManager fieldMgr(bulk);
-  sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeeded, meta.get_fields().size());
-
-  const int bytes_per_team = 0;
-  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(
-    dataNeededNGP, meta.spatial_dimension()) ;
-
-  auto team_exec = sierra::nalu::get_host_team_policy(
-    buckets.size(), bytes_per_team, bytes_per_thread);
-
-  Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team) {
-      auto& b = *buckets[team.league_rank()];
-      const auto length = b.size();
-
-      EXPECT_EQ(b.topology(), topo);
-
-      sierra::nalu::ScratchViews<double> preReqData(
-        team, ndim, topo.num_nodes(), dataNeededNGP);
-
-      Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, length), [&](const size_t& k) {
-          stk::mesh::Entity element = b[k];
-          sierra::nalu::fill_pre_req_data(
-            dataNeededNGP, ngpMesh, stk::topology::ELEMENT_RANK, element,
-            preReqData);
-          sierra::nalu::fill_master_element_views(dataNeededNGP, preReqData);
-
-          std::vector<double> rhoU(ndim);
-          std::vector<double> v_shape_function(
-            meSCS->num_integration_points() * meSCS->nodesPerElement_);
-          meSCS->shape_fcn(v_shape_function.data());
-          double *mdot = stk::mesh::field_data(massFlowRate, element);
-          auto& v_densityNp1 = preReqData.get_scratch_view_1D(densityNp1);
-          auto& v_velocityNp1 = preReqData.get_scratch_view_2D(velocityNp1);
-          auto& v_scs_areav = preReqData.get_me_views(
-            sierra::nalu::CURRENT_COORDINATES).scs_areav;
-
-          for (int ip=0; ip < meSCS->num_integration_points(); ++ip) {
-            for (int j=0; j < ndim; ++j) {
-              rhoU[j] = 0.0;
-            }
-            const int offset = ip * meSCS->nodesPerElement_;
-
-            for (int ic=0; ic < meSCS->nodesPerElement_; ++ic) {
-              const double r = v_shape_function[offset+ic];
-              for (int j=0; j < ndim; ++j) {
-                rhoU[j] += r * v_densityNp1(ic) * v_velocityNp1(ic, j);
-              }
-            }
-
-            double tmdot = 0.0;
-            for (int j=0; j < ndim; j++) {
-              tmdot += rhoU[j] * v_scs_areav(ip, j);
-            }
-            mdot[ip] = tmdot;
-          }
-        });
-    });
-}
-#endif
 
 void calc_projected_nodal_gradient_interior(
   stk::mesh::BulkData& bulk,

--- a/unit_tests/ngp_kernels/CMakeLists.txt
+++ b/unit_tests/ngp_kernels/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_sources(GlobalUnitSourceList
   UnitTestNgpKernel.C
+  UnitTestNgpLoops.C
   )

--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -1,0 +1,422 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "gtest/gtest.h"
+#include "UnitTestUtils.h"
+
+#include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpFieldOps.h"
+
+#include <cmath>
+
+class NgpLoopTest : public ::testing::Test
+{
+public:
+  NgpLoopTest()
+    : meta(3),
+      bulk(meta, MPI_COMM_WORLD),
+      partVec(),
+      density(&meta.declare_field<ScalarFieldType>(
+                 stk::topology::NODE_RANK, "density")),
+      pressure(&meta.declare_field<ScalarFieldType>(
+                 stk::topology::NODE_RANK, "pressure")),
+      velocity(&meta.declare_field<VectorFieldType>(
+                 stk::topology::NODE_RANK, "velocity")),
+      mdotEdge(&meta.declare_field<ScalarFieldType>(
+                 stk::topology::EDGE_RANK, "mass_flow_rate")),
+      massFlowRate(&meta.declare_field<GenericFieldType>(
+                     stk::topology::ELEM_RANK, "mass_flow_rate_scs"))
+  {
+    const double ten = 10.0;
+    const double zero = 0.0;
+    const double oneVec[3] = {1.0, 1.0, 1.0};
+    sierra::nalu::HexSCS hex8SCS;
+    stk::mesh::put_field_on_mesh(*density, meta.universal_part(), 1, &ten);
+    stk::mesh::put_field_on_mesh(*pressure, meta.universal_part(), 1, &zero);
+    stk::mesh::put_field_on_mesh(*velocity, meta.universal_part(), 3, oneVec);
+    stk::mesh::put_field_on_mesh(
+      *massFlowRate, meta.universal_part(), hex8SCS.num_integration_points(),
+      &zero);
+    stk::mesh::put_field_on_mesh(*mdotEdge, meta.universal_part(), 1, &zero);
+  }
+
+  ~NgpLoopTest() = default;
+
+  void fill_mesh_and_init_fields(const std::string& meshSpec = "generated:2x2x2")
+  {
+    unit_test_utils::fill_hex8_mesh(meshSpec, bulk);
+    partVec = { meta.get_part("block_1")};
+
+    coordField = static_cast<const VectorFieldType*>(meta.coordinate_field());
+    EXPECT_TRUE(coordField != nullptr);
+  }
+
+  stk::mesh::MetaData meta;
+  stk::mesh::BulkData bulk;
+  stk::mesh::PartVector partVec;
+  const VectorFieldType* coordField{nullptr};
+  ScalarFieldType* density{nullptr};
+  ScalarFieldType* pressure{nullptr};
+  VectorFieldType* velocity{nullptr};
+  ScalarFieldType* mdotEdge{nullptr};
+  GenericFieldType* massFlowRate{nullptr};
+};
+
+void basic_node_loop(
+  const stk::mesh::BulkData& bulk,
+  ScalarFieldType& pressure)
+{
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  const double presSet = 4.0;
+
+  const auto& meta = bulk.mesh_meta_data();
+  stk::mesh::Selector sel = meta.universal_part();
+  ngp::Mesh ngpMesh(bulk);
+  ngp::Field<double> ngpPressure(bulk, pressure);
+
+  sierra::nalu::nalu_ngp::run_entity_algorithm(
+    ngpMesh, stk::topology::NODE_RANK, sel,
+    KOKKOS_LAMBDA(const typename Traits::MeshIndex& meshIdx) {
+      ngpPressure.get(meshIdx, 0) = presSet;
+    });
+
+  ngpPressure.modify_on_device();
+  ngpPressure.sync_to_host();
+
+  // Do checks
+  {
+    const auto& bkts = bulk.get_buckets(stk::topology::NODE_RANK, sel);
+    const double tol = 1.0e-16;
+    for (const auto* b: bkts) {
+      for (const auto node: *b) {
+        const double* pres = stk::mesh::field_data(pressure, node);
+        EXPECT_NEAR(presSet, pres[0], tol);
+      }
+    }
+  }
+}
+
+void basic_elem_loop(
+  const stk::mesh::BulkData& bulk,
+  ScalarFieldType& pressure,
+  GenericFieldType& massFlowRate)
+{
+  const double flowRate = 4.0;
+  const double presSet = 10.0;
+
+  ngp::Mesh ngpMesh(bulk);
+  ngp::Field<double> ngpMassFlowRate(bulk, massFlowRate);
+  ngp::Field<double> ngpPressure(bulk, pressure);
+
+  const auto& meta = bulk.mesh_meta_data();
+  stk::mesh::Selector sel = meta.universal_part();
+
+  sierra::nalu::nalu_ngp::run_elem_algorithm(
+    ngpMesh, stk::topology::ELEMENT_RANK, sel,
+    KOKKOS_LAMBDA(const sierra::nalu::nalu_ngp::EntityInfo<ngp::Mesh>& einfo) {
+      ngpMassFlowRate.get(einfo.meshIdx, 0) = flowRate;
+
+      const auto& nodes = einfo.entityNodes;
+      const int numNodes = nodes.size();
+      for (int i=0; i < numNodes; ++i)
+        ngpPressure.get(ngpMesh, nodes[i], 0) = presSet;
+    });
+
+  ngpMassFlowRate.modify_on_device();
+  ngpMassFlowRate.sync_to_host();
+  ngpPressure.modify_on_device();
+  ngpPressure.sync_to_host();
+
+
+  {
+    const auto& elemBuckets = bulk.get_buckets(stk::topology::ELEM_RANK,  sel);
+    const double tol = 1.0e-16;
+    for (const stk::mesh::Bucket* b : elemBuckets)
+    {
+      for (stk::mesh::Entity elem : *b)
+      {
+        const double* flowRateData = stk::mesh::field_data(massFlowRate, elem);
+        EXPECT_NEAR(flowRate, *flowRateData, tol);
+
+        const stk::mesh::Entity* nodes = bulk.begin_nodes(elem);
+        const unsigned numNodes = bulk.num_nodes(elem);
+        for (unsigned n = 0; n < numNodes; ++n)
+        {
+          const double* pres = stk::mesh::field_data(pressure, nodes[n]);
+          EXPECT_NEAR(presSet, pres[0], tol);
+        }
+      }
+    }
+  }
+}
+
+void basic_edge_loop(
+  const stk::mesh::BulkData& bulk,
+  ScalarFieldType& pressure,
+  ScalarFieldType& mdotEdge)
+{
+  const double flowRate = 4.0;
+  const double presSet = 10.0;
+
+  ngp::Mesh ngpMesh(bulk);
+  ngp::Field<double> ngpMassFlowRate(bulk, mdotEdge);
+  ngp::Field<double> ngpPressure(bulk, pressure);
+
+  const auto& meta = bulk.mesh_meta_data();
+  stk::mesh::Selector sel = meta.universal_part();
+
+  sierra::nalu::nalu_ngp::run_edge_algorithm(
+    ngpMesh, sel,
+    KOKKOS_LAMBDA(const sierra::nalu::nalu_ngp::EntityInfo<ngp::Mesh>& einfo) {
+      ngpMassFlowRate.get(einfo.meshIdx, 0) = flowRate;
+
+      const auto& nodes = einfo.entityNodes;
+      const int numNodes = nodes.size();
+      for (int i=0; i < numNodes; ++i)
+        ngpPressure.get(ngpMesh, nodes[i], 0) = presSet;
+    });
+
+  {
+    const auto& edgeBuckets = bulk.get_buckets(stk::topology::EDGE_RANK,  sel);
+    const double tol = 1.0e-16;
+    for (const stk::mesh::Bucket* b : edgeBuckets)
+    {
+      for (stk::mesh::Entity edge : *b)
+      {
+        const double* flowRateData = stk::mesh::field_data(mdotEdge, edge);
+        EXPECT_NEAR(flowRate, *flowRateData, tol);
+
+        const stk::mesh::Entity* nodes = bulk.begin_nodes(edge);
+        const unsigned numNodes = bulk.num_nodes(edge);
+        for (unsigned n = 0; n < numNodes; ++n)
+        {
+          const double* pres = stk::mesh::field_data(pressure, nodes[n]);
+          EXPECT_NEAR(presSet, pres[0], tol);
+        }
+      }
+    }
+  }
+}
+
+void elem_loop_scratch_views(
+  const stk::mesh::BulkData& bulk,
+  ScalarFieldType& pressure,
+  VectorFieldType& velocity)
+{
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Hex8Traits = sierra::nalu::AlgTraitsHex8;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  typedef Kokkos::DualView<double*, Kokkos::LayoutRight, sierra::nalu::DeviceSpace> DoubleTypeView;
+
+  const auto& meta = bulk.mesh_meta_data();
+  sierra::nalu::ElemDataRequests dataReq(meta);
+  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<
+    sierra::nalu::AlgTraitsHex8>();
+  dataReq.add_cvfem_volume_me(meSCV);
+
+  auto* coordsField = bulk.mesh_meta_data().coordinate_field();
+  dataReq.add_coordinates_field(*coordsField, 3, sierra::nalu::CURRENT_COORDINATES);
+  dataReq.add_gathered_nodal_field(velocity, 3);
+  dataReq.add_gathered_nodal_field(pressure, 1);
+  dataReq.add_master_element_call(
+    sierra::nalu::SCV_VOLUME, sierra::nalu::CURRENT_COORDINATES);
+  dataReq.add_master_element_call(
+    sierra::nalu::SCV_SHIFTED_SHAPE_FCN, sierra::nalu::CURRENT_COORDINATES);
+
+  sierra::nalu::nalu_ngp::MeshInfo<> meshInfo(bulk);
+  stk::mesh::Selector sel = meta.universal_part();
+
+  const unsigned velID = velocity.mesh_meta_data_ordinal();
+  const unsigned presID = pressure.mesh_meta_data_ordinal();
+
+  // Field updates
+  Traits::DblType xVel = 1.0;
+  Traits::DblType yVel = 2.0;
+  Traits::DblType zVel = 3.0;
+
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  auto ngpVel = fieldMgr.get_field<double>(velID);
+
+  const int numNodes = 8;
+  DoubleTypeView volCheck("scv_volume", numNodes);
+  Kokkos::deep_copy(volCheck.h_view, 0.0);
+  volCheck.template modify<typename DoubleTypeView::host_mirror_space>();
+  volCheck.template sync<typename DoubleTypeView::execution_space>();
+
+  sierra::nalu::nalu_ngp::run_elem_algorithm(
+    meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
+    KOKKOS_LAMBDA(ElemSimdData& edata) {
+      const auto ngpVelOp = sierra::nalu::nalu_ngp::simd_field_updater(ngpMesh, ngpVel, edata);
+
+      Traits::DblType test = 0.0;
+      auto& scrViews = edata.simdScrView;
+      auto& v_pres = scrViews.get_scratch_view_1D(presID);
+      auto& v_vel = scrViews.get_scratch_view_2D(velID);
+      auto& scv_vol =
+        scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES).scv_volume;
+
+      test += v_vel(0, 0) + v_pres(0) * scv_vol(0);
+
+      for (int i=0; i < numNodes; ++i) {
+        volCheck.d_view(i) = stk::simd::get_data(scv_vol(i), 0);
+
+        ngpVelOp.set(i, 0, xVel);
+        ngpVelOp.set(i, 1, yVel);
+        ngpVelOp.set(i, 2, zVel);
+      }
+    });
+
+  ngpVel.modify_on_device();
+  ngpVel.sync_to_host();
+
+  volCheck.modify<DoubleTypeView::execution_space>();
+  volCheck.sync<DoubleTypeView::host_mirror_space>();
+
+  for (int i=0; i < numNodes; ++i)
+    EXPECT_NEAR(volCheck.h_view(i), 0.125, 1.0e-12);
+
+  {
+    const double xVel = 1.0;
+    const double yVel = 2.0;
+    const double zVel = 3.0;
+    const auto& elemBuckets = bulk.get_buckets(stk::topology::ELEM_RANK,  sel);
+    const double tol = 1.0e-16;
+    for (const stk::mesh::Bucket* b : elemBuckets)
+    {
+      for (stk::mesh::Entity elem : *b) {
+        const stk::mesh::Entity* nodes = bulk.begin_nodes(elem);
+        for (int i=0; i < Hex8Traits::nodesPerElement_; ++i) {
+          const double* velptr = stk::mesh::field_data(velocity, nodes[i]);
+          EXPECT_NEAR(velptr[0], xVel, tol);
+          EXPECT_NEAR(velptr[1], yVel, tol);
+          EXPECT_NEAR(velptr[2], zVel, tol);
+        }
+      }
+    }
+  }
+}
+void calc_mdot_elem_loop(
+  const stk::mesh::BulkData& bulk,
+  ScalarFieldType& density,
+  VectorFieldType& velocity,
+  GenericFieldType& massFlowRate)
+{
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Hex8Traits = sierra::nalu::AlgTraitsHex8;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+
+  const auto& meta = bulk.mesh_meta_data();
+  sierra::nalu::ElemDataRequests dataReq(meta);
+  auto meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element<Hex8Traits>();
+  dataReq.add_cvfem_surface_me(meSCS);
+
+  auto* coordsField = bulk.mesh_meta_data().coordinate_field();
+  dataReq.add_coordinates_field(*coordsField, 3, sierra::nalu::CURRENT_COORDINATES);
+  dataReq.add_gathered_nodal_field(velocity, 3);
+  dataReq.add_gathered_nodal_field(density, 1);
+  dataReq.add_master_element_call(
+    sierra::nalu::SCS_AREAV, sierra::nalu::CURRENT_COORDINATES);
+  dataReq.add_master_element_call(
+    sierra::nalu::SCS_SHIFTED_SHAPE_FCN, sierra::nalu::CURRENT_COORDINATES);
+
+  sierra::nalu::nalu_ngp::MeshInfo<> meshInfo(bulk);
+  stk::mesh::Selector sel = meta.universal_part();
+
+  const unsigned velID = velocity.mesh_meta_data_ordinal();
+  const unsigned rhoID = density.mesh_meta_data_ordinal();
+  const auto mdotID = massFlowRate.mesh_meta_data_ordinal();
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  ngp::Field<double> ngpMdot = fieldMgr.get_field<double>(mdotID);
+
+  sierra::nalu::nalu_ngp::run_elem_algorithm(
+    meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
+    KOKKOS_LAMBDA(ElemSimdData& edata) {
+      // SIMD Element field operation handler
+      const auto mdotOps = sierra::nalu::nalu_ngp::simd_field_updater(
+        ngpMesh, ngpMdot, edata);
+
+      NALU_ALIGNED Traits::DblType rhoU[Hex8Traits::nDim_];
+      auto& scrViews = edata.simdScrView;
+      auto& v_rho = scrViews.get_scratch_view_1D(rhoID);
+      auto& v_vel = scrViews.get_scratch_view_2D(velID);
+      auto& meViews = scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
+      auto& v_area = meViews.scs_areav;
+      auto& v_shape_fcn = meViews.scs_shifted_shape_fcn;
+
+      for (int ip = 0; ip < Hex8Traits::numScsIp_; ++ip) {
+        for (int d=0; d < Hex8Traits::nDim_; ++d)
+          rhoU[d] = 0.0;
+
+        for (int ic=0; ic < Hex8Traits::nodesPerElement_; ++ic) {
+          const auto r = v_shape_fcn(ip, ic);
+          for (int d=0; d < Hex8Traits::nDim_; ++d)
+            rhoU[d] += r * v_rho(ic) * v_vel(ic, d);
+        }
+
+        Traits::DblType tmdot = 0.0;
+        for (int d=0; d < Hex8Traits::nDim_; ++d)
+          tmdot += rhoU[d] * v_area(ip, d);
+
+        mdotOps.ip_set(ip, tmdot);
+      }
+    });
+
+  ngpMdot.modify_on_device();
+  ngpMdot.sync_to_host();
+
+  {
+    const double flowRate = 2.5;
+    const auto& elemBuckets = bulk.get_buckets(stk::topology::ELEM_RANK,  sel);
+    const double tol = 1.0e-16;
+    for (const stk::mesh::Bucket* b : elemBuckets)
+    {
+      for (stk::mesh::Entity elem : *b)
+      {
+        const double* flowRateData = stk::mesh::field_data(massFlowRate, elem);
+        for (int i=0; i < Hex8Traits::numScsIp_; ++i)
+          EXPECT_NEAR(flowRate, std::abs(flowRateData[i]), tol);
+      }
+    }
+  }
+}
+
+TEST_F(NgpLoopTest, NGP_basic_node_loop)
+{
+  fill_mesh_and_init_fields("generated:2x2x2");
+
+  basic_node_loop(bulk, *pressure);
+}
+
+TEST_F(NgpLoopTest, NGP_basic_elem_loop)
+{
+  fill_mesh_and_init_fields("generated:2x2x2");
+
+  basic_elem_loop(bulk, *pressure, *massFlowRate);
+}
+
+TEST_F(NgpLoopTest, NGP_basic_edge_loop)
+{
+  fill_mesh_and_init_fields("generated:2x2x2");
+
+  basic_edge_loop(bulk, *pressure, *mdotEdge);
+}
+
+TEST_F(NgpLoopTest, NGP_elem_loop_scratch_views)
+{
+  fill_mesh_and_init_fields("generated:2x2x2");
+
+  elem_loop_scratch_views(bulk, *pressure, *velocity);
+}
+
+TEST_F(NgpLoopTest, NGP_calc_mdot_elem_loop)
+{
+  fill_mesh_and_init_fields("generated:2x2x2");
+
+  calc_mdot_elem_loop(bulk, *density, *velocity, *massFlowRate);
+}


### PR DESCRIPTION
Introduce wrapper functions that accept a C++ lambda or functor to abstract out
the looping process over buckets, and the handling of ScratchViews for element,
face/element based looping constructs. These constructs will be used to replace
current algorithms that deal with field modification so that they can occur on
device instead of host.

- NgpTypes: Introduce data structures to ease handling NGP data. In preparation
for replacing logic within the code that currently use MetaData/Bulkdata with
ngp::Mesh and ngp::Field<T>, start introducing some convenience types. Replace
handling of ngp data in Realm with the one using wrapper.

- Introduce convenience wrappers to update NGP field data with 
`stk::simd::Double` right hand sides.

- Check looping strategy and field modification using mass flow rate computation in unit tests.

- Convert massFlowRate calculator in unit tests to use NGP loops