### PR TITLE
Add Cartesian Aligned Strong Symmetry BC

### DIFF
--- a/include/Enums.h
+++ b/include/Enums.h
@@ -42,7 +42,10 @@ enum AlgorithmType{
    */
   REF_PRESSURE = 15, 
  
-  TOP_ABL = 16
+  TOP_ABL = 16,
+  X_SYM_STRONG = 17,
+  Y_SYM_STRONG = 18,
+  Z_SYM_STRONG = 19
 };
 
 enum BoundaryConditionType{

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -224,6 +224,7 @@ public:
 
   // saved of mesh parts that are not to be projected
   std::vector<stk::mesh::Part *> notProjectedPart_;
+  std::array<std::vector<stk::mesh::Part*>,3> notProjectedDir_;
 };
 
 class ContinuityEquationSystem : public EquationSystem {

--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -312,9 +312,11 @@ struct SymmetryUserData : public UserData {
     Z_DIR_STRONG
   };
   SymmetryTypes symmType_;
+  bool useProjections_;
   SymmetryUserData()
     : UserData(),
-      symmType_(SymmetryTypes::GENERAL_WEAK)
+      symmType_(SymmetryTypes::GENERAL_WEAK),
+      useProjections_(false)
   {}
 };
 

--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -305,8 +305,16 @@ struct OversetUserData : public UserData {
 };
 
 struct SymmetryUserData : public UserData {
+  enum class SymmetryTypes{
+    GENERAL_WEAK,
+    X_DIR_STRONG,
+    Y_DIR_STRONG,
+    Z_DIR_STRONG
+  };
+  SymmetryTypes symmType_;
   SymmetryUserData()
-    : UserData()
+    : UserData(),
+      symmType_(SymmetryTypes::GENERAL_WEAK)
   {}
 };
 

--- a/include/master_element/Tri33DCVFEM.h
+++ b/include/master_element/Tri33DCVFEM.h
@@ -42,6 +42,15 @@ public:
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
 
+  KOKKOS_FUNCTION void shape_fcn(
+    SharedMemView<DoubleType**, DeviceShmem> & shpfc) override;
+
+  KOKKOS_FUNCTION void shifted_shape_fcn(
+    SharedMemView<DoubleType**, DeviceShmem> &shpfc) override;
+
+  KOKKOS_FUNCTION void tri_shape_fcn(
+    const double *isoParCoords, SharedMemView<DoubleType**, DeviceShmem> &shpfc);
+
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
   void determinant(

--- a/include/user_functions/GaussJetVelocityAuxFunction.h
+++ b/include/user_functions/GaussJetVelocityAuxFunction.h
@@ -1,0 +1,46 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef GaussJetVelocityAuxFunction_h
+#define GaussJetVelocityAuxFunction_h
+
+#include <AuxFunction.h>
+
+#include <vector>
+
+namespace sierra{
+namespace nalu{
+
+class GaussJetVelocityAuxFunction : public AuxFunction
+{
+public:
+
+  GaussJetVelocityAuxFunction(
+    const unsigned beginPos,
+    const unsigned endPos);
+
+  virtual ~GaussJetVelocityAuxFunction() {}
+  
+  using AuxFunction::do_evaluate;
+  virtual void do_evaluate(
+    const double * coords,
+    const double time,
+    const unsigned spatialDimension,
+    const unsigned numPoints,
+    double * fieldPtr,
+    const unsigned fieldSize,
+    const unsigned beginPos,
+    const unsigned endPos) const;
+  
+private:
+  const double u_m;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -213,6 +213,7 @@
 #include <user_functions/OneTwoTenVelocityAuxFunction.h>
 
 #include <user_functions/PerturbedShearLayerAuxFunctions.h>
+#include <user_functions/GaussJetVelocityAuxFunction.h>
 
 // deprecated
 #include <ContinuityMassElemSuppAlgDep.h>
@@ -1578,6 +1579,9 @@ MomentumEquationSystem::register_inflow_bc(
     }
     else if ( fcnName == "wind_energy_power_law") {
       theAuxFunc = new WindEnergyPowerLawAuxFunction(0,nDim,theParams);
+    }
+    else if ( fcnName == "GaussJet") {
+      theAuxFunc = new GaussJetVelocityAuxFunction(0,nDim);
     }
     else {
       throw std::runtime_error("MomentumEquationSystem::register_inflow_bc: limited functions supported");
@@ -3026,6 +3030,9 @@ ContinuityEquationSystem::register_inflow_bc(
       }
       else if ( fcnName == "wind_energy_power_law") {
           theAuxFunc = new WindEnergyPowerLawAuxFunction(0,nDim,theParams);
+      }
+      else if ( fcnName == "GaussJet") {
+        theAuxFunc = new GaussJetVelocityAuxFunction(0,nDim);
       }
       else {
         throw std::runtime_error("ContEquationSystem::register_inflow_bc: limited functions supported");

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -2117,10 +2117,10 @@ MomentumEquationSystem::register_symmetry_bc(
 
   using SYMMTYPES = SymmetryUserData::SymmetryTypes;
   const SYMMTYPES symmType = symmBCData.userData_.symmType_;
-  unsigned beginPos, endPos;
+  unsigned beginPos{0}, endPos{1};
   stk::mesh::MetaData &meta_data = realm_.meta_data();
   const unsigned nDim = meta_data.spatial_dimension();
-  AlgorithmType pickTheType;
+  AlgorithmType pickTheType = algType;
   switch(symmType){
    case SYMMTYPES::GENERAL_WEAK:
      return;

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -2173,6 +2173,17 @@ MomentumEquationSystem::register_symmetry_bc(
   if(!symmBCData.userData_.useProjections_){
     notProjectedDir_[beginPos].push_back(part);
   }
+  if(linsys_->linearSolver_->getConfig()->useSegregatedSolver()){
+    NaluEnv::self().naluOutputP0()
+      << "Warning: You are currently using a segregated solver with a strong symmetry boundary "
+      << "condition. This leads to an approximation of the momentum equation for the tangential "
+      << "velocity component(s) at the symmetry surface because it deletes LHS sensitivities."
+      << std::endl
+      << "Warning (cont): Testing shows the error to be negligible, but "
+      << "if strange behavior is encountered it is recommended that you "
+      << "switch to the monolithic solve (segregated_solver: no)."
+      << std::endl;
+  }
 
   // register boundary data; velocity_bc
   const std::string bcFieldName = "strong_sym_velocity";

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -2138,6 +2138,9 @@ MomentumEquationSystem::register_symmetry_bc(
   }
 
   endPos = beginPos + 1;
+  if(!symmBCData.userData_.useProjections_){
+    notProjectedPart_.push_back(part);
+  }
 
   // register boundary data; velocity_bc
   const std::string bcFieldName = "strong_sym_velocity";

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -203,6 +203,9 @@ namespace sierra
       symmetryBC.theBcType_ = SYMMETRY_BC;
       const YAML::Node& symmetryUserData = node["symmetry_user_data"];
       symmetryBC.userData_ = symmetryUserData.as<SymmetryUserData>();
+      if(symmetryUserData["use_projections"]){
+        symmetryBC.userData_.useProjections_ = symmetryUserData["use_projections"].as<bool>();
+      }
       if(symmetryUserData["symmetry_type"]){
         const std::string symmType =
             symmetryUserData["symmetry_type"].as<std::string>();

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -203,6 +203,27 @@ namespace sierra
       symmetryBC.theBcType_ = SYMMETRY_BC;
       const YAML::Node& symmetryUserData = node["symmetry_user_data"];
       symmetryBC.userData_ = symmetryUserData.as<SymmetryUserData>();
+      if(symmetryUserData["symmetry_type"]){
+        const std::string symmType =
+            symmetryUserData["symmetry_type"].as<std::string>();
+        if(symmType == "generalized_weak" || symmType == "default"){
+          // do nothing already set, but keep for parse checking
+        }
+        else if(symmType == "x_direction_strong"){
+          symmetryBC.userData_.symmType_ = SymmetryUserData::SymmetryTypes::X_DIR_STRONG;
+        }
+        else if(symmType == "y_direction_strong"){
+          symmetryBC.userData_.symmType_ = SymmetryUserData::SymmetryTypes::Y_DIR_STRONG;
+        }
+        else if(symmType == "z_direction_strong"){
+          symmetryBC.userData_.symmType_ = SymmetryUserData::SymmetryTypes::Z_DIR_STRONG;
+        }
+        else{
+          throw std::runtime_error(
+            "Unrecognized value for symmetry_type: " + symmType
+            );
+        }
+      }
     }
 
     void operator >>(const YAML::Node& node,

--- a/src/master_element/Tri33DCVFEM.C
+++ b/src/master_element/Tri33DCVFEM.C
@@ -79,6 +79,11 @@ Tri3DSCS::shape_fcn(double *shpfc)
   tri_shape_fcn(numIntPoints_, &intgLoc_[0], shpfc);
 }
 
+void Tri3DSCS::shape_fcn(SharedMemView<DoubleType**, DeviceShmem> &shpfc)
+{
+  tri_shape_fcn(intgLoc_, shpfc);
+}
+
 //--------------------------------------------------------------------------
 //-------- shifted_shape_fcn -----------------------------------------------
 //--------------------------------------------------------------------------
@@ -86,6 +91,11 @@ void
 Tri3DSCS::shifted_shape_fcn(double *shpfc)
 {
   tri_shape_fcn(numIntPoints_, &intgLocShift_[0], shpfc);
+}
+
+void Tri3DSCS::shifted_shape_fcn(SharedMemView<DoubleType**, DeviceShmem> &shpfc)
+{
+  tri_shape_fcn(intgLocShift_, shpfc);
 }
 
 //--------------------------------------------------------------------------
@@ -105,6 +115,21 @@ Tri3DSCS::tri_shape_fcn(
     shape_fcn[    threej] = 1.0 - xi - eta;
     shape_fcn[1 + threej] = xi;
     shape_fcn[2 + threej] = eta;
+  }
+}
+
+void
+Tri3DSCS::tri_shape_fcn(
+  const double* isoParCoods, SharedMemView<DoubleType**, DeviceShmem> & shpfc)
+{
+  for (int j=0; j<numIntPoints_; ++j)
+  {
+    const int k = 2*j;
+    const DoubleType xi = isoParCoods[k];
+    const DoubleType eta = isoParCoods[k+1];
+    shpfc(j, 0) = 1.0-xi-eta;
+    shpfc(j, 1) = xi;
+    shpfc(j, 2) = eta;
   }
 }
 

--- a/src/user_functions/CMakeLists.txt
+++ b/src/user_functions/CMakeLists.txt
@@ -8,6 +8,7 @@ add_sources(GlobalSourceList
    ConvectingTaylorVortexPressureAuxFunction.C
    ConvectingTaylorVortexVelocityAuxFunction.C
    FlowPastCylinderTempAuxFunction.C
+   GaussJetVelocityAuxFunction.C
    KovasznayPressureAuxFunction.C
    KovasznayVelocityAuxFunction.C
    LinearRampMeshDisplacementAuxFunction.C

--- a/src/user_functions/GaussJetVelocityAuxFunction.C
+++ b/src/user_functions/GaussJetVelocityAuxFunction.C
@@ -21,7 +21,7 @@ GaussJetVelocityAuxFunction::GaussJetVelocityAuxFunction(
   const unsigned beginPos,
   const unsigned endPos) :
   AuxFunction(beginPos, endPos),
-    u_m(1.0) 	// bulk velocity
+    u_m(10.0) 	// bulk velocity
 {
   // does nothing
 }

--- a/src/user_functions/GaussJetVelocityAuxFunction.C
+++ b/src/user_functions/GaussJetVelocityAuxFunction.C
@@ -1,0 +1,70 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#include <user_functions/GaussJetVelocityAuxFunction.h>
+#include <algorithm>
+
+// basic c++
+#include <cmath>
+#include <vector>
+#include <stdexcept>
+
+namespace sierra{
+namespace nalu{
+
+GaussJetVelocityAuxFunction::GaussJetVelocityAuxFunction(
+  const unsigned beginPos,
+  const unsigned endPos) :
+  AuxFunction(beginPos, endPos),
+    u_m(1.0) 	// bulk velocity
+{
+  // does nothing
+}
+
+void
+GaussJetVelocityAuxFunction::do_evaluate(
+  const double *coords,
+  const double /*time*/,
+  const unsigned spatialDimension,
+  const unsigned numPoints,
+  double * fieldPtr,
+  const unsigned fieldSize,
+  const unsigned /*beginPos*/,
+  const unsigned /*endPos*/) const
+{
+  if(spatialDimension == 2)
+  {
+    for(unsigned p=0; p < numPoints; ++p) {
+
+      const double x = coords[0];
+
+      fieldPtr[0] = 0.0;
+      fieldPtr[1] = -u_m*exp(-10.0*x*x);
+      fieldPtr += fieldSize;
+      coords += spatialDimension;
+    }
+  }
+  else{
+    for(unsigned p=0; p < numPoints; ++p) {
+
+      const double x = coords[0];
+      const double y = coords[1];
+      const double r2 = x*x+y*y;
+
+      fieldPtr[0] = 0.0;
+      fieldPtr[1] = 0.0;
+      fieldPtr[2] = -u_m*exp(-10.0*r2);
+
+      fieldPtr += fieldSize;
+      coords += spatialDimension;
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace Sierra


### PR DESCRIPTION
Add option to apply a symmetry bc strongly for a plane who's normal aligns with one of the principle Cartesian directions.

Bonus features:
- Gaussian jet bc added to user functions. This was used for a test case
- Kokkosify tri33D shape function calls 