### PR TITLE
Convert field updates in EquationSystems to NGP versions

### DIFF
--- a/include/ngp_utils/NgpFieldBLAS.h
+++ b/include/ngp_utils/NgpFieldBLAS.h
@@ -1,0 +1,139 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef NGPFIELDBLAS_H
+#define NGPFIELDBLAS_H
+
+#include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpLoopUtils.h"
+
+namespace sierra {
+namespace nalu {
+namespace nalu_ngp {
+
+/** Operation: `y = alpha * x + beta * y`
+ *
+ *  @param ngpMesh Instance of ngp::Mesh
+ *  @param sel Selector where the operation is applied
+ */
+template<
+  typename Mesh,
+  typename FieldType,
+  typename ScalarType>
+inline void field_axpby(
+  const Mesh& ngpMesh,
+  const stk::mesh::Selector& sel,
+  const ScalarType alpha,
+  const FieldType& xField,
+  const ScalarType beta,
+  FieldType& yField,
+  const unsigned numComponents = 1,
+  const stk::topology::rank_t rank = stk::topology::NODE_RANK)
+{
+  static_assert(
+    std::is_same<typename FieldType::value_type, ScalarType>::value,
+    "Mismatch on field data types");
+
+  using Traits = NGPMeshTraits<Mesh>;
+  using MeshIndex = typename Traits::MeshIndex;
+
+  nalu_ngp::run_entity_algorithm(
+    ngpMesh, rank, sel,
+    KOKKOS_LAMBDA(const MeshIndex& mi) {
+      for (unsigned d=0; d < numComponents; ++d)
+        yField.get(mi, d) =
+          alpha * xField.get(mi, d) +
+          beta * yField.get(mi, d);
+    });
+
+  // Indicate modification on device for future synchronization
+  yField.modify_on_device();
+}
+
+template<typename Mesh, typename FieldType>
+inline void field_copy(
+  const Mesh& ngpMesh,
+  const stk::mesh::Selector& sel,
+  FieldType& dest,
+  const FieldType& src,
+  const unsigned numComponents = 1,
+  const stk::topology::rank_t rank = stk::topology::NODE_RANK)
+{
+  using Traits = NGPMeshTraits<Mesh>;
+  using MeshIndex = typename Traits::MeshIndex;
+
+  nalu_ngp::run_entity_algorithm(
+    ngpMesh, rank, sel,
+    KOKKOS_LAMBDA(const MeshIndex& mi) {
+      for (unsigned d=0; d < numComponents; ++d)
+        dest.get(mi, d) = src.get(mi, d);
+    });
+
+  // Indicate modification on device for future synchronization
+  dest.modify_on_device();
+}
+
+template<
+  typename MeshInfoType,
+  typename ScalarType>
+inline void field_axpby(
+  const MeshInfoType& meshInfo,
+  const stk::mesh::Selector& sel,
+  const ScalarType alpha,
+  const stk::mesh::FieldBase& xField,
+  const ScalarType beta,
+  stk::mesh::FieldBase& yField,
+  const unsigned numComponents,
+  const stk::topology::rank_t rank = stk::topology::NODE_RANK)
+{
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  const auto ngpXfield = fieldMgr.template get_field<ScalarType>(
+    xField.mesh_meta_data_ordinal());
+  auto ngpYfield = fieldMgr.template get_field<ScalarType>(
+    yField.mesh_meta_data_ordinal());
+
+  field_axpby(
+    meshInfo.ngp_mesh(), sel, alpha, ngpXfield, beta, ngpYfield, numComponents,
+    rank);
+}
+
+template<typename MeshInfoType>
+inline void field_axpby(
+  const MeshInfoType& meshInfo,
+  const stk::mesh::Selector& sel,
+  const double alpha,
+  const ScalarFieldType& xField,
+  const double beta,
+  ScalarFieldType& yField,
+  const stk::topology::rank_t rank = stk::topology::NODE_RANK)
+{
+  constexpr unsigned nComp = 1;
+  field_axpby(meshInfo, sel, alpha, xField, beta, yField,
+              nComp, rank);
+}
+
+template<typename MeshInfoType>
+inline void field_axpby(
+  const MeshInfoType& meshInfo,
+  const stk::mesh::Selector& sel,
+  const double alpha,
+  const VectorFieldType& xField,
+  const double beta,
+  VectorFieldType& yField,
+  const stk::topology::rank_t rank = stk::topology::NODE_RANK)
+{
+  constexpr unsigned nComp = 3;
+  field_axpby(meshInfo, sel, alpha, xField, beta, yField,
+              nComp, rank);
+}
+
+}  // nalu_ngp
+}  // nalu
+}  // sierra
+
+
+#endif /* NGPFIELDBLAS_H */

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -8,6 +8,8 @@
 #ifndef NGPLOOPUTILS_H
 #define NGPLOOPUTILS_H
 
+#include <type_traits>
+
 #include "ngp_utils/NgpTypes.h"
 #include "ngp_utils/NgpScratchData.h"
 #include "ngp_utils/NgpMEUtils.h"
@@ -134,6 +136,95 @@ void run_entity_algorithm(
           algorithm(meshIdx);
         });
     });
+}
+
+/** Execute the given functor for all entities and perform global reduction
+ *
+ *  The functor is called with two argument MeshIndex, a struct containing a
+ *  pointer to the NGP bucket and the index into the bucket array for this
+ *  entity, and accumulator for reduction.
+ *
+ *  @param mesh A STK NGP mesh instance
+ *  @param rank Rank for the loop (node, elem, face, etc.)
+ *  @param sel  STK mesh selector to choose buckets for looping
+ *  @param algorithm A functor that will be executed for each entity
+ *  @param reduceVal A scalar value that has the reduced value
+ */
+template<typename Mesh, typename AlgFunctor, typename ReducerType>
+void run_entity_par_reduce(
+  const Mesh& mesh,
+  const stk::topology::rank_t rank,
+  const stk::mesh::Selector& sel,
+  const AlgFunctor algorithm,
+  ReducerType& reduceVal,
+  typename std::enable_if<std::is_arithmetic<ReducerType>::value, int>::type* = nullptr)
+{
+  using Traits         = NGPMeshTraits<Mesh>;
+  using TeamPolicy     = typename Traits::TeamPolicy;
+  using TeamHandleType = typename Traits::TeamHandleType;
+  using MeshIndex      = typename Traits::MeshIndex;
+
+  const auto& buckets = mesh.get_bucket_ids(rank, sel);
+  auto team_exec = TeamPolicy(buckets.size(), Kokkos::AUTO);
+
+  Kokkos::parallel_reduce(
+    team_exec,
+    KOKKOS_LAMBDA(const TeamHandleType& team, ReducerType& teamVal) {
+      auto bktId = buckets.device_get(team.league_rank());
+      auto& bkt = mesh.get_bucket(rank, bktId);
+
+      ReducerType bktVal = 0.0;
+      const size_t bktLen = bkt.size();
+      Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(team, bktLen),
+        [&](const size_t& bktIndex, ReducerType& threadVal) {
+          MeshIndex meshIdx{&bkt, static_cast<unsigned>(bktIndex)};
+          algorithm(meshIdx, threadVal);
+        }, bktVal);
+
+      teamVal += bktVal;
+    }, reduceVal);
+}
+
+template<typename Mesh, typename AlgFunctor, typename ReducerType>
+void run_entity_par_reduce(
+  const Mesh& mesh,
+  const stk::topology::rank_t rank,
+  const stk::mesh::Selector& sel,
+  const AlgFunctor algorithm,
+  ReducerType& reduceVal,
+  typename std::enable_if<!std::is_arithmetic<ReducerType>::value, int>::type* = nullptr)
+{
+  using Traits         = NGPMeshTraits<Mesh>;
+  using TeamPolicy     = typename Traits::TeamPolicy;
+  using TeamHandleType = typename Traits::TeamHandleType;
+  using MeshIndex      = typename Traits::MeshIndex;
+  using value_type     = typename ReducerType::value_type;
+
+  const auto& buckets = mesh.get_bucket_ids(rank, sel);
+  auto team_exec = TeamPolicy(buckets.size(), Kokkos::AUTO);
+
+  Kokkos::parallel_reduce(
+    team_exec,
+    KOKKOS_LAMBDA(const TeamHandleType& team, value_type& teamVal) {
+      auto bktId = buckets.device_get(team.league_rank());
+      auto& bkt = mesh.get_bucket(rank, bktId);
+
+      value_type bktVal;
+      const size_t bktLen = bkt.size();
+      Kokkos::parallel_reduce(
+        Kokkos::TeamThreadRange(team, bktLen),
+        [&](const size_t& bktIndex, value_type& threadVal) {
+          MeshIndex meshIdx{&bkt, static_cast<unsigned>(bktIndex)};
+          algorithm(meshIdx, threadVal);
+        }, ReducerType(bktVal));
+
+      Kokkos::single(
+        Kokkos::PerTeam(team),
+        [&]() {
+          reduceVal.join(teamVal, bktVal);
+        });
+    }, reduceVal);
 }
 
 /** Execute the given functor for all edges in a Kokkos parallel loop

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -182,7 +182,11 @@ void run_entity_par_reduce(
           algorithm(meshIdx, threadVal);
         }, bktVal);
 
-      teamVal += bktVal;
+      Kokkos::single(
+        Kokkos::PerTeam(team),
+        [&]() {
+          teamVal += bktVal;
+        });
     }, reduceVal);
 }
 


### PR DESCRIPTION
This pull-request is related to #336 and converts field operations within EquationSystems to use the `ngp::Mesh` and `ngp::Field` data structures to perform updates on the device. 