### PR TITLE
Fix for NALU_ALIGN for Summit.

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -15,7 +15,7 @@
 #include <Kokkos_Core.hpp>
 
 #ifdef KOKKOS_ENABLE_CUDA
-#define NALU_ALIGNED alignof(std::max_align_t)
+#define NALU_ALIGNED alignas(sizeof(long double))
 #else
 #define NALU_ALIGNED alignas(KOKKOS_MEMORY_ALIGNMENT)
 #endif

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -8,11 +8,17 @@
 #ifndef INCLUDE_KOKKOSINTERFACE_H_
 #define INCLUDE_KOKKOSINTERFACE_H_
 
+#include <cstddef>
+
 #include <stk_mesh/base/Entity.hpp>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core.hpp>
 
+#ifdef KOKKOS_ENABLE_CUDA
+#define NALU_ALIGNED alignof(std::max_align_t)
+#else
 #define NALU_ALIGNED alignas(KOKKOS_MEMORY_ALIGNMENT)
+#endif
 
 #if defined(__INTEL_COMPILER)
 #define POINTER_RESTRICT restrict


### PR DESCRIPTION
We were using KOKKOS_MEMORY_ALIGNMENT (which is 64) to align
static arrays.  On Summit this gives a warning that it
is greater than 16 and it appears that because of the warning
the alignment attribute is ignored.

This commmit will change to alignof(std::max_align_t)
if compiling for the GPU.  Not sure this will compile
everywhere.

I seem to recall that KOKKOS_MEMORY_ALIGNMENT was set to 64
because this was needed for SIMD and I think Nalu even
pushed for this a couple of years ago. So I'm not sure the
Kokkos macro can be changed.