### PR TITLE
Fix Ksgs unit test to handle dual nodal volume with 2 states

### DIFF
--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -646,7 +646,7 @@ public:
       maxLengthScale_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "sst_max_length_scale")),
       fOneBlend_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "sst_f_one_blending")),
       evisc_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "effective_viscosity")),
-      dualNodalVolume_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "dual_nodal_volume")),
+      dualNodalVolume_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "dual_nodal_volume", 2)),
       dkdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dkdx")),
       dwdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dwdx")),
       dhdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dhdx")),


### PR DESCRIPTION
I should have caught this before my other pull requests. Making this a pull request to be sure this is all I need to do to fix it. I ran all the unit tests now and they pass.