### PR TITLE
Set stack size on GPU.

### DIFF
--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -681,15 +681,8 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
   MasterElement* /* meFC */,
   MasterElement* meSCS,
   MasterElement* meSCV,
-  MasterElement*
-#ifndef KOKKOS_ENABLE_CUDA
-      meFEM
-#endif
-  ,
-  int
-#ifndef KOKKOS_ENABLE_CUDA
-     faceOrdinal
-#endif
+  MasterElement* meFEM,
+  int faceOrdinal
   )
 {
   for(unsigned i=0; i<dataEnums.size(); ++i) {
@@ -703,7 +696,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
          meSCS->determinant(*coordsView, scs_areav);
          break;
-#ifndef KOKKOS_ENABLE_CUDA
       case SCS_FACE_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_FACE_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_FACE_GRAD_OP requested.");
@@ -714,7 +706,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_SHIFTED_FACE_GRAD_OP requested.");
          meSCS->shifted_face_grad_op(faceOrdinal, *coordsView, dndx_shifted_fc_scs);
        break;
-#endif
       case SCS_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
@@ -755,7 +746,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_SHIFTED_GRAD_OP requested.");
         meSCV->shifted_grad_op(*coordsView, dndx_scv_shifted, deriv_scv);
         break;
-#ifndef KOKKOS_ENABLE_CUDA
       case FEM_GRAD_OP:
          NGP_ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
@@ -766,7 +756,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
          meFEM->shifted_grad_op_fem(*coordsView, dndx_fem, deriv_fem, det_j_fem);
          break;
-#endif
 
       default: break;
     }

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -52,6 +52,9 @@ public:
 
   static bool debug_;
   int serializedIOGroupSize_;
+private:
+  size_t    default_stack_size;
+  const size_t nalu_stack_size=4096;
 };
 
 } // namespace nalu

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -44,13 +44,21 @@ Simulation::Simulation(const YAML::Node& root_node) :
     transfers_(NULL),
     linearSolvers_(NULL),
     serializedIOGroupSize_(0)
-{}
+{
+#ifdef KOKKOS_ENABLE_CUDA
+  cudaDeviceGetLimit (&default_stack_size, cudaLimitStackSize);
+  cudaDeviceSetLimit (cudaLimitStackSize, nalu_stack_size);
+#endif
+}
 
 Simulation::~Simulation() {
   delete realms_;
   delete transfers_;
   delete timeIntegrator_;
   delete linearSolvers_;
+#ifdef KOKKOS_ENABLE_CUDA
+  cudaDeviceSetLimit (cudaLimitStackSize, default_stack_size);
+#endif
 }
 
 // Timers


### PR DESCRIPTION
Seems we sometimes run out of stack which can give some odd runtime errors.  The default stack on some platforms is 1024.  Kokkos always sets this to 2048 before all kernal launches.  This sets it to 4096 during any simulation.   See if this fixes our problems with ScratchViews.