### PR TITLE
Velocity initial condition with wake and induction using mom. theory

### DIFF
--- a/include/user_functions/WindEnergyMomWakeInductionAuxFunction.h
+++ b/include/user_functions/WindEnergyMomWakeInductionAuxFunction.h
@@ -1,0 +1,75 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef WINDENERGYMOMWAKEINDUCTIONAUXFUNCTION_H
+#define WINDENERGYMOMWAKEINDUCTIONAUXFUNCTION_H
+
+#include "AuxFunction.h"
+#include <vector>
+#include <array>
+
+namespace sierra{
+namespace nalu{
+
+
+
+/** Create power law velocity profile aux function for wind energy applications
+ *
+ *  This function is used as an initial condition, primarily in
+ *  simulation of wind turbines under uniform inflow. It sets up the
+ *  velocity field corresponding to the induction and the wake region
+ *  using the simple model based on 1D momentum theory from
+ *  E. Branlard and M. Gaunaa, Cylindrical vortex wake model: right
+ *  cylinder, Wind Energy, 18, 11, Nov. 2015.
+ *  
+. The function implemented is 
+ * \f[
+ *  u = u - u_z
+ *  \bar{z} = z/R
+ *  u_z = \frac{\gamma}{2} \left ( 1 + \frac{\bar{z}}{ \sqrt{1 + \bar{z}^2} } \right )
+ *  \left ( \frac{R_w(\bar{z})}{R} \right )^2 = \frac{1 - a}{1 - a \left ( 1 + \frac{\bar{z}}{ \sqrt{1+\bar{z}^2 } } \right )}
+ * \f]
+ */
+class WindEnergyMomWakeInductionAuxFunction : public AuxFunction
+{
+public:
+
+  WindEnergyMomWakeInductionAuxFunction(
+    const unsigned beginPos,
+    const unsigned endPos,
+    const std::vector<double> &theParams);
+
+  virtual ~WindEnergyMomWakeInductionAuxFunction() {}
+  
+  using AuxFunction::do_evaluate;
+  virtual void do_evaluate(
+    const double * coords,
+    const double time,
+    const unsigned spatialDimension,
+    const unsigned numPoints,
+    double * fieldPtr,
+    const unsigned fieldSize,
+    const unsigned beginPos,
+    const unsigned endPos) const;
+  
+private:
+
+    //Turbine location
+    std::array<double,3> turbine_loc_;
+    double ct_; //Thrust coefficient
+    double dia_; //Turbine diameter
+    double r_; //Turbine radius
+    // Velocity vector at reference height
+    std::array<double,3> u_infty_;
+    double u_mag_; // Velocity magnitude
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+
+#endif /* WINDENERGYMOMWAKEINDUCTIONAUXFUNCTION_H */

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -190,6 +190,7 @@
 
 #include <user_functions/BoundaryLayerPerturbationAuxFunction.h>
 
+#include <user_functions/WindEnergyMomWakeInductionAuxFunction.h>
 #include <user_functions/WindEnergyPowerLawAuxFunction.h>
 
 #include <user_functions/KovasznayVelocityAuxFunction.h>
@@ -630,6 +631,16 @@ LowMachEquationSystem::register_initial_condition_fcn(
         }
         else {
             throw std::runtime_error("Wind Energy Power Law aux function missing parameters in initial condition");
+        }
+    }
+    else if ( fcnName == "wind_energy_mom_wake_induction") {
+        auto it = theParams.find(dofName);
+        if (it != theParams.end()) {
+            auto& fp = it->second;
+            theAuxFunc = new WindEnergyMomWakeInductionAuxFunction(0,nDim,fp);
+        }
+        else {
+            throw std::runtime_error("Wind Energy Momentum Wake/Induction aux function missing parameters in initial condition");
         }
     }
     else if (fcnName == "kovasznay") {

--- a/src/user_functions/CMakeLists.txt
+++ b/src/user_functions/CMakeLists.txt
@@ -51,6 +51,7 @@ add_sources(GlobalSourceList
    VariableDensityNonIsoTemperatureAuxFunction.C
    VariableDensityPressureAuxFunction.C
    VariableDensityVelocityAuxFunction.C
+   WindEnergyMomWakeInductionAuxFunction.C
    WindEnergyPowerLawAuxFunction.C
    WindEnergyTaylorVortexAuxFunction.C
    WindEnergyTaylorVortexPressureAuxFunction.C

--- a/src/user_functions/WindEnergyMomWakeInductionAuxFunction.C
+++ b/src/user_functions/WindEnergyMomWakeInductionAuxFunction.C
@@ -1,0 +1,94 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "user_functions/WindEnergyMomWakeInductionAuxFunction.h"
+
+// basic c++
+#include <cmath>
+#include <array>
+
+namespace sierra{
+namespace nalu{
+
+WindEnergyMomWakeInductionAuxFunction::WindEnergyMomWakeInductionAuxFunction(
+  const unsigned beginPos,
+  const unsigned endPos,
+  const std::vector<double> &params) :
+  AuxFunction(beginPos, endPos)
+{
+  // check size and populate
+  if ( params.size() != 8 )
+    throw std::runtime_error("Realm::setup_initial_conditions: wind_energy_mom_ind_wake requires 8 params: ");
+  turbine_loc_[0] = params[0];
+  turbine_loc_[1] = params[1];
+  turbine_loc_[2] = params[2];
+  ct_ = params[3];
+  dia_ = params[4];
+  r_ = 0.5 * dia_ ; 
+  u_infty_[0] = params[5];
+  u_infty_[1] = params[6];
+  u_infty_[2] = params[7];
+  u_mag_ = std::sqrt(u_infty_[0] * u_infty_[0] + u_infty_[1] * u_infty_[1] + u_infty_[2] * u_infty_[2]);
+  for (auto i=0;i<3;i++)
+      u_infty_[i] = u_infty_[i]/u_mag_; //Normalize u_infty to store the flow direction
+  
+}
+
+void
+WindEnergyMomWakeInductionAuxFunction::do_evaluate(
+  const double *coords,
+  const double /*time*/,
+  const unsigned /*spatialDimension*/,
+  const unsigned numPoints,
+  double * fieldPtr,
+  const unsigned fieldSize,
+  const unsigned /*beginPos*/,
+  const unsigned /*endPos*/) const
+{
+
+    std::array<double,3> c_rel; // Coordinates relative to turbine
+    double rsq;
+    double crel_dot_n;
+    double u_def;
+    double sqrt_one_p_zsq;
+    double a = 0.5 * (1.0 - std::sqrt(1.0 - ct_)); // Induction
+    double gamma_t = -2.0 * a * u_mag_;
+    double r_wake_sq;
+    
+    for(unsigned p=0; p < numPoints; ++p) {
+        
+
+        for (auto i=0; i < 3; i++)
+            c_rel[i] = coords[i] - turbine_loc_[i];
+        crel_dot_n = 0.0;
+        for (auto i=0; i < 3; i++)
+            crel_dot_n += c_rel[i] * u_infty_[i];
+        rsq = 0.0;
+        for (auto i=0; i < 3; i++) {
+            c_rel[i] = c_rel[i] - crel_dot_n * u_infty_[i];
+            rsq += c_rel[i] * c_rel[i];
+        }
+
+        crel_dot_n = crel_dot_n/r_; // Normalize w.r.t turbine radius
+        sqrt_one_p_zsq = std::sqrt(1.0 + crel_dot_n * crel_dot_n);
+        
+        r_wake_sq = r_ * r_ * (1.0 - a)/ (1.0 - a * (1.0 + crel_dot_n/std::sqrt(1.0 + crel_dot_n*crel_dot_n) ) );
+        rsq = rsq/r_wake_sq;
+        
+        u_def = gamma_t * 0.5 * (1.0 + crel_dot_n / sqrt_one_p_zsq ) *   ( 0.5 * (1.0 - std::tanh( (rsq - 1.0) * 100.0 ) ) ) * ( 0.5 * (1.0 - std::tanh( (crel_dot_n - 16.0)*0.5 ) ) );
+        
+        fieldPtr[0] = (u_mag_ + u_def) * u_infty_[0];
+        fieldPtr[1] = (u_mag_ + u_def) * u_infty_[1];
+        fieldPtr[2] = (u_mag_ + u_def) * u_infty_[2];
+        
+        fieldPtr += fieldSize;
+        coords += fieldSize;
+    }
+}
+
+} // namespace nalu
+} // namespace Sierra


### PR DESCRIPTION
Create an initial condition for a turbine simulation with wake and induction calculated using momentum theory. This should help speed up any simulations of turbines. The model accounts for wake expansion and is designed to taper off after 8 diameters over a distance of 1D. Tested to work with actuator line simulations.

![velprofile_mom_wake_induction](https://user-images.githubusercontent.com/5861743/63900733-c1913900-c9be-11e9-9436-97beee213cb3.png)

```
      - user_function: ic_1
        target_name: fluid
        user_function_name:
         velocity: wind_energy_mom_wake_induction
        user_function_parameters:
          velocity:
            - 0.0  # Turbine location - x
            - 0.0  # Turbine location - y
            - 0.0  # Turbine location - z
            - 0.43  # Thrust coefficient
            - 126.0  # Turbine diameter
            - 8.0  # U infinity - x
            - 0.0  # U infinity - y
            - 0.0  # U infinity - z





