### PR TITLE
ElemDataRequests checks and proposal to remove ScratchMeInfo

### DIFF
--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -56,10 +56,14 @@ public:
     ElemDataRequestsGPU dataNeededNGP(
       fieldMgr, dataNeededByKernels_, meta_data.get_fields().size());
 
+    const auto reqType = (entityRank_ == stk::topology::ELEM_RANK)
+                           ? ElemReqType::ELEM : ElemReqType::FACE;
+
     const int bytes_per_team = 0;
     const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(
       lhsSize, rhsSize_, scratchIdsSize, meta_data.spatial_dimension(),
-      dataNeededNGP);
+      dataNeededNGP, reqType);
+
     stk::mesh::Selector elemSelector = meta_data.locally_owned_part() &
                                        stk::mesh::selectUnion(partVec_) &
                                        !realm_.get_inactive_selector();

--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -23,10 +23,10 @@ namespace nalu{
 class MasterElement;
 
 enum ELEM_DATA_NEEDED {
-  FC_AREAV = 0,
+  FC_AREAV = 0, BEGIN_FC = FC_AREAV,
   FC_SHAPE_FCN,
-  FC_SHIFTED_SHAPE_FCN,
-  SCS_AREAV,
+  FC_SHIFTED_SHAPE_FCN, END_FC = FC_SHIFTED_SHAPE_FCN,
+  SCS_AREAV, BEGIN_SCS = SCS_AREAV,
   SCS_FACE_GRAD_OP,
   SCS_SHIFTED_FACE_GRAD_OP,
   SCS_GRAD_OP,
@@ -35,16 +35,16 @@ enum ELEM_DATA_NEEDED {
   SCS_MIJ,
   SCV_MIJ,
   SCS_SHAPE_FCN,
-  SCS_SHIFTED_SHAPE_FCN,
-  SCV_VOLUME,
+  SCS_SHIFTED_SHAPE_FCN, END_SCS = SCS_SHIFTED_SHAPE_FCN,
+  SCV_VOLUME, BEGIN_SCV = SCV_VOLUME,
   SCV_GRAD_OP,
   SCV_SHIFTED_GRAD_OP,
   SCV_SHAPE_FCN,
-  SCV_SHIFTED_SHAPE_FCN,
-  FEM_GRAD_OP,
+  SCV_SHIFTED_SHAPE_FCN, END_SCV = SCV_SHIFTED_SHAPE_FCN,
+  FEM_GRAD_OP, BEGIN_FEM = FEM_GRAD_OP,
   FEM_SHIFTED_GRAD_OP,
   FEM_SHAPE_FCN,
-  FEM_SHIFTED_SHAPE_FCN,
+  FEM_SHIFTED_SHAPE_FCN, END_FEM = FEM_SHIFTED_SHAPE_FCN
 };
 
 enum COORDS_TYPES {
@@ -103,21 +103,11 @@ public:
       dataEnums(),
       coordsFields_(),
       fields(), meFC_(nullptr), meSCS_(nullptr), meSCV_(nullptr), meFEM_(nullptr)
-  {
-  }
+  {}
 
   void add_master_element_call(
     ELEM_DATA_NEEDED data,
-    COORDS_TYPES cType = CURRENT_COORDINATES
-  )
-  {
-   auto it = coordsFields_.find(cType);
-   NGP_ThrowRequireMsg(
-     it != coordsFields_.end(),
-     "ElemDataRequests:add_master_element_call: Coordinates field "
-     "must be registered to ElemDataRequests before registering MasterElement");
-    dataEnums[cType].insert(data);
-  }
+    COORDS_TYPES cType = CURRENT_COORDINATES);
 
   void add_gathered_nodal_field(const stk::mesh::FieldBase& field, unsigned scalarsPerNode);
 
@@ -206,7 +196,7 @@ public:
     auto it = coordsFields_.find(cType);
     NGP_ThrowRequireMsg(
       it != coordsFields_.end(),
-     "ElemDataRequests:add_master_element_call: Coordinates field "
+     "ElemDataRequests:get_coordinates_field: Coordinates field "
      "must be registered to ElemDataRequests before access");
     return it->second;
   }

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -74,15 +74,16 @@ struct SharedMemData_FaceElem {
          unsigned nDim,
          const ElemDataRequestsGPU& faceDataNeeded,
          const ElemDataRequestsGPU& elemDataNeeded,
-         const ScratchMeInfo& meElemInfo,
+         unsigned nodesPerFace,
+         unsigned nodesPerElem,
          unsigned rhsSize)
-     : simdFaceViews(team, nDim, meElemInfo.nodesPerFace_, faceDataNeeded),
-       simdElemViews(team, nDim, meElemInfo, elemDataNeeded)
+     : simdFaceViews(team, nDim, nodesPerFace, faceDataNeeded),
+       simdElemViews(team, nDim, nodesPerElem, elemDataNeeded)
     {
 #ifndef KOKKOS_ENABLE_CUDA
         for(int simdIndex=0; simdIndex<simdLen; ++simdIndex) {
-          faceViews[simdIndex] = std::unique_ptr<ScratchViews<double,TEAMHANDLETYPE,SHMEM> >(new ScratchViews<double,TEAMHANDLETYPE,SHMEM>(team, nDim, meElemInfo.nodesPerFace_, faceDataNeeded));
-          elemViews[simdIndex] = std::unique_ptr<ScratchViews<double,TEAMHANDLETYPE,SHMEM> >(new ScratchViews<double,TEAMHANDLETYPE,SHMEM>(team, nDim, meElemInfo, elemDataNeeded));
+          faceViews[simdIndex] = std::unique_ptr<ScratchViews<double,TEAMHANDLETYPE,SHMEM> >(new ScratchViews<double,TEAMHANDLETYPE,SHMEM>(team, nDim, nodesPerFace, faceDataNeeded));
+          elemViews[simdIndex] = std::unique_ptr<ScratchViews<double,TEAMHANDLETYPE,SHMEM> >(new ScratchViews<double,TEAMHANDLETYPE,SHMEM>(team, nDim, nodesPerElem, elemDataNeeded));
         }
 #else
         faceViews[0] = &simdFaceViews;

--- a/include/ngp_utils/NgpMEUtils.h
+++ b/include/ngp_utils/NgpMEUtils.h
@@ -27,6 +27,15 @@ enum struct METype
   FEM                           //!< FEM
 };
 
+/** Type of element data requested by the algorithm in ScratchViews
+ */
+enum struct ElemReqType
+{
+  ELEM = 0,
+  FACE,
+  FACE_ELEM
+};
+
 template<typename DataReqType>
 MasterElement* get_me_instance(const DataReqType& dataReq, const METype meType)
 {

--- a/src/ElemDataRequests.C
+++ b/src/ElemDataRequests.C
@@ -101,6 +101,34 @@ void ElemDataRequests::add_coordinates_field(
   add_gathered_nodal_field(field, scalarsPerNode);
 }
 
+
+void ElemDataRequests::add_master_element_call(
+  ELEM_DATA_NEEDED data,
+  COORDS_TYPES cType)
+{
+  auto it = coordsFields_.find(cType);
+  NGP_ThrowRequireMsg(
+    it != coordsFields_.end(),
+    "ElemDataRequests:add_master_element_call: Coordinates field "
+    "must be registered to ElemDataRequests before registering MasterElement call");
+
+  // Check that the appropriate MasterElement has been registered
+  if ((data >= BEGIN_FC) && (data <= END_FC )) {
+    NGP_ThrowRequire(meFC_ != nullptr);
+  }
+  else if ((data >= BEGIN_SCS) && (data <= END_SCS )) {
+    NGP_ThrowRequire(meSCS_ != nullptr);
+  }
+  else if ((data >= BEGIN_SCV) && (data <= END_SCV )) {
+    NGP_ThrowRequire(meSCV_ != nullptr);
+  }
+  else if ((data >= BEGIN_FEM) && (data <= END_FEM )) {
+    NGP_ThrowRequire(meFEM_ != nullptr);
+  }
+
+  dataEnums[cType].insert(data);
+}
+
 }
 }
 

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -180,7 +180,8 @@ void gather_elem_node_field(const stk::mesh::FieldBase& field,
   }
 }
 
-int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeeded, int nDim)
+int get_num_scalars_pre_req_data(
+  const ElemDataRequestsGPU& dataNeeded, int nDim, const ElemReqType reqType)
 {
   /* master elements are allowed to be null if they are not required */
   MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
@@ -188,14 +189,35 @@ int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeeded, int nDim
   MasterElement *meSCV = dataNeeded.get_cvfem_volume_me();
   MasterElement *meFEM = dataNeeded.get_fem_volume_me();
 
-  const bool faceDataNeeded = meFC != nullptr
-    && meSCS == nullptr && meSCV == nullptr && meFEM == nullptr;
-  const bool elemDataNeeded = meFC == nullptr
-    && (meSCS != nullptr || meSCV != nullptr || meFEM != nullptr);
+  // A MasterElement corresponding to ELEM_RANK has been registered
+  const bool hasElemME = (meSCS != nullptr || meSCV != nullptr || meFEM != nullptr);
+  // A MasterElement corresponding to side_rank() has been registered
+  const bool hasFaceME = (meFC != nullptr);
 
-  NGP_ThrowRequireMsg(faceDataNeeded != elemDataNeeded,
-    "An algorithm has been registered with conflicting face/element data requests");
+  switch (reqType) {
+  case ElemReqType::ELEM:
+    NGP_ThrowRequireMsg(
+      hasElemME,
+      "Requesting ELEM data, but no ELEM_RANK master element has been registered");
+    break;
 
+  case ElemReqType::FACE:
+    NGP_ThrowRequireMsg(
+      hasFaceME,
+      "Request SIDE_RANK data, but no SIDE_RANK master element has been registered");
+    break;
+
+  case ElemReqType::FACE_ELEM:
+    // In case of FACE_ELEM register meFC so that numFaceIp can be queried
+    NGP_ThrowRequireMsg(
+      (hasElemME && hasFaceME),
+      "Requesting FACE_ELEM data but does not have necessary MasterElements");
+    break;
+
+  }
+
+  // The previous check guarantees that we get the correct nodesPerEntity for
+  // all request types
   const int nodesPerEntity = nodes_per_entity(dataNeeded);
 
   int numScalars = 0;
@@ -207,9 +229,6 @@ int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeeded, int nDim
     unsigned scalarsPerEntity = fieldInfo.scalarsDim1;
     unsigned entitiesPerElem = fieldEntityRank==stk::topology::NODE_RANK ? nodesPerEntity : 1;
 
-    // Catch errors if user requests nodal field but has not registered any
-    // MasterElement we need to get nodesPerEntity
-    NGP_ThrowRequire(entitiesPerElem > 0);
     if (fieldInfo.scalarsDim2 > 1) {
       scalarsPerEntity *= fieldInfo.scalarsDim2;
     }
@@ -231,136 +250,6 @@ int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeeded, int nDim
     bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false; bool needDerivFC = false;
     bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false; bool needDetjFC = false;
 
-    for(unsigned d=0; d<dataEnums.size(); ++d) {
-      ELEM_DATA_NEEDED data = dataEnums(d);
-      switch(data)
-      {
-        case FC_AREAV:
-          numScalars += nDim * numFaceIp;
-          break;
-        case FC_SHAPE_FCN:
-        case FC_SHIFTED_SHAPE_FCN:
-          numScalars += numFaceIp * nodesPerEntity;
-          break;
-        case SCS_AREAV:
-          numScalars += nDim * numScsIp;
-          break;
-        case SCS_FACE_GRAD_OP:
-        case SCS_SHIFTED_FACE_GRAD_OP:
-          dndxLengthFC = nodesPerEntity*numFaceIp*nDim;
-          needDerivFC = true;
-          needDetjFC = true;
-          numScalars += dndxLengthFC;
-          break;
-        case SCS_GRAD_OP:
-        case SCS_SHIFTED_GRAD_OP:
-          dndxLength = nodesPerEntity*numScsIp*nDim;
-          needDeriv = true;
-          needDetj = true;
-          numScalars += dndxLength;
-          break;
-        case SCS_SHAPE_FCN:
-        case SCS_SHIFTED_SHAPE_FCN:
-          numScalars += nodesPerEntity*numScsIp;
-          break;
-        case SCV_VOLUME:
-          numScalars += numScvIp;
-          break;
-        case SCV_GRAD_OP:
-          dndxLength = nodesPerEntity*numScvIp*nDim;
-          needDerivScv = true;
-          needDetjScv = true;
-          numScalars += dndxLength;
-          break;
-        case SCV_SHAPE_FCN:
-        case SCV_SHIFTED_SHAPE_FCN:
-          numScalars += nodesPerEntity*numScvIp;
-          break;
-        case SCS_GIJ:
-          gUpperLength = nDim*nDim*numScsIp;
-          gLowerLength = nDim*nDim*numScsIp;
-          needDeriv = true;
-          numScalars += (gUpperLength + gLowerLength );
-          break;
-        case FEM_GRAD_OP:
-        case FEM_SHIFTED_GRAD_OP:
-          dndxLength = nodesPerEntity*numFemIp*nDim;
-          needDerivFem = true;
-          needDetjFem = true;
-          numScalars += dndxLength;
-          break;
-        case FEM_SHAPE_FCN:
-        case FEM_SHIFTED_SHAPE_FCN:
-          numScalars += nodesPerEntity*numFemIp;
-          break;
-        default: break;
-      }
-    }
-
-    if (needDerivFC)
-      numScalars += nodesPerEntity*numFaceIp*nDim;
-
-    if (needDeriv)
-      numScalars += nodesPerEntity*numScsIp*nDim;
-
-    if (needDerivScv)
-      numScalars += nodesPerEntity*numScvIp*nDim;
-
-    if (needDerivFem)
-      numScalars += nodesPerEntity*numFemIp*nDim;
-
-    if (needDetjFC)
-      numScalars += numFaceIp;
-
-    if (needDetj)
-      numScalars += numScsIp;
-
-    if (needDetjScv)
-      numScalars += numScvIp;
-
-    if (needDetjFem)
-      numScalars += numFemIp;
-  }
-
-  // Add a 64 byte padding to the buffer size requested
-  return numScalars + 8;
-}
-
-int get_num_scalars_pre_req_data(const ElemDataRequestsGPU& dataNeeded, int nDim, const ScratchMeInfo &meInfo)
-{
-  const int nodesPerEntity = meInfo.nodalGatherSize_;
-  const int numFaceIp = meInfo.numFaceIp_;
-  const int numScsIp = meInfo.numScsIp_;
-  const int numScvIp = meInfo.numScvIp_;
-  const int numFemIp = meInfo.numFemIp_;
-  int numScalars = 0;
-
-  const ElemDataRequestsGPU::FieldInfoView& neededFields = dataNeeded.get_fields();
-  for(unsigned f=0; f<neededFields.size(); ++f) {
-    const FieldInfoNGP& fieldInfo = neededFields(f);
-    stk::mesh::EntityRank fieldEntityRank = get_entity_rank(fieldInfo);
-    unsigned scalarsPerEntity = fieldInfo.scalarsDim1;
-    unsigned entitiesPerElem = fieldEntityRank==stk::topology::NODE_RANK ? nodesPerEntity : 1;
-
-    // Catch errors if user requests nodal field but has not registered any
-    // MasterElement we need to get nodesPerEntity
-    NGP_ThrowRequire(entitiesPerElem > 0);
-    if (fieldInfo.scalarsDim2 > 1) {
-      scalarsPerEntity *= fieldInfo.scalarsDim2;
-    }
-    numScalars += entitiesPerElem*scalarsPerEntity;
-  }
-
-  const ElemDataRequestsGPU::CoordsTypesView& coordsTypes = dataNeeded.get_coordinates_types();
-  for(unsigned i=0; i<coordsTypes.size(); ++i) {
-    auto cType = coordsTypes(i);
-    int dndxLength = 0, dndxLengthFC = 0, gUpperLength = 0, gLowerLength = 0;
-
-    // Updated logic for data sharing of deriv and det_j
-    bool needDeriv = false; bool needDerivScv = false; bool needDerivFem = false; bool needDerivFC = false;
-    bool needDetj = false; bool needDetjScv = false; bool needDetjFem = false; bool needDetjFC = false;
-
-    const ElemDataRequestsGPU::DataEnumView& dataEnums = dataNeeded.get_data_enums(cType);
     for(unsigned d=0; d<dataEnums.size(); ++d) {
       ELEM_DATA_NEEDED data = dataEnums(d);
       switch(data)

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -81,6 +81,10 @@ public:
    : discreteLaplacianOfPressure_(discreteLaplacianOfPressure),
      nodalPressureField_(nodalPressureField)
   {
+    // add the master element
+    sierra::nalu::MasterElement* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
+    dataNeeded.add_cvfem_surface_me(meSCS);
+
     //here are the element-data pre-requisites we want computed before
     //our elem_execute method is called.
     dataNeeded.add_coordinates_field(*coordField, 3,
@@ -90,10 +94,6 @@ public:
     dataNeeded.add_master_element_call(sierra::nalu::SCS_GRAD_OP,
                                        sierra::nalu::CURRENT_COORDINATES);
     dataNeeded.add_gathered_nodal_field(*nodalPressureField, 1);
-
-    // add the master element
-    sierra::nalu::MasterElement* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
-    dataNeeded.add_cvfem_surface_me(meSCS);
   }
 
   virtual ~DiscreteLaplacianSuppAlg() {}

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -133,7 +133,7 @@ public:
 
       sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeededByKernels_, meta.get_fields().size());
       const int bytes_per_team = 0;
-      const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension());
+      const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension(), sierra::nalu::ElemReqType::ELEM);
       auto team_exec = sierra::nalu::get_host_team_policy(elemBuckets.size(), bytes_per_team, bytes_per_thread);
       Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team)
       {

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -78,6 +78,7 @@ void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* press
 {
   stk::topology elemTopo = stk::topology::HEX_8;
   sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
+  const int nodesPerElement = sierra::nalu::AlgTraitsHex8::nodesPerElement_;
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
   dataReq.add_cvfem_volume_me(meSCV);
 
@@ -89,12 +90,6 @@ void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* press
   dataReq.add_master_element_call(sierra::nalu::SCV_VOLUME, sierra::nalu::CURRENT_COORDINATES);
 
   EXPECT_EQ(3u, dataReq.get_fields().size());
-
-  sierra::nalu::ScratchMeInfo meInfo;
-  meInfo.nodalGatherSize_ = elemTopo.num_nodes();
-  meInfo.nodesPerFace_ = 4;
-  meInfo.nodesPerElement_ = elemTopo.num_nodes();
-  meInfo.numScvIp_ = meSCV->num_integration_points();
 
   const stk::mesh::MetaData& meta = bulk.mesh_meta_data();
   ngp::FieldManager fieldMgr(bulk);
@@ -132,7 +127,7 @@ void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* press
   {
     const ngp::Mesh::BucketType& b = ngpMesh.get_bucket(stk::topology::ELEM_RANK, team.league_rank());
 
-    sierra::nalu::ScratchViews<double,TeamType,ShmemType> scrviews(team, ngpMesh.get_spatial_dimension(), meInfo, dataNGP);
+    sierra::nalu::ScratchViews<double,TeamType,ShmemType> scrviews(team, ngpMesh.get_spatial_dimension(), nodesPerElement, dataNGP);
 
     sierra::nalu::SharedMemView<double**,ShmemType> simdlhs =
         sierra::nalu::get_shmem_view_2D<double,TeamType,ShmemType>(team, rhsSize, rhsSize);

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -126,7 +126,7 @@ public:
 
       sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeededByKernels_, meta.get_fields().size());
       const int bytes_per_team = 0;
-      const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension());
+      const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension(), sierra::nalu::ElemReqType::ELEM);
       auto team_exec = sierra::nalu::get_host_team_policy(elemBuckets.size(), bytes_per_team, bytes_per_thread);
       Kokkos::parallel_for(team_exec, [&](const sierra::nalu::TeamHandleType& team)
       {

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -903,7 +903,7 @@ void calc_projected_nodal_gradient_interior(
   sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
-  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension()) ;
+  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension(), sierra::nalu::ElemReqType::ELEM) ;
 
   auto v_shape_function = Kokkos::View<double**>("shape_function", meSCS->num_integration_points(), meSCS->nodesPerElement_);
 
@@ -987,7 +987,7 @@ void calc_projected_nodal_gradient_interior(
   sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
-  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension()) ;
+  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension(), sierra::nalu::ElemReqType::ELEM) ;
 
   auto v_shape_function = Kokkos::View<double**>("shape_function", meSCS->num_integration_points(), meSCS->nodesPerElement_);
 
@@ -1074,7 +1074,7 @@ void calc_projected_nodal_gradient_boundary(
   sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
-  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension()) ;
+  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension(), sierra::nalu::ElemReqType::ELEM) ;
 
   auto v_shape_function = Kokkos::View<double**>("shape_function", meBC->num_integration_points(), meBC->nodesPerElement_);
 
@@ -1152,7 +1152,7 @@ void calc_projected_nodal_gradient_boundary(
   sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
-  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension()) ;
+  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension(), sierra::nalu::ElemReqType::ELEM) ;
 
   auto v_shape_function = Kokkos::View<double**>("shape_function", meBC->num_integration_points(), meBC->nodesPerElement_);
 
@@ -1227,7 +1227,7 @@ void calc_dual_nodal_volume(
   sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeeded, meta.get_fields().size());
 
   const int bytes_per_team = 0;
-  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension()) ;
+  const int bytes_per_thread = sierra::nalu::get_num_bytes_pre_req_data<double>(dataNeededNGP, meta.spatial_dimension(), sierra::nalu::ElemReqType::ELEM) ;
 
   auto v_shape_function = Kokkos::View<double**>("shape_function", meSCV->num_integration_points(), meSCV->nodesPerElement_);
 


### PR DESCRIPTION
This pull request adds two features

- Add checks to `ElemDataRequests::add_master_element_call` to ensure that the necessary `MasterElement` instances have been registered when the user requests element data. This is a pre-requisite before removing `ScratchMeInfo`

- Remove `ScratchMeInfo` and duplicated methods in `ScratchViews` and use a single interface for populating ScratchViews. Fix code that was using `ScratchMeInfo` previously. 

Design issues:

- I had to _inject_ the `meFC` instance into `elemDataNeeded` in `AssembleFaceElemSolverAlgorithm` so that it can query `numFaceIp` to handle `SCS_FACE_GRAD_OP`. Is this OK? 