### PR TITLE
Use coeff applier in AssembleNGPNodeSolverAlgorithm

### DIFF
--- a/include/AssembleNodeSolverAlgorithm.h
+++ b/include/AssembleNodeSolverAlgorithm.h
@@ -31,7 +31,8 @@ public:
     Realm &realm,
     stk::mesh::Part *part,
     EquationSystem *eqSystem);
-  virtual ~AssembleNodeSolverAlgorithm() {}
+
+  virtual ~AssembleNodeSolverAlgorithm() = default;
   virtual void initialize_connectivity();
   virtual void execute();
 

--- a/src/AssembleNGPNodeSolverAlgorithm.C
+++ b/src/AssembleNGPNodeSolverAlgorithm.C
@@ -91,10 +91,12 @@ AssembleNGPNodeSolverAlgorithm::execute()
   const stk::mesh::EntityRank entityRank = stk::topology::NODE_RANK;
   const int rhsSize = rhsSize_;
 
-#ifndef KOKKOS_ENABLE_CUDA
-  const int nodesPerEntity = 1;
+#ifdef KOKKOS_ENABLE_CUDA
+  CoeffApplier* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
+  CoeffApplier* deviceCoeffApplier = coeffApplier->device_pointer();
 #endif
 
+  const int nodesPerEntity = 1;
   const int bytes_per_team = 0;
   const int bytes_per_thread = calc_shmem_bytes_per_thread(rhsSize);
 
@@ -133,9 +135,17 @@ AssembleNGPNodeSolverAlgorithm::execute()
           this->apply_coeff(
             nodesPerEntity, smdata.ngpNodes, smdata.scratchIds,
             smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
+#else
+          (*deviceCoeffApplier)(
+            nodesPerEntity, smdata.ngpNodes, smdata.scratchIds,
+            smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
 #endif
         });
     });
+#ifdef KOKKOS_ENABLE_CUDA
+    coeffApplier->free_device_pointer();
+    delete coeffApplier;
+#endif
 }
 
 }  // nalu

--- a/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
@@ -34,12 +34,10 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_gcl_node)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_,9.375);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_,0.0);
-#endif
 }


### PR DESCRIPTION
This was much easier than I expected assuming I did it right. I kept looking at `AssembleNodeSolverAlgorithm.h` and thought it was going to need a lot more modifications, until I finally realized there was a `AssembleNGPNodeSolverAlgorithm.h`.

Hopefully I can finish off the node kernel ifdefs after this now.