### PR TITLE
Removing CUDA ifdefs from more kernel unit tests

### DIFF
--- a/unit_tests/kernels/UnitTestWallDistElem.C
+++ b/unit_tests/kernels/UnitTestWallDistElem.C
@@ -11,7 +11,6 @@
 
 #include "kernel/WallDistElemKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 namespace wall_dist_default {
@@ -41,7 +40,6 @@ static constexpr double lhs[8][8] = {
 }
 } // hex8_golds
 } // anonymous
-#endif
 
 TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist)
 {
@@ -65,7 +63,6 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -73,7 +70,6 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist)
   namespace gold_values = hex8_golds::wall_dist_default;
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 0.125);
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }
 
 TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_shifted)
@@ -99,7 +95,6 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_shifted)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -107,5 +102,4 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_shifted)
   namespace gold_values = hex8_golds::wall_dist_lumped;
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 0.125);
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->lhs_, gold_values::lhs);
-#endif
 }

--- a/unit_tests/node_kernels/UnitTestEnthalpyABLForceNode.C
+++ b/unit_tests/node_kernels/UnitTestEnthalpyABLForceNode.C
@@ -31,7 +31,6 @@ TEST_F(EnthalpyKernelHex8Mesh, NGP_abl_force)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -39,5 +38,4 @@ TEST_F(EnthalpyKernelHex8Mesh, NGP_abl_force)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 37.5, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, 0.0, 1.0e-12);
-#endif
 }

--- a/unit_tests/node_kernels/UnitTestKsgsNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestKsgsNodeKernel.C
@@ -11,7 +11,6 @@
 
 #include "node_kernels/TKEKsgsNodeKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 namespace tke_ksgs {
@@ -35,7 +34,6 @@ static constexpr double lhs[8][8] = {
 } // tke_ksgs
 } // hex8_golds
 }
-#endif
 
 TEST_F(KsgsKernelHex8Mesh, NGP_tke_ksgs_node)
 {
@@ -60,7 +58,6 @@ TEST_F(KsgsKernelHex8Mesh, NGP_tke_ksgs_node)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -71,5 +68,4 @@ TEST_F(KsgsKernelHex8Mesh, NGP_tke_ksgs_node)
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
-#endif
 }

--- a/unit_tests/node_kernels/UnitTestMomentumABLForceNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumABLForceNode.C
@@ -31,7 +31,6 @@ TEST_F(MomentumNodeHex8Mesh, NGP_abl_force)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -39,5 +38,4 @@ TEST_F(MomentumNodeHex8Mesh, NGP_abl_force)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 1.25, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<24>(helperObjs.linsys->lhs_, 0.0, 1.0e-12);
-#endif
 }

--- a/unit_tests/node_kernels/UnitTestMomentumBodyForceNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumBodyForceNode.C
@@ -30,7 +30,6 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -38,5 +37,4 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force)
 
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 1.0, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<24>(helperObjs.linsys->lhs_, 0.0, 1.0e-12);
-#endif
 }

--- a/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
@@ -46,7 +46,6 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_coriolis)
   EXPECT_NEAR(cor.upVector_[1], 0.0, tol);
   EXPECT_NEAR(cor.upVector_[2], 1.0, tol);
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -61,5 +60,4 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_coriolis)
     rhsExact[nnDim + 2] = 0.125 * (-cor.Jxz_  - cor.Jyz_);
   }
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, rhsExact.data());
-#endif
 }

--- a/unit_tests/node_kernels/UnitTestMomentumGclSrcNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumGclSrcNodeKernel.C
@@ -14,7 +14,6 @@
 
 #include <vector>
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace gold_values {
 namespace momentum_gcl {
@@ -27,7 +26,6 @@ static constexpr double rhs[24] =
 } // momentum_gcl
 } // gold_values
 } // anonymous namespace
-#endif
 
 TEST_F(MomentumNodeHex8Mesh, NGP_momentum_gcl_node)
 {
@@ -52,7 +50,6 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_gcl_node)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -61,5 +58,4 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_gcl_node)
   unit_test_kernel_utils::expect_all_near(
     helperObjs.linsys->rhs_, gold_values::momentum_gcl::rhs, 1.0e-14);
   unit_test_kernel_utils::expect_all_near<24>(helperObjs.linsys->lhs_, 0.0);
-#endif
 }

--- a/unit_tests/node_kernels/UnitTestMomentumMassBDFNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumMassBDFNodeKernel.C
@@ -11,7 +11,6 @@
 
 #include "node_kernels/MomentumMassBDFNodeKernel.h"
 
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace bdf_golds {
 namespace momentum_mass {
@@ -29,7 +28,6 @@ static constexpr double rhs[24] =
 } // momentum_mass
 } // bdf_golds
 } // anonymous namespace
-#endif
 
 TEST_F(MomentumKernelHex8Mesh, NGP_momentum_mass_node)
 {
@@ -56,7 +54,6 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_mass_node)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 24u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 24u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 24u);
@@ -72,6 +69,4 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_mass_node)
     helperObjs.linsys->rhs_, gold_values::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near_2d(
     helperObjs.linsys->lhs_, lhsExact.data());
-#endif
-
 }

--- a/unit_tests/node_kernels/UnitTestSSTNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestSSTNodeKernel.C
@@ -14,8 +14,6 @@
 #include "node_kernels/SDRSSTNodeKernel.h"
 #include "node_kernels/SDRSSTDESNodeKernel.h"
 
-
-#ifndef KOKKOS_ENABLE_CUDA
 namespace {
 namespace hex8_golds {
 namespace tke_sst {
@@ -100,8 +98,6 @@ static constexpr double lhs[8][8] = {
 } // hex8_golds
 }
 
-#endif
-
 TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_node)
 {
   // Only execute for 1 processor runs
@@ -122,7 +118,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_node)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -133,7 +128,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_node)
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
-#endif
 }
 
 TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_node)
@@ -156,7 +150,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_node)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -167,7 +160,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_node)
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
-#endif
 }
 
 TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_node)
@@ -190,7 +182,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_node)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -201,7 +192,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_node)
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
-#endif
 }
 
 TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_des_node)
@@ -224,7 +214,6 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_des_node)
 
   helperObjs.execute();
 
-#ifndef KOKKOS_ENABLE_CUDA
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -236,5 +225,4 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_des_node)
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
-#endif
 }


### PR DESCRIPTION
Thanks to @alanw0, it looks like we can remove the remaining ifdefs from the node kernels.