### PR TITLE
Fix parallel consistency for the minimum distance clipping utility in SST

### DIFF
--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -24,6 +24,8 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 
 // stk_io
@@ -480,6 +482,10 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
          *minD = std::max(*minD, ypbip);
        }
      }
+   }
+   stk::mesh::parallel_max(realm_.bulk_data(), {minDistanceToWall_});
+   if (realm_.hasPeriodic_) {
+     realm_.periodic_field_update(minDistanceToWall_, 1);
    }
 }
 


### PR DESCRIPTION
* The minimum distance clipping utility was missing a parallel consistency operation
* Doesn't affect any of the tests.  It's somewhat unlikely to come up as a problem.