### PR TITLE
LowMach and WallDist: Convert nodal grad computation to NGP version

### DIFF
--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -9,9 +9,11 @@
 #ifndef LowMachEquationSystem_h
 #define LowMachEquationSystem_h
 
-#include <EquationSystem.h>
-#include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include "EquationSystem.h"
+#include "FieldTypeDef.h"
+#include "NaluParsing.h"
+
+#include "ngp_algorithms/NodalGradAlgDriver.h"
 
 namespace stk{
 struct topology;
@@ -205,8 +207,8 @@ public:
   ScalarFieldType *tvisc_;
   ScalarFieldType *evisc_;
   ScalarFieldType* Udiag_{nullptr};
-  
-  AssembleNodalGradUAlgorithmDriver *assembleNodalGradAlgDriver_;
+
+  VectorNodalGradAlgDriver nodalGradAlgDriver_;
   AlgorithmDriver *diffFluxCoeffAlgDriver_;
   AlgorithmDriver *tviscAlgDriver_;
   AlgorithmDriver *cflReyAlgDriver_;

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -298,7 +298,7 @@ public:
 
   ScalarFieldType *pTmp_;
 
-  AssembleNodalGradPAlgorithmDriver *assembleNodalGradPAlgDriver_;
+  ScalarNodalGradAlgDriver nodalGradAlgDriver_;
   ComputeMdotAlgorithmDriver *computeMdotAlgDriver_;
   ProjectedNodalGradientEquationSystem *projectedNodalGradEqs_;
 };

--- a/include/WallDistEquationSystem.h
+++ b/include/WallDistEquationSystem.h
@@ -10,6 +10,7 @@
 
 #include "EquationSystem.h"
 #include "FieldTypeDef.h"
+#include "ngp_algorithms/NodalGradAlgDriver.h"
 
 #include <memory>
 
@@ -85,7 +86,7 @@ private:
   ScalarFieldType* dualNodalVolume_{nullptr};
   VectorFieldType* edgeAreaVec_{nullptr};
 
-  std::unique_ptr<AssembleNodalGradAlgorithmDriver> assembleNodalGradAlgDriver_;
+  ScalarNodalGradAlgDriver nodalGradAlgDriver_;
 
   int pValue_{2};
 

--- a/include/ngp_algorithms/NgpAlgDriver.h
+++ b/include/ngp_algorithms/NgpAlgDriver.h
@@ -25,55 +25,55 @@ namespace nalu {
 
 class Realm;
 
-inline bool is_ho_element(const stk::topology topo)
+inline bool is_ngp_element(const stk::topology topo)
 {
-  if (topo.is_super_topology()) return true;
+  if (topo.is_super_topology()) return false;
 
-  bool isHO = true;
+  bool isNGP = false;
   switch (topo.value()) {
   case stk::topology::HEX_8:
   case stk::topology::TET_4:
   case stk::topology::PYRAMID_5:
   case stk::topology::WEDGE_6:
   case stk::topology::QUAD_4_2D:
-  case stk::topology::TRI_3_2D:
-    isHO = false;
+    isNGP = true;
     break;
 
+  case stk::topology::TRI_3_2D:
   case stk::topology::HEX_27:
   case stk::topology::QUAD_9_2D:
-    isHO = true;
+    isNGP = false;
     break;
 
   default:
     throw std::logic_error("Invalid element topology provided");
   }
 
-  return isHO;
+  return isNGP;
 }
 
-inline bool is_ho_face(const stk::topology topo)
+inline bool is_ngp_face(const stk::topology topo)
 {
-  if (topo.is_super_topology()) return true;
+  if (topo.is_super_topology()) return false;
 
-  bool isHO = true;
+  bool isNGP = false;
   switch (topo.value()) {
   case stk::topology::QUAD_4:
-  case stk::topology::TRI_3:
-  case stk::topology::LINE_2:
-    isHO = false;
+    isNGP = true;
     break;
 
+  case stk::topology::TRI_3:
+  case stk::topology::LINE_2:
   case stk::topology::QUAD_9:
   case stk::topology::LINE_3:
-    isHO = true;
+    isNGP = false;
     break;
 
   default:
     throw std::logic_error("Invalid face topology provided");
   }
 
-  return isHO;
+  return isNGP;
 }
 
 template<template <typename> class T, int order, typename... Args>
@@ -246,8 +246,7 @@ public:
     const std::string& algSuffix,
     Args&&... args)
   {
-    const auto topo = part->topology();
-    const std::string entityName = "algorithm_" + topo.name();
+    const std::string entityName = "algorithm";
     const std::string algName = unique_name(
       algType, entityName, algSuffix);
 
@@ -296,7 +295,7 @@ public:
     const std::string& algSuffix,
     Args&&... args)
   {
-    if (is_ho_element(part->topology()))
+    if (!is_ngp_element(part->topology()))
       register_legacy_algorithm<LegacyAlg>(
         algType, part, algSuffix, std::forward<Args>(args)...);
     else
@@ -345,7 +344,7 @@ public:
     const std::string& algSuffix,
     Args&&... args)
   {
-    if (is_ho_face(part->topology()))
+    if (!is_ngp_face(part->topology()))
       register_legacy_algorithm<LegacyAlg>(
         algType, part, algSuffix, std::forward<Args>(args)...);
     else

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1157,7 +1157,8 @@ MomentumEquationSystem::register_interior_algorithm(
       nodalGradAlgDriver_.register_edge_algorithm<VectorNodalGradEdgeAlg>(
         algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone);
     else
-      nodalGradAlgDriver_.register_elem_algorithm<VectorNodalGradElemAlg>(
+      nodalGradAlgDriver_.register_elem_algorithm<
+        VectorNodalGradElemAlg, AssembleNodalGradUElemAlgorithm>(
         algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone,
         edgeNodalGradient_);
   }
@@ -1633,7 +1634,8 @@ MomentumEquationSystem::register_inflow_bc(
   
   // non-solver; contribution to Gjui; allow for element-based shifted
   if ( !managePNG_ ) {
-    nodalGradAlgDriver_.register_face_algorithm<VectorNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<
+      VectorNodalGradBndryElemAlg, AssembleNodalGradUBoundaryAlgorithm>(
         algType, part, "momentum_nodal_grad", theBcField, &dudxNone,
         edgeNodalGradient_);
   }
@@ -1697,7 +1699,8 @@ MomentumEquationSystem::register_open_bc(
 
   // non-solver; contribution to Gjui; allow for element-based shifted
   if ( !managePNG_ ) {
-    nodalGradAlgDriver_.register_face_algorithm<VectorNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<
+      VectorNodalGradBndryElemAlg, AssembleNodalGradUBoundaryAlgorithm>(
       algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone,
       edgeNodalGradient_);
   }
@@ -1868,7 +1871,8 @@ MomentumEquationSystem::register_wall_bc(
   // non-solver; contribution to Gjui; allow for element-based shifted
   if ( !managePNG_ ) {
     const AlgorithmType algTypePNG = anyWallFunctionActivated ? WALL_FCN : WALL;
-    nodalGradAlgDriver_.register_face_algorithm<VectorNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<
+      VectorNodalGradBndryElemAlg, AssembleNodalGradUBoundaryAlgorithm>(
       algTypePNG, part, "momentum_nodal_grad", theBcField, &dudxNone,
       edgeNodalGradient_);
   }
@@ -2071,7 +2075,8 @@ MomentumEquationSystem::register_symmetry_bc(
 
   // non-solver; contribution to Gjui; allow for element-based shifted
   if ( !managePNG_ ) {
-    nodalGradAlgDriver_.register_face_algorithm<VectorNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<
+      VectorNodalGradBndryElemAlg, AssembleNodalGradUBoundaryAlgorithm>(
       algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone,
       edgeNodalGradient_);
   }
@@ -2161,7 +2166,8 @@ MomentumEquationSystem::register_abltop_bc(
 
   // non-solver; contribution to Gjui; allow for element-based shifted
   if ( !managePNG_ ) {
-    nodalGradAlgDriver_.register_face_algorithm<VectorNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<
+      VectorNodalGradBndryElemAlg, AssembleNodalGradUBoundaryAlgorithm>(
       algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone,
       edgeNodalGradient_);
   }
@@ -2253,7 +2259,8 @@ MomentumEquationSystem::register_non_conformal_bc(
   // non-solver; contribution to Gjui; DG algorithm decides on locations for integration points
   if ( !managePNG_ ) {
     if ( edgeNodalGradient_ ) {
-      nodalGradAlgDriver_.register_face_algorithm<VectorNodalGradBndryElemAlg>(
+      nodalGradAlgDriver_.register_face_algorithm<
+        VectorNodalGradBndryElemAlg, AssembleNodalGradUBoundaryAlgorithm>(
         algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone,
         edgeNodalGradient_);
     }
@@ -2758,7 +2765,8 @@ ContinuityEquationSystem::register_interior_algorithm(
       nodalGradAlgDriver_.register_edge_algorithm<ScalarNodalGradEdgeAlg>(
         algType, part, "continuity_nodal_grad", &pressureNone, &dpdxNone);
     else
-      nodalGradAlgDriver_.register_elem_algorithm<ScalarNodalGradElemAlg>(
+      nodalGradAlgDriver_.register_elem_algorithm<
+        ScalarNodalGradElemAlg, AssembleNodalGradElemAlgorithm>(
         algType, part, "continuity_nodal_grad",
         &pressureNone, &dpdxNone, edgeNodalGradient_);
   }
@@ -3065,7 +3073,7 @@ ContinuityEquationSystem::register_inflow_bc(
 
   // non-solver; contribution to Gjp; allow for element-based shifted
   if ( !managePNG_ ) {
-    nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg, AssembleNodalGradBoundaryAlgorithm>(
       algType, part, "continuity_nodal_grad",
       &pressureNone, &dpdxNone, edgeNodalGradient_);
   }
@@ -3257,7 +3265,7 @@ ContinuityEquationSystem::register_wall_bc(
 
   // non-solver; contribution to Gjp; allow for element-based shifted
   if ( !managePNG_ ) {
-    nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg, AssembleNodalGradBoundaryAlgorithm>(
       algType, part, "continuity_nodal_grad",
       &pressureNone, &dpdxNone, edgeNodalGradient_);
   }
@@ -3281,7 +3289,7 @@ ContinuityEquationSystem::register_symmetry_bc(
 
   // non-solver; contribution to Gjp; allow for element-based shifted
   if ( !managePNG_ ) {
-    nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg, AssembleNodalGradBoundaryAlgorithm>(
       algType, part, "continuity_nodal_grad",
       &pressureNone, &dpdxNone, edgeNodalGradient_);
   }
@@ -3395,7 +3403,7 @@ ContinuityEquationSystem::register_abltop_bc(
 
   // non-solver; contribution to Gjp; allow for element-based shifted
   if ( !managePNG_ ) {
-    nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg>(
+    nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg, AssembleNodalGradBoundaryAlgorithm>(
       algType, part, "continuity_nodal_grad",
       &pressureNone, &dpdxNone, edgeNodalGradient_);
   }
@@ -3479,7 +3487,7 @@ ContinuityEquationSystem::register_non_conformal_bc(
   // non-solver; contribution to Gjp; DG algorithm decides on locations for integration points
   if ( !managePNG_ ) {
     if ( edgeNodalGradient_ ) {    
-      nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg>(
+      nodalGradAlgDriver_.register_face_algorithm<ScalarNodalGradBndryElemAlg, AssembleNodalGradBoundaryAlgorithm>(
         algType, part, "continuity_nodal_grad",
         pressure_, dpdx_, edgeNodalGradient_);
     }

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1157,8 +1157,7 @@ MomentumEquationSystem::register_interior_algorithm(
       nodalGradAlgDriver_.register_edge_algorithm<VectorNodalGradEdgeAlg>(
         algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone);
     else
-      nodalGradAlgDriver_.register_elem_algorithm<
-        VectorNodalGradElemAlg, AssembleNodalGradUElemAlgorithm>(
+      nodalGradAlgDriver_.register_legacy_algorithm<AssembleNodalGradUElemAlgorithm>(
         algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone,
         edgeNodalGradient_);
   }
@@ -2765,8 +2764,7 @@ ContinuityEquationSystem::register_interior_algorithm(
       nodalGradAlgDriver_.register_edge_algorithm<ScalarNodalGradEdgeAlg>(
         algType, part, "continuity_nodal_grad", &pressureNone, &dpdxNone);
     else
-      nodalGradAlgDriver_.register_elem_algorithm<
-        ScalarNodalGradElemAlg, AssembleNodalGradElemAlgorithm>(
+      nodalGradAlgDriver_.register_legacy_algorithm<AssembleNodalGradElemAlgorithm>(
         algType, part, "continuity_nodal_grad",
         &pressureNone, &dpdxNone, edgeNodalGradient_);
   }


### PR DESCRIPTION
This pull request converts the nodal gradient computations in LowMach and WallDistance equation systems to the NGP versions for edge and boundary conditions. The logic will revert to legacy algorithms for higher-order elements, and for master elements that do not yet have the NGP versions of `shape_fcn`, `shifted_shape_fcn`, and `determinant`. The changes introduce the following diffs when running on NREL Eagle with GCC-7.4.0. 

```
FAIL: ablNeutralEdge..........................    37.3934s 4.1546e-11 3.9255e-09
FAIL: ablNeutralEdgeSegregated................    32.6675s 5.5864e-11 1.9708e-08
FAIL: ablStableElem...........................    26.1436s 1.4123e-11 7.0389e-09
FAIL: ablUnstableEdge.........................    25.1137s 3.4646e-11 6.4021e-09
FAIL: ablUnstableEdge_ra......................    14.5301s 6.1098e-12 9.9495e-12
FAIL: ablUnstableEdge_rst.....................    14.4154s 2.1640e-11 1.1979e-12
FAIL: edgeHybridFluids........................    25.1988s 1.3996e-14 1.3217e-11
FAIL: ekmanSpiral.............................     4.6628s 1.6290e-15 3.8705e-13
FAIL: ekmanSpiralConsolidated.................    11.8261s 1.6120e-15 3.9991e-13
FAIL: elemBackStepLRSST.......................     1.3114s 8.3000e-14 1.0504e-14
FAIL: elemBackStepLRSST_Input.................     1.6480s 1.0001e-14 3.8420e-16
FAIL: elemHybridFluids........................    29.9057s 1.1610e-15 1.2623e-12
FAIL: elemHybridFluidsShift...................    27.8430s 1.0074e-12 3.1469e-10
FAIL: fluidsPmrChtPeriodic....................    51.5288s 6.1760e-13 8.4642e-13
FAIL: heliumPlume_rst.........................    63.3010s 5.2000e-14 3.4867e-14
FAIL: milestoneRun............................    36.7007s 1.0001e-15 7.8702e-16
FAIL: milestoneRunConsolidated................    30.9833s 1.0001e-15 5.8026e-16
FAIL: waleElemXflowMixFrac3.5m................   204.8209s 1.0700e-14 2.7426e-14
```

