### PR TITLE
Periodic max not periodic sum for SST min dist

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -234,6 +234,10 @@ class Realm {
     const unsigned &sizeOfTheField,
     const bool &bypassFieldCheck = true) const;
 
+  void periodic_field_max(
+    stk::mesh::FieldBase *theField,
+    const unsigned &sizeOfTheField) const;
+
   void periodic_delta_solution_update(
      stk::mesh::FieldBase *theField,
      const unsigned &sizeOfField) const;

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -3154,6 +3154,15 @@ Realm::periodic_field_update(
   periodicManager_->apply_constraints(theField, sizeOfField, bypassFieldCheck, addSlaves, setSlaves);
 }
 
+
+void
+Realm::periodic_field_max(
+  stk::mesh::FieldBase *theField,
+  const unsigned &sizeOfField) const
+{
+  periodicManager_->apply_max_field(theField, sizeOfField);
+}
+
 //--------------------------------------------------------------------------
 //-------- periodic_delta_solution_update -------------------------------------------
 //--------------------------------------------------------------------------

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -485,7 +485,7 @@ ShearStressTransportEquationSystem::clip_min_distance_to_wall()
    }
    stk::mesh::parallel_max(realm_.bulk_data(), {minDistanceToWall_});
    if (realm_.hasPeriodic_) {
-     realm_.periodic_field_update(minDistanceToWall_, 1);
+     realm_.periodic_field_max(minDistanceToWall_, 1);
    }
 }
 


### PR DESCRIPTION
* Swap periodic field update, which actually does the periodic sum operation, to the periodic max.
* https://github.com/Exawind/nalu-wind/issues/344