### PR TITLE
Change from long double to double aligned on GPU

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -15,7 +15,7 @@
 #include <Kokkos_Core.hpp>
 
 #ifdef KOKKOS_ENABLE_CUDA
-#define NALU_ALIGNED alignas(sizeof(long double))
+#define NALU_ALIGNED alignas(sizeof(double))
 #else
 #define NALU_ALIGNED alignas(KOKKOS_MEMORY_ALIGNMENT)
 #endif

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -545,7 +545,7 @@ template<typename T, typename TEAMHANDLETYPE, typename SHMEM>
 void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new_me(
   const ElemDataRequestsGPU::DataEnumView& dataEnums,
   SharedMemView<double**, SHMEM>* coordsView,
-  MasterElement* /* meFC */,
+  MasterElement* meFC,
   MasterElement* meSCS,
   MasterElement* meSCV,
   MasterElement* meFEM,
@@ -560,7 +560,9 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
     switch(dataEnums(i))
     {
       case FC_AREAV:
-        ThrowRequireMsg(false, "ERROR, non-interleaving FC_AREAV is not supported.");
+        ThrowRequireMsg(meFC != nullptr, "ERROR, meFC needs to be non-null if FC_AREAV is requested.");
+        ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
+        meFC->determinant(1, &((*coordsView)(0, 0)), &fc_areav(0, 0), &error);
         break;
       case SCS_AREAV:
         ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
@@ -678,7 +680,7 @@ template<typename T, typename TEAMHANDLETYPE, typename SHMEM>
 void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new_me(
   const ElemDataRequestsGPU::DataEnumView& dataEnums,
   SharedMemView<DoubleType**, SHMEM>* coordsView,
-  MasterElement* /* meFC */,
+  MasterElement* meFC,
   MasterElement* meSCS,
   MasterElement* meSCV,
   MasterElement*
@@ -696,8 +698,10 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
     switch(dataEnums(i))
     {
       case FC_AREAV:
-        NGP_ThrowRequireMsg(false, "FC_AREAV not implemented yet.");
-        break;
+         NGP_ThrowRequireMsg(meFC != nullptr, "ERROR, meFC needs to be non-null if SCS_AREAV is requested.");
+         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
+         meFC->determinant(*coordsView, fc_areav);
+         break;
       case SCS_AREAV:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_AREAV is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");

--- a/src/master_element/Edge22DCVFEM.C
+++ b/src/master_element/Edge22DCVFEM.C
@@ -77,19 +77,19 @@ void Edge2DSCS::determinant(
     }
   }
   for (int idim=0; idim<dim; ++idim)
-    c[idim] = ( p[idim][1] + p[idim][2] ) * half;
+    c[idim] = ( p[idim][0] + p[idim][1] ) * half;
 
-  DoubleType dx13 = coords(1,1) - c[1];
-  DoubleType dy13 = coords(1,2) - c[2];
+  DoubleType dx13 = coords(0,0) - c[0];
+  DoubleType dy13 = coords(0,1) - c[1];
 
-  area(1,1) = -dy13;
-  area(1,2) =  dx13;
+  area(0,0) = -dy13;
+  area(0,1) =  dx13;
 
-  dx13 = coords(2,1) - c[1];
-  dy13 = coords(2,2) - c[2];
+  dx13 = coords(1,0) - c[0];
+  dy13 = coords(1,1) - c[1];
 
-  area(2,1) =  dy13;
-  area(2,2) = -dx13;
+  area(1,0) =  dy13;
+  area(1,1) = -dx13;
 }
 
 void Edge2DSCS::determinant(

--- a/src/master_element/Edge32DCVFEM.C
+++ b/src/master_element/Edge32DCVFEM.C
@@ -98,7 +98,7 @@ void Edge32DSCS::determinant(
   SharedMemView<DoubleType**, DeviceShmem> &coords,
   SharedMemView<DoubleType**, DeviceShmem> &area) {
 
-  std::array<DoubleType,2> areaVector;
+  DoubleType areaVector[2];
   const DoubleType x0 = coords(0,0); const DoubleType y0 = coords(0,1);
   const DoubleType x1 = coords(1,0); const DoubleType y1 = coords(1,1);
   const DoubleType x2 = coords(2,0); const DoubleType y2 = coords(2,1);

--- a/unit_tests/UnitTestKokkosMEBC.h
+++ b/unit_tests/UnitTestKokkosMEBC.h
@@ -67,14 +67,19 @@ public:
 
      elemDataNeeded().add_coordinates_field(
        *coordinates_, BcAlgTraits::nDim_, sierra::nalu::CURRENT_COORDINATES);
+
+     faceDataNeeded().add_coordinates_field(
+       *coordinates_, BcAlgTraits::nDim_, sierra::nalu::CURRENT_COORDINATES);
    }
 
    void init_me_data()
    {
-     meFC_ = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
+     meFC_  = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::faceTopo_);
      meSCS_ = sierra::nalu::MasterElementRepo::get_surface_master_element(BcAlgTraits::elemTopo_);
      // Register them to ElemDataRequests
-    faceDataNeeded().add_cvfem_face_me(meFC_);
+    //faceDataNeeded().add_cvfem_surface_me(meSCS_);
+    faceDataNeeded().add_cvfem_face_me   (meFC_);
+    elemDataNeeded().add_cvfem_face_me   (meFC_);
     elemDataNeeded().add_cvfem_surface_me(meSCS_);
    }
 
@@ -94,10 +99,10 @@ public:
 #endif
    }
 
-  sierra::nalu::ElemDataRequests& faceDataNeeded()
-  {
-    return helperObjs_->assembleFaceElemSolverAlg->faceDataNeeded_;
-  }
+sierra::nalu::ElemDataRequests& faceDataNeeded()
+{
+  return helperObjs_->assembleFaceElemSolverAlg->faceDataNeeded_;
+}
 
   sierra::nalu::ElemDataRequests& elemDataNeeded()
   {


### PR DESCRIPTION
The NALU_ALIGNED macro forces certain alignment for arrays inside of algorithms.  It is defined for both SIMD and GPU builds.  For GPU builds the value of "long double" produces compiler warnings.  Try "double" instead. 