### PR TITLE
Fix calls to device instances of MasterElements from within host code

### DIFF
--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -16,6 +16,7 @@
 #include <SimdInterface.h>
 #include <SharedMemData.h>
 #include <CopyAndInterleave.h>
+#include <ngp_utils/NgpMEUtils.h>
 
 namespace stk {
 namespace mesh {
@@ -45,17 +46,13 @@ public:
       int nDim = bulk.mesh_meta_data().spatial_dimension();
       int totalNumFields = bulk.mesh_meta_data().get_fields().size();
 
-      sierra::nalu::MasterElement* meFC = faceDataNeeded_.get_cvfem_face_me();
-      sierra::nalu::MasterElement* meSCS = faceDataNeeded_.get_cvfem_surface_me();
-      sierra::nalu::MasterElement* meSCV = faceDataNeeded_.get_cvfem_volume_me();
-
       sierra::nalu::ScratchMeInfo meElemInfo;
       meElemInfo.nodalGatherSize_ = nodesPerElem_;
       meElemInfo.nodesPerFace_ = nodesPerFace_;
       meElemInfo.nodesPerElement_ = nodesPerElem_;
-      meElemInfo.numFaceIp_ = meFC != nullptr ? meFC->num_integration_points() : 0;
-      meElemInfo.numScsIp_ = meSCS != nullptr ? meSCS->num_integration_points() : 0;
-      meElemInfo.numScvIp_ = meSCV != nullptr ? meSCV->num_integration_points() : 0;
+      meElemInfo.numFaceIp_ = num_integration_points(faceDataNeeded_, METype::FACE);
+      meElemInfo.numScsIp_  = num_integration_points(elemDataNeeded_, METype::SCS);
+      meElemInfo.numScvIp_  = num_integration_points(elemDataNeeded_, METype::SCV);
       int rhsSize = meElemInfo.nodalGatherSize_*numDof_, lhsSize = rhsSize*rhsSize, scratchIdsSize = rhsSize;
 
       const ngp::Mesh& ngpMesh = realm_.ngp_mesh();

--- a/include/ElemDataRequestsGPU.h
+++ b/include/ElemDataRequestsGPU.h
@@ -76,29 +76,7 @@ public:
 
   ElemDataRequestsGPU(
     const ngp::FieldManager& fieldMgr,
-    const ElemDataRequests& dataReq, unsigned totalFields)
-    : dataEnums(),
-      hostDataEnums(),
-      coordsFields_(),
-      hostCoordsFields_(),
-      coordsFieldsTypes_(),
-      hostCoordsFieldsTypes_(),
-      totalNumFields(totalFields),
-      fields(),
-      hostFields(),
-      meFC_(dataReq.get_cvfem_face_me()),
-      meSCS_(dataReq.get_cvfem_surface_me()),
-      meSCV_(dataReq.get_cvfem_volume_me()),
-      meFEM_(dataReq.get_fem_volume_me())
-  {
-    fill_host_data_enums(dataReq, CURRENT_COORDINATES);
-    fill_host_data_enums(dataReq, MODEL_COORDINATES);
-
-    fill_host_fields(dataReq, fieldMgr);
-    fill_host_coords_fields(dataReq, fieldMgr);
-
-    copy_to_device();
-  }
+    const ElemDataRequests& dataReq, unsigned totalFields);
 
   ~ElemDataRequestsGPU() {}
 
@@ -142,61 +120,15 @@ public:
   MasterElement *get_fem_volume_me() const {return meFEM_;}
 
 private:
-  void copy_to_device()
-  {
-    if (hostDataEnums[CURRENT_COORDINATES].size() > 0) {
-      Kokkos::deep_copy(dataEnums[CURRENT_COORDINATES], hostDataEnums[CURRENT_COORDINATES]);
-    }
-    if (hostDataEnums[MODEL_COORDINATES].size() > 0) {
-      Kokkos::deep_copy(dataEnums[MODEL_COORDINATES], hostDataEnums[MODEL_COORDINATES]);
-    }
-    Kokkos::deep_copy(coordsFields_, hostCoordsFields_);
-    Kokkos::deep_copy(coordsFieldsTypes_, hostCoordsFieldsTypes_);
-    Kokkos::deep_copy(fields, hostFields);
-  }
+  void copy_to_device();
 
-  void fill_host_data_enums(const ElemDataRequests& dataReq, COORDS_TYPES ctype)
-  {
-    if (dataReq.get_data_enums(ctype).size() > 0) {
-      dataEnums[ctype] = DataEnumView("DataEnumsCurrentCoords", dataReq.get_data_enums(ctype).size());
-      hostDataEnums[ctype] = Kokkos::create_mirror_view(dataEnums[ctype]);
-      unsigned i=0;
-      for(ELEM_DATA_NEEDED d : dataReq.get_data_enums(ctype)) {
-        hostDataEnums[ctype](i++) = d;
-      }
-    }
-  }
+  void fill_host_data_enums(const ElemDataRequests& dataReq, COORDS_TYPES ctype);
 
   void fill_host_fields(
-    const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr)
-  {
-    fields = FieldInfoView("Fields", dataReq.get_fields().size());
-    hostFields = Kokkos::create_mirror_view(fields);
-    unsigned i = 0;
-    for (const FieldInfo& finfo : dataReq.get_fields()) {
-      hostFields(i++) = FieldInfoType(
-        fieldMgr.get_field<double>(finfo.field->mesh_meta_data_ordinal()),
-        finfo.scalarsDim1, finfo.scalarsDim2);
-    }
-  }
+    const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr);
 
   void fill_host_coords_fields(
-    const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr)
-  {
-    coordsFields_ = FieldView("CoordsFields", dataReq.get_coordinates_map().size());
-    coordsFieldsTypes_ = CoordsTypesView("CoordsFieldsTypes", dataReq.get_coordinates_map().size());
-
-    hostCoordsFields_ = Kokkos::create_mirror_view(coordsFields_);
-    hostCoordsFieldsTypes_ = Kokkos::create_mirror_view(coordsFieldsTypes_);
-
-    unsigned i = 0;
-    for (auto iter : dataReq.get_coordinates_map()) {
-      hostCoordsFields_(i) =
-        fieldMgr.get_field<double>(iter.second->mesh_meta_data_ordinal());
-      hostCoordsFieldsTypes_(i) = iter.first;
-      ++i;
-    }
-  }
+    const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr);
 
   DataEnumView dataEnums[MAX_COORDS_TYPES];
   DataEnumView::HostMirror hostDataEnums[MAX_COORDS_TYPES];

--- a/include/ngp_utils/NgpMEUtils.h
+++ b/include/ngp_utils/NgpMEUtils.h
@@ -1,0 +1,114 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef NGPMEUTILS_H
+#define NGPMEUTILS_H
+
+/** \file
+ *  \brief Utility functions to extract ME info from device instances
+ */
+
+#include "master_element/MasterElement.h"
+
+namespace sierra {
+namespace nalu {
+
+/** Types of MasterElements that can be registered with ElemDataRequests
+ */
+enum struct METype
+{
+  SCV = 0,                      //!< CVFEM Volume
+  SCS,                          //!< CVFEM Surface
+  FACE,                         //!< CVFEM Face
+  FEM                           //!< FEM
+};
+
+template<typename DataReqType>
+MasterElement* get_me_instance(const DataReqType& dataReq, const METype meType)
+{
+  MasterElement* me = nullptr;
+
+  switch(meType) {
+  case METype::SCV:
+    me = dataReq.get_cvfem_volume_me();
+    break;
+
+  case METype::SCS:
+    me = dataReq.get_cvfem_surface_me();
+    break;
+
+  case METype::FACE:
+    me = dataReq.get_cvfem_face_me();
+    break;
+
+  case METype::FEM:
+    me = dataReq.get_fem_volume_me();
+    break;
+  }
+
+  return me;
+}
+
+template<typename DataReqType>
+int nodes_per_entity(const DataReqType& dataReq, const METype meType)
+{
+  auto* me = get_me_instance(dataReq, meType);
+
+  // Return immediately if ME is not registered
+  if (me == nullptr) return 0;
+
+  int npe = 0;
+  Kokkos::parallel_reduce(
+    1, KOKKOS_LAMBDA(int, int& n) {
+      n = me->nodesPerElement_;
+    }, npe);
+
+  return npe;
+}
+
+template<typename DataReqType>
+int num_integration_points(const DataReqType& dataReq, const METype meType)
+{
+  auto* me = get_me_instance(dataReq, meType);
+
+  // Return immediately if ME is not registered
+  if (me == nullptr) return 0;
+
+  int nips = 0;
+  Kokkos::parallel_reduce(
+    1, KOKKOS_LAMBDA(int, int& n) {
+      n = me->num_integration_points();
+    }, nips);
+
+  return nips;
+}
+
+template<typename DataReqType>
+int nodes_per_entity(const DataReqType& dataReq)
+{
+  auto* meFC  = dataReq.get_cvfem_face_me();
+  auto* meSCS = dataReq.get_cvfem_surface_me();
+  auto* meSCV = dataReq.get_cvfem_volume_me();
+  auto* meFEM = dataReq.get_fem_volume_me();
+
+  int npe =
+    (meSCS != nullptr)
+      ? nodes_per_entity(dataReq, METype::SCS)
+      : (meSCV != nullptr)
+          ? nodes_per_entity(dataReq, METype::SCV)
+          : (meFEM != nullptr)
+              ? nodes_per_entity(dataReq, METype::FEM)
+              : (meFC != nullptr) ? nodes_per_entity(dataReq, METype::FACE) : 0;
+
+  return npe;
+}
+
+}  // nalu
+}  // sierra
+
+
+#endif /* NGPMEUTILS_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -92,6 +92,7 @@ add_sources(GlobalSourceList
    EffectiveDiffFluxCoeffAlgorithm.C
    EffectiveSSTDiffFluxCoeffAlgorithm.C
    ElemDataRequests.C
+   ElemDataRequestsGPU.C
    EnthalpyABLSrcNodeSuppAlg.C
    EnthalpyEffectiveDiffFluxCoeffAlgorithm.C
    EnthalpyEquationSystem.C

--- a/src/ElemDataRequestsGPU.C
+++ b/src/ElemDataRequestsGPU.C
@@ -1,0 +1,98 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "ElemDataRequestsGPU.h"
+
+namespace sierra {
+namespace nalu {
+
+ElemDataRequestsGPU::ElemDataRequestsGPU(
+  const ngp::FieldManager& fieldMgr,
+  const ElemDataRequests& dataReq, unsigned totalFields)
+  : dataEnums(),
+    hostDataEnums(),
+    coordsFields_(),
+    hostCoordsFields_(),
+    coordsFieldsTypes_(),
+    hostCoordsFieldsTypes_(),
+    totalNumFields(totalFields),
+    fields(),
+    hostFields(),
+    meFC_(dataReq.get_cvfem_face_me()),
+    meSCS_(dataReq.get_cvfem_surface_me()),
+    meSCV_(dataReq.get_cvfem_volume_me()),
+    meFEM_(dataReq.get_fem_volume_me())
+{
+  fill_host_data_enums(dataReq, CURRENT_COORDINATES);
+  fill_host_data_enums(dataReq, MODEL_COORDINATES);
+
+  fill_host_fields(dataReq, fieldMgr);
+  fill_host_coords_fields(dataReq, fieldMgr);
+
+  copy_to_device();
+}
+
+void ElemDataRequestsGPU::copy_to_device()
+{
+  if (hostDataEnums[CURRENT_COORDINATES].size() > 0) {
+    Kokkos::deep_copy(dataEnums[CURRENT_COORDINATES], hostDataEnums[CURRENT_COORDINATES]);
+  }
+  if (hostDataEnums[MODEL_COORDINATES].size() > 0) {
+    Kokkos::deep_copy(dataEnums[MODEL_COORDINATES], hostDataEnums[MODEL_COORDINATES]);
+  }
+  Kokkos::deep_copy(coordsFields_, hostCoordsFields_);
+  Kokkos::deep_copy(coordsFieldsTypes_, hostCoordsFieldsTypes_);
+  Kokkos::deep_copy(fields, hostFields);
+}
+
+void
+ElemDataRequestsGPU::fill_host_data_enums(
+  const ElemDataRequests& dataReq, COORDS_TYPES ctype)
+{
+  if (dataReq.get_data_enums(ctype).size() > 0) {
+    dataEnums[ctype] = DataEnumView("DataEnumsCurrentCoords", dataReq.get_data_enums(ctype).size());
+    hostDataEnums[ctype] = Kokkos::create_mirror_view(dataEnums[ctype]);
+    unsigned i=0;
+    for(ELEM_DATA_NEEDED d : dataReq.get_data_enums(ctype)) {
+      hostDataEnums[ctype](i++) = d;
+    }
+  }
+}
+
+void ElemDataRequestsGPU::fill_host_fields(
+  const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr)
+{
+  fields = FieldInfoView("Fields", dataReq.get_fields().size());
+  hostFields = Kokkos::create_mirror_view(fields);
+  unsigned i = 0;
+  for (const FieldInfo& finfo : dataReq.get_fields()) {
+    hostFields(i++) = FieldInfoType(
+      fieldMgr.get_field<double>(finfo.field->mesh_meta_data_ordinal()),
+      finfo.scalarsDim1, finfo.scalarsDim2);
+  }
+}
+
+void ElemDataRequestsGPU::fill_host_coords_fields(
+  const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr)
+{
+  coordsFields_ = FieldView("CoordsFields", dataReq.get_coordinates_map().size());
+  coordsFieldsTypes_ = CoordsTypesView("CoordsFieldsTypes", dataReq.get_coordinates_map().size());
+
+  hostCoordsFields_ = Kokkos::create_mirror_view(coordsFields_);
+  hostCoordsFieldsTypes_ = Kokkos::create_mirror_view(coordsFieldsTypes_);
+
+  unsigned i = 0;
+  for (auto iter : dataReq.get_coordinates_map()) {
+    hostCoordsFields_(i) =
+      fieldMgr.get_field<double>(iter.second->mesh_meta_data_ordinal());
+    hostCoordsFieldsTypes_(i) = iter.first;
+    ++i;
+  }
+}
+
+}  // nalu
+}  // sierra

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -6,6 +6,7 @@
 /*------------------------------------------------------------------------*/
 
 #include <ScratchViews.h>
+#include <ngp_utils/NgpMEUtils.h>
 
 #include <NaluEnv.h>
 
@@ -195,11 +196,7 @@ int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeeded, int nDim
   NGP_ThrowRequireMsg(faceDataNeeded != elemDataNeeded,
     "An algorithm has been registered with conflicting face/element data requests");
 
-  const int nodesPerEntity = meSCS != nullptr ? meSCS->nodesPerElement_
-    : meSCV != nullptr ? meSCV->nodesPerElement_
-    : meFEM != nullptr ? meFEM->nodesPerElement_
-    : meFC  != nullptr ? meFC->nodesPerElement_
-    : 0;
+  const int nodesPerEntity = nodes_per_entity(dataNeeded);
 
   int numScalars = 0;
 
@@ -219,10 +216,10 @@ int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeeded, int nDim
     numScalars += entitiesPerElem*scalarsPerEntity;
   }
 
-  const int numFaceIp = meFC != nullptr ? meFC->num_integration_points() : 0;
-  const int numScsIp = meSCS != nullptr ? meSCS->num_integration_points() : 0;
-  const int numScvIp = meSCV != nullptr ? meSCV->num_integration_points() : 0;
-  const int numFemIp = meFEM != nullptr ? meFEM->num_integration_points() : 0;
+  const int numFaceIp = num_integration_points(dataNeeded, METype::FACE);
+  const int numScsIp  = num_integration_points(dataNeeded, METype::SCS);
+  const int numScvIp  = num_integration_points(dataNeeded, METype::SCV);
+  const int numFemIp  = num_integration_points(dataNeeded, METype::FEM);
 
   const ElemDataRequestsGPU::CoordsTypesView& coordsTypes = dataNeeded.get_coordinates_types();
   for(unsigned i=0; i<coordsTypes.size(); ++i) {


### PR DESCRIPTION
This pull request addresses the issues discussed in #286. The commits create query methods to device ME instances (within `ElemDataRequests` or `ElemDataRequestsGPU`) from host code, and replaces the necessary calls in `ScratchViews.C` and `AssembleFaceElemSolverAlgorithm.h` with these query methods. 

Other changes:
- Refactor `ElemDataRequests.h` and move the method implementations to a C++ source file
- Refactor NGP loop utilities to use the new ME query methods and remove unused code. 