### PR TITLE
Fix Wale model to use the deviatoric part of the square of the velocity gradient tensor

### DIFF
--- a/docs/source/theory/turbulenceModeling.rst
+++ b/docs/source/theory/turbulenceModeling.rst
@@ -142,7 +142,7 @@ while :math:`S^d_{ij}` is,
 .. math::
    :label: wale-sdij
 
-   S^d_{ij} = \frac{1}{2} \left( g^2_{ij} + g^2_{ji}\right).
+   S^d_{ij} = \frac{1}{2} \left( g^2_{ij} + g^2_{ji}\right) - \frac{1}{3} \delta_{ij} g^2_{kk}.
 
 
 Finally, the velocity gradient squared ters are


### PR DESCRIPTION
* The WALE model in nalu-wind uses the full square of velocity gradient tensor rather than just the deviatoric part like in the Nicoud and Ducros paper.  

* This will cause a bunch of tests to diff:
  * TestTurbulenceAlgorithm.turbviscwalealgorithm
  * ablUnstableEdge
  * ablUnstableEdge_ra
  * ductElemWedge
  * heatedWaterChannelEdge
  * ablStableElem
  * heatedWaterChannelElem
  * hoHelium
  *  nonIsoNonUniformEdgeOpenJet 
  * nonIsoNonUniformElemOpenJet
  * waleElemXflowMixFrac3.5m

I think it's probably best to rebless them with gold files from the NREL machine. 
