### PR TITLE
Cleanup periodic_field_update in preparation for ngp conversion

### DIFF
--- a/include/PeriodicManager.h
+++ b/include/PeriodicManager.h
@@ -60,15 +60,15 @@ class PeriodicManager {
   // holder for master += slave; slave = master
   void apply_constraints(
     stk::mesh::FieldBase *,
-    const unsigned &sizeOfField,
-    const bool &bypassFieldCheck,
-    const bool &addSlaves = true,
-    const bool &setSlaves = true);
+    const unsigned sizeOfField,
+    const bool bypassFieldCheck,
+    const bool addSlaves = true,
+    const bool setSlaves = true);
 
   // find the max
   void apply_max_field(
     stk::mesh::FieldBase *,
-    const unsigned &sizeOfField);
+    const unsigned sizeOfField);
 
   void manage_ghosting_object();
 
@@ -159,13 +159,13 @@ class PeriodicManager {
 
   void add_slave_to_master(
     stk::mesh::FieldBase *theField,
-    const unsigned &sizeOfField,
-    const bool &bypassFieldCheck);
+    const unsigned sizeOfField,
+    const bool bypassFieldCheck);
 
   void set_slave_to_master(
     stk::mesh::FieldBase *theField,
-    const unsigned &sizeOfField,
-    const bool &bypassFieldCheck);
+    const unsigned sizeOfField,
+    const bool bypassFieldCheck);
 
 };
 


### PR DESCRIPTION
This commit makes MPI communication more efficient. There were
some extra (un-needed) calls to parallel_communicate_field. Also,
Instead of making separate calls to copy_owned_to_shared and
communicate_field_data(aura,...), it is more efficient to make a
single call to communicate_field_data(bulk, ...) because this call
includes shared and all ghostings for a single round of MPI calls.