### PR TITLE
Convert solution update in EquationSystem to NGP version

### DIFF
--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -236,6 +236,17 @@ public:
     get_required(node, "convergence_tolerance", convergenceTolerance_);
   }
 
+  /** Update field with delta solution of linear solve
+   */
+  virtual void solution_update(
+    const double delta_frac,
+    const stk::mesh::FieldBase& delta,
+    const double field_frac,
+    stk::mesh::FieldBase& field,
+    const unsigned numComponents = 1,
+    const stk::topology::rank_t rank = stk::topology::NODE_RANK);
+
+
   Simulation *root();
   EquationSystems *parent();
 

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -1240,12 +1240,9 @@ EnthalpyEquationSystem::solve_and_update()
 
     // update
     double timeA = NaluEnv::self().nalu_time();
-    field_axpby(
-      realm_.meta_data(),
-      realm_.bulk_data(),
+    solution_update(
       1.0, *hTmp_,
-      1.0, enthalpy_->field_of_state(stk::mesh::StateNP1),
-      realm_.get_activate_aura());
+      1.0, enthalpy_->field_of_state(stk::mesh::StateNP1));
     double timeB = NaluEnv::self().nalu_time();
     timerAssemble_ += (timeB-timeA);
 

--- a/src/EquationSystem.C
+++ b/src/EquationSystem.C
@@ -25,6 +25,9 @@
 // overset
 #include <overset/AssembleOversetSolverConstraintAlgorithm.h>
 
+// ngp
+#include "ngp_utils/NgpFieldBLAS.h"
+
 #include <stk_mesh/base/Field.hpp>
 
 // stk
@@ -515,6 +518,24 @@ EquationSystem::post_iter_work()
   for (auto it: postIterAlgDriver_) {
     it->execute();
   }
+}
+
+void EquationSystem::solution_update(
+  const double delta_frac,
+  const stk::mesh::FieldBase& delta,
+  const double field_frac,
+  stk::mesh::FieldBase& field,
+  const unsigned numComponents,
+  const stk::topology::rank_t rank)
+{
+  const auto& meshInfo = realm_.mesh_info();
+  const auto& meta = realm_.meta_data();
+  const stk::mesh::Selector sel = (
+    meta.locally_owned_part() | meta.globally_shared_part() | meta.aura_part())
+    & stk::mesh::selectField(field);
+
+  nalu_ngp::field_axpby(
+    meshInfo, sel, delta_frac, delta, field_frac, field, numComponents, rank);
 }
 
 } // namespace nalu

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -725,12 +725,10 @@ LowMachEquationSystem::solve_and_update()
 
     // update all of velocity
     timeA = NaluEnv::self().nalu_time();
-    field_axpby(
-      realm_.meta_data(),
-      realm_.bulk_data(),
+    solution_update(
       1.0, *momentumEqSys_->uTmp_,
       1.0, momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1),
-      realm_.get_activate_aura());
+      realm_.meta_data().spatial_dimension());
     timeB = NaluEnv::self().nalu_time();
     momentumEqSys_->timerAssemble_ += (timeB-timeA);
 
@@ -750,12 +748,9 @@ LowMachEquationSystem::solve_and_update()
 
     // update pressure
     timeA = NaluEnv::self().nalu_time();
-    field_axpby(
-      realm_.meta_data(),
-      realm_.bulk_data(),
+    solution_update(
       1.0, *continuityEqSys_->pTmp_,
-      1.0, *continuityEqSys_->pressure_,
-      realm_.get_activate_aura());
+      1.0, *continuityEqSys_->pressure_);
     timeB = NaluEnv::self().nalu_time();
     continuityEqSys_->timerAssemble_ += (timeB-timeA);
 
@@ -773,12 +768,9 @@ LowMachEquationSystem::solve_and_update()
     const double relaxFP = realm_.solutionOptions_->get_relaxation_factor(dofName);
     if (std::fabs(1.0 - relaxFP) > 1.0e-3) {
       timeA = NaluEnv::self().nalu_time();
-      field_axpby(
-        realm_.meta_data(),
-        realm_.bulk_data(),
+      solution_update(
         (relaxFP - 1.0), *continuityEqSys_->pTmp_,
-        1.0, *continuityEqSys_->pressure_,
-        realm_.get_activate_aura());
+        1.0, *continuityEqSys_->pressure_);
       continuityEqSys_->compute_projected_nodal_gradient();
       timeB = NaluEnv::self().nalu_time();
       continuityEqSys_->timerAssemble_ += (timeB-timeA);
@@ -829,12 +821,9 @@ LowMachEquationSystem::post_adapt_work()
       continuityEqSys_->assemble_and_solve(continuityEqSys_->pTmp_);
       
       // update pressure
-      field_axpby(
-          realm_.meta_data(),
-          realm_.bulk_data(),
-          1.0, *continuityEqSys_->pTmp_,
-          1.0, *continuityEqSys_->pressure_,
-          realm_.get_activate_aura());
+      solution_update(
+        1.0, *continuityEqSys_->pTmp_,
+        1.0, *continuityEqSys_->pressure_);
     }
     
     // compute mdot


### PR DESCRIPTION
This pull request is a replacement for #332 and does the field update (`x^{k+1} = x^{k} + dx`) on the device. This assumes that the solution vector (from TpetraLinearSystem is up to date on device). @alanw0 is working on a pull request to handle that in `copy_tpetra_to_stk` 