### PR TITLE
Convert ComputeABLWallFrictionVelocity to NGP

### DIFF
--- a/include/ngp_algorithms/ABLWallFrictionVelAlg.h
+++ b/include/ngp_algorithms/ABLWallFrictionVelAlg.h
@@ -1,0 +1,76 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef ABLWALLFRICTIONVELALG_H
+#define ABLWALLFRICTIONVELALG_H
+
+#include "Algorithm.h"
+#include "ElemDataRequests.h"
+#include "SimdInterface.h"
+
+#include "stk_mesh/base/Types.hpp"
+
+namespace sierra {
+namespace nalu {
+
+template <typename BcAlgTraits>
+class ABLWallFrictionVelAlg : public Algorithm
+{
+public:
+  using DblType = double;
+
+  ABLWallFrictionVelAlg(
+    Realm&,
+    stk::mesh::Part*,
+    const bool,
+    const double,
+    const double,
+    const double,
+    const double);
+
+  virtual ~ABLWallFrictionVelAlg() = default;
+
+  virtual void execute() override;
+
+private:
+  ElemDataRequests faceData_;
+
+  unsigned velocityNp1_     {stk::mesh::InvalidOrdinal};
+  unsigned bcVelocity_      {stk::mesh::InvalidOrdinal};
+  unsigned density_         {stk::mesh::InvalidOrdinal};
+  unsigned bcHeatFlux_      {stk::mesh::InvalidOrdinal};
+  unsigned specificHeat_    {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_  {stk::mesh::InvalidOrdinal};
+  unsigned wallFricVel_     {stk::mesh::InvalidOrdinal};
+  unsigned wallNormDist_    {stk::mesh::InvalidOrdinal};
+
+  //! Acceleration due to gravity (m/s^2)
+  const DoubleType gravity_;
+
+  //! Roughness height (m)
+  const DoubleType z0_;
+
+  //! Reference temperature (K)
+  const DoubleType Tref_;
+
+  //! von Karman constant
+  const DoubleType kappa_{0.41};
+  const DoubleType beta_m_{5.0};
+  const DoubleType beta_h_{5.0};
+  const DoubleType gamma_m_{16.0};
+  const DoubleType gamma_h_{16.0};
+
+  bool useShifted_{false};
+
+  MasterElement* meFC_{nullptr};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* ABLWALLFRICTIONVELALG_H */

--- a/include/ngp_algorithms/NgpAlgDriver.h
+++ b/include/ngp_algorithms/NgpAlgDriver.h
@@ -194,6 +194,32 @@ Algorithm* create_face_algorithm(
   }
 }
 
+template<template <typename> class T, typename... Args>
+Algorithm* create_face_elem_algorithm(
+  const int dimension,
+  const stk::topology faceTopo,
+  const stk::topology elemTopo,
+  Args&&... args)
+{
+  if (dimension == 2) {
+    throw std::runtime_error("NGP face_elem algorithm not implemented");
+  }
+
+  switch (faceTopo) {
+  case stk::topology::QUAD_4:
+    switch (elemTopo) {
+    case stk::topology::HEX_8:
+      return new T<AlgTraitsQuad4Hex8>(std::forward<Args>(args)...);
+
+    default:
+      throw std::runtime_error("NGP face_elem algorithm not implemented");
+    }
+
+  default:
+    throw std::runtime_error("NGP face_elem algorithm not implemented");
+  }
+}
+
 class NgpAlgDriver
 {
 public:

--- a/include/ngp_algorithms/WallFuncGeometryAlg.h
+++ b/include/ngp_algorithms/WallFuncGeometryAlg.h
@@ -1,0 +1,49 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef WALLFUNCGEOMETRYALG_H
+#define WALLFUNCGEOMETRYALG_H
+
+#include "Algorithm.h"
+#include "ElemDataRequests.h"
+
+#include "stk_mesh/base/Types.hpp"
+
+namespace sierra {
+namespace nalu {
+
+template <typename BcAlgTraits>
+class WallFuncGeometryAlg : public Algorithm
+{
+public:
+  using DblType = double;
+
+  WallFuncGeometryAlg(Realm&, stk::mesh::Part*);
+
+  virtual ~WallFuncGeometryAlg() = default;
+
+  virtual void execute() override;
+
+private:
+  ElemDataRequests faceData_;
+  ElemDataRequests elemData_;
+
+  unsigned coordinates_ {stk::mesh::InvalidOrdinal};
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
+  unsigned wallNormDistBip_ {stk::mesh::InvalidOrdinal};
+  unsigned wallArea_ {stk::mesh::InvalidOrdinal};
+  unsigned wallNormDist_ {stk::mesh::InvalidOrdinal};
+
+  MasterElement* meFC_{nullptr};
+  MasterElement* meSCS_{nullptr};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* WALLFUNCGEOMETRYALG_H */

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -1,0 +1,310 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "ngp_algorithms/ABLWallFrictionVelAlg.h"
+
+#include "BuildTemplates.h"
+#include "master_element/MasterElement.h"
+#include "master_element/MasterElementFactory.h"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpFieldOps.h"
+#include "ScratchViews.h"
+#include "SolutionOptions.h"
+#include "utils/StkHelpers.h"
+#include "wind_energy/MoninObukhov.h"
+
+#include "stk_mesh/base/Field.hpp"
+
+namespace sierra {
+namespace nalu {
+
+namespace {
+
+template <typename PsiFunc>
+KOKKOS_FUNCTION
+double calc_utau(
+  const double uh,
+  const double zh,
+  const double term1,
+  const double Tflux,
+  const double Lfac,
+  const double kappa,
+  PsiFunc psi_func,
+  const double psi_fac)
+{
+  const double eps = 1.0e-8;
+  const double convTol = 1.0e-7;
+  const double perturb = 1.0e-3;
+  const int maxIters = 40;
+
+  // Return utau as epsilon if the velocity at surface is zero
+  if (stk::math::abs(uh) < eps)
+    return eps;
+
+  double utau0, utau1;
+  // Proceed with normal computations
+  utau0 = kappa * uh / term1;
+  if (Tflux > 0.0) utau0 *= 3.0;
+
+  utau1 = (1.0 + perturb) * utau0;
+
+  bool converged = false;
+  double utau = utau0;
+  for (int k=0; k < maxIters; ++k) {
+    double L0 = utau0 * utau0 * utau0 * Lfac;
+    double L1 = utau1 * utau1 * utau1 * Lfac;
+
+    double sgnq = (Tflux > 0.0) ? 1.0 : -1.0;
+    L0 = - sgnq * stk::math::max(1.0e-10, stk::math::abs(L0));
+    L1 = - sgnq * stk::math::max(1.1e-10, stk::math::abs(L1));
+
+    const double znorm0 = zh / L0;
+    const double znorm1 = zh / L1;
+
+    const double denom0 = term1 - psi_func(znorm0, psi_fac);
+    const double denom1 = term1 - psi_func(znorm1, psi_fac);
+
+    const double f0 = utau0 - uh * kappa / denom0;
+    const double f1 = utau1 - uh * kappa / denom1;
+
+    double dutau = utau1 - utau0;
+    dutau = (dutau > 0.0)
+      ? (stk::math::max(1.0e-15, dutau))
+      : (stk::math::min(-1.0e-15, dutau));
+
+    double fprime = (f1 - f0) / dutau;
+    fprime = (fprime > 0.0)
+      ? (stk::math::max(1.0e-15, fprime))
+      : (stk::math::min(-1.0e-15, fprime));
+
+    const double utau_tmp = utau1;
+    utau1 = utau0 - f0 / fprime;
+    utau0 = utau_tmp;
+
+    if (stk::math::abs(f1) < convTol) {
+      converged = true;
+      utau = stk::math::max(0.0, utau1);
+      break;
+    }
+  }
+
+  if (!converged) printf("Issue with utau");
+  return utau;
+}
+
+}
+
+template <typename BcAlgTraits>
+ABLWallFrictionVelAlg<BcAlgTraits>::ABLWallFrictionVelAlg(
+  Realm& realm,
+  stk::mesh::Part* part,
+  const bool useShifted,
+  const double gravity,
+  const double z0,
+  const double Tref,
+  const double kappa)
+  : Algorithm(realm, part),
+    faceData_(realm.meta_data()),
+    velocityNp1_(
+      get_field_ordinal(realm.meta_data(), "velocity", stk::mesh::StateNP1)),
+    bcVelocity_(get_field_ordinal(realm.meta_data(), "wall_velocity_bc")),
+    density_(get_field_ordinal(realm.meta_data(), "density")),
+    bcHeatFlux_(get_field_ordinal(realm.meta_data(), "heat_flux_bc")),
+    specificHeat_(get_field_ordinal(realm.meta_data(), "specific_heat")),
+    exposedAreaVec_(get_field_ordinal(
+      realm.meta_data(), "exposed_area_vector", realm.meta_data().side_rank())),
+    wallFricVel_(get_field_ordinal(
+      realm.meta_data(),
+      "wall_friction_velocity_bip",
+      realm.meta_data().side_rank())),
+    wallNormDist_(get_field_ordinal(
+      realm.meta_data(),
+      "wall_normal_distance_bip",
+      realm.meta_data().side_rank())),
+    gravity_(gravity),
+    z0_(z0),
+    Tref_(Tref),
+    kappa_(kappa),
+    useShifted_(useShifted),
+    meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element<
+          BcAlgTraits>())
+{
+  faceData_.add_cvfem_face_me(meFC_);
+
+  faceData_.add_coordinates_field(
+    realm.meta_data().coordinate_field()->mesh_meta_data_ordinal(),
+    BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  faceData_.add_gathered_nodal_field(velocityNp1_, BcAlgTraits::nDim_);
+  faceData_.add_gathered_nodal_field(bcVelocity_, BcAlgTraits::nDim_);
+  faceData_.add_gathered_nodal_field(density_, 1);
+  faceData_.add_gathered_nodal_field(bcHeatFlux_, 1);
+  faceData_.add_gathered_nodal_field(specificHeat_, 1);
+  faceData_.add_face_field(
+    exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+  faceData_.add_face_field(wallNormDist_, BcAlgTraits::numFaceIp_);
+
+  auto shp_fcn = useShifted_ ? FC_SHIFTED_SHAPE_FCN : FC_SHAPE_FCN;
+  faceData_.add_master_element_call(shp_fcn, CURRENT_COORDINATES);
+}
+
+template<typename BcAlgTraits>
+void ABLWallFrictionVelAlg<BcAlgTraits>::execute()
+{
+  namespace mo = abl_monin_obukhov;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  const auto& meshInfo = realm_.mesh_info();
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  auto ngpUtau = fieldMgr.template get_field<double>(wallFricVel_);
+
+  // Bring class members into local scope for device capture
+  const unsigned velID = velocityNp1_;
+  const unsigned bcVelID = bcVelocity_;
+  const unsigned rhoID = density_;
+  const unsigned bcHeatFluxID = bcHeatFlux_;
+  const unsigned specHeatID = specificHeat_;
+  const unsigned areaVecID = exposedAreaVec_;
+  const unsigned wDistID = wallNormDist_;
+
+  const DoubleType gravity = gravity_;
+  const DoubleType z0 = z0_;
+  const DoubleType Tref = Tref_;
+  const DoubleType kappa = kappa_;
+  const DoubleType beta_m = beta_m_;
+  const DoubleType gamma_m = gamma_m_;
+
+  const bool useShifted = useShifted_;
+
+  const double eps = 1.0e-8;
+  const DoubleType Lmax = 1.0e8;
+
+  const stk::mesh::Selector sel = realm_.meta_data().locally_owned_part()
+    & stk::mesh::selectUnion(partVec_);
+
+  nalu_ngp::run_elem_algorithm(
+    meshInfo, realm_.meta_data().side_rank(), faceData_, sel,
+    KOKKOS_LAMBDA(ElemSimdData& edata) {
+      const auto utauOps = nalu_ngp::simd_elem_field_updater(
+        ngpMesh, ngpUtau, edata);
+
+      // Unit normal vector
+      NALU_ALIGNED DoubleType nx[BcAlgTraits::nDim_];
+      NALU_ALIGNED DoubleType velIp[BcAlgTraits::nDim_];
+      NALU_ALIGNED DoubleType bcVelIp[BcAlgTraits::nDim_];
+
+      auto& scrViews = edata.simdScrView;
+      const auto& v_vel = scrViews.get_scratch_view_2D(velID);
+      const auto& v_bcvel = scrViews.get_scratch_view_2D(bcVelID);
+      const auto& v_rho = scrViews.get_scratch_view_1D(rhoID);
+      const auto& v_bcHeatFlux = scrViews.get_scratch_view_1D(bcHeatFluxID);
+      const auto& v_specHeat = scrViews.get_scratch_view_1D(specHeatID);
+      const auto& v_areavec = scrViews.get_scratch_view_2D(areaVecID);
+      const auto& v_wallnormdist = scrViews.get_scratch_view_1D(wDistID);
+
+      const auto meViews = scrViews.get_me_views(CURRENT_COORDINATES);
+      const auto& v_shape_fcn = useShifted
+        ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
+
+      for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
+        DoubleType aMag = 0.0;
+        for (int d=0; d < BcAlgTraits::nDim_; ++d) {
+          aMag += v_areavec(ip, d) * v_areavec(ip, d);
+        }
+        aMag = stk::math::sqrt(aMag);
+
+        // unit normal and reset velocities
+        for (int d=0; d < BcAlgTraits::nDim_; ++d) {
+          nx[d] = v_areavec(ip, d) / aMag;
+          velIp[d] = 0.0;
+          bcVelIp[d] = 0.0;
+        }
+
+        const DoubleType zh = v_wallnormdist(ip);
+
+        DoubleType heatFluxIp = 0.0;
+        DoubleType rhoIp = 0.0;
+        DoubleType CpIp = 0.0;
+        for (int ic =0; ic < BcAlgTraits::nodesPerElement_; ++ic) {
+          const DoubleType r = v_shape_fcn(ip, ic);
+          heatFluxIp += r * v_bcHeatFlux(ic);
+          rhoIp += r * v_rho(ic);
+          CpIp += r * v_specHeat(ic);
+
+          for (int d=0; d < BcAlgTraits::nDim_; ++d) {
+            velIp[d] += r * v_vel(ic, d);
+            bcVelIp[d] += r * v_bcvel(ic, d);
+          }
+        }
+
+        DoubleType uTangential = 0.0;
+        for (int i=0; i < BcAlgTraits::nDim_; ++i) {
+          DoubleType uiTan = 0.0;
+          DoubleType uiBcTan = 0.0;
+
+          for (int j=0; j < BcAlgTraits::nDim_; ++j) {
+            DoubleType ninj = nx[i] * nx[j];
+            if (i == j) {
+              const DoubleType om_ninj = 1.0 - ninj;
+              uiTan += om_ninj * velIp[j];
+              uiBcTan += om_ninj * bcVelIp[j];
+            } else {
+              uiTan -= ninj * velIp[j];
+              uiBcTan -= ninj * bcVelIp[j];
+            }
+          }
+          uTangential += (uiTan - uiBcTan) * (uiTan - uiBcTan);
+        }
+        uTangential = stk::math::sqrt(uTangential);
+
+        const DoubleType Tflux = heatFluxIp / (rhoIp * CpIp);
+        const DoubleType Lfac = stk::math::if_then_else(
+          (stk::math::abs(Tflux) < eps), Lmax,
+          (-Tref / (kappa * gravity * Tflux)));
+        const DoubleType term = stk::math::log(zh / z0);
+
+        DoubleType utau_calc;
+        for (int si = 0; si < edata.numSimdElems; ++si) {
+          const double Tflux1 = stk::simd::get_data(Tflux, si);
+
+          double utau;
+          if (Tflux1 < -eps) {
+            utau = calc_utau(
+              stk::simd::get_data(uTangential, si),
+              stk::simd::get_data(zh, si),
+              stk::simd::get_data(term, si),
+              stk::simd::get_data(Tflux, si),
+              stk::simd::get_data(Lfac, si),
+              stk::simd::get_data(kappa, si),
+              mo::psim_stable<double>,
+              stk::simd::get_data(beta_m, si));
+          } else if (Tflux1 > eps) {
+            utau = calc_utau(
+              stk::simd::get_data(uTangential, si),
+              stk::simd::get_data(zh, si),
+              stk::simd::get_data(term, si),
+              stk::simd::get_data(Tflux, si),
+              stk::simd::get_data(Lfac, si),
+              stk::simd::get_data(kappa, si),
+              mo::psim_unstable<double>,
+              stk::simd::get_data(gamma_m, si));
+          } else {
+            utau = stk::simd::get_data(kappa, si) *
+                   stk::simd::get_data(uTangential, si) /
+                   stk::simd::get_data(term, si);
+          }
+
+          stk::simd::set_data(utau_calc, si, utau);
+        }
+        utauOps(ip) = utau_calc;
+      }
+    });
+}
+
+INSTANTIATE_KERNEL_FACE(ABLWallFrictionVelAlg);
+
+}  // nalu
+}  // sierra

--- a/src/ngp_algorithms/CMakeLists.txt
+++ b/src/ngp_algorithms/CMakeLists.txt
@@ -7,6 +7,8 @@ add_sources(GlobalSourceList
   EnthalpyEffDiffFluxCoeffAlg.C
   MdotEdgeAlg.C
   TurbViscKsgsAlg.C
+  WallFuncGeometryAlg.C
+  ABLWallFrictionVelAlg.C
 
   # Algorithm Drivers
   NgpAlgDriver.C

--- a/src/ngp_algorithms/WallFuncGeometryAlg.C
+++ b/src/ngp_algorithms/WallFuncGeometryAlg.C
@@ -1,0 +1,170 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "ngp_algorithms/WallFuncGeometryAlg.h"
+
+#include "BuildTemplates.h"
+#include "master_element/MasterElementFactory.h"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpFieldOps.h"
+#include "Realm.h"
+#include "utils/StkHelpers.h"
+
+#include "stk_mesh/base/FieldParallel.hpp"
+#include "stk_util/parallel/ParallelReduce.hpp"
+
+namespace sierra {
+namespace nalu {
+
+template<typename BcAlgTraits>
+WallFuncGeometryAlg<BcAlgTraits>::WallFuncGeometryAlg(
+  Realm& realm,
+  stk::mesh::Part* part)
+  : Algorithm(realm, part),
+    faceData_(realm.meta_data()),
+    elemData_(realm.meta_data()),
+    coordinates_(
+      get_field_ordinal(realm.meta_data(), realm.get_coordinates_name())),
+    exposedAreaVec_(get_field_ordinal(
+      realm.meta_data(), "exposed_area_vector", realm.meta_data().side_rank())),
+    wallNormDistBip_(get_field_ordinal(
+                   realm.meta_data(),
+                   "wall_normal_distance_bip",
+                   realm.meta_data().side_rank())),
+    wallArea_(get_field_ordinal(realm.meta_data(), "assembled_wall_area_wf")),
+    wallNormDist_(get_field_ordinal(realm.meta_data(), "assembled_wall_normal_distance")),
+    meFC_(MasterElementRepo::get_surface_master_element<
+          typename BcAlgTraits::FaceTraits>()),
+    meSCS_(MasterElementRepo::get_surface_master_element<
+           typename BcAlgTraits::ElemTraits>())
+{
+  faceData_.add_cvfem_face_me(meFC_);
+  elemData_.add_cvfem_surface_me(meSCS_);
+
+  faceData_.add_coordinates_field(
+    coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+  faceData_.add_face_field(
+    exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
+
+  elemData_.add_coordinates_field(
+    coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
+}
+
+template<typename BcAlgTraits>
+void WallFuncGeometryAlg<BcAlgTraits>::execute()
+{
+  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using SimdDataType = nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+
+  const auto& meta = realm_.meta_data();
+
+  const auto& meshInfo = realm_.mesh_info();
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  auto wdistBip = fieldMgr.template get_field<double>(wallNormDistBip_);
+  auto wdist = fieldMgr.template get_field<double>(wallNormDist_);
+  auto warea = fieldMgr.template get_field<double>(wallArea_);
+
+  const stk::mesh::Selector sel = meta.locally_owned_part()
+    & stk::mesh::selectUnion(partVec_);
+
+  // Bring class members into local scope for device capture
+  const unsigned coordsID = coordinates_;
+  const unsigned exposedAreaVecID = exposedAreaVec_;
+  auto* meSCS = meSCS_;
+  auto* meFC = meFC_;
+
+  // Zero out nodal fields
+  wdist.set_all(ngpMesh, 0.0);
+  warea.set_all(ngpMesh, 0.0);
+
+  nalu_ngp::run_face_elem_algorithm(
+    meshInfo, faceData_, elemData_, sel,
+    KOKKOS_LAMBDA(SimdDataType& fdata) {
+      const auto areaOps = nalu_ngp::simd_nodal_field_updater(
+        ngpMesh, warea, fdata);
+      const auto distOps = nalu_ngp::simd_nodal_field_updater(
+        ngpMesh, wdist, fdata);
+      const auto dBipOps = nalu_ngp::simd_elem_field_updater(
+        ngpMesh, wdistBip, fdata);
+
+      auto& v_coord = fdata.simdElemView.get_scratch_view_2D(coordsID);
+      auto& v_area = fdata.simdFaceView.get_scratch_view_2D(exposedAreaVecID);
+
+      const int* faceIpNodeMap = meFC->ipNodeMap();
+      for (int ip=0; ip < BcAlgTraits::numFaceIp_; ++ip) {
+        DoubleType aMag = 0.0;
+        for (int d=0; d < BcAlgTraits::nDim_; ++d)
+          aMag += v_area(ip, d) * v_area(ip, d);
+        aMag = stk::math::sqrt(aMag);
+
+        const int nodeR = meSCS->ipNodeMap(fdata.faceOrd)[ip];
+        const int nodeL = meSCS->opposingNodes(fdata.faceOrd, ip);
+
+        DoubleType ypBip = 0.0;
+        for (int d=0; d < BcAlgTraits::nDim_; ++d) {
+          const DoubleType nj = v_area(ip, d) / aMag;
+          const DoubleType ej = 0.25 * (v_coord(nodeR, d) - v_coord(nodeL, d));
+          ypBip += nj * ej * nj * ej;
+        }
+        ypBip = stk::math::sqrt(ypBip);
+
+        // Update the wall distance boundary integration pt (Bip)
+        dBipOps(ip) = ypBip;
+
+        // Accumulate to the nearest node
+        const int ni = faceIpNodeMap[ip];
+        distOps(ni, 0) += aMag * ypBip;
+        areaOps(ni, 0) += aMag;
+      }
+    });
+
+  {
+    // TODO replace logic with STK NGP parallel sum, but still need to handle
+    // periodic the old way
+    wdist.modify_on_device();
+    wdist.sync_to_host();
+    warea.modify_on_device();
+    warea.sync_to_host();
+
+    // Synchronize fields for parallel runs
+    stk::mesh::FieldBase* wallAreaF = meta.get_field(
+      stk::topology::NODE_RANK, "assembled_wall_area_wf");
+    stk::mesh::FieldBase* wallDistF = meta.get_field(
+      stk::topology::NODE_RANK, "assembled_wall_normal_distance");
+    stk::mesh::parallel_sum(realm_.bulk_data(),
+                            {wallAreaF, wallDistF});
+
+    if (realm_.hasPeriodic_) {
+      const unsigned nComponents = 1;
+      const bool bypassFieldChk = false;
+      realm_.periodic_field_update(wallAreaF, nComponents, bypassFieldChk);
+      realm_.periodic_field_update(wallDistF, nComponents, bypassFieldChk);
+    }
+
+    wdist.modify_on_host();
+    wdist.sync_to_device();
+    warea.modify_on_host();
+    warea.sync_to_device();
+  }
+
+  sierra::nalu::nalu_ngp::run_entity_algorithm(
+    ngpMesh, stk::topology::NODE_RANK, sel,
+    KOKKOS_LAMBDA(const MeshIndex& mi) {
+      wdist.get(mi, 0) /= warea.get(mi, 0);
+    });
+
+  // Indicate that we have modified but don't sync it
+  wdist.modify_on_device();
+  warea.modify_on_device();
+  wdistBip.modify_on_device();
+}
+
+INSTANTIATE_KERNEL_FACE_ELEMENT(WallFuncGeometryAlg);
+
+}  // nalu
+}  // sierra


### PR DESCRIPTION
This pull-request converts ABL wall friction velocity calculations to NGP version. The original algorithm is split into two: 1. a geometry computation part (assembled wall area and normals) that is no only performed once during initialization and then only recomputed if there is mesh motion, and 2. the wall friction velocity computation that is called in place of the old algorithm.