### PR TITLE
Improve Tpetra matrix initialization performance

### DIFF
--- a/include/FieldTypeDef.h
+++ b/include/FieldTypeDef.h
@@ -13,6 +13,8 @@
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_ngp/Ngp.hpp>
 
+#include "LinearSolverTypes.h" // for GlobalOrdinal
+
 #ifdef NALU_USES_HYPRE
 #include "HYPRE_utilities.h"
 #endif
@@ -46,6 +48,7 @@ typedef HYPRE_Int HypreIntType;
 typedef int HypreIntType;
 #endif
 
+typedef stk::mesh::Field<LinSys::GlobalOrdinal> TpetIDFieldType;
 typedef stk::mesh::Field<HypreIntType> HypreIDFieldType;
 
 } // namespace nalu

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -657,6 +657,7 @@ class Realm {
    *  endIdx(MPI_rank) + 1.
    */
   HypreIDFieldType* hypreGlobalId_{nullptr};
+  TpetIDFieldType* tpetGlobalId_{nullptr};
 
   /** Flag indicating whether Hypre solver is being used for any of the equation
    * systems.

--- a/include/TpetraLinearSystemHelpers.h
+++ b/include/TpetraLinearSystemHelpers.h
@@ -74,6 +74,16 @@ void add_lengths_to_comm(const stk::mesh::BulkData&  /* bulk */,
                          const stk::mesh::EntityId* colEntityIds,
                          const int* colOwners);
 
+void add_lengths_to_comm_tpet(const stk::mesh::BulkData&  /* bulk */,
+                              TpetIDFieldType * tpetGID_label,
+                         stk::CommNeighbors& commNeighbors,
+                         int entity_a_owner,
+                         stk::mesh::EntityId entityId_a,
+                              //                         unsigned numDof,
+                         unsigned numColEntities,
+                         const stk::mesh::EntityId* colEntityIds,
+                         const int* colOwners);
+
 void communicate_remote_columns(const stk::mesh::BulkData& bulk,
                                 const std::vector<int>& neighborProcs,
                                 stk::CommNeighbors& commNeighbors,

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -877,6 +877,9 @@ Realm::setup_nodal_fields()
   hypreGlobalId_ = &(metaData_->declare_field<HypreIDFieldType>(
                        stk::topology::NODE_RANK, "hypre_global_id"));
 #endif
+  tpetGlobalId_ = &(metaData_->declare_field<TpetIDFieldType>(
+                       stk::topology::NODE_RANK, "tpet_global_id"));
+
   // register global id and rank fields on all parts
   const stk::mesh::PartVector parts = metaData_->get_parts();
   for ( size_t ipart = 0; ipart < parts.size(); ++ipart ) {
@@ -886,6 +889,8 @@ Realm::setup_nodal_fields()
 #ifdef NALU_USES_HYPRE
     stk::mesh::put_field_on_mesh(*hypreGlobalId_, *parts[ipart], nullptr);
 #endif
+    stk::mesh::put_field_on_mesh(*tpetGlobalId_, *parts[ipart], nullptr);
+    stk::mesh::field_fill(std::numeric_limits<LinSys::GlobalOrdinal>::max(), *tpetGlobalId_);
   }
 
 

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -219,7 +219,6 @@ void TpetraLinearSystem::beginLinearSystemConstruction()
 
   // Also, we'll build up our own local id map. Note: first we number
   // the owned nodes then we number the sharedNotOwned nodes.
-  LocalOrdinal localId = 0;
 
   // make separate arrays that hold the owned and sharedNotOwned gids
   std::vector<stk::mesh::Entity> owned_nodes, shared_not_owned_nodes;
@@ -245,17 +244,62 @@ void TpetraLinearSystem::beginLinearSystemConstruction()
   std::vector<stk::mesh::Entity>::iterator iter = std::unique(owned_nodes.begin(), owned_nodes.end(), CompareEntityEqualById(bulkData, realm_.naluGlobalId_));
   owned_nodes.erase(iter, owned_nodes.end());
 
+  ThrowRequire((int)maxOwnedRowId_ == (int)(owned_nodes.size()*numDof_)); // if this is never tripped, then the above unique is useless. !!!
+
+  // use the Contiguous Map constructor. 
+
+   const Teuchos::RCP<LinSys::Comm> tpetraComm = Teuchos::rcp(new LinSys::Comm(bulkData.parallel()));
+  ownedRowsMap_ = Teuchos::rcp(new LinSys::Map(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
+                                               maxOwnedRowId_, // must have *numDof_ 
+                                               1,
+                                               tpetraComm));
   myLIDs_.clear();
-  //KOKKOS: Loop noparallel push_back totalGids_ (std::vector)
+  myLIDs_.reserve(maxOwnedRowId_ +  numSharedNotOwnedNotLocallyOwned*numDof_);
+
+  LocalOrdinal localId = 0;
+  int gstart = 0;
+
+  GlobalOrdinal gomin   = ownedRowsMap_->getMinGlobalIndex();
+
+  if(realm_.tpetGlobalId_ == nullptr) {
+    std::cout << " beginLinearSystemConstruction tpetGlobalID_ is null"
+              <<std::endl<<std::flush;
+  }
+  ThrowRequire(realm_.naluGlobalId_ != nullptr);
+  ThrowRequire(realm_.tpetGlobalId_ != nullptr);
+
   for(stk::mesh::Entity entity : owned_nodes) {
     const stk::mesh::EntityId entityId = *stk::mesh::field_data(*realm_.naluGlobalId_, entity);
     myLIDs_[entityId] = numDof_*localId++;
-    for(unsigned idof=0; idof < numDof_; ++ idof) {
-      const GlobalOrdinal gid = GID_(entityId, numDof_, idof);
-      ownedGids.push_back(gid);
-    }
+    auto *  thisgid = stk::mesh::field_data(*realm_.tpetGlobalId_, entity);
+    ThrowRequire(thisgid != nullptr);
+    ThrowRequireMsg( gomin + numDof_ * gstart != 0 , "gid == 0 in owned node assignment loop");
+    auto basegid = gomin + numDof_ * gstart;
+    (*thisgid) = basegid;
+    for(unsigned idof=0; idof < numDof_; ++ idof) ownedGids.push_back(basegid + idof);
+    gstart++;
   }
   ThrowRequire(localId == numOwnedNodes);
+  // communicate the newly stored GID's.
+
+  std::vector<const stk::mesh::FieldBase*> fVec{realm_.tpetGlobalId_};
+  stk::mesh::copy_owned_to_shared(bulkData, fVec);
+  stk::mesh::communicate_field_data(bulkData.aura_ghosting(), fVec);
+  if (realm_.oversetManager_ != nullptr &&
+      realm_.oversetManager_->oversetGhosting_ != nullptr)
+    stk::mesh::communicate_field_data(
+      *realm_.oversetManager_->oversetGhosting_, fVec);
+
+  if (realm_.nonConformalManager_ != nullptr &&
+      realm_.nonConformalManager_->nonConformalGhosting_ != nullptr)
+    stk::mesh::communicate_field_data(  
+      *realm_.nonConformalManager_->nonConformalGhosting_, fVec);
+  
+  if (realm_.periodicManager_ != nullptr &&
+      realm_.periodicManager_->periodicGhosting_ != nullptr) {
+    realm_.periodicManager_->parallel_communicate_field(realm_.tpetGlobalId_);
+    realm_.periodicManager_->periodic_parallel_communicate_field(realm_.tpetGlobalId_);
+  }
 
   // now sharedNotOwned:
   for(const stk::mesh::Bucket* bptr : buckets) {
@@ -273,18 +317,23 @@ void TpetraLinearSystem::beginLinearSystemConstruction()
   for (unsigned inode=0; inode < shared_not_owned_nodes.size(); ++inode) {
     stk::mesh::Entity entity = shared_not_owned_nodes[inode];
     const stk::mesh::EntityId naluId = *stk::mesh::field_data(*realm_.naluGlobalId_, entity);
-    entity = get_entity_master(bulkData, entity, naluId);
+    auto masterentity = get_entity_master(bulkData, entity, naluId);
     myLIDs_[naluId] = numDof_*localId++;
-    int owner = bulkData.parallel_owner_rank(entity);
+    int owner = bulkData.parallel_owner_rank(masterentity);
+    auto basegid = *stk::mesh::field_data(*realm_.tpetGlobalId_, masterentity);
+
+    ThrowRequireMsg(basegid!=0, " shared node loop master tpet gid ");
+    
+    if(entity != masterentity) 
+      *stk::mesh::field_data(*realm_.tpetGlobalId_, entity) = basegid;
+    
     for(unsigned idof=0; idof < numDof_; ++ idof) {
-      const GlobalOrdinal gid = GID_(naluId, numDof_, idof);
+      GlobalOrdinal gid = basegid+idof;
       sharedNotOwnedGids.push_back(gid);
       sharedPids_.push_back(owner);
     }
   }
 
-  const Teuchos::RCP<LinSys::Comm> tpetraComm = Teuchos::rcp(new LinSys::Comm(bulkData.parallel()));
-  ownedRowsMap_ = Teuchos::rcp(new LinSys::Map(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), ownedGids, 1, tpetraComm));
   sharedNotOwnedRowsMap_ = Teuchos::rcp(new LinSys::Map(Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(), sharedNotOwnedGids, 1, tpetraComm));
 
   exporter_ = Teuchos::rcp(new LinSys::Export(sharedNotOwnedRowsMap_, ownedRowsMap_));
@@ -341,7 +390,6 @@ void TpetraLinearSystem::buildNodeGraph(const stk::mesh::PartVector & parts)
 {
   beginLinearSystemConstruction();
   stk::mesh::MetaData & metaData = realm_.meta_data();
-//if (realm_.bulk_data().parallel_rank()==0) std::cerr<<"buildNodeGraph"<<std::endl;
 
   const stk::mesh::Selector s_owned = metaData.locally_owned_part()
     & stk::mesh::selectUnion(parts)
@@ -406,7 +454,6 @@ void TpetraLinearSystem::buildReducedElemToNodeGraph(const stk::mesh::PartVector
 {
   beginLinearSystemConstruction();
   stk::mesh::MetaData & metaData = realm_.meta_data();
-//if (realm_.bulk_data().parallel_rank()==0) std::cerr<<"buildReducedElemToNodeGraph"<<std::endl;
 
   const stk::mesh::Selector s_owned = metaData.locally_owned_part()
     & stk::mesh::selectUnion(parts)
@@ -481,7 +528,6 @@ void TpetraLinearSystem::buildNonConformalNodeGraph(const stk::mesh::PartVector 
 {
   stk::mesh::BulkData & bulkData = realm_.bulk_data();
   beginLinearSystemConstruction();
-//if (realm_.bulk_data().parallel_rank()==0) std::cerr<<"buildNonConformalNodeGraph"<<std::endl;
 
   std::vector<stk::mesh::Entity> entities;
 
@@ -589,7 +635,7 @@ void TpetraLinearSystem::copy_stk_to_tpetra(stk::mesh::FieldBase * stkField,
 
     const int fieldSize = field_bytes_per_entity(*stkField, b) / (sizeof(double));
 
-    ThrowRequire(numVectors == fieldSize);
+    ThrowRequireMsg(numVectors == fieldSize, "TpetraLinearSystem::copy_stk_to_tpetra");
 
     const stk::mesh::Bucket::size_type length = b.size();
 
@@ -603,11 +649,13 @@ void TpetraLinearSystem::copy_stk_to_tpetra(stk::mesh::FieldBase * stkField,
       if ((status & DS_SkippedDOF) || (status & DS_SharedNotOwnedDOF))
         continue;
 
-      const stk::mesh::EntityId nodeId = *stk::mesh::field_data(*realm_.naluGlobalId_, node);
+      const stk::mesh::EntityId nodeTpetGID = *stk::mesh::field_data(*realm_.tpetGlobalId_, node);
+      ThrowRequireMsg(nodeTpetGID != 0 && nodeTpetGID != std::numeric_limits<LinSys::GlobalOrdinal>::max()
+                      , " in copy_stk_to_tpetra ");
       for(int d=0; d < fieldSize; ++d)
       {
         const size_t stkIndex = k*fieldSize + d;
-        tpetraField->replaceGlobalValue(nodeId, d, stkFieldPtr[stkIndex]);
+        tpetraField->replaceGlobalValue(nodeTpetGID, d, stkFieldPtr[stkIndex]);
       }
     }
   }
@@ -706,8 +754,9 @@ void TpetraLinearSystem::compute_graph_row_lengths(const std::vector<stk::mesh::
 
     const bool entity_a_shared = entity_a_status & DS_SharedNotOwnedDOF;
     if (entity_a_shared) {
-        add_lengths_to_comm(bulk, commNeighbors, entity_a_owner, entityId_a,
-                            numDof_, numColEntities, colEntityIds.data(), colOwners.data());
+      add_lengths_to_comm_tpet(bulk, realm_.tpetGlobalId_,commNeighbors, entity_a_owner, entityId_a,
+                               //                               numDof_, 
+                               numColEntities, colEntityIds.data(), colOwners.data());
     }
 
     for(size_t ii=0; ii<numColEntities; ++ii) {
@@ -723,7 +772,9 @@ void TpetraLinearSystem::compute_graph_row_lengths(const std::vector<stk::mesh::
 
         const bool entity_b_shared = entity_b_status & DS_SharedNotOwnedDOF;
         if (entity_b_shared) {
-            add_lengths_to_comm(bulk, commNeighbors, colOwners[ii], entityId_b, numDof_, 1, &entityId_a, &entity_a_owner);
+            add_lengths_to_comm_tpet(bulk, realm_.tpetGlobalId_, commNeighbors, colOwners[ii], entityId_b, 
+                                     // numDof_, 
+                                     1, &entityId_a, &entity_a_owner);
         }
     }
   }
@@ -748,11 +799,14 @@ void TpetraLinearSystem::insert_graph_connections(const std::vector<stk::mesh::E
 
     const stk::mesh::Entity entity_a = rowEntities[i];
     int dofStatus_a = getDofStatus(entity_a);
+    ThrowRequireMsg(entityToColLID_[entity_a.local_offset()] != -1 ,  "insert_graph_connections bad lid ");
     localDofs_a[0] = entityToColLID_[entity_a.local_offset()];
-
     for(size_t j=0; j<numColEntities; ++j) {
       const stk::mesh::Entity entity_b = entities_b[j];
       dofStatus[j] = getDofStatus(entity_b);
+
+      ThrowRequireMsg(entityToColLID_[entity_b.local_offset()] != -1 , "insert_graph_connections bad lid #2 ");
+
       localDofs_b[j] = entityToColLID_[entity_b.local_offset()];
     }
 
@@ -798,16 +852,41 @@ void TpetraLinearSystem::fill_entity_to_row_LID_mapping()
 
 void TpetraLinearSystem::fill_entity_to_col_LID_mapping()
 {
-    const stk::mesh::BulkData& bulk = realm_.bulk_data();
+  const stk::mesh::BulkData& bulk = realm_.bulk_data();
+  stk::mesh::Selector selector = bulk.mesh_meta_data().universal_part() & !(realm_.get_inactive_selector());
     entityToColLID_ = LinSys::EntityToLIDView("entityToLID",bulk.get_size_of_entity_index_space());
-    const stk::mesh::BucketVector& nodeBuckets = bulk.buckets(stk::topology::NODE_RANK);
+    const stk::mesh::BucketVector& nodeBuckets = realm_.get_buckets(stk::topology::NODE_RANK,selector);
     for(const stk::mesh::Bucket* bptr : nodeBuckets) {
         const stk::mesh::Bucket& b = *bptr;
         const stk::mesh::EntityId* nodeIds = stk::mesh::field_data(*realm_.naluGlobalId_, b);
         for(size_t i=0; i<b.size(); ++i) {
             stk::mesh::Entity node = b[i];
-            GlobalOrdinal gid = GID_(nodeIds[i], numDof_, 0);
-            entityToColLID_[node.local_offset()] = totalColsMap_->getLocalElement(gid);
+
+            GlobalOrdinal gid =-1;
+            // needed because of some shared and ghost nodes. 
+            if (nodeIds[i] != bulk.identifier(node)) {
+              stk::mesh::Entity master = get_entity_master(bulk, node, nodeIds[i]);
+              if (master != node) {
+                gid = * stk::mesh::field_data(*realm_.tpetGlobalId_, master);
+                entityToColLID_[node.local_offset()] = totalColsMap_->getLocalElement(gid);
+              }
+              else
+                gid =  * stk::mesh::field_data(*realm_.tpetGlobalId_, node);
+            }
+            else
+              gid =  * stk::mesh::field_data(*realm_.tpetGlobalId_, node);
+
+            // GlobalOrdinal gid = tpetGIds[i];
+            
+            if(gid == 0 || gid == -1 || gid == std::numeric_limits<LinSys::GlobalOrdinal>::max() ) {
+              // This is needed because of a very small chance a ghost node doesn't have a master
+              // with a valid gid. ctests shows that entityToColLID_ is never accessed TpetraLinearSystem
+              // at those locations: CF SumInto and insert_graph_connections.
+              // Question: Can the selector be modified to eliminate ghost nodes from this loop?
+              entityToColLID_[node.local_offset()] = -1;
+            }
+            else
+              entityToColLID_[node.local_offset()] = totalColsMap_->getLocalElement(gid);
         }
     }
 }
@@ -826,8 +905,10 @@ void TpetraLinearSystem::storeOwnersForShared()
       if (status & DS_SharedNotOwnedDOF) {
         stk::mesh::EntityId naluId = *stk::mesh::field_data(*realm_.naluGlobalId_, node);
         stk::mesh::Entity master = get_entity_master(bulkData, node, naluId);
+        GlobalOrdinal gidbase = * stk::mesh::field_data(*realm_.tpetGlobalId_, master);
+        ThrowRequire(gidbase != 0);
         for(unsigned idof=0; idof < numDof_; ++ idof) {
-          GlobalOrdinal gid = GID_(naluId, numDof_, idof);
+          GlobalOrdinal gid = gidbase+idof;
           ownersAndGids_.insert(std::make_pair(bulkData.parallel_owner_rank(master), gid));
         }
       }
@@ -1132,6 +1213,7 @@ void TpetraLinearSystem::sumInto(unsigned numEntities,
   for(int i = 0; i < n_obj; i++) {
     const stk::mesh::Entity entity = entities[i];
     const LocalOrdinal localOffset = entityToColLID_[entity.local_offset()];
+    ThrowRequireMsg(localOffset != -1 , "sumInto bad lid #1 ");
     for(size_t d=0; d < numDof_; ++d) {
       size_t lid = i*numDof_ + d;
       localIds[lid] = localOffset + d;
@@ -1264,6 +1346,7 @@ void TpetraLinearSystem::sumInto(const std::vector<stk::mesh::Entity> & entities
   for(size_t i = 0; i < n_obj; i++) {
     const stk::mesh::Entity entity = entities[i];
     const LocalOrdinal localOffset = entityToColLID_[entity.local_offset()];
+    ThrowRequireMsg(localOffset != -1 , "sumInto bad lid #2 ");
     for(size_t d=0; d < numDof_; ++d) {
       size_t lid = i*numDof_ + d;
       scratchIds[lid] = localOffset + d;
@@ -1918,8 +2001,6 @@ int getDofStatus_impl(stk::mesh::Entity node, const Realm& realm)
       }
     }
   }
-
-  //std::cerr << "has_non_matching_boundary_face_alg= " << has_non_matching_boundary_face_alg << " hasPeriodic= " << hasPeriodic << std::endl;
 
   if (has_non_matching_boundary_face_alg && hasPeriodic) {
     std::ostringstream ostr;

--- a/unit_tests/UnitTestTpetraHelperObjects.h
+++ b/unit_tests/UnitTestTpetraHelperObjects.h
@@ -179,7 +179,6 @@ struct TpetraHelperObjectsElem : public TpetraHelperObjectsBase {
   {
     linsys->buildElemToNodeGraph({&realm.metaData_->universal_part()});
     linsys->finalizeLinearSystem();
-
     assembleElemSolverAlg->execute();
     for (auto kern: assembleElemSolverAlg->activeKernels_)
       kern->free_on_device();
@@ -206,13 +205,11 @@ struct TpetraHelperObjectsFaceElem : public TpetraHelperObjectsBase {
   {
     linsys->buildElemToNodeGraph({&realm.metaData_->universal_part()});
     linsys->finalizeLinearSystem();
-
     assembleFaceElemSolverAlg->execute();
     for (auto kern: assembleFaceElemSolverAlg->activeKernels_)
-      kern->free_on_device();
+      kern->free_on_device();  
     assembleFaceElemSolverAlg->activeKernels_.clear();
   }
-
   sierra::nalu::AssembleFaceElemSolverAlgorithm* assembleFaceElemSolverAlg;
 };
 

--- a/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
@@ -70,6 +70,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
   unit_test_utils::TpetraHelperObjectsEdge helperObjs(bulk_, numDof);
 
   helperObjs.realm.naluGlobalId_ = naluGlobalId_;
+  helperObjs.realm.tpetGlobalId_ = tpetGlobalId_;
+
   helperObjs.realm.set_global_id();
 
   helperObjs.create<sierra::nalu::ScalarEdgeSolverAlg>(

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -255,6 +255,9 @@ public:
       naluGlobalId_(
         &meta_.declare_field<GlobalIdFieldType>(
           stk::topology::NODE_RANK, "nalu_global_id",1)),
+      tpetGlobalId_(
+        &meta_.declare_field<TpetIDFieldType>(
+          stk::topology::NODE_RANK, "tpet_global_id",1)),
       dnvField_(&meta_.declare_field<ScalarFieldType>(
                   stk::topology::NODE_RANK, "dual_nodal_volume",2)),
       divMeshVelField_(&meta_.declare_field<ScalarFieldType>(
@@ -264,6 +267,7 @@ public:
           stk::topology::EDGE_RANK, "edge_area_vector"))
   {
     stk::mesh::put_field_on_mesh(*naluGlobalId_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*tpetGlobalId_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*dnvField_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*divMeshVelField_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*edgeAreaVec_, meta_.universal_part(), spatialDim_, nullptr);
@@ -302,9 +306,12 @@ public:
   stk::mesh::PartVector partVec_;
 
   sierra::nalu::SolutionOptions solnOpts_;
+  typedef long   GlobalOrdinal;
+  typedef stk::mesh::Field<GlobalOrdinal> TpetIDFieldType;
 
   const VectorFieldType* coordinates_{nullptr};
   GlobalIdFieldType* naluGlobalId_{nullptr};
+  TpetIDFieldType* tpetGlobalId_{nullptr};
   ScalarFieldType* dnvField_{nullptr};
   ScalarFieldType* divMeshVelField_{nullptr};
   VectorFieldType* edgeAreaVec_{nullptr};

--- a/unit_tests/kernels/UnitTestScalarAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestScalarAdvDiffElem.C
@@ -79,7 +79,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion_tpetra)
     return;
 
   fill_mesh_and_init_fields(true);
-
+  
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
   solnOpts_.meshDeformation_ = false;
@@ -89,6 +89,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion_tpetra)
   unit_test_utils::TpetraHelperObjectsElem helperObjs(bulk_, stk::topology::HEX_8, numDof, partVec_[0]);
 
   helperObjs.realm.naluGlobalId_ = naluGlobalId_;
+  helperObjs.realm.tpetGlobalId_ = tpetGlobalId_;
+
   helperObjs.realm.set_global_id();
 
   // Initialize the kernel
@@ -98,7 +100,6 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion_tpetra)
 
   // Register the kernel for execution
   helperObjs.assembleElemSolverAlg->activeKernels_.push_back(advKernel.get());
-
   // Populate LHS and RHS
   helperObjs.execute();
 


### PR DESCRIPTION
This modifications speeds up the Tpetra branch on the 5MW problem.

Additional  code optimization will follow this base PR.

```      
         5/19 head       This PR
cores    total time      total time     % change
-----    ----------      ----------    ---------
 4096     1391.0          1323.4         4.8
 8192      807.6           797.6         1.2
16384      619             518.8        16.2
```