### PR TITLE
Remove ifdef statements for CUDA in many element unit tests

### DIFF
--- a/unit_tests/kernels/UnitTestContinuityAdvElem.C
+++ b/unit_tests/kernels/UnitTestContinuityAdvElem.C
@@ -11,7 +11,6 @@
 
 #include "kernel/ContinuityAdvElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 namespace advection_default {
@@ -59,8 +58,6 @@ static constexpr double lhs[8][8] = {
 } // hex8_golds
 } // anonymous namespace
 
-#endif
-
 /// Continuity advection with default Solution options
 TEST_F(ContinuityKernelHex8Mesh, NGP_advection_default)
 {
@@ -94,7 +91,6 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_advection_default)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -103,7 +99,6 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_advection_default)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }
 
 /// Continuity advection kernel
@@ -142,7 +137,6 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_advection_reduced_sens_cvfem_poisson)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -151,7 +145,6 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_advection_reduced_sens_cvfem_poisson)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }
 
 /// Continuity advection kernel
@@ -190,7 +183,6 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_advection_reduced_shift_cvfem_poisson)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -199,5 +191,4 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_advection_reduced_shift_cvfem_poisson)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }

--- a/unit_tests/kernels/UnitTestContinuityInflowElem.C
+++ b/unit_tests/kernels/UnitTestContinuityInflowElem.C
@@ -11,7 +11,6 @@
 
 #include "kernel/ContinuityInflowElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 
@@ -21,7 +20,6 @@ static constexpr double rhs[4] = {
 
 }
 } // anonymous namespace
-#endif
 
 TEST_F(ContinuityKernelHex8Mesh, inflow)
 {
@@ -59,7 +57,6 @@ TEST_F(ContinuityKernelHex8Mesh, inflow)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 4u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 4u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 4u);
@@ -67,5 +64,4 @@ TEST_F(ContinuityKernelHex8Mesh, inflow)
   unit_test_kernel_utils::expect_all_near(
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<4>(helperObjs.linsys->lhs_, 0.0);
-#endif
 }

--- a/unit_tests/kernels/UnitTestContinuityMassElem.C
+++ b/unit_tests/kernels/UnitTestContinuityMassElem.C
@@ -45,14 +45,12 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_density_time_derivative)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,-12.5);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_,0.0);
-#endif
 }
 
 TEST_F(ContinuityKernelHex8Mesh, NGP_density_time_derivative_lumped)
@@ -89,12 +87,10 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_density_time_derivative_lumped)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,-12.5);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_,0.0);
-#endif
 }

--- a/unit_tests/kernels/UnitTestContinuityOpenElem.C
+++ b/unit_tests/kernels/UnitTestContinuityOpenElem.C
@@ -11,7 +11,6 @@
 
 #include "kernel/ContinuityOpenElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 
@@ -20,7 +19,6 @@ static constexpr double rhs[8] = {
 };
 }
 } // anonymous namespacek
-#endif
 
 TEST_F(ContinuityKernelHex8Mesh, open)
 {
@@ -59,7 +57,6 @@ TEST_F(ContinuityKernelHex8Mesh, open)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -67,5 +64,4 @@ TEST_F(ContinuityKernelHex8Mesh, open)
   unit_test_kernel_utils::expect_all_near(
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, 0.0);
-#endif
 }

--- a/unit_tests/kernels/UnitTestMomentumActuatorSrcElem.C
+++ b/unit_tests/kernels/UnitTestMomentumActuatorSrcElem.C
@@ -33,7 +33,6 @@ TEST_F(ActuatorSourceKernelHex8Mesh, NGP_actuator_source)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -50,6 +49,5 @@ TEST_F(ActuatorSourceKernelHex8Mesh, NGP_actuator_source)
 
   unit_test_kernel_utils::expect_all_near_2d(helperObjs.linsys->lhs_,lhsExact.data());
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,rhsExact.data());
-#endif
 }
 

--- a/unit_tests/kernels/UnitTestMomentumAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestMomentumAdvDiffElem.C
@@ -11,7 +11,6 @@
 
 #include "kernel/MomentumAdvDiffElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 namespace advection_diffusion {
@@ -271,7 +270,6 @@ static constexpr double lhs[24][24] = {
 } // advection_diffusion
 } // hex8_golds
 } // anonymous namespace
-#endif
 
 TEST_F(MomentumKernelHex8Mesh, NGP_advection_diffusion)
 {
@@ -297,7 +295,6 @@ TEST_F(MomentumKernelHex8Mesh, NGP_advection_diffusion)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -305,5 +302,4 @@ TEST_F(MomentumKernelHex8Mesh, NGP_advection_diffusion)
   namespace gold_values = ::hex8_golds::advection_diffusion;
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }

--- a/unit_tests/kernels/UnitTestMomentumBuoyancyBoussinesqSrcElem.C
+++ b/unit_tests/kernels/UnitTestMomentumBuoyancyBoussinesqSrcElem.C
@@ -43,7 +43,6 @@ TEST_F(MomentumKernelHex8Mesh, NGP_buoyancy_boussinesq)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -56,6 +55,5 @@ TEST_F(MomentumKernelHex8Mesh, NGP_buoyancy_boussinesq)
     rhsExact[i] = -0.125 * solnOpts_.gravity_[2] * expFac * (300.0 - solnOpts_.referenceTemperature_);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,rhsExact.data());
-#endif
 }
 

--- a/unit_tests/kernels/UnitTestMomentumBuoyancySrcElem.C
+++ b/unit_tests/kernels/UnitTestMomentumBuoyancySrcElem.C
@@ -41,7 +41,6 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_buoyancy_src_elem)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -52,6 +51,5 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_buoyancy_src_elem)
     rhsExact[i] = 0.125 * solnOpts_.gravity_[2] * (1.0 - solnOpts_.referenceDensity_);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,rhsExact.data());
-#endif
 }
 

--- a/unit_tests/kernels/UnitTestMomentumCoriolisSrcElem.C
+++ b/unit_tests/kernels/UnitTestMomentumCoriolisSrcElem.C
@@ -15,8 +15,6 @@
 
 #include <random>
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 TEST_F(MomentumKernelHex8Mesh, coriolis)
 {
   fill_mesh_and_init_fields();
@@ -58,7 +56,6 @@ TEST_F(MomentumKernelHex8Mesh, coriolis)
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
 
-
   // TEST: checks consistency with the Jacobian in CoriolisSrc
 
   // Exact solution
@@ -71,6 +68,4 @@ TEST_F(MomentumKernelHex8Mesh, coriolis)
   }
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, rhsExact.data());
 }
-
-#endif
 

--- a/unit_tests/kernels/UnitTestMomentumHybridTurbElem.C
+++ b/unit_tests/kernels/UnitTestMomentumHybridTurbElem.C
@@ -11,8 +11,6 @@
 
 #include "kernel/MomentumHybridTurbElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 namespace {
 namespace hex8_golds {
 namespace MomentumHybridTurbElemKernel {
@@ -272,7 +270,6 @@ static constexpr double lhs[24][24] = {
 } // namespace MomentumHybridTurbElemKernel
 } // namespace hex8_golds
 } // anonymous namespace
-#endif
 
 TEST_F(HybridTurbKernelHex8Mesh, NGP_momentum_hybrid_turb_elem_kernel)
 {
@@ -299,7 +296,6 @@ TEST_F(HybridTurbKernelHex8Mesh, NGP_momentum_hybrid_turb_elem_kernel)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -309,6 +305,5 @@ TEST_F(HybridTurbKernelHex8Mesh, NGP_momentum_hybrid_turb_elem_kernel)
     helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<24>(
     helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }
 

--- a/unit_tests/kernels/UnitTestMomentumMassElem.C
+++ b/unit_tests/kernels/UnitTestMomentumMassElem.C
@@ -11,8 +11,6 @@
 
 #include "kernel/MomentumMassElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 namespace {
 namespace hex8_golds {
 namespace momentum_time_derivative {
@@ -143,8 +141,6 @@ static constexpr double rhs[24] = {
 } // hex8_golds
 } // anonymous namespace
 
-#endif
-
 TEST_F(MomentumKernelHex8Mesh, NGP_momentum_time_derivative)
 {
   fill_mesh_and_init_fields();
@@ -179,7 +175,6 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_time_derivative)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -187,7 +182,6 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_time_derivative)
   namespace gold_values = ::hex8_golds::momentum_time_derivative;
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<24>(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }
 
 TEST_F(MomentumKernelHex8Mesh, NGP_momentum_time_derivative_lumped)
@@ -224,7 +218,6 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_time_derivative_lumped)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   namespace gold_values = ::hex8_golds::momentum_time_derivative_lumped;
   // Exact LHS expected
   std::vector<double> lhsExact(576, 0.0);
@@ -236,5 +229,4 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_time_derivative_lumped)
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near_2d(helperObjs.linsys->lhs_, lhsExact.data());
-#endif
 }

--- a/unit_tests/kernels/UnitTestMomentumUpwAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestMomentumUpwAdvDiffElem.C
@@ -11,8 +11,6 @@
 
 #include "kernel/MomentumUpwAdvDiffElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 namespace {
 namespace hex8_golds {
 namespace advection_diffusion {
@@ -275,8 +273,6 @@ static constexpr double lhs[24][24] = {
 } // hex8_golds
 } // anonymous namespace
 
-#endif
-
 TEST_F(MomentumKernelHex8Mesh, NGP_momentum_upw_advection_diffusion)
 {
   if (bulk_.parallel_size() > 1) return;
@@ -307,7 +303,6 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_upw_advection_diffusion)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -317,5 +312,4 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_upw_advection_diffusion)
     helperObjs.linsys->rhs_, gold_values::rhs, 1.0e-14);
   unit_test_kernel_utils::expect_all_near<24>(
     helperObjs.linsys->lhs_, gold_values::lhs, 1.0e-14);
-#endif
 }

--- a/unit_tests/kernels/UnitTestSSTSrcElem.C
+++ b/unit_tests/kernels/UnitTestSSTSrcElem.C
@@ -13,8 +13,6 @@
 #include "kernel/TurbKineticEnergySSTDESSrcElemKernel.h"
 #include "kernel/SpecificDissipationRateSSTSrcElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 namespace {
 namespace hex8_golds {
 namespace TurbKineticEnergySSTSrcElemKernel {
@@ -178,8 +176,6 @@ static constexpr double rhs[8] = {
 } // namespace hex8_golds
 } // anonymous namespace
 
-#endif
-
 TEST_F(SSTKernelHex8Mesh, NGP_turb_kinetic_energy_sst_src_elem)
 {
 
@@ -209,8 +205,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_turb_kinetic_energy_sst_src_elem)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
-
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -220,8 +214,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_turb_kinetic_energy_sst_src_elem)
     helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, gold_values::lhs);
-
-#endif
 }
 
 TEST_F(SSTKernelHex8Mesh, NGP_turb_kinetic_energy_sst_des_src_elem)
@@ -253,8 +245,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_turb_kinetic_energy_sst_des_src_elem)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
-
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -264,8 +254,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_turb_kinetic_energy_sst_des_src_elem)
     helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, gold_values::lhs);
-
-#endif
 
 }
 
@@ -298,8 +286,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_specific_dissipation_rate_sst_src_elem)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
-
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -309,7 +295,5 @@ TEST_F(SSTKernelHex8Mesh, NGP_specific_dissipation_rate_sst_src_elem)
     helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, gold_values::lhs);
-
-#endif
 }
 

--- a/unit_tests/kernels/UnitTestScalarMassElem.C
+++ b/unit_tests/kernels/UnitTestScalarMassElem.C
@@ -11,8 +11,6 @@
 
 #include "kernel/ScalarMassElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 namespace {
 namespace hex8_golds {
 namespace scalar_mass {
@@ -54,8 +52,6 @@ static constexpr double rhs[8] = {
 } // hex8_golds
 } // anonymous namespace
 
-#endif
-
 /// Scalar advection/diffusion (will use mixture fraction as scalar)
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_mass)
 {
@@ -93,7 +89,6 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_mass)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -101,7 +96,6 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_mass)
   namespace gold_values = hex8_golds::scalar_mass;
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }
 
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_time_derivative_lumped)
@@ -142,7 +136,6 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_time_derivative_lumped)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -152,5 +145,4 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_time_derivative_lumped)
       helperObjs.linsys->rhs_, gold_values::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(
       helperObjs.linsys->lhs_, gold_values::lhs, 1.0e-12);
-#endif
 }

--- a/unit_tests/kernels/UnitTestScalarUpwAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestScalarUpwAdvDiffElem.C
@@ -11,8 +11,6 @@
 
 #include "kernel/ScalarUpwAdvDiffElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 namespace {
 namespace hex8_golds {
 namespace advection_diffusion {
@@ -36,8 +34,6 @@ static constexpr double rhs[8] = {
 } // advection_diffusion
 } // hex8_golds
 } // anonymous namespace
-
-#endif
 
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_upw_advection_diffusion)
 {
@@ -69,7 +65,6 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_upw_advection_diffusion)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -77,5 +72,4 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_upw_advection_diffusion)
   namespace gold_values = hex8_golds::advection_diffusion;
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, gold_values::rhs);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }

--- a/unit_tests/kernels/UnitTestTurbKineticEnergyKsgsDesignOrderSrcElem.C
+++ b/unit_tests/kernels/UnitTestTurbKineticEnergyKsgsDesignOrderSrcElem.C
@@ -11,8 +11,6 @@
 
 #include "kernel/TurbKineticEnergyKsgsDesignOrderSrcElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 namespace {
 namespace hex8_golds {
 namespace TurbKineticEnergyKsgsDesignOrderSrcElemKernel {
@@ -43,8 +41,6 @@ static constexpr double rhs[8] = {
 } // namespace hex8_golds
 } // anonymous namespace
 
-#endif
-
 TEST_F(KsgsKernelHex8Mesh, NGP_turb_kinetic_energy_ksgs_design_order_src_elem_kernel)
 {
 
@@ -73,8 +69,6 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_kinetic_energy_ksgs_design_order_src_elem_ke
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
-
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -85,7 +79,5 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_kinetic_energy_ksgs_design_order_src_elem_ke
     helperObjs.linsys->rhs_, gold_values::rhs, 1.0e-14);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, gold_values::lhs, 1.0e-14);
-
-#endif
 }
 

--- a/unit_tests/kernels/UnitTestTurbKineticEnergyKsgsSrcElem.C
+++ b/unit_tests/kernels/UnitTestTurbKineticEnergyKsgsSrcElem.C
@@ -11,8 +11,6 @@
 
 #include "kernel/TurbKineticEnergyKsgsSrcElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
-
 namespace {
 namespace hex8_golds {
 namespace TurbKineticEnergyKsgsSrcElemKernel {
@@ -43,8 +41,6 @@ static constexpr double rhs[8] = {
 } // namespace hex8_golds
 } // anonymous namespace
 
-#endif
-
 TEST_F(KsgsKernelHex8Mesh, NGP_turb_kinetic_energy_ksgs_src_elem_kernel)
 {
 
@@ -73,8 +69,6 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_kinetic_energy_ksgs_src_elem_kernel)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
-
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -85,8 +79,5 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_kinetic_energy_ksgs_src_elem_kernel)
     helperObjs.linsys->rhs_, gold_values::rhs, 1.0e-14);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, gold_values::lhs, 1.0e-14);
-
-#endif
 }
-
 


### PR DESCRIPTION
Not all element kernels in #295 have NGP labeled tests, but this removes the ifdefs for all element unit tests that do have NGP tests. Results seem to be fine and all the unit tests pass for me on Eagle.