### PR TITLE
Fix AssembleEdgeSolverAlgorithm to use coeff-applier...

### DIFF
--- a/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
@@ -11,7 +11,6 @@
 
 #include "edge_kernels/ContinuityEdgeSolverAlg.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 static constexpr double rhs[8] = {
@@ -33,7 +32,6 @@ static constexpr double lhs[8][8] =
 
 } // hex8_golds
 } // anonymous namespace
-#endif
 
 TEST_F(ContinuityEdgeHex8Mesh, NGP_advection)
 {
@@ -60,13 +58,10 @@ TEST_F(ContinuityEdgeHex8Mesh, NGP_advection)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
-  EXPECT_EQ(helperObjs.linsys->numSumIntoCalls_, 12);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, hex8_golds::lhs);
-#endif
 }


### PR DESCRIPTION
...so that the edge-based kernels can sum contributions into the
linear system on the GPU.
Verified that the unit-test in UnitTestContinuityAdvEdge works
on GPU with the ifdefs removed so that the gold-value comparisons
happen now.