### PR TITLE
Fix setting cudaLimitStackSize for unit tests.

### DIFF
--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -52,6 +52,9 @@ public:
 
   static bool debug_;
   int serializedIOGroupSize_;
+private:
+  size_t    default_stack_size;
+  const size_t nalu_stack_size=16384;
 };
 
 } // namespace nalu

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -52,9 +52,6 @@ public:
 
   static bool debug_;
   int serializedIOGroupSize_;
-private:
-  size_t    default_stack_size;
-  const size_t nalu_stack_size=16384;
 };
 
 } // namespace nalu

--- a/unit_tests.C
+++ b/unit_tests.C
@@ -22,6 +22,10 @@ int main(int argc, char **argv)
     Kokkos::initialize(argc, argv);
     int returnVal = 0;
 
+    const size_t nalu_stack_size=16384;
+#ifdef KOKKOS_ENABLE_CUDA
+    cudaDeviceSetLimit (cudaLimitStackSize, nalu_stack_size);
+#endif
     // Create a dummy nested scope to ensure destructors are called before
     // Kokkos::finalize_all. The instances owning threaded Kokkos loops must be
     // cleared out before Kokkos::finalize is called.


### PR DESCRIPTION
With this and the fix for the NgpLoopTest.NGP_basic_face_elem_loop test, all the NGP unit tests pass for me with all of the NGP unit tests pass.  The link warnings are still there and it seems odd that just those two little master element functions would cause the stack size to increase so.