### PR TITLE
Revert "Cleanup periodic_field_update in preparation for ngp conversi…

### DIFF
--- a/include/PeriodicManager.h
+++ b/include/PeriodicManager.h
@@ -60,15 +60,15 @@ class PeriodicManager {
   // holder for master += slave; slave = master
   void apply_constraints(
     stk::mesh::FieldBase *,
-    const unsigned sizeOfField,
-    const bool bypassFieldCheck,
-    const bool addSlaves = true,
-    const bool setSlaves = true);
+    const unsigned &sizeOfField,
+    const bool &bypassFieldCheck,
+    const bool &addSlaves = true,
+    const bool &setSlaves = true);
 
   // find the max
   void apply_max_field(
     stk::mesh::FieldBase *,
-    const unsigned sizeOfField);
+    const unsigned &sizeOfField);
 
   void manage_ghosting_object();
 
@@ -159,13 +159,13 @@ class PeriodicManager {
 
   void add_slave_to_master(
     stk::mesh::FieldBase *theField,
-    const unsigned sizeOfField,
-    const bool bypassFieldCheck);
+    const unsigned &sizeOfField,
+    const bool &bypassFieldCheck);
 
   void set_slave_to_master(
     stk::mesh::FieldBase *theField,
-    const unsigned sizeOfField,
-    const bool bypassFieldCheck);
+    const unsigned &sizeOfField,
+    const bool &bypassFieldCheck);
 
 };
 

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -708,7 +708,8 @@ PeriodicManager::parallel_communicate_field(
   const unsigned pSize = bulk_data.parallel_size();
   if ( pSize > 1 ) {
     std::vector< const stk::mesh::FieldBase *> fieldVec(1, theField);
-    stk::mesh::communicate_field_data(bulk_data, fieldVec);
+    stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+    stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
   }
 }
 
@@ -750,23 +751,21 @@ PeriodicManager::update_global_id_field()
 void
 PeriodicManager::apply_constraints(
   stk::mesh::FieldBase *theField,
-  const unsigned sizeOfField,
-  const bool bypassFieldCheck,
-  const bool addSlaves,
-  const bool setSlaves)
+  const unsigned &sizeOfField,
+  const bool &bypassFieldCheck,
+  const bool &addSlaves,
+  const bool &setSlaves)
 {
-  parallel_communicate_field(theField);
 
   // update periodically ghosted fields within add_ and set_
-  if ( addSlaves ) {
+  if ( addSlaves )
     add_slave_to_master(theField, sizeOfField, bypassFieldCheck);
-    parallel_communicate_field(theField);
-  }
   if ( setSlaves )
     set_slave_to_master(theField, sizeOfField, bypassFieldCheck);
 
   // parallel communicate shared and aura-ed entities
   parallel_communicate_field(theField);
+
 }
 
 
@@ -776,8 +775,9 @@ PeriodicManager::apply_constraints(
 void
 PeriodicManager::apply_max_field(
   stk::mesh::FieldBase *theField,
-  const unsigned sizeOfField)
+  const unsigned &sizeOfField)
 {
+
   periodic_parallel_communicate_field(theField);
 
   for ( size_t k = 0; k < masterSlaveCommunicator_.size(); ++k) {
@@ -807,9 +807,12 @@ PeriodicManager::apply_max_field(
 void
 PeriodicManager::add_slave_to_master(
   stk::mesh::FieldBase *theField,
-  const unsigned sizeOfField,
-  const bool bypassFieldCheck)
+  const unsigned &sizeOfField,
+  const bool &bypassFieldCheck)
 {
+  
+  periodic_parallel_communicate_field(theField);
+
   // iterate vector of masterEntity:slaveEntity pairs
   if ( bypassFieldCheck ) {
     // fields are expected to be defined on all master/slave nodes
@@ -845,6 +848,9 @@ PeriodicManager::add_slave_to_master(
       }
     }
   }
+
+  periodic_parallel_communicate_field(theField);
+
 }
 
 //--------------------------------------------------------------------------
@@ -853,9 +859,12 @@ PeriodicManager::add_slave_to_master(
 void
 PeriodicManager::set_slave_to_master(
   stk::mesh::FieldBase *theField,
-  const unsigned sizeOfField,
-  const bool bypassFieldCheck)
+  const unsigned &sizeOfField,
+  const bool &bypassFieldCheck)
 {
+
+  periodic_parallel_communicate_field(theField);
+
   // iterate vector of masterEntity:slaveEntity pairs
   if ( bypassFieldCheck ) {
     // fields are expected to be defined on all master/slave nodes
@@ -892,6 +901,9 @@ PeriodicManager::set_slave_to_master(
       }
     }
   }
+
+  periodic_parallel_communicate_field(theField);
+
 }
 
 } // namespace nalu


### PR DESCRIPTION
…on (#365)"

This reverts commit 7004321cda46cafb23376e3e7a1ff15cb2e42ce3.

There is clearly something I'm missing about the MPI communication
associated with periodic updates, so I'm reverting this commit until
I can get it straightened out.