### PR TITLE
WIP: Explore switching CudaUVMSpace to CudaSpace in KokkosInterface

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -32,12 +32,18 @@ namespace sierra {
 namespace nalu {
 
 #ifdef KOKKOS_ENABLE_CUDA
-   typedef Kokkos::CudaUVMSpace::memory_space    MemSpace;
+typedef Kokkos::CudaSpace    MemSpace;
+typedef Kokkos::CudaUVMSpace UVMSpace;
 #elif defined(KOKKOS_HAVE_OPENMP)
-   typedef Kokkos::OpenMP       MemSpace;
+typedef Kokkos::OpenMP       MemSpace;
+typedef Kokkos::OpenMP       UVMSpace;
 #else
-   typedef Kokkos::HostSpace    MemSpace;
+typedef Kokkos::HostSpace    MemSpace;
+typedef Kokkos::HostSpace    UVMSpace;
 #endif
+
+// Tpetra requires UVM on Cuda
+using LinSysMemSpace = UVMSpace;
 
 using HostSpace = Kokkos::DefaultHostExecutionSpace;
 using DeviceSpace = Kokkos::DefaultExecutionSpace;
@@ -129,12 +135,14 @@ void kokkos_parallel_reduce(SizeType n, Function loop_body, ReduceType& reduce, 
     Kokkos::parallel_reduce(debuggingName, Kokkos::RangePolicy<Kokkos::Serial>(0, n), loop_body, reduce);
 }
 
-template<typename T>
+template<typename T, typename MemorySpace=MemSpace>
 inline T* kokkos_malloc_on_device(const std::string& debuggingName) {
-  return static_cast<T*>(Kokkos::kokkos_malloc(debuggingName, sizeof(T)));
+  return static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(debuggingName, sizeof(T)));
 }
-inline void kokkos_free_on_device(void * ptr) { Kokkos::kokkos_free(ptr); }
-}
+
+template<typename MemorySpace=MemSpace>
+inline void kokkos_free_on_device(void* ptr)
+{ Kokkos::kokkos_free<MemorySpace>(ptr); }
 
 template<typename T>
 KOKKOS_FUNCTION
@@ -145,7 +153,7 @@ void set_zero(T* values, unsigned length)
     }
 }
 
-}
-
+} // nalu
+} // sierra
 
 #endif /* INCLUDE_KOKKOSINTERFACE_H_ */

--- a/include/LinearSolver.h
+++ b/include/LinearSolver.h
@@ -78,7 +78,7 @@ public:
     rowPointersData = rowPointers.data();
 
     size_t nnz = compute_row_pointers(rowPointers, rowLengths);
-    colIndices = Kokkos::View<LocalOrdinal*,MemSpace>(Kokkos::ViewAllocateWithoutInitializing("colIndices"), nnz);
+    colIndices = Kokkos::View<LocalOrdinal*,LinSysMemSpace>(Kokkos::ViewAllocateWithoutInitializing("colIndices"), nnz);
     Kokkos::deep_copy(colIndices, INVALID);
   }
 

--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -87,6 +87,8 @@ typedef Belos::LinearProblem<Scalar, MultiVector, Operator>                Linea
 typedef Belos::SolverManager<Scalar, MultiVector, Operator>                SolverManager;
 typedef Belos::TpetraSolverFactory<Scalar, MultiVector, Operator>          SolverFactory;
 typedef Ifpack2::Preconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node> Preconditioner;
+
+using EntityToLIDView = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,LinSysMemSpace>;
 };
 
 

--- a/include/NGPInstance.h
+++ b/include/NGPInstance.h
@@ -67,7 +67,7 @@ inline void destroy(T* obj)
   Kokkos::parallel_for(debuggingName, 1, KOKKOS_LAMBDA(const int) {
       obj->~T();
     });
-  Kokkos::kokkos_free(obj);
+  kokkos_free_on_device(obj);
 }
 
 /** Wrapper object to hold device pointers within a Kokkos::View

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -154,8 +154,8 @@ public:
                              LinSys::LocalMatrix sharedNotOwnedLclMatrix,
                              LinSys::LocalVector ownedLclRhs,
                              LinSys::LocalVector sharedNotOwnedLclRhs,
-                             Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityLIDs,
-                             Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityColLIDs,
+                             LinSys::EntityToLIDView entityLIDs,
+                             LinSys::EntityToLIDView entityColLIDs,
                              int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof)
     : ownedLocalMatrix_(ownedLclMatrix),
       sharedNotOwnedLocalMatrix_(sharedNotOwnedLclMatrix),
@@ -186,8 +186,8 @@ public:
   private:
     LinSys::LocalMatrix ownedLocalMatrix_, sharedNotOwnedLocalMatrix_;
     LinSys::LocalVector ownedLocalRhs_, sharedNotOwnedLocalRhs_;
-    Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToLID_;
-    Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToColLID_;
+    LinSys::EntityToLIDView entityToLID_;
+    LinSys::EntityToLIDView entityToColLID_;
     int maxOwnedRowId_, maxSharedNotOwnedRowId_;
     unsigned numDof_;
     TpetraLinSysCoeffApplier* devicePointer_;
@@ -271,8 +271,8 @@ private:
   Teuchos::RCP<LinSys::Export>      exporter_;
 
   MyLIDMapType myLIDs_;
-  Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToColLID_;
-  Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToLID_;
+  LinSys::EntityToLIDView entityToColLID_;
+  LinSys::EntityToLIDView entityToLID_;
   LocalOrdinal maxOwnedRowId_; // = num_owned_nodes * numDof_
   LocalOrdinal maxSharedNotOwnedRowId_; // = (num_owned_nodes + num_sharedNotOwned_nodes) * numDof_
 

--- a/include/TpetraSegregatedLinearSystem.h
+++ b/include/TpetraSegregatedLinearSystem.h
@@ -153,8 +153,8 @@ public:
                              LinSys::LocalMatrix sharedNotOwnedLclMatrix,
                              LinSys::LocalVector ownedLclRhs,
                              LinSys::LocalVector sharedNotOwnedLclRhs,
-                             Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityLIDs,
-                             Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityColLIDs,
+                             LinSys::EntityToLIDView entityLIDs,
+                             LinSys::EntityToLIDView entityColLIDs,
                              int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof)
     : ownedLocalMatrix_(ownedLclMatrix),
       sharedNotOwnedLocalMatrix_(sharedNotOwnedLclMatrix),
@@ -185,8 +185,8 @@ public:
   private:
     LinSys::LocalMatrix ownedLocalMatrix_, sharedNotOwnedLocalMatrix_;
     LinSys::LocalVector ownedLocalRhs_, sharedNotOwnedLocalRhs_;
-    Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToLID_;
-    Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToColLID_;
+    LinSys::EntityToLIDView entityToLID_;
+    LinSys::EntityToLIDView entityToColLID_;
     int maxOwnedRowId_, maxSharedNotOwnedRowId_;
     unsigned numDof_;
     TpetraLinSysCoeffApplier* devicePointer_;
@@ -270,8 +270,8 @@ private:
   Teuchos::RCP<LinSys::Export>      exporter_;
 
   MyLIDMapType myLIDs_;
-  Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToColLID_;
-  Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToLID_;
+  LinSys::EntityToLIDView entityToColLID_;
+  LinSys::EntityToLIDView entityToLID_;
   LocalOrdinal maxOwnedRowId_; // = num_owned_nodes * numDof_
   LocalOrdinal maxSharedNotOwnedRowId_; // = (num_owned_nodes + num_sharedNotOwned_nodes) * numDof_
 

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -775,7 +775,7 @@ void TpetraLinearSystem::fill_entity_to_row_LID_mapping()
 {
   const stk::mesh::BulkData& bulk = realm_.bulk_data();
   stk::mesh::Selector selector = bulk.mesh_meta_data().universal_part() & !(realm_.get_inactive_selector());
-  entityToLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
+  entityToLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
   const stk::mesh::BucketVector& nodeBuckets = realm_.get_buckets(stk::topology::NODE_RANK, selector);
   for(const stk::mesh::Bucket* bptr : nodeBuckets) {
     const stk::mesh::Bucket& b = *bptr;
@@ -800,7 +800,7 @@ void TpetraLinearSystem::fill_entity_to_row_LID_mapping()
 void TpetraLinearSystem::fill_entity_to_col_LID_mapping()
 {
     const stk::mesh::BulkData& bulk = realm_.bulk_data();
-    entityToColLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
+    entityToColLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
     const stk::mesh::BucketVector& nodeBuckets = bulk.buckets(stk::topology::NODE_RANK);
     for(const stk::mesh::Bucket* bptr : nodeBuckets) {
         const stk::mesh::Bucket& b = *bptr;

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -770,7 +770,7 @@ void TpetraSegregatedLinearSystem::fill_entity_to_row_LID_mapping()
 {
   const stk::mesh::BulkData& bulk = realm_.bulk_data();
   stk::mesh::Selector selector = bulk.mesh_meta_data().universal_part() & !(realm_.get_inactive_selector());
-  entityToLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
+  entityToLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
   const stk::mesh::BucketVector& nodeBuckets = realm_.get_buckets(stk::topology::NODE_RANK, selector);
   for(const stk::mesh::Bucket* bptr : nodeBuckets) {
     const stk::mesh::Bucket& b = *bptr;
@@ -795,7 +795,7 @@ void TpetraSegregatedLinearSystem::fill_entity_to_row_LID_mapping()
 void TpetraSegregatedLinearSystem::fill_entity_to_col_LID_mapping()
 {
     const stk::mesh::BulkData& bulk = realm_.bulk_data();
-    entityToColLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
+    entityToColLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
     const stk::mesh::BucketVector& nodeBuckets = bulk.buckets(stk::topology::NODE_RANK);
     for(const stk::mesh::Bucket* bptr : nodeBuckets) {
         const stk::mesh::Bucket& b = *bptr;


### PR DESCRIPTION
I noticed that we were using `CudaUVMSpace` as our default `MemSpace` 

https://github.com/Exawind/nalu-wind/blob/2e2163b2de50a67279051fb8ab6ed2da4e759024/include/KokkosInterface.h#L34-L40

So today I did some code changes to switch that to `CudaSpace` while keeping the memory space for Tpetra still the UVM space (the code in this pull request). With this change, I get the following error 

```console
terminate called after throwing an instance of 'std::runtime_error'
  what():  cudaDeviceSynchronize() error( cudaErrorIllegalAddress): an illegal memory access was encountered ../packages/kokkos/core/src/Cuda/Kokkos_Cuda_Impl.cpp:119
Traceback functionality not available
```

on line 153 https://github.com/Exawind/nalu-wind/blob/2e2163b2de50a67279051fb8ab6ed2da4e759024/include/ElemDataRequestsGPU.h#L145-L156

If I comment out line 153, the unit test runs fine. I am scratching my head as to why the `coordsFields_` is an odd case while the other `Kokkos::View` objects seem to copy over fine. This view is an array with just one element, if that matters. 
