### PR TITLE
Switch the default GPU memory space from CudaUVMSpace to CudaSpace

### DIFF
--- a/include/ElemDataRequestsGPU.h
+++ b/include/ElemDataRequestsGPU.h
@@ -46,6 +46,28 @@ struct FieldInfoNGP {
   unsigned scalarsDim2;
 };
 
+struct CoordFieldInfo
+{
+  CoordFieldInfo(NGPDoubleFieldType& fld)
+    : coordField(fld)
+  {}
+
+  KOKKOS_FUNCTION
+  CoordFieldInfo() = default;
+
+  KOKKOS_FUNCTION
+  CoordFieldInfo(const CoordFieldInfo&) = default;
+
+  KOKKOS_FUNCTION
+  ~CoordFieldInfo() = default;
+
+  KOKKOS_FUNCTION
+  operator const NGPDoubleFieldType&() const
+  { return coordField; }
+
+  NGPDoubleFieldType coordField;
+};
+
 KOKKOS_INLINE_FUNCTION
 stk::mesh::EntityRank get_entity_rank(const FieldInfoNGP& fieldInfo)
 {
@@ -71,7 +93,7 @@ public:
   typedef NGPDoubleFieldType FieldType;
   typedef Kokkos::View<COORDS_TYPES*, Kokkos::LayoutRight, MemSpace> CoordsTypesView;
   typedef Kokkos::View<ELEM_DATA_NEEDED*, Kokkos::LayoutRight, MemSpace> DataEnumView;
-  typedef Kokkos::View<NGPDoubleFieldType*, Kokkos::LayoutRight, MemSpace> FieldView;
+  typedef Kokkos::View<CoordFieldInfo*, Kokkos::LayoutRight, MemSpace> FieldView;
   typedef Kokkos::View<FieldInfoType*, Kokkos::LayoutRight, MemSpace> FieldInfoView;
 
   ElemDataRequestsGPU(
@@ -105,7 +127,23 @@ public:
   { return coordsFieldsTypes_; }
 
   KOKKOS_FUNCTION
-  const FieldInfoView& get_fields() const { return fields; }  
+  const FieldInfoView& get_fields() const { return fields; }
+
+  const DataEnumView::HostMirror&
+  get_host_data_enums(const COORDS_TYPES cType) const
+  { return hostDataEnums[cType]; }
+
+  const FieldView::HostMirror&
+  get_host_coordinates_fields() const
+  { return hostCoordsFields_; }
+
+  const CoordsTypesView::HostMirror&
+  get_host_coordinates_types() const
+  { return hostCoordsFieldsTypes_; }
+
+  const FieldInfoView::HostMirror&
+  get_host_fields() const
+  { return hostFields; }
 
   KOKKOS_FUNCTION
   unsigned get_total_num_fields() const { return totalNumFields; }

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -32,12 +32,18 @@ namespace sierra {
 namespace nalu {
 
 #ifdef KOKKOS_ENABLE_CUDA
-   typedef Kokkos::CudaUVMSpace::memory_space    MemSpace;
+typedef Kokkos::CudaSpace    MemSpace;
+typedef Kokkos::CudaUVMSpace UVMSpace;
 #elif defined(KOKKOS_HAVE_OPENMP)
-   typedef Kokkos::OpenMP       MemSpace;
+typedef Kokkos::OpenMP       MemSpace;
+typedef Kokkos::OpenMP       UVMSpace;
 #else
-   typedef Kokkos::HostSpace    MemSpace;
+typedef Kokkos::HostSpace    MemSpace;
+typedef Kokkos::HostSpace    UVMSpace;
 #endif
+
+// Tpetra requires UVM on Cuda
+using LinSysMemSpace = UVMSpace;
 
 using HostSpace = Kokkos::DefaultHostExecutionSpace;
 using DeviceSpace = Kokkos::DefaultExecutionSpace;
@@ -129,12 +135,14 @@ void kokkos_parallel_reduce(SizeType n, Function loop_body, ReduceType& reduce, 
     Kokkos::parallel_reduce(debuggingName, Kokkos::RangePolicy<Kokkos::Serial>(0, n), loop_body, reduce);
 }
 
-template<typename T>
+template<typename T, typename MemorySpace=MemSpace>
 inline T* kokkos_malloc_on_device(const std::string& debuggingName) {
-  return static_cast<T*>(Kokkos::kokkos_malloc(debuggingName, sizeof(T)));
+  return static_cast<T*>(Kokkos::kokkos_malloc<MemorySpace>(debuggingName, sizeof(T)));
 }
-inline void kokkos_free_on_device(void * ptr) { Kokkos::kokkos_free(ptr); }
-}
+
+template<typename MemorySpace=MemSpace>
+inline void kokkos_free_on_device(void* ptr)
+{ Kokkos::kokkos_free<MemorySpace>(ptr); }
 
 template<typename T>
 KOKKOS_FUNCTION
@@ -145,7 +153,7 @@ void set_zero(T* values, unsigned length)
     }
 }
 
-}
-
+} // nalu
+} // sierra
 
 #endif /* INCLUDE_KOKKOSINTERFACE_H_ */

--- a/include/LinearSolver.h
+++ b/include/LinearSolver.h
@@ -78,7 +78,7 @@ public:
     rowPointersData = rowPointers.data();
 
     size_t nnz = compute_row_pointers(rowPointers, rowLengths);
-    colIndices = Kokkos::View<LocalOrdinal*,MemSpace>(Kokkos::ViewAllocateWithoutInitializing("colIndices"), nnz);
+    colIndices = Kokkos::View<LocalOrdinal*,LinSysMemSpace>(Kokkos::ViewAllocateWithoutInitializing("colIndices"), nnz);
     Kokkos::deep_copy(colIndices, INVALID);
   }
 

--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -87,6 +87,8 @@ typedef Belos::LinearProblem<Scalar, MultiVector, Operator>                Linea
 typedef Belos::SolverManager<Scalar, MultiVector, Operator>                SolverManager;
 typedef Belos::TpetraSolverFactory<Scalar, MultiVector, Operator>          SolverFactory;
 typedef Ifpack2::Preconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node> Preconditioner;
+
+using EntityToLIDView = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,LinSysMemSpace>;
 };
 
 

--- a/include/NGPInstance.h
+++ b/include/NGPInstance.h
@@ -67,7 +67,7 @@ inline void destroy(T* obj)
   Kokkos::parallel_for(debuggingName, 1, KOKKOS_LAMBDA(const int) {
       obj->~T();
     });
-  Kokkos::kokkos_free(obj);
+  kokkos_free_on_device(obj);
 }
 
 /** Wrapper object to hold device pointers within a Kokkos::View

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -154,8 +154,8 @@ public:
                              LinSys::LocalMatrix sharedNotOwnedLclMatrix,
                              LinSys::LocalVector ownedLclRhs,
                              LinSys::LocalVector sharedNotOwnedLclRhs,
-                             Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityLIDs,
-                             Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityColLIDs,
+                             LinSys::EntityToLIDView entityLIDs,
+                             LinSys::EntityToLIDView entityColLIDs,
                              int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof)
     : ownedLocalMatrix_(ownedLclMatrix),
       sharedNotOwnedLocalMatrix_(sharedNotOwnedLclMatrix),
@@ -186,8 +186,8 @@ public:
   private:
     LinSys::LocalMatrix ownedLocalMatrix_, sharedNotOwnedLocalMatrix_;
     LinSys::LocalVector ownedLocalRhs_, sharedNotOwnedLocalRhs_;
-    Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToLID_;
-    Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToColLID_;
+    LinSys::EntityToLIDView entityToLID_;
+    LinSys::EntityToLIDView entityToColLID_;
     int maxOwnedRowId_, maxSharedNotOwnedRowId_;
     unsigned numDof_;
     TpetraLinSysCoeffApplier* devicePointer_;
@@ -271,8 +271,8 @@ private:
   Teuchos::RCP<LinSys::Export>      exporter_;
 
   MyLIDMapType myLIDs_;
-  Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToColLID_;
-  Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToLID_;
+  LinSys::EntityToLIDView entityToColLID_;
+  LinSys::EntityToLIDView entityToLID_;
   LocalOrdinal maxOwnedRowId_; // = num_owned_nodes * numDof_
   LocalOrdinal maxSharedNotOwnedRowId_; // = (num_owned_nodes + num_sharedNotOwned_nodes) * numDof_
 

--- a/include/TpetraSegregatedLinearSystem.h
+++ b/include/TpetraSegregatedLinearSystem.h
@@ -153,8 +153,8 @@ public:
                              LinSys::LocalMatrix sharedNotOwnedLclMatrix,
                              LinSys::LocalVector ownedLclRhs,
                              LinSys::LocalVector sharedNotOwnedLclRhs,
-                             Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityLIDs,
-                             Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityColLIDs,
+                             LinSys::EntityToLIDView entityLIDs,
+                             LinSys::EntityToLIDView entityColLIDs,
                              int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof)
     : ownedLocalMatrix_(ownedLclMatrix),
       sharedNotOwnedLocalMatrix_(sharedNotOwnedLclMatrix),
@@ -185,8 +185,8 @@ public:
   private:
     LinSys::LocalMatrix ownedLocalMatrix_, sharedNotOwnedLocalMatrix_;
     LinSys::LocalVector ownedLocalRhs_, sharedNotOwnedLocalRhs_;
-    Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToLID_;
-    Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToColLID_;
+    LinSys::EntityToLIDView entityToLID_;
+    LinSys::EntityToLIDView entityToColLID_;
     int maxOwnedRowId_, maxSharedNotOwnedRowId_;
     unsigned numDof_;
     TpetraLinSysCoeffApplier* devicePointer_;
@@ -270,8 +270,8 @@ private:
   Teuchos::RCP<LinSys::Export>      exporter_;
 
   MyLIDMapType myLIDs_;
-  Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToColLID_;
-  Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace> entityToLID_;
+  LinSys::EntityToLIDView entityToColLID_;
+  LinSys::EntityToLIDView entityToLID_;
   LocalOrdinal maxOwnedRowId_; // = num_owned_nodes * numDof_
   LocalOrdinal maxSharedNotOwnedRowId_; // = (num_owned_nodes + num_sharedNotOwned_nodes) * numDof_
 

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -59,7 +59,8 @@ ngp_calc_thread_shmem_size(
 {
   int preReqSize = get_num_bytes_pre_req_data<T>(dataReq, ndim, reqType);
   int mdvSize = MultiDimViews<T>::bytes_needed(
-    dataReq.get_total_num_fields(), count_needed_field_views(dataReq));
+    dataReq.get_total_num_fields(),
+    count_needed_field_views(dataReq.get_host_fields()));
 
 #ifndef KOKKOS_ENABLE_CUDA
   // On host account for extra data to store the SIMD and non-SIMD versions of

--- a/src/ElemDataRequestsGPU.C
+++ b/src/ElemDataRequestsGPU.C
@@ -87,8 +87,8 @@ void ElemDataRequestsGPU::fill_host_coords_fields(
 
   unsigned i = 0;
   for (auto iter : dataReq.get_coordinates_map()) {
-    hostCoordsFields_(i) =
-      fieldMgr.get_field<double>(iter.second->mesh_meta_data_ordinal());
+    hostCoordsFields_(i) = CoordFieldInfo(
+      fieldMgr.get_field<double>(iter.second->mesh_meta_data_ordinal()));
     hostCoordsFieldsTypes_(i) = iter.first;
     ++i;
   }

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -222,12 +222,14 @@ int get_num_scalars_pre_req_data(
 
   int numScalars = 0;
 
-  const ElemDataRequestsGPU::FieldInfoView& neededFields = dataNeeded.get_fields();
-  for(unsigned f=0; f<neededFields.size(); ++f) {
+  const ElemDataRequestsGPU::FieldInfoView::HostMirror& neededFields =
+    dataNeeded.get_host_fields();
+  for (unsigned f = 0; f < neededFields.size(); ++f) {
     const FieldInfoNGP& fieldInfo = neededFields(f);
     stk::mesh::EntityRank fieldEntityRank = fieldInfo.field.get_rank();
     unsigned scalarsPerEntity = fieldInfo.scalarsDim1;
-    unsigned entitiesPerElem = fieldEntityRank==stk::topology::NODE_RANK ? nodesPerEntity : 1;
+    unsigned entitiesPerElem =
+      fieldEntityRank == stk::topology::NODE_RANK ? nodesPerEntity : 1;
 
     if (fieldInfo.scalarsDim2 > 1) {
       scalarsPerEntity *= fieldInfo.scalarsDim2;
@@ -240,10 +242,12 @@ int get_num_scalars_pre_req_data(
   const int numScvIp  = num_integration_points(dataNeeded, METype::SCV);
   const int numFemIp  = num_integration_points(dataNeeded, METype::FEM);
 
-  const ElemDataRequestsGPU::CoordsTypesView& coordsTypes = dataNeeded.get_coordinates_types();
-  for(unsigned i=0; i<coordsTypes.size(); ++i) {
+  const ElemDataRequestsGPU::CoordsTypesView::HostMirror& coordsTypes =
+    dataNeeded.get_host_coordinates_types();
+  for (unsigned i = 0; i < coordsTypes.size(); ++i) {
     auto cType = coordsTypes(i);
-    const ElemDataRequestsGPU::DataEnumView& dataEnums = dataNeeded.get_data_enums(cType);
+    const ElemDataRequestsGPU::DataEnumView::HostMirror& dataEnums =
+      dataNeeded.get_host_data_enums(cType);
     int dndxLength = 0, dndxLengthFC = 0, gUpperLength = 0, gLowerLength = 0;
 
     // Updated logic for data sharing of deriv and det_j

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -775,7 +775,7 @@ void TpetraLinearSystem::fill_entity_to_row_LID_mapping()
 {
   const stk::mesh::BulkData& bulk = realm_.bulk_data();
   stk::mesh::Selector selector = bulk.mesh_meta_data().universal_part() & !(realm_.get_inactive_selector());
-  entityToLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
+  entityToLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
   const stk::mesh::BucketVector& nodeBuckets = realm_.get_buckets(stk::topology::NODE_RANK, selector);
   for(const stk::mesh::Bucket* bptr : nodeBuckets) {
     const stk::mesh::Bucket& b = *bptr;
@@ -800,7 +800,7 @@ void TpetraLinearSystem::fill_entity_to_row_LID_mapping()
 void TpetraLinearSystem::fill_entity_to_col_LID_mapping()
 {
     const stk::mesh::BulkData& bulk = realm_.bulk_data();
-    entityToColLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
+    entityToColLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
     const stk::mesh::BucketVector& nodeBuckets = bulk.buckets(stk::topology::NODE_RANK);
     for(const stk::mesh::Bucket* bptr : nodeBuckets) {
         const stk::mesh::Bucket& b = *bptr;

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -770,7 +770,7 @@ void TpetraSegregatedLinearSystem::fill_entity_to_row_LID_mapping()
 {
   const stk::mesh::BulkData& bulk = realm_.bulk_data();
   stk::mesh::Selector selector = bulk.mesh_meta_data().universal_part() & !(realm_.get_inactive_selector());
-  entityToLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
+  entityToLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
   const stk::mesh::BucketVector& nodeBuckets = realm_.get_buckets(stk::topology::NODE_RANK, selector);
   for(const stk::mesh::Bucket* bptr : nodeBuckets) {
     const stk::mesh::Bucket& b = *bptr;
@@ -795,7 +795,7 @@ void TpetraSegregatedLinearSystem::fill_entity_to_row_LID_mapping()
 void TpetraSegregatedLinearSystem::fill_entity_to_col_LID_mapping()
 {
     const stk::mesh::BulkData& bulk = realm_.bulk_data();
-    entityToColLID_ = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,MemSpace>("entityToLID",bulk.get_size_of_entity_index_space());
+    entityToColLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
     const stk::mesh::BucketVector& nodeBuckets = bulk.buckets(stk::topology::NODE_RANK);
     for(const stk::mesh::Bucket* bptr : nodeBuckets) {
         const stk::mesh::Bucket& b = *bptr;

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -167,6 +167,9 @@ TEST_F(Hex8MeshWithNSOFields, NGPScratchViews)
 {
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
+  const double velVec[3] = {1.0, 0.0, 0.0};
+  stk::mesh::field_fill(velVec, *velocity);
+
   do_the_test(bulk, pressure, velocity);
 }
 


### PR DESCRIPTION
This pull request implements the necessary changes to switch the default memory space to CudaSpace

- Introduce multiple `MemSpace` definitions so that Nalu can allocate to `CudaSpace` while `TpetraLinearSystem` can continue to use `CudaUVMSpace`
- Fix `ElemDataRequestsGPU` and `ScratchViews` so that they access the correct `View` in host/device