### PR TITLE
Change sign in the abl_top BC

### DIFF
--- a/examples/nalu_input_fileX
+++ b/examples/nalu_input_fileX
@@ -508,7 +508,7 @@ class mapping_object_class():
                                 - self.yaml_setup['temperature_heights'][-2])
                 # Assign the initial condition
                 var['abltop_user_data']['normal_temperature_gradient'] = \
-                    TGradUpper
+                    -TGradUpper
 
 
     def set_density(self):


### PR DESCRIPTION
This is a bug fix in the example scripts.
The abl_top normal temperature gradient had the incorrect sign.