### PR TITLE
Add shear initial/boundary condition specification using power law

### DIFF
--- a/include/user_functions/WindEnergyPowerLawAuxFunction.h
+++ b/include/user_functions/WindEnergyPowerLawAuxFunction.h
@@ -1,0 +1,68 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef WINDENERGYPOWERLAWAUXFUNCTION_H
+#define WINDENERGYPOWERLAWAUXFUNCTION_H
+
+#include "AuxFunction.h"
+#include <vector>
+#include <array>
+
+namespace sierra{
+namespace nalu{
+
+
+
+/** Create power law velocity profile aux function for wind energy applications
+ *
+ *  This function is used as an initial or boundary condition,
+ *  primarily in simulation of wind turbines under specified shear
+ *  with a power law profile. The function implemented is 
+ * \f[]
+ *  u = u_{ref} \left ( \frac{y - y_{offset}}{y_{ref}} \right )^{shear_exp} \frac{1}{2} \left ( tanh (y - y_{offset}) + 1 \right )
+ * \f]
+ */
+class WindEnergyPowerLawAuxFunction : public AuxFunction
+{
+public:
+
+  WindEnergyPowerLawAuxFunction(
+    const unsigned beginPos,
+    const unsigned endPos,
+    const std::vector<double> &theParams);
+
+  virtual ~WindEnergyPowerLawAuxFunction() {}
+  
+  using AuxFunction::do_evaluate;
+  virtual void do_evaluate(
+    const double * coords,
+    const double time,
+    const unsigned spatialDimension,
+    const unsigned numPoints,
+    double * fieldPtr,
+    const unsigned fieldSize,
+    const unsigned beginPos,
+    const unsigned endPos) const;
+  
+private:
+
+    int coord_dir_{2}; // Coordinate direction - 0/1/2
+    double y_offset_{0.0}; //Offset for coordinate
+    double y_ref_{0.0}; // Reference height
+    double shear_exp_{0.12} ; // Exponent for power law
+    // Velocity vector at reference height
+    std::array<double,3> u_ref_{{8.0,0.0,0.0}}; 
+    double u_mag_{8.0}; // Velocity magnitude
+    double u_min_{4.0}; // Minimum velocity to cut off power law
+    double u_max_{12.0}; // Maximum velocity to cut off power law
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+
+#endif /* WINDENERGYPOWERLAWAUXFUNCTION_H */

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -190,6 +190,8 @@
 
 #include <user_functions/BoundaryLayerPerturbationAuxFunction.h>
 
+#include <user_functions/WindEnergyPowerLawAuxFunction.h>
+
 #include <user_functions/KovasznayVelocityAuxFunction.h>
 #include <user_functions/KovasznayPressureAuxFunction.h>
 
@@ -619,6 +621,16 @@ LowMachEquationSystem::register_initial_condition_fcn(
       else {
         throw std::runtime_error("Boundary_layer_perturbation missing parameters");
       }
+    }
+    else if ( fcnName == "wind_energy_power_law") {
+        auto it = theParams.find(dofName);
+        if (it != theParams.end()) {
+            auto& fp = it->second;
+            theAuxFunc = new WindEnergyPowerLawAuxFunction(0,nDim,fp);
+        }
+        else {
+            throw std::runtime_error("Widn Energy Power Law aux function missing parameters in initial condition");
+        }
     }
     else if (fcnName == "kovasznay") {
       theAuxFunc = new KovasznayVelocityAuxFunction(0, nDim);
@@ -1611,6 +1623,9 @@ MomentumEquationSystem::register_inflow_bc(
     }
     else if ( fcnName == "kovasznay") {
       theAuxFunc = new KovasznayVelocityAuxFunction(0,nDim);
+    }
+    else if ( fcnName == "wind_energy_power_law") {
+      theAuxFunc = new WindEnergyPowerLawAuxFunction(0,nDim,theParams);
     }
     else {
       throw std::runtime_error("MomentumEquationSystem::register_inflow_bc: limited functions supported");

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -3113,6 +3113,9 @@ ContinuityEquationSystem::register_inflow_bc(
       else if ( fcnName == "BoussinesqNonIso") {
         theAuxFunc = new BoussinesqNonIsoVelocityAuxFunction(0, nDim);
       }
+      else if ( fcnName == "wind_energy_power_law") {
+          theAuxFunc = new WindEnergyPowerLawAuxFunction(0,nDim,theParams);
+      }
       else {
         throw std::runtime_error("ContEquationSystem::register_inflow_bc: limited functions supported");
       }

--- a/src/user_functions/CMakeLists.txt
+++ b/src/user_functions/CMakeLists.txt
@@ -51,6 +51,7 @@ add_sources(GlobalSourceList
    VariableDensityNonIsoTemperatureAuxFunction.C
    VariableDensityPressureAuxFunction.C
    VariableDensityVelocityAuxFunction.C
+   WindEnergyPowerLawAuxFunction.C
    WindEnergyTaylorVortexAuxFunction.C
    WindEnergyTaylorVortexPressureAuxFunction.C
 )

--- a/src/user_functions/WindEnergyPowerLawAuxFunction.C
+++ b/src/user_functions/WindEnergyPowerLawAuxFunction.C
@@ -1,0 +1,79 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "user_functions/WindEnergyPowerLawAuxFunction.h"
+#include <algorithm>
+
+// basic c++
+#include <cmath>
+#include <vector>
+#include <stdexcept>
+
+namespace sierra{
+namespace nalu{
+
+WindEnergyPowerLawAuxFunction::WindEnergyPowerLawAuxFunction(
+  const unsigned beginPos,
+  const unsigned endPos,
+  const std::vector<double> &params) :
+  AuxFunction(beginPos, endPos)
+{
+  // check size and populate
+  if ( params.size() != 8 )
+    throw std::runtime_error("Realm::setup_initial_conditions: wind_energy_power_law requires 8 params: ");
+  coord_dir_  = int(params[0]);
+  y_offset_ = params[1];
+  y_ref_ = params[2];
+  shear_exp_ = params[3];
+  u_ref_[0] = params[4];
+  u_ref_[1] = params[5];
+  u_ref_[2] = params[6];
+  u_mag_ = std::sqrt(u_ref_[0] * u_ref_[0] + u_ref_[1] * u_ref_[1] + u_ref_[2] * u_ref_[2]);
+  u_min_ = params[7];
+  u_max_ = params[8];
+}
+
+void
+WindEnergyPowerLawAuxFunction::do_evaluate(
+  const double *coords,
+  const double /*time*/,
+  const unsigned /*spatialDimension*/,
+  const unsigned numPoints,
+  double * fieldPtr,
+  const unsigned fieldSize,
+  const unsigned /*beginPos*/,
+  const unsigned /*endPos*/) const
+{
+  for(unsigned p=0; p < numPoints; ++p) {
+
+    const double y = coords[coord_dir_];
+
+    const double power_law_fn = std::pow( (y - y_offset_)/y_ref_ , shear_exp_ ) * 0.5 * ( std::tanh( (y - y_ref_)) + 1.0) ;
+
+    if ( u_mag_* power_law_fn < u_min_)  {
+        fieldPtr[0] = u_ref_[0]/u_mag_ * u_min_ ;
+        fieldPtr[1] = u_ref_[1]/u_mag_ * u_min_ ;
+        fieldPtr[2] = u_ref_[2]/u_mag_ * u_min_ ;
+    }
+    else if ( u_mag_* power_law_fn > u_max_)  {
+        fieldPtr[0] = u_ref_[0]/u_mag_ * u_max_ ;
+        fieldPtr[1] = u_ref_[1]/u_mag_ * u_max_ ;
+        fieldPtr[2] = u_ref_[2]/u_mag_ * u_max_ ;
+    }
+    else {
+        fieldPtr[0] = u_ref_[0] * power_law_fn;
+        fieldPtr[1] = u_ref_[1] * power_law_fn;
+        fieldPtr[2] = u_ref_[2] * power_law_fn;
+    }
+    
+    fieldPtr += fieldSize;
+    coords += fieldSize;
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/user_functions/WindEnergyPowerLawAuxFunction.C
+++ b/src/user_functions/WindEnergyPowerLawAuxFunction.C
@@ -23,8 +23,8 @@ WindEnergyPowerLawAuxFunction::WindEnergyPowerLawAuxFunction(
   AuxFunction(beginPos, endPos)
 {
   // check size and populate
-  if ( params.size() != 8 )
-    throw std::runtime_error("Realm::setup_initial_conditions: wind_energy_power_law requires 8 params: ");
+  if ( params.size() != 9 )
+    throw std::runtime_error("Realm::setup_initial_conditions: wind_energy_power_law requires 9 params: ");
   coord_dir_  = int(params[0]);
   y_offset_ = params[1];
   y_ref_ = params[2];
@@ -52,7 +52,11 @@ WindEnergyPowerLawAuxFunction::do_evaluate(
 
     const double y = coords[coord_dir_];
 
-    const double power_law_fn = std::pow( (y - y_offset_)/y_ref_ , shear_exp_ ) * 0.5 * ( std::tanh( (y - y_ref_)) + 1.0) ;
+    double power_law_fn = 0.0;
+
+    if ( (y - y_offset_) > 0.0) {
+        power_law_fn = std::pow( (y - y_offset_)/y_ref_ , shear_exp_ );
+    }
 
     if ( u_mag_* power_law_fn < u_min_)  {
         fieldPtr[0] = u_ref_[0]/u_mag_ * u_min_ ;


### PR DESCRIPTION
This pull request adds the capability to specify an initial/boundary condition specification using a power law. Also adds an option to limit the minimum and maximum velocity.

Attached image shows the use of the AuxFunction in a real case setting with the following inputs

`    initial_conditions:

      - user_function: ic_1
        target_name: fluid
        user_function_name:
         velocity: wind_energy_power_law
        user_function_parameters:
          velocity:
            - 2          # Coordinate direction
            - -90.0   # Offset height
            - 90.0     # Reference height
            - 0.12      # Shear exponent
            - 9.792   # Reference velocity - x component
            - 0.0       # Reference velocity - y component
            - 0.0       # Reference velocity - z component
            - 4.0       # Minimum velocity
            - 12.0     # Maximum velocity`

![ShearProfile](https://user-images.githubusercontent.com/5861743/63307266-13dda600-c2ab-11e9-983c-812ca5e3017d.png)