### PR TITLE
Introduce driver code for geometry & TKE ABL wall function computations

### DIFF
--- a/include/Enums.h
+++ b/include/Enums.h
@@ -17,20 +17,23 @@ namespace nalu {
 
 enum AlgorithmType{
   INTERIOR  = 0,
-  INFLOW    = 1,
-  WALL      = 2,
-  WALL_FCN  = 3,
-  OPEN      = 4,
-  MASS      = 5,
-  SRC       = 6,
-  SYMMETRY  = 7,
-  WALL_HF   = 8,
-  WALL_CHT  = 9,
-  WALL_RAD  = 10,
-  NON_CONFORMAL = 11,
-  ELEM_SOURCE = 12,
-  OVERSET = 13,
-  WALL_ABL = 14,
+  BOUNDARY,
+  INFLOW    ,
+  WALL      ,
+  WALL_FCN  ,
+  OPEN      ,
+  MASS      ,
+  SRC       ,
+  SYMMETRY  ,
+  WALL_HF   ,
+  WALL_CHT  ,
+  WALL_RAD  ,
+  NON_CONFORMAL ,
+  ELEM_SOURCE ,
+  OVERSET ,
+  WALL_ABL ,
+
+  TOP_ABL,
 
   /** Set the reference pressure at a node.
    *
@@ -40,9 +43,7 @@ enum AlgorithmType{
    *
    * \sa FixPressureAtNodeAlgorithm
    */
-  REF_PRESSURE = 15, 
- 
-  TOP_ABL = 16
+  REF_PRESSURE
 };
 
 enum BoundaryConditionType{

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -54,6 +54,7 @@ class Algorithm;
 class AlgorithmDriver;
 class AuxFunctionAlgorithm;
 class ComputeGeometryAlgorithmDriver;
+class GeometryAlgDriver;
 
 class NonConformalManager;
 class ErrorIndicatorAlgorithmDriver;
@@ -419,6 +420,7 @@ class Realm {
 
   // algorithm drivers managed by region
   ComputeGeometryAlgorithmDriver *computeGeometryAlgDriver_;
+  std::unique_ptr<GeometryAlgDriver> geometryAlgDriver_{nullptr};
   ErrorIndicatorAlgorithmDriver *errorIndicatorAlgDriver_;
 # if defined (NALU_USES_PERCEPT)  
   Adapter *adapter_;

--- a/include/TurbKineticEnergyEquationSystem.h
+++ b/include/TurbKineticEnergyEquationSystem.h
@@ -14,6 +14,7 @@
 #include <NaluParsing.h>
 
 #include "ngp_algorithms/NodalGradAlgDriver.h"
+#include "ngp_algorithms/TKEWallFuncAlgDriver.h"
 
 namespace stk{
 struct topology;
@@ -96,8 +97,7 @@ public:
   ScalarFieldType *evisc_;
   
   ScalarNodalGradAlgDriver nodalGradAlgDriver_;
-  NgpAlgDriver wallFuncAlgDriver_;
-
+  std::unique_ptr<TKEWallFuncAlgDriver> wallFuncAlgDriver_;
   std::unique_ptr<Algorithm> effDiffFluxCoeffAlg_;
   const TurbulenceModel turbulenceModel_;
 

--- a/include/ngp_algorithms/GeometryAlgDriver.h
+++ b/include/ngp_algorithms/GeometryAlgDriver.h
@@ -1,0 +1,57 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef GEOMETRYALGDRIVER_H
+#define GEOMETRYALGDRIVER_H
+
+#include "ngp_algorithms/NgpAlgDriver.h"
+#include "FieldTypeDef.h"
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+class GeometryAlgDriver : public NgpAlgDriver
+{
+public:
+  GeometryAlgDriver(Realm&);
+
+  virtual ~GeometryAlgDriver() = default;
+
+  //! Reset fields before calling algorithms
+  virtual void pre_work() override;
+
+  //! Synchronize fields after algorithms have done their work
+  virtual void post_work() override;
+
+  /** Register wall function geometry calculation algorithm
+   *
+   *  Need a specialization here to track whether the user has requested wall functions
+   */
+  template<template <typename> class FaceElemAlg, class... Args>
+  void register_wall_func_algorithm(
+    AlgorithmType algType,
+    stk::mesh::Part* part,
+    const stk::topology elemTopo,
+    const std::string& algSuffix,
+    Args&&... args)
+  {
+    register_face_elem_algorithm<FaceElemAlg>(
+      algType, part, elemTopo, algSuffix, std::forward<Args>(args)...);
+    hasWallFunc_ = true;
+  }
+
+private:
+  bool hasWallFunc_{false};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* GEOMETRYALGDRIVER_H */

--- a/include/ngp_algorithms/GeometryAlgDriver.h
+++ b/include/ngp_algorithms/GeometryAlgDriver.h
@@ -16,6 +16,26 @@ namespace nalu {
 
 class Realm;
 
+/** Compute geometry fields
+ *
+ *  This class coordinates the computation of the following fields:
+ *    - dual_nodal_volume
+ *    - element_volume
+ *    - edge_area_vector
+ *    - exposed_area_vector
+ *    - assembled_wall_area_wf
+ *    - assembled_wall_normal_distance
+ *
+ *  While the volume computation happens at every invocation of the execute()
+ *  method, the remaining fields are only computed if the user has requested
+ *  certain options in the input file. The design follows a driver/algorithm
+ *  pattern as the actual NGP computation of the fields for elements/edges/faces
+ *  etc. are done using algorithms that are templated on the element topologies.
+ *  See GeometryInteriorAlg and GeometryBoundaryAlg for more details of the
+ *  exact computations.
+ *
+ *  \sa GeometryInteriorAlg, GeometryBoundaryAlg
+ */
 class GeometryAlgDriver : public NgpAlgDriver
 {
 public:
@@ -47,6 +67,7 @@ public:
   }
 
 private:
+  //! Flag to track whether wall functions are active
   bool hasWallFunc_{false};
 };
 

--- a/include/ngp_algorithms/GeometryBoundaryAlg.h
+++ b/include/ngp_algorithms/GeometryBoundaryAlg.h
@@ -1,0 +1,46 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef GEOMETRYBOUNDARYALG_H
+#define GEOMETRYBOUNDARYALG_H
+
+#include "Algorithm.h"
+#include "ElemDataRequests.h"
+#include "FieldTypeDef.h"
+
+#include "stk_mesh/base/Types.hpp"
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+template <typename AlgTraits>
+class GeometryBoundaryAlg : public Algorithm
+{
+public:
+  GeometryBoundaryAlg(
+    Realm&,
+    stk::mesh::Part*);
+
+  virtual ~GeometryBoundaryAlg() = default;
+
+  virtual void execute() override;
+
+private:
+  ElemDataRequests dataNeeded_;
+
+  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
+
+  MasterElement* meSCS_{nullptr};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* GEOMETRYBOUNDARYALG_H */

--- a/include/ngp_algorithms/GeometryBoundaryAlg.h
+++ b/include/ngp_algorithms/GeometryBoundaryAlg.h
@@ -19,6 +19,10 @@ namespace nalu {
 
 class Realm;
 
+/** Compute exposed area vectors for the boundaries
+ *
+ *  \sa GeometryAlgDriver, GeometryInteriorAlg
+ */
 template <typename AlgTraits>
 class GeometryBoundaryAlg : public Algorithm
 {

--- a/include/ngp_algorithms/GeometryInteriorAlg.h
+++ b/include/ngp_algorithms/GeometryInteriorAlg.h
@@ -19,6 +19,13 @@ namespace nalu {
 
 class Realm;
 
+/** Compute nodal/element volumes and edge area vectors
+ *
+ *  "edge_area_vector" is only computed if the user has requested edge-based
+ *  finite-volume in the input file.
+ *
+ *  \sa GeometryAlgDriver, GeometryBoundaryAlg
+ */
 template <typename AlgTraits>
 class GeometryInteriorAlg : public Algorithm
 {

--- a/include/ngp_algorithms/GeometryInteriorAlg.h
+++ b/include/ngp_algorithms/GeometryInteriorAlg.h
@@ -1,0 +1,53 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef GEOMETRYINTERIORALG_H
+#define GEOMETRYINTERIORALG_H
+
+#include "Algorithm.h"
+#include "ElemDataRequests.h"
+#include "FieldTypeDef.h"
+
+#include "stk_mesh/base/Types.hpp"
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+template <typename AlgTraits>
+class GeometryInteriorAlg : public Algorithm
+{
+public:
+  GeometryInteriorAlg(
+    Realm&,
+    stk::mesh::Part*);
+
+  virtual ~GeometryInteriorAlg() = default;
+
+  virtual void execute() override;
+
+private:
+  void compute_dual_nodal_volume();
+
+  void compute_edge_area_vector();
+
+  ElemDataRequests dataNeeded_;
+
+  unsigned dualNodalVol_ {stk::mesh::InvalidOrdinal};
+  unsigned elemVol_ {stk::mesh::InvalidOrdinal};
+  unsigned edgeAreaVec_ {stk::mesh::InvalidOrdinal};
+
+  MasterElement* meSCV_{nullptr};
+  MasterElement* meSCS_{nullptr};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* GEOMETRYINTERIORALG_H */

--- a/include/ngp_algorithms/NgpAlgDriver.h
+++ b/include/ngp_algorithms/NgpAlgDriver.h
@@ -19,206 +19,12 @@
 #include "nalu_make_unique.h"
 #include "NaluEnv.h"
 #include "element_promotion/ElementDescription.h"
+#include "ngp_utils/NgpCreateElemInstance.h"
 
 namespace sierra {
 namespace nalu {
 
 class Realm;
-
-inline bool is_ngp_element(const stk::topology topo)
-{
-  if (topo.is_super_topology()) return false;
-
-  bool isNGP = false;
-  switch (topo.value()) {
-  case stk::topology::HEX_8:
-  case stk::topology::TET_4:
-  case stk::topology::PYRAMID_5:
-  case stk::topology::WEDGE_6:
-  case stk::topology::QUAD_4_2D:
-    isNGP = true;
-    break;
-
-  case stk::topology::TRI_3_2D:
-  case stk::topology::HEX_27:
-  case stk::topology::QUAD_9_2D:
-    isNGP = false;
-    break;
-
-  default:
-    throw std::logic_error("Invalid element topology provided");
-  }
-
-  return isNGP;
-}
-
-inline bool is_ngp_face(const stk::topology topo)
-{
-  if (topo.is_super_topology()) return false;
-
-  bool isNGP = false;
-  switch (topo.value()) {
-  case stk::topology::QUAD_4:
-    isNGP = true;
-    break;
-
-  case stk::topology::TRI_3:
-  case stk::topology::LINE_2:
-  case stk::topology::QUAD_9:
-  case stk::topology::LINE_3:
-    isNGP = false;
-    break;
-
-  default:
-    throw std::logic_error("Invalid face topology provided");
-  }
-
-  return isNGP;
-}
-
-template<template <typename> class T, int order, typename... Args>
-Algorithm* create_ho_elem_algorithm(
-  const int dimension,
-  Args&&... args)
-{
-  if (dimension == 2)
-    return new T<AlgTraitsQuadGL_2D<order>>(std::forward<Args>(args)...);
-
-  return new T<AlgTraitsHexGL<order>>(std::forward<Args>(args)...);
-}
-
-template<template <typename> class T, typename... Args>
-Algorithm* create_elem_algorithm(
-  const int dimension,
-  const stk::topology topo,
-  Args&&... args)
-{
-  if (!topo.is_super_topology()) {
-    switch (topo.value()) {
-    case stk::topology::HEX_8:
-      return new T<AlgTraitsHex8>(std::forward<Args>(args)...);
-    case stk::topology::HEX_27:
-      return new T<AlgTraitsHex27>(std::forward<Args>(args)...);
-    case stk::topology::TET_4:
-      return new T<AlgTraitsTet4>(std::forward<Args>(args)...);
-    case stk::topology::PYRAMID_5:
-      return new T<AlgTraitsPyr5>(std::forward<Args>(args)...);
-    case stk::topology::WEDGE_6:
-      return new T<AlgTraitsWed6>(std::forward<Args>(args)...);
-    case stk::topology::QUAD_4_2D:
-      return new T<AlgTraitsQuad4_2D>(std::forward<Args>(args)...);
-    case stk::topology::QUAD_9_2D:
-      return new T<AlgTraitsQuad9_2D>(std::forward<Args>(args)...);
-    case stk::topology::TRI_3_2D:
-      return new T<AlgTraitsTri3_2D>(std::forward<Args>(args)...);
-    default:
-      return nullptr;
-    }
-  } else {
-    int poly_order = poly_order_from_topology(dimension, topo);
-    switch (poly_order) {
-    case 2:
-      return create_ho_elem_algorithm<T, 2>(
-        dimension, std::forward<Args>(args)...);
-    case 3:
-      return create_ho_elem_algorithm<T, 3>(
-        dimension, std::forward<Args>(args)...);
-    case 4:
-      return create_ho_elem_algorithm<T, 4>(
-        dimension, std::forward<Args>(args)...);
-    case USER_POLY_ORDER:
-      return create_ho_elem_algorithm<T, USER_POLY_ORDER>(
-        dimension, std::forward<Args>(args)...);
-    default:
-      ThrowRequireMsg(
-        false, "Polynomial order" + std::to_string(poly_order) +
-                 "is not supported by default.  "
-                 "Specify USER_POLY_ORDER and recompile to run.");
-      return nullptr;
-    }
-  }
-}
-
-template<template <typename> class T, typename... Args>
-Algorithm* create_face_algorithm(
-  const int dimension,
-  const stk::topology topo,
-  Args&&... args)
-{
-  if (!topo.is_super_topology()) {
-    switch (topo.value()) {
-    case stk::topology::QUAD_4:
-      return new T<AlgTraitsQuad4>(std::forward<Args>(args)...);
-    case stk::topology::QUAD_9:
-      return new T<AlgTraitsQuad9>(std::forward<Args>(args)...);
-    case stk::topology::TRI_3:
-      return new T<AlgTraitsTri3>(std::forward<Args>(args)...);
-    case stk::topology::LINE_2:
-      return new T<AlgTraitsEdge_2D>(std::forward<Args>(args)...);
-    case stk::topology::LINE_3:
-      return new T<AlgTraitsEdge3_2D>(std::forward<Args>(args)...);
-    default:
-      return nullptr;
-    }
-  } else {
-    int poly_order = poly_order_from_topology(dimension, topo);
-    if (dimension == 2) {
-      switch (poly_order) {
-      case 2:
-        return new T<AlgTraitsEdgeGL<2>>(std::forward<Args>(args)...);
-      case 3:
-        return new T<AlgTraitsEdgeGL<2>>(std::forward<Args>(args)...);
-      case 4:
-        return new T<AlgTraitsEdgeGL<2>>(std::forward<Args>(args)...);
-      case USER_POLY_ORDER:
-        return new T<AlgTraitsEdgeGL<USER_POLY_ORDER>>(
-          std::forward<Args>(args)...);
-      default:
-        return nullptr;
-      }
-    } else {
-      switch (poly_order) {
-      case 2:
-        return new T<AlgTraitsQuadGL<2>>(std::forward<Args>(args)...);
-      case 3:
-        return new T<AlgTraitsQuadGL<3>>(std::forward<Args>(args)...);
-      case 4:
-        return new T<AlgTraitsQuadGL<4>>(std::forward<Args>(args)...);
-      case USER_POLY_ORDER:
-        return new T<AlgTraitsQuadGL<USER_POLY_ORDER>>(
-          std::forward<Args>(args)...);
-      default:
-        return nullptr;
-      }
-    }
-  }
-}
-
-template<template <typename> class T, typename... Args>
-Algorithm* create_face_elem_algorithm(
-  const int dimension,
-  const stk::topology faceTopo,
-  const stk::topology elemTopo,
-  Args&&... args)
-{
-  if (dimension == 2) {
-    throw std::runtime_error("NGP face_elem algorithm not implemented");
-  }
-
-  switch (faceTopo) {
-  case stk::topology::QUAD_4:
-    switch (elemTopo) {
-    case stk::topology::HEX_8:
-      return new T<AlgTraitsQuad4Hex8>(std::forward<Args>(args)...);
-
-    default:
-      throw std::runtime_error("NGP face_elem algorithm not implemented");
-    }
-
-  default:
-    throw std::runtime_error("NGP face_elem algorithm not implemented");
-  }
-}
 
 class NgpAlgDriver
 {
@@ -301,7 +107,7 @@ public:
     const auto it = algMap_.find(algName);
     if (it == algMap_.end()) {
       algMap_[algName].reset(
-        create_elem_algorithm<ElemAlg>(
+        nalu_ngp::create_elem_algorithm<Algorithm, ElemAlg>(
           nDim_, topo, realm_, part, std::forward<Args>(args)...));
       NaluEnv::self().naluOutputP0()
         << "Created algorithm = " << algName << std::endl;
@@ -321,7 +127,7 @@ public:
     const std::string& algSuffix,
     Args&&... args)
   {
-    if (!is_ngp_element(part->topology()))
+    if (!nalu_ngp::is_ngp_element(part->topology()))
       register_legacy_algorithm<LegacyAlg>(
         algType, part, algSuffix, std::forward<Args>(args)...);
     else
@@ -351,7 +157,7 @@ public:
     const auto it = algMap_.find(algName);
     if (it == algMap_.end()) {
       algMap_[algName].reset(
-        create_face_algorithm<FaceAlg>(
+        nalu_ngp::create_face_algorithm<Algorithm, FaceAlg>(
           nDim_, topo, realm_, part, std::forward<Args>(args)...));
       NaluEnv::self().naluOutputP0()
         << "Created algorithm = " << algName << std::endl;
@@ -370,7 +176,7 @@ public:
     const std::string& algSuffix,
     Args&&... args)
   {
-    if (!is_ngp_face(part->topology()))
+    if (!nalu_ngp::is_ngp_face(part->topology()))
       register_legacy_algorithm<LegacyAlg>(
         algType, part, algSuffix, std::forward<Args>(args)...);
     else

--- a/include/ngp_algorithms/TKEWallFuncAlg.h
+++ b/include/ngp_algorithms/TKEWallFuncAlg.h
@@ -17,6 +17,17 @@
 namespace sierra {
 namespace nalu {
 
+/** Compute nodal TKE values when using ABL wall function
+ *
+ *  Use a driver/algorithm style design to allow the actual computation to be
+ *  templated on the face element type. Computation of the "wall_model_tke_bc"
+ *  field is performed in TKEWallFuncAlg class. This field is synchronized in
+ *  parallel as well as host/device in TKEWallFuncAlgDriver::post_work and
+ *  "turbulent_ke" and "tke_bc" fields are updated for the wall boundaries where
+ *  wall function is being used.
+ *
+ *  \sa TKEWallFuncAlgDriver
+ */
 template<typename BcAlgTraits>
 class TKEWallFuncAlg : public Algorithm
 {

--- a/include/ngp_algorithms/TKEWallFuncAlg.h
+++ b/include/ngp_algorithms/TKEWallFuncAlg.h
@@ -30,12 +30,9 @@ public:
 private:
   ElemDataRequests faceData_;
 
-  unsigned tke_ {stk::mesh::InvalidOrdinal};
-  unsigned bctke_ {stk::mesh::InvalidOrdinal};
   unsigned bcNodalTke_ {stk::mesh::InvalidOrdinal};
   unsigned exposedAreaVec_  {stk::mesh::InvalidOrdinal};
   unsigned wallFricVel_ {stk::mesh::InvalidOrdinal};
-  unsigned wallArea_ {stk::mesh::InvalidOrdinal};
 
   DoubleType cMu_;
 

--- a/include/ngp_algorithms/TKEWallFuncAlgDriver.h
+++ b/include/ngp_algorithms/TKEWallFuncAlgDriver.h
@@ -14,6 +14,17 @@
 namespace sierra {
 namespace nalu {
 
+/** Compute nodal TKE values when using ABL wall function
+ *
+ *  Use a driver/algorithm style design to allow the actual computation to be
+ *  templated on the face element type. Computation of the "wall_model_tke_bc"
+ *  field is performed in TKEWallFuncAlg class. This field is synchronized in
+ *  parallel as well as host/device in TKEWallFuncAlgDriver::post_work and
+ *  "turbulent_ke" and "tke_bc" fields are updated for the wall boundaries where
+ *  wall function is being used.
+ *
+ *  \sa TKEWallFuncAlg
+ */
 class TKEWallFuncAlgDriver : public NgpAlgDriver
 {
 public:

--- a/include/ngp_algorithms/TKEWallFuncAlgDriver.h
+++ b/include/ngp_algorithms/TKEWallFuncAlgDriver.h
@@ -1,0 +1,41 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#ifndef TKEWALLFUNCALGDRIVER_H
+#define TKEWALLFUNCALGDRIVER_H
+
+#include "ngp_algorithms/NgpAlgDriver.h"
+#include "FieldTypeDef.h"
+
+namespace sierra {
+namespace nalu {
+
+class TKEWallFuncAlgDriver : public NgpAlgDriver
+{
+public:
+  TKEWallFuncAlgDriver(Realm&);
+
+  virtual ~TKEWallFuncAlgDriver() = default;
+
+  //! Reset fields before calling algorithms
+  virtual void pre_work() override;
+
+  //! Synchronize fields after algorithms have done their work
+  virtual void post_work() override;
+
+private:
+  unsigned tke_ {stk::mesh::InvalidOrdinal};
+  unsigned bctke_ {stk::mesh::InvalidOrdinal};
+  unsigned bcNodalTke_ {stk::mesh::InvalidOrdinal};
+  unsigned wallArea_ {stk::mesh::InvalidOrdinal};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* TKEWALLFUNCALGDRIVER_H */

--- a/include/ngp_utils/NgpCreateElemInstance.h
+++ b/include/ngp_utils/NgpCreateElemInstance.h
@@ -1,0 +1,263 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+/** \file NgpCreateElemInstance.h
+ *  Utilities to create MasterElement templated instances of element algorithms
+ *
+ *  The Nalu-Wind NGP design requires element algorithms to be specialized on
+ *  MasterElement types using AlgTraits (e.g., AlgTraitsHex8). This header
+ *  contains utility functions that ease the creation of specialized instances
+ *  for element, face, face-element pair based on topology of the part being
+ *  processed. Most functions here will return a pointer to the base type (e.g.,
+ *  Algorithm, Kernel, etc.).
+ */
+
+#ifndef NGPCREATEELEMINSTANCE_H
+#define NGPCREATEELEMINSTANCE_H
+
+#include "AlgTraits.h"
+#include "BuildTemplates.h"
+#include "element_promotion/ElementDescription.h"
+
+namespace sierra {
+namespace nalu {
+namespace nalu_ngp {
+
+/** Has the MasterElement for the topolgy fully transitioned to NGP?
+ *
+ *  A helpful query method to track progress of MasterElement conversions during
+ *  instantiation of the algorithm. Useful for choosing legacy algorithms during
+ *  transition period.
+ *
+ *  @param topo Part topology
+ *  @return True if the master element is NGP ready, false otherwise.
+ */
+inline bool is_ngp_element(const stk::topology topo)
+{
+  if (topo.is_super_topology()) return false;
+
+  bool isNGP = false;
+  switch (topo.value()) {
+  case stk::topology::HEX_8:
+  case stk::topology::TET_4:
+  case stk::topology::PYRAMID_5:
+  case stk::topology::WEDGE_6:
+  case stk::topology::QUAD_4_2D:
+    isNGP = true;
+    break;
+
+  case stk::topology::TRI_3_2D:
+  case stk::topology::HEX_27:
+  case stk::topology::QUAD_9_2D:
+    isNGP = false;
+    break;
+
+  default:
+    throw std::logic_error("Invalid element topology provided");
+  }
+
+  return isNGP;
+}
+
+/** Has the sideset MasterElement for the topolgy fully transitioned to NGP?
+ *
+ *  A helpful query method to track progress of MasterElement conversions during
+ *  instantiation of the algorithm. Useful for choosing legacy algorithms during
+ *  transition period.
+ *
+ *  @param topo Part topology
+ *  @return True if the master element is NGP ready, false otherwise.
+ */
+inline bool is_ngp_face(const stk::topology topo)
+{
+  if (topo.is_super_topology()) return false;
+
+  bool isNGP = false;
+  switch (topo.value()) {
+  case stk::topology::QUAD_4:
+    isNGP = true;
+    break;
+
+  case stk::topology::TRI_3:
+  case stk::topology::LINE_2:
+  case stk::topology::QUAD_9:
+  case stk::topology::LINE_3:
+    isNGP = false;
+    break;
+
+  default:
+    throw std::logic_error("Invalid face topology provided");
+  }
+
+  return isNGP;
+}
+
+/** Create a higher-order element Algorithm/Kernel
+ *
+ *  Create a specialized instance of a templated algorithm (or any element based
+ *  operation class) and return a pointer to the base class of that algorithm.
+ *
+ *  @param dimension Dimensionality of the problem
+ *  @param args Arguments necessary for the constructor of the algorithm
+ *  @return Pointer to the base class of the newly created algorithm
+ */
+template<typename BaseType, template <typename> class T, int order, typename... Args>
+BaseType* create_ho_elem_algorithm(
+  const int dimension,
+  Args&&... args)
+{
+  if (dimension == 2)
+    return new T<AlgTraitsQuadGL_2D<order>>(std::forward<Args>(args)...);
+
+  return new T<AlgTraitsHexGL<order>>(std::forward<Args>(args)...);
+}
+
+/** Create an interior element algorithm for the given topology
+ */
+template<typename BaseType, template <typename> class T, typename... Args>
+BaseType* create_elem_algorithm(
+  const int dimension,
+  const stk::topology topo,
+  Args&&... args)
+{
+  if (!topo.is_super_topology()) {
+    switch (topo.value()) {
+    case stk::topology::HEX_8:
+      return new T<AlgTraitsHex8>(std::forward<Args>(args)...);
+    case stk::topology::HEX_27:
+      return new T<AlgTraitsHex27>(std::forward<Args>(args)...);
+    case stk::topology::TET_4:
+      return new T<AlgTraitsTet4>(std::forward<Args>(args)...);
+    case stk::topology::PYRAMID_5:
+      return new T<AlgTraitsPyr5>(std::forward<Args>(args)...);
+    case stk::topology::WEDGE_6:
+      return new T<AlgTraitsWed6>(std::forward<Args>(args)...);
+    case stk::topology::QUAD_4_2D:
+      return new T<AlgTraitsQuad4_2D>(std::forward<Args>(args)...);
+    case stk::topology::QUAD_9_2D:
+      return new T<AlgTraitsQuad9_2D>(std::forward<Args>(args)...);
+    case stk::topology::TRI_3_2D:
+      return new T<AlgTraitsTri3_2D>(std::forward<Args>(args)...);
+    default:
+      return nullptr;
+    }
+  } else {
+    int poly_order = poly_order_from_topology(dimension, topo);
+    switch (poly_order) {
+    case 2:
+      return create_ho_elem_algorithm<BaseType, T, 2>(
+        dimension, std::forward<Args>(args)...);
+    case 3:
+      return create_ho_elem_algorithm<BaseType, T, 3>(
+        dimension, std::forward<Args>(args)...);
+    case 4:
+      return create_ho_elem_algorithm<BaseType, T, 4>(
+        dimension, std::forward<Args>(args)...);
+    case USER_POLY_ORDER:
+      return create_ho_elem_algorithm<BaseType, T, USER_POLY_ORDER>(
+        dimension, std::forward<Args>(args)...);
+    default:
+      ThrowRequireMsg(
+        false, "Polynomial order" + std::to_string(poly_order) +
+                 "is not supported by default.  "
+                 "Specify USER_POLY_ORDER and recompile to run.");
+      return nullptr;
+    }
+  }
+}
+
+/** Create a boundary algorithm for a given topology
+ */
+template<typename BaseType, template <typename> class T, typename... Args>
+BaseType* create_face_algorithm(
+  const int dimension,
+  const stk::topology topo,
+  Args&&... args)
+{
+  if (!topo.is_super_topology()) {
+    switch (topo.value()) {
+    case stk::topology::QUAD_4:
+      return new T<AlgTraitsQuad4>(std::forward<Args>(args)...);
+    case stk::topology::QUAD_9:
+      return new T<AlgTraitsQuad9>(std::forward<Args>(args)...);
+    case stk::topology::TRI_3:
+      return new T<AlgTraitsTri3>(std::forward<Args>(args)...);
+    case stk::topology::LINE_2:
+      return new T<AlgTraitsEdge_2D>(std::forward<Args>(args)...);
+    case stk::topology::LINE_3:
+      return new T<AlgTraitsEdge3_2D>(std::forward<Args>(args)...);
+    default:
+      return nullptr;
+    }
+  } else {
+    int poly_order = poly_order_from_topology(dimension, topo);
+    if (dimension == 2) {
+      switch (poly_order) {
+      case 2:
+        return new T<AlgTraitsEdgeGL<2>>(std::forward<Args>(args)...);
+      case 3:
+        return new T<AlgTraitsEdgeGL<2>>(std::forward<Args>(args)...);
+      case 4:
+        return new T<AlgTraitsEdgeGL<2>>(std::forward<Args>(args)...);
+      case USER_POLY_ORDER:
+        return new T<AlgTraitsEdgeGL<USER_POLY_ORDER>>(
+          std::forward<Args>(args)...);
+      default:
+        return nullptr;
+      }
+    } else {
+      switch (poly_order) {
+      case 2:
+        return new T<AlgTraitsQuadGL<2>>(std::forward<Args>(args)...);
+      case 3:
+        return new T<AlgTraitsQuadGL<3>>(std::forward<Args>(args)...);
+      case 4:
+        return new T<AlgTraitsQuadGL<4>>(std::forward<Args>(args)...);
+      case USER_POLY_ORDER:
+        return new T<AlgTraitsQuadGL<USER_POLY_ORDER>>(
+          std::forward<Args>(args)...);
+      default:
+        return nullptr;
+      }
+    }
+  }
+}
+
+/** Create a boundary algorithm that depends on both the face topology and the
+ *  connected element topology.
+ */
+template<typename BaseType, template <typename> class T, typename... Args>
+BaseType* create_face_elem_algorithm(
+  const int dimension,
+  const stk::topology faceTopo,
+  const stk::topology elemTopo,
+  Args&&... args)
+{
+  if (dimension == 2) {
+    throw std::runtime_error("NGP face_elem algorithm not implemented");
+  }
+
+  switch (faceTopo) {
+  case stk::topology::QUAD_4:
+    switch (elemTopo) {
+    case stk::topology::HEX_8:
+      return new T<AlgTraitsQuad4Hex8>(std::forward<Args>(args)...);
+
+    default:
+      throw std::runtime_error("NGP face_elem algorithm not implemented");
+    }
+
+  default:
+    throw std::runtime_error("NGP face_elem algorithm not implemented");
+  }
+}
+
+}  // nalu_ngp
+}  // nalu
+}  // sierra
+
+#endif /* NGPCREATEELEMINSTANCE_H */

--- a/include/ngp_utils/NgpCreateElemInstance.h
+++ b/include/ngp_utils/NgpCreateElemInstance.h
@@ -246,9 +246,27 @@ BaseType* create_face_elem_algorithm(
     switch (elemTopo) {
     case stk::topology::HEX_8:
       return new T<AlgTraitsQuad4Hex8>(std::forward<Args>(args)...);
+    case stk::topology::PYRAMID_5:
+      return new T<AlgTraitsQuad4Pyr5>(std::forward<Args>(args)...);
+    case stk::topology::WEDGE_6:
+      return new T<AlgTraitsQuad4Wed6>(std::forward<Args>(args)...);
 
     default:
-      throw std::runtime_error("NGP face_elem algorithm not implemented");
+      throw std::runtime_error("NGP face_elem algorithm not implemented for QUAD_4 and "
+                               + elemTopo.name() + " pair.");
+    }
+
+  case stk::topology::TRI_3:
+    switch(elemTopo) {
+    case stk::topology::TET_4:
+      return new T<AlgTraitsTri3Tet4>(std::forward<Args>(args)...);
+    case stk::topology::PYRAMID_5:
+      return new T<AlgTraitsTri3Pyr5>(std::forward<Args>(args)...);
+    case stk::topology::WEDGE_6:
+      return new T<AlgTraitsTri3Wed6>(std::forward<Args>(args)...);
+    default :
+      throw std::runtime_error("NGP face_elem algorithm is not implemented for TRI_3 and "
+                               + elemTopo.name() + " pair.");
     }
 
   default:

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -147,6 +147,7 @@
 
 // ngp
 #include "ngp_algorithms/ABLWallFrictionVelAlg.h"
+#include "ngp_algorithms/GeometryAlgDriver.h"
 #include "ngp_algorithms/MdotEdgeAlg.h"
 #include "ngp_algorithms/NodalGradEdgeAlg.h"
 #include "ngp_algorithms/NodalGradElemAlg.h"
@@ -1912,19 +1913,8 @@ MomentumEquationSystem::register_wall_bc(
       ReferenceTemperature Tref = userData.referenceTemperature_;
       const double referenceTemperature = Tref.referenceTemperature_;
 
-      {
-        // TODO Fix implementation when refactoring Geometry calcs in Realm
-        auto& algMap = realm_.computeGeometryAlgDriver_->algMap_;
-        auto it = algMap.find(wfAlgType);
-        if (it == algMap.end()) {
-          algMap[wfAlgType] = nalu_ngp::create_face_elem_algorithm<
-            Algorithm, WallFuncGeometryAlg>(
-            realm_.meta_data().spatial_dimension(), part->topology(),
-            get_elem_topo(realm_, *part), realm_, part);
-        } else {
-          it->second->partVec_.push_back(part);
-        }
-      }
+      realm_.geometryAlgDriver_->register_wall_func_algorithm<WallFuncGeometryAlg>(
+        wfAlgType, part, get_elem_topo(realm_, *part), "geometry_wall_func");
 
       wallFuncAlgDriver_.register_face_algorithm<ABLWallFrictionVelAlg>(
         wfAlgType, part, "abl_wall_func", realm_.realmUsesEdges_,

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1917,11 +1917,10 @@ MomentumEquationSystem::register_wall_bc(
         auto& algMap = realm_.computeGeometryAlgDriver_->algMap_;
         auto it = algMap.find(wfAlgType);
         if (it == algMap.end()) {
-          algMap[wfAlgType] = create_face_elem_algorithm<WallFuncGeometryAlg>(
-            realm_.meta_data().spatial_dimension(),
-            part->topology(),
-            get_elem_topo(realm_, *part),
-            realm_, part);
+          algMap[wfAlgType] = nalu_ngp::create_face_elem_algorithm<
+            Algorithm, WallFuncGeometryAlg>(
+            realm_.meta_data().spatial_dimension(), part->topology(),
+            get_elem_topo(realm_, *part), realm_, part);
         } else {
           it->second->partVec_.push_back(part);
         }

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -142,7 +142,6 @@ TurbKineticEnergyEquationSystem::TurbKineticEnergyEquationSystem(
     tvisc_(NULL),
     evisc_(NULL),
     nodalGradAlgDriver_(realm_, "dkdx"),
-    wallFuncAlgDriver_(realm_),
     turbulenceModel_(realm_.solutionOptions_->turbulenceModel_),
     projectedNodalGradEqs_(NULL),
     isInit_(true)
@@ -657,12 +656,14 @@ TurbKineticEnergyEquationSystem::register_wall_bc(
   }
 
   if ( wallFunctionApproach ) {
-
     // need to register the assembles wall value for tke; can not share with tke_bc
     ScalarFieldType *theAssembledField = &(meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "wall_model_tke_bc"));
     stk::mesh::put_field_on_mesh(*theAssembledField, *part, nullptr);
 
-    wallFuncAlgDriver_.register_face_algorithm<TKEWallFuncAlg>(
+    if (!wallFuncAlgDriver_)
+      wallFuncAlgDriver_.reset(new TKEWallFuncAlgDriver(realm_));
+
+    wallFuncAlgDriver_->register_face_algorithm<TKEWallFuncAlg>(
       algType, part, "tke_wall_func");
   }
   else if ( tkeSpecified ) {
@@ -932,7 +933,8 @@ TurbKineticEnergyEquationSystem::compute_effective_diff_flux_coeff()
 void
 TurbKineticEnergyEquationSystem::compute_wall_model_parameters()
 {
-  wallFuncAlgDriver_.execute();
+  if (wallFuncAlgDriver_)
+    wallFuncAlgDriver_->execute();
 }
 
 //--------------------------------------------------------------------------

--- a/src/ngp_algorithms/CMakeLists.txt
+++ b/src/ngp_algorithms/CMakeLists.txt
@@ -11,9 +11,12 @@ add_sources(GlobalSourceList
   WallFuncGeometryAlg.C
   ABLWallFrictionVelAlg.C
   TKEWallFuncAlg.C
+  GeometryInteriorAlg.C
+  GeometryBoundaryAlg.C
 
   # Algorithm Drivers
   NgpAlgDriver.C
   NodalGradAlgDriver.C
   TKEWallFuncAlgDriver.C
+  GeometryAlgDriver.C
   )

--- a/src/ngp_algorithms/CMakeLists.txt
+++ b/src/ngp_algorithms/CMakeLists.txt
@@ -15,4 +15,5 @@ add_sources(GlobalSourceList
   # Algorithm Drivers
   NgpAlgDriver.C
   NodalGradAlgDriver.C
+  TKEWallFuncAlgDriver.C
   )

--- a/src/ngp_algorithms/GeometryAlgDriver.C
+++ b/src/ngp_algorithms/GeometryAlgDriver.C
@@ -68,6 +68,7 @@ void GeometryAlgDriver::post_work()
   const auto& ngpMesh = realm_.ngp_mesh();
   const auto& fieldMgr = realm_.ngp_field_manager();
 
+  // TODO: Convert to NGP version of parallel and periodic updates
   auto* dualVol = meta.template get_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "dual_nodal_volume");
   std::vector<const stk::mesh::FieldBase*> fields{dualVol};

--- a/src/ngp_algorithms/GeometryAlgDriver.C
+++ b/src/ngp_algorithms/GeometryAlgDriver.C
@@ -1,0 +1,145 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "ngp_algorithms/GeometryAlgDriver.h"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "Realm.h"
+#include "utils/StkHelpers.h"
+
+#include "stk_mesh/base/Field.hpp"
+#include "stk_mesh/base/FieldParallel.hpp"
+#include "stk_mesh/base/FieldBLAS.hpp"
+#include "stk_mesh/base/MetaData.hpp"
+
+namespace sierra {
+namespace nalu {
+
+GeometryAlgDriver::GeometryAlgDriver(
+  Realm& realm
+) : NgpAlgDriver(realm)
+{}
+
+void GeometryAlgDriver::pre_work()
+{
+  const auto& meta = realm_.meta_data();
+  auto* dualVol = meta.template get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "dual_nodal_volume");
+
+  stk::mesh::field_fill(0.0, *dualVol);
+
+  const auto& meshInfo = realm_.mesh_info();
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  auto ngpDualVol = fieldMgr.template get_field<double>(dualVol->mesh_meta_data_ordinal());
+
+  ngpDualVol.set_all(ngpMesh, 0.0);
+
+  if (realm_.realmUsesEdges_) {
+    auto* edgeAreaVec = meta.template get_field<VectorFieldType>(
+      stk::topology::EDGE_RANK, "edge_area_vector");
+    stk::mesh::field_fill(0.0, *edgeAreaVec);
+
+    auto ngpEdgeArea = fieldMgr.template get_field<double>(
+      edgeAreaVec->mesh_meta_data_ordinal());
+    ngpEdgeArea.set_all(ngpMesh, 0.0);
+  }
+
+  if (hasWallFunc_) {
+    const auto wallNormDist = get_field_ordinal(meta, "assembled_wall_normal_distance");
+    const auto wallArea = get_field_ordinal(meta, "assembled_wall_area_wf");
+    auto wdist = fieldMgr.template get_field<double>(wallNormDist);
+    auto warea = fieldMgr.template get_field<double>(wallArea);
+
+    wdist.set_all(ngpMesh, 0.0);
+    warea.set_all(ngpMesh, 0.0);
+  }
+}
+
+void GeometryAlgDriver::post_work()
+{
+  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+
+  const auto& meta = realm_.meta_data();
+  const auto& bulk = realm_.bulk_data();
+  const auto& ngpMesh = realm_.ngp_mesh();
+  const auto& fieldMgr = realm_.ngp_field_manager();
+
+  auto* dualVol = meta.template get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "dual_nodal_volume");
+  std::vector<const stk::mesh::FieldBase*> fields{dualVol};
+
+  if (realm_.realmUsesEdges_) {
+    auto* edgeAreaVec = meta.template get_field<VectorFieldType>(
+      stk::topology::EDGE_RANK, "edge_area_vector");
+    fields.push_back(edgeAreaVec);
+  }
+
+  if (hasWallFunc_) {
+    stk::mesh::FieldBase* wallAreaF = meta.get_field(
+      stk::topology::NODE_RANK, "assembled_wall_area_wf");
+    stk::mesh::FieldBase* wallDistF = meta.get_field(
+      stk::topology::NODE_RANK, "assembled_wall_normal_distance");
+    fields.push_back(wallAreaF);
+    fields.push_back(wallDistF);
+  }
+
+  for (auto* fld: fields) {
+    auto ngpFld = fieldMgr.get_field<double>(fld->mesh_meta_data_ordinal());
+    ngpFld.modify_on_device();
+    ngpFld.sync_to_host();
+  }
+
+  stk::mesh::parallel_sum(bulk, fields);
+
+  if (realm_.hasPeriodic_) {
+    const unsigned nComponents = 1;
+    realm_.periodic_field_update(dualVol, nComponents);
+
+    if (hasWallFunc_) {
+      const bool bypassFieldCheck = false;
+      stk::mesh::FieldBase* wallAreaF = meta.get_field(
+        stk::topology::NODE_RANK, "assembled_wall_area_wf");
+      stk::mesh::FieldBase* wallDistF = meta.get_field(
+        stk::topology::NODE_RANK, "assembled_wall_normal_distance");
+      realm_.periodic_field_update(wallAreaF, nComponents, bypassFieldCheck);
+      realm_.periodic_field_update(wallDistF, nComponents, bypassFieldCheck);
+    }
+  }
+
+  for (auto* fld: fields) {
+    auto ngpFld = fieldMgr.get_field<double>(fld->mesh_meta_data_ordinal());
+    ngpFld.modify_on_host();
+    ngpFld.sync_to_device();
+  }
+
+  if (hasWallFunc_) {
+    stk::mesh::FieldBase* wallDistF = meta.get_field(
+      stk::topology::NODE_RANK, "assembled_wall_normal_distance");
+
+    const stk::mesh::Selector sel =
+      (realm_.meta_data().locally_owned_part() |
+       realm_.meta_data().globally_shared_part()) &
+      stk::mesh::selectField(*wallDistF);
+
+    const auto wallNormDist = get_field_ordinal(meta, "assembled_wall_normal_distance");
+    const auto wallArea = get_field_ordinal(meta, "assembled_wall_area_wf");
+    auto wdist = fieldMgr.template get_field<double>(wallNormDist);
+    auto warea = fieldMgr.template get_field<double>(wallArea);
+
+    sierra::nalu::nalu_ngp::run_entity_algorithm(
+      ngpMesh, stk::topology::NODE_RANK, sel,
+      KOKKOS_LAMBDA(const MeshIndex& mi) {
+        wdist.get(mi, 0) /= warea.get(mi, 0);
+      });
+
+    wdist.modify_on_device();
+    warea.modify_on_device();
+  }
+}
+
+}  // nalu
+}  // sierra

--- a/src/ngp_algorithms/GeometryBoundaryAlg.C
+++ b/src/ngp_algorithms/GeometryBoundaryAlg.C
@@ -23,11 +23,11 @@ namespace nalu {
 
 template <typename AlgTraits>
 GeometryBoundaryAlg<AlgTraits>::GeometryBoundaryAlg(
-  Realm& realm,
-  stk::mesh::Part* part
-) : Algorithm(realm, part),
+  Realm& realm, stk::mesh::Part* part)
+  : Algorithm(realm, part),
     dataNeeded_(realm_.meta_data()),
-    exposedAreaVec_(get_field_ordinal(realm.meta_data(), "exposed_area_vector", realm.meta_data().side_rank())),
+    exposedAreaVec_(get_field_ordinal(
+      realm.meta_data(), "exposed_area_vector", realm.meta_data().side_rank())),
     meSCS_(MasterElementRepo::get_surface_master_element<AlgTraits>())
 {
   dataNeeded_.add_cvfem_surface_me(meSCS_);

--- a/src/ngp_algorithms/GeometryBoundaryAlg.C
+++ b/src/ngp_algorithms/GeometryBoundaryAlg.C
@@ -1,0 +1,73 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "ngp_algorithms/GeometryBoundaryAlg.h"
+#include "BuildTemplates.h"
+#include "master_element/MasterElement.h"
+#include "master_element/MasterElementFactory.h"
+#include "ngp_algorithms/ViewHelper.h"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpFieldOps.h"
+#include "Realm.h"
+#include "ScratchViews.h"
+#include "SolutionOptions.h"
+#include "utils/StkHelpers.h"
+
+
+namespace sierra {
+namespace nalu {
+
+template <typename AlgTraits>
+GeometryBoundaryAlg<AlgTraits>::GeometryBoundaryAlg(
+  Realm& realm,
+  stk::mesh::Part* part
+) : Algorithm(realm, part),
+    dataNeeded_(realm_.meta_data()),
+    exposedAreaVec_(get_field_ordinal(realm.meta_data(), "exposed_area_vector", realm.meta_data().side_rank())),
+    meSCS_(MasterElementRepo::get_surface_master_element<AlgTraits>())
+{
+  dataNeeded_.add_cvfem_surface_me(meSCS_);
+  const auto coordID = get_field_ordinal(
+    realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());
+  dataNeeded_.add_coordinates_field(coordID, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataNeeded_.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+}
+
+template<typename AlgTraits>
+void GeometryBoundaryAlg<AlgTraits>::execute()
+{
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+
+  auto meshInfo = realm_.mesh_info();
+  const auto& meta = meshInfo.meta();
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  auto exposedAreaVec = fieldMgr.template get_field<double>(exposedAreaVec_);
+  const auto areaVecOps = nalu_ngp::simd_elem_field_updater(ngpMesh, exposedAreaVec);
+
+  const stk::mesh::Selector sel = meta.locally_owned_part()
+    & stk::mesh::selectUnion(partVec_);
+
+  sierra::nalu::nalu_ngp::run_elem_algorithm(
+    meshInfo, meta.side_rank(), dataNeeded_, sel,
+    KOKKOS_LAMBDA(ElemSimdDataType & edata) {
+      auto& scrViews = edata.simdScrView;
+      const auto& meViews = scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
+      const auto& v_area = meViews.scs_areav;
+
+      for (int ip = 0; ip < AlgTraits::numFaceIp_; ++ip)
+        for (int d=0; d < AlgTraits::nDim_; ++d)
+          areaVecOps(edata, ip * AlgTraits::nDim_ + d) = v_area(ip, d);
+    });
+
+  exposedAreaVec.modify_on_device();
+}
+
+INSTANTIATE_KERNEL_FACE(GeometryBoundaryAlg)
+
+}  // nalu
+}  // sierra

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -1,0 +1,158 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "ngp_algorithms/GeometryInteriorAlg.h"
+#include "BuildTemplates.h"
+#include "master_element/MasterElement.h"
+#include "master_element/MasterElementFactory.h"
+#include "ngp_algorithms/ViewHelper.h"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpFieldOps.h"
+#include "Realm.h"
+#include "ScratchViews.h"
+#include "SolutionOptions.h"
+#include "utils/StkHelpers.h"
+
+
+namespace sierra {
+namespace nalu {
+
+template <typename AlgTraits>
+GeometryInteriorAlg<AlgTraits>::GeometryInteriorAlg(
+  Realm& realm,
+  stk::mesh::Part* part
+) : Algorithm(realm, part),
+    dataNeeded_(realm.meta_data()),
+    dualNodalVol_(get_field_ordinal(realm_.meta_data(), "dual_nodal_volume")),
+    elemVol_(get_field_ordinal(realm_.meta_data(), "element_volume", stk::topology::ELEM_RANK)),
+    meSCV_(MasterElementRepo::get_volume_master_element<AlgTraits>()),
+    meSCS_(MasterElementRepo::get_surface_master_element<AlgTraits>())
+{
+  dataNeeded_.add_cvfem_volume_me(meSCV_);
+  dataNeeded_.add_cvfem_surface_me(meSCS_);
+
+  const auto coordID = get_field_ordinal(
+    realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());
+  dataNeeded_.add_coordinates_field(coordID, AlgTraits::nDim_, CURRENT_COORDINATES);
+  dataNeeded_.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
+
+  if (realm_.realmUsesEdges_) {
+    edgeAreaVec_ = get_field_ordinal(realm_.meta_data(), "edge_area_vector",
+                                     stk::topology::EDGE_RANK);
+    dataNeeded_.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
+  }
+}
+
+template <typename AlgTraits>
+void GeometryInteriorAlg<AlgTraits>::execute()
+{
+  compute_dual_nodal_volume();
+
+  if (realm_.realmUsesEdges_)
+    compute_edge_area_vector();
+}
+
+template <typename AlgTraits>
+void GeometryInteriorAlg<AlgTraits>::compute_dual_nodal_volume()
+{
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+
+  auto meshInfo = realm_.mesh_info();
+  const auto& meta = meshInfo.meta();
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  auto dualVol = fieldMgr.template get_field<double>(dualNodalVol_);
+  auto elemVol = fieldMgr.template get_field<double>(elemVol_);
+  const auto dnvOps = nalu_ngp::simd_elem_nodal_field_updater(ngpMesh, dualVol);
+  const auto elemVolOps = nalu_ngp::simd_elem_field_updater(ngpMesh, elemVol);
+
+  const stk::mesh::Selector sel = meta.locally_owned_part()
+    & stk::mesh::selectUnion(partVec_)
+    & !(realm_.get_inactive_selector());
+
+  nalu_ngp::run_elem_algorithm(
+    meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
+    KOKKOS_LAMBDA(ElemSimdDataType& edata){
+      const int* ipNodeMap = meSCV_->ipNodeMap();
+
+      auto& scrView = edata.simdScrView;
+      const auto& meViews = scrView.get_me_views(CURRENT_COORDINATES);
+      const auto& v_scv_vol = meViews.scv_volume;
+
+      for (int ip=0; ip < AlgTraits::numScvIp_; ++ip) {
+        const auto nn = ipNodeMap[ip];
+        dnvOps(edata, nn, 0) += v_scv_vol(ip);
+        elemVolOps(edata, 0) += v_scv_vol(ip);
+      }
+    });
+
+  dualVol.modify_on_device();
+  elemVol.modify_on_device();
+}
+
+template <typename AlgTraits>
+void GeometryInteriorAlg<AlgTraits>::compute_edge_area_vector()
+{
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+
+  auto meshInfo = realm_.mesh_info();
+  const auto& meta = meshInfo.meta();
+  const auto ngpMesh = meshInfo.ngp_mesh();
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  auto edgeAreaVec = fieldMgr.template get_field<double>(edgeAreaVec_);
+
+  const stk::mesh::Selector sel = meta.locally_owned_part()
+    & stk::mesh::selectUnion(partVec_)
+    & !(realm_.get_inactive_selector());
+
+  nalu_ngp::run_elem_algorithm(
+    meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
+    KOKKOS_LAMBDA(ElemSimdDataType& edata) {
+      const int* lrscv = meSCS_->adjacentNodes();
+      const int* scsIpEdgeMap = meSCS_->scsIpEdgeOrd();
+
+      auto& scrView = edata.simdScrView;
+      const auto& meViews = scrView.get_me_views(CURRENT_COORDINATES);
+      const auto& v_areav = meViews.scs_areav;
+
+      // Manually de-interleave here
+      for (int si=0; si < edata.numSimdElems; ++si) {
+        const auto edges = ngpMesh.get_edges(
+          stk::topology::ELEM_RANK,
+          ngpMesh.fast_mesh_index(edata.elemInfo[si].entity));
+        for (int ip = 0; ip < AlgTraits::numScsIp_; ++ip) {
+          // Edge for this integration point
+          const int nedge = scsIpEdgeMap[ip];
+          // Index of "left" node in the element relations
+          const int iLn = lrscv[2 * ip];
+
+          // Nodes connected to this edge
+          const auto edgeID = ngpMesh.fast_mesh_index(edges[nedge]);
+          const auto edge_nodes = ngpMesh.get_nodes(stk::topology::EDGE_RANK, edgeID);
+
+          // Left node comparison
+          const auto lnElemId = edata.elemInfo[si].entityNodes[iLn];
+          const auto lnEdgeId = edge_nodes[0];
+
+          const double sign = (lnElemId == lnEdgeId) ? 1.0 : -1.0;
+
+          for (int d=0; d < AlgTraits::nDim_; ++d) {
+            Kokkos::atomic_add(
+              &edgeAreaVec.get(edgeID, d),
+              stk::simd::get_data(v_areav(ip, d), si) * sign);
+          }
+        }
+      }
+    });
+
+  edgeAreaVec.modify_on_device();
+}
+
+INSTANTIATE_KERNEL(GeometryInteriorAlg)
+
+}  // nalu
+}  // sierra

--- a/src/ngp_algorithms/TKEWallFuncAlgDriver.C
+++ b/src/ngp_algorithms/TKEWallFuncAlgDriver.C
@@ -1,0 +1,91 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "ngp_algorithms/TKEWallFuncAlgDriver.h"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "Realm.h"
+#include "utils/StkHelpers.h"
+
+#include "stk_mesh/base/Field.hpp"
+#include "stk_mesh/base/FieldParallel.hpp"
+#include "stk_mesh/base/FieldBLAS.hpp"
+#include "stk_mesh/base/MetaData.hpp"
+
+namespace sierra {
+namespace nalu {
+
+TKEWallFuncAlgDriver::TKEWallFuncAlgDriver(
+  Realm& realm
+) : NgpAlgDriver(realm)
+{}
+
+void TKEWallFuncAlgDriver::pre_work()
+{
+  // Defer getting the field ordinals until after equation systems have done
+  // their initialization
+  tke_ = get_field_ordinal(realm_.meta_data(), "turbulent_ke", stk::mesh::StateNP1);
+  bctke_ = get_field_ordinal(realm_.meta_data(), "tke_bc");
+  bcNodalTke_ = get_field_ordinal(realm_.meta_data(), "wall_model_tke_bc");
+  wallArea_ = get_field_ordinal(realm_.meta_data(), "assembled_wall_area_wf");
+
+  const auto& ngpMesh = realm_.ngp_mesh();
+  const auto& fieldMgr = realm_.ngp_field_manager();
+  auto ngpBcNodalTke = fieldMgr.template get_field<double>(bcNodalTke_);
+
+  // Reset 'assembled' BC TKE nodal field
+  ngpBcNodalTke.set_all(ngpMesh, 0.0);
+}
+
+void TKEWallFuncAlgDriver::post_work()
+{
+  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  const auto& ngpMesh = realm_.ngp_mesh();
+  const auto& fieldMgr = realm_.ngp_field_manager();
+  auto ngpBcNodalTke = fieldMgr.get_field<double>(bcNodalTke_);
+  auto ngpTke = fieldMgr.get_field<double>(tke_);
+  auto ngpBcTke = fieldMgr.get_field<double>(bctke_);
+  auto ngpWallArea = fieldMgr.get_field<double>(wallArea_);
+
+  // TODO: Replace logic with STK NGP parallel sum, handle periodic the NGP way
+  ngpBcNodalTke.sync_to_host();
+
+  stk::mesh::FieldBase* bcNodalTkeField =
+    realm_.meta_data().get_fields()[bcNodalTke_];
+  stk::mesh::parallel_sum(realm_.bulk_data(), {bcNodalTkeField});
+
+  if (realm_.hasPeriodic_) {
+    const unsigned nComp = 1;
+    const bool bypassFieldCheck = false;
+    realm_.periodic_field_update(bcNodalTkeField, nComp, bypassFieldCheck);
+  }
+
+  // Normalize the computed BC TKE at integration points with assembled wall
+  // area and assign it to TKE and TKE BC fields on this sideset for use in the
+  // next solve.
+  const stk::mesh::Selector sel =
+    (realm_.meta_data().locally_owned_part() |
+     realm_.meta_data().globally_shared_part()) &
+    stk::mesh::selectField(*realm_.meta_data().get_field(
+      stk::topology::NODE_RANK, "wall_model_tke_bc"));
+
+  nalu_ngp::run_entity_algorithm(
+    ngpMesh, stk::topology::NODE_RANK, sel,
+    KOKKOS_LAMBDA(const MeshIndex& mi) {
+      const double warea = ngpWallArea.get(mi, 0);
+      const double tkeVal = ngpBcNodalTke.get(mi, 0) / warea;
+      ngpBcNodalTke.get(mi, 0) = tkeVal;
+      ngpBcTke.get(mi, 0) = tkeVal;
+      ngpTke.get(mi, 0) = tkeVal;
+    });
+
+  ngpBcNodalTke.modify_on_device();
+  ngpBcTke.modify_on_device();
+  ngpTke.modify_on_device();
+}
+
+}  // nalu
+}  // sierra

--- a/src/ngp_algorithms/WallFuncGeometryAlg.C
+++ b/src/ngp_algorithms/WallFuncGeometryAlg.C
@@ -83,10 +83,6 @@ void WallFuncGeometryAlg<BcAlgTraits>::execute()
   auto* meSCS = meSCS_;
   auto* meFC = meFC_;
 
-  // // Zero out nodal fields
-  // wdist.set_all(ngpMesh, 0.0);
-  // warea.set_all(ngpMesh, 0.0);
-
   nalu_ngp::run_face_elem_algorithm(
     meshInfo, faceData_, elemData_, sel,
     KOKKOS_LAMBDA(SimdDataType& fdata) {
@@ -120,51 +116,6 @@ void WallFuncGeometryAlg<BcAlgTraits>::execute()
         areaOps(fdata, ni, 0) += aMag;
       }
     });
-
-  // {
-  //   // TODO replace logic with STK NGP parallel sum, but still need to handle
-  //   // periodic the old way
-  //   wdist.modify_on_device();
-  //   wdist.sync_to_host();
-  //   warea.modify_on_device();
-  //   warea.sync_to_host();
-
-  //   // Synchronize fields for parallel runs
-  //   stk::mesh::FieldBase* wallAreaF = meta.get_field(
-  //     stk::topology::NODE_RANK, "assembled_wall_area_wf");
-  //   stk::mesh::FieldBase* wallDistF = meta.get_field(
-  //     stk::topology::NODE_RANK, "assembled_wall_normal_distance");
-  //   stk::mesh::parallel_sum(realm_.bulk_data(),
-  //                           {wallAreaF, wallDistF});
-
-  //   if (realm_.hasPeriodic_) {
-  //     const unsigned nComponents = 1;
-  //     const bool bypassFieldChk = false;
-  //     realm_.periodic_field_update(wallAreaF, nComponents, bypassFieldChk);
-  //     realm_.periodic_field_update(wallDistF, nComponents, bypassFieldChk);
-  //   }
-
-  //   wdist.modify_on_host();
-  //   wdist.sync_to_device();
-  //   warea.modify_on_host();
-  //   warea.sync_to_device();
-
-  //   const stk::mesh::Selector sel =
-  //     (realm_.meta_data().locally_owned_part() |
-  //      realm_.meta_data().globally_shared_part()) &
-  //     stk::mesh::selectUnion(partVec_);
-
-  //   sierra::nalu::nalu_ngp::run_entity_algorithm(
-  //     ngpMesh, stk::topology::NODE_RANK, sel,
-  //     KOKKOS_LAMBDA(const MeshIndex& mi) {
-  //       wdist.get(mi, 0) /= warea.get(mi, 0);
-  //     });
-
-  //   // Indicate that we have modified but don't sync it
-  //   wdist.modify_on_device();
-  //   warea.modify_on_device();
-  //   wdistBip.modify_on_device();
-  // }
 }
 
 INSTANTIATE_KERNEL_FACE_ELEMENT(WallFuncGeometryAlg)

--- a/unit_tests/UnitTestTpetra.C
+++ b/unit_tests/UnitTestTpetra.C
@@ -216,6 +216,9 @@ sierra::nalu::Realm& setup_realm(unit_test_utils::NaluTest& naluObj, const std::
 {
   sierra::nalu::Realm& realm = naluObj.create_realm();
   realm.setup_nodal_fields();
+
+  auto& part = realm.meta_data().declare_part("block_1");
+  realm.register_nodal_fields(&part);
   unit_test_utils::fill_hex8_mesh(meshSpec, realm.bulk_data());
   realm.set_global_id();
   return realm;

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -264,13 +264,23 @@ public:
                   stk::topology::NODE_RANK, "div_mesh_velocity")),
       edgeAreaVec_(
         &meta_.declare_field<VectorFieldType>(
-          stk::topology::EDGE_RANK, "edge_area_vector"))
+          stk::topology::EDGE_RANK, "edge_area_vector")),
+      elementVolume_(
+        &meta_.declare_field<ScalarFieldType>(
+          stk::topology::ELEM_RANK, "element_volume")),
+      exposedAreaVec_(
+        &meta_.declare_field<GenericFieldType>(
+          meta_.side_rank(), "exposed_area_vector"))
   {
     stk::mesh::put_field_on_mesh(*naluGlobalId_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*tpetGlobalId_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*dnvField_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*divMeshVelField_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*edgeAreaVec_, meta_.universal_part(), spatialDim_, nullptr);
+    stk::mesh::put_field_on_mesh(*elementVolume_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(
+      *exposedAreaVec_, meta_.universal_part(),
+      spatialDim_ * sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
   }
 
   virtual ~TestKernelHex8Mesh() {}
@@ -297,6 +307,9 @@ public:
     stk::mesh::field_fill(1.25, *divMeshVelField_);
     unit_test_kernel_utils::calc_edge_area_vec(
       bulk_, sierra::nalu::AlgTraitsHex8::topo_, *coordinates_, *edgeAreaVec_);
+    unit_test_kernel_utils::calc_exposed_area_vec(
+      bulk_, sierra::nalu::AlgTraitsQuad4::topo_, *coordinates_,
+      *exposedAreaVec_);
   }
 
   stk::ParallelMachine comm_;
@@ -315,6 +328,8 @@ public:
   ScalarFieldType* dnvField_{nullptr};
   ScalarFieldType* divMeshVelField_{nullptr};
   VectorFieldType* edgeAreaVec_{nullptr};
+  ScalarFieldType* elementVolume_{nullptr};
+  GenericFieldType* exposedAreaVec_{nullptr};
 };
 
 /** Test Fixture for Low-Mach Kernels
@@ -345,9 +360,6 @@ public:
       Udiag_(
         &meta_.declare_field<ScalarFieldType>(
           stk::topology::NODE_RANK, "momentum_diag", 2)),
-      exposedAreaVec_(
-        &meta_.declare_field<GenericFieldType>(
-          meta_.side_rank(), "exposed_area_vector")),
       velocityBC_(
         &meta_.declare_field<VectorFieldType>(
           stk::topology::NODE_RANK, "velocity_bc"))
@@ -357,9 +369,6 @@ public:
     stk::mesh::put_field_on_mesh(*density_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*pressure_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*Udiag_, meta_.universal_part(), 1, nullptr);
-    stk::mesh::put_field_on_mesh(
-      *exposedAreaVec_, meta_.universal_part(),
-      spatialDim_ * sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
     stk::mesh::put_field_on_mesh(*velocityBC_, meta_.universal_part(), spatialDim_, nullptr);
   }
 
@@ -375,9 +384,6 @@ public:
     unit_test_kernel_utils::dpdx_test_function(bulk_, *coordinates_, *dpdx_);
     stk::mesh::field_fill(1.0, *density_);
     stk::mesh::field_fill(1.0, *Udiag_);
-    unit_test_kernel_utils::calc_exposed_area_vec(
-      bulk_, sierra::nalu::AlgTraitsQuad4::topo_, *coordinates_,
-      *exposedAreaVec_);
     unit_test_kernel_utils::velocity_test_function(bulk_, *coordinates_, *velocityBC_);
   }
 
@@ -386,7 +392,6 @@ public:
   ScalarFieldType* density_{nullptr};
   ScalarFieldType* pressure_{nullptr};
   ScalarFieldType* Udiag_{nullptr};
-  GenericFieldType* exposedAreaVec_{nullptr};
   VectorFieldType* velocityBC_{nullptr};
 };
 
@@ -448,7 +453,7 @@ public:
     stk::mesh::put_field_on_mesh(
       *openMassFlowRate_, meta_.universal_part(),
       sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
-    stk::mesh::put_field_on_mesh(*openVelocityBC_, meta_.universal_part(), spatialDim_, nullptr);
+   stk::mesh::put_field_on_mesh(*openVelocityBC_, meta_.universal_part(), spatialDim_, nullptr);
   }
 
   virtual ~MomentumKernelHex8Mesh() {}
@@ -705,7 +710,13 @@ public:
       dkdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dkdx")),
       dwdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dwdx")),
       dhdx_(&meta_.declare_field<VectorFieldType>( stk::topology::NODE_RANK, "dhdx")),
-      specificHeat_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "specific_heat"))
+      specificHeat_(&meta_.declare_field<ScalarFieldType>( stk::topology::NODE_RANK, "specific_heat")),
+      wallNormDistBip_(&meta_.declare_field<GenericFieldType>(
+                         stk::topology::FACE_RANK, "wall_normal_distance_bip")),
+      wallArea_(&meta_.declare_field<ScalarFieldType>(
+                  stk::topology::NODE_RANK, "assembled_wall_area_wf")),
+      wallNormDist_(&meta_.declare_field<ScalarFieldType>(
+                      stk::topology::NODE_RANK, "assembled_wall_normal_distance"))
   {
     stk::mesh::put_field_on_mesh(*viscosity_, meta_.universal_part(), 1, nullptr);
     stk::mesh::put_field_on_mesh(*tke_, meta_.universal_part(), 1, nullptr);
@@ -721,6 +732,11 @@ public:
     stk::mesh::put_field_on_mesh(*dwdx_, meta_.universal_part(),  spatialDim_, nullptr);
     stk::mesh::put_field_on_mesh(*dhdx_, meta_.universal_part(),  spatialDim_, nullptr);
     stk::mesh::put_field_on_mesh(*specificHeat_, meta_.universal_part(),  1, nullptr);
+    stk::mesh::put_field_on_mesh(
+      *wallNormDistBip_, meta_.universal_part(),
+      sierra::nalu::AlgTraitsQuad4::numFaceIp_, nullptr);
+    stk::mesh::put_field_on_mesh(*wallArea_, meta_.universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*wallNormDist_, meta_.universal_part(),  1, nullptr);
   }
 
   virtual ~KsgsKernelHex8Mesh() = default;
@@ -766,6 +782,9 @@ public:
   VectorFieldType*    dwdx_{nullptr};
   VectorFieldType*    dhdx_{nullptr};
   ScalarFieldType*    specificHeat_{nullptr};
+  GenericFieldType*   wallNormDistBip_{nullptr};
+  ScalarFieldType*    wallArea_{nullptr};
+  ScalarFieldType*    wallNormDist_{nullptr};
 };
 
 /** Test Fixture for the hybrid turbulence Kernels
@@ -870,8 +889,6 @@ public:
                                                          "mass_flow_rate_scs")),
     dzdx_(&meta_.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dzdx")),
     dpdx_(&meta_.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx",2)),
-    exposedAreaVec_(&meta_.declare_field<GenericFieldType>(
-                      meta_.side_rank(), "exposed_area_vector")),
     openMassFlowRate_(&meta_.declare_field<GenericFieldType>(meta_.side_rank(),
                                                          "open_mass_flow_rate")),
     massFlowRateEdge_(&meta_.declare_field<ScalarFieldType>(
@@ -894,9 +911,6 @@ public:
     stk::mesh::put_field_on_mesh(*dzdx_, meta_.universal_part(), spatialDim_, nullptr);
     stk::mesh::put_field_on_mesh(*dpdx_, meta_.universal_part(), spatialDim_, nullptr);
     stk::mesh::put_field_on_mesh(
-      *exposedAreaVec_, meta_.universal_part(),
-      spatialDim_ * sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
-    stk::mesh::put_field_on_mesh(
       *openMassFlowRate_, meta_.universal_part(),
       sierra::nalu::AlgTraitsQuad4::numScsIp_, nullptr);
     stk::mesh::put_field_on_mesh(
@@ -917,9 +931,6 @@ public:
                                                                          viscPrimary_, viscSecondary_);
     unit_test_kernel_utils::calc_mass_flow_rate_scs(
       bulk_, stk::topology::HEX_8, *coordinates_, *density_, *velocity_, *massFlowRate_);
-    unit_test_kernel_utils::calc_exposed_area_vec(
-      bulk_, sierra::nalu::AlgTraitsQuad4::topo_, *coordinates_,
-      *exposedAreaVec_);
     unit_test_kernel_utils::calc_open_mass_flow_rate(
       bulk_, stk::topology::QUAD_4, *coordinates_, *density_, *velocity_,
       *exposedAreaVec_, *openMassFlowRate_);
@@ -935,7 +946,6 @@ public:
   GenericFieldType* massFlowRate_{nullptr};
   VectorFieldType* dzdx_{nullptr};
   VectorFieldType* dpdx_{nullptr};
-  GenericFieldType* exposedAreaVec_{nullptr};
   GenericFieldType* openMassFlowRate_{nullptr};
   ScalarFieldType* massFlowRateEdge_{nullptr};
 

--- a/unit_tests/ngp_algorithms/CMakeLists.txt
+++ b/unit_tests/ngp_algorithms/CMakeLists.txt
@@ -6,4 +6,5 @@ add_sources(GlobalUnitSourceList
   UnitTestEnthalpyDiffFluxCoeffAlg.C 
   UnitTestMdotAlg.C
   UnitTestTurbViscKsgsAlg.C
+  UnitTestGeometryAlg.C
   )

--- a/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
@@ -114,7 +114,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
 
   geomAlgDriver.execute();
 
-  // Edge area vector check
+  // Exposed area vector check
   {
     stk::mesh::Selector sel(*part);
     const auto& bkts = bulk_.get_buckets(stk::topology::FACE_RANK, sel);
@@ -162,7 +162,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_geometry_wall_func)
 
   geomAlgDriver.execute();
 
-  // Edge area vector check
+  // wall distance and area check
   {
     stk::mesh::Selector sel(*part);
     const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);

--- a/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
@@ -1,0 +1,181 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "kernels/UnitTestKernelUtils.h"
+#include "UnitTestHelperObjects.h"
+
+#include "AlgTraits.h"
+#include "ngp_algorithms/GeometryInteriorAlg.h"
+#include "ngp_algorithms/GeometryBoundaryAlg.h"
+#include "ngp_algorithms/WallFuncGeometryAlg.h"
+#include "ngp_algorithms/GeometryAlgDriver.h"
+#include "utils/StkHelpers.h"
+
+TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
+{
+  // Only execute for 1 processor runs
+  if (bulk_.parallel_size() > 1) return;
+
+  fill_mesh_and_init_fields();
+
+  // zero out fields
+  stk::mesh::field_fill(0.0, *dnvField_);
+  stk::mesh::field_fill(0.0, *elementVolume_);
+  stk::mesh::field_fill(0.0, *edgeAreaVec_);
+
+  unit_test_utils::HelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+
+  // Force computation of edge area vector
+  helperObjs.realm.realmUsesEdges_ = true;
+
+  sierra::nalu::GeometryAlgDriver geomAlgDriver(helperObjs.realm);
+
+  geomAlgDriver.register_elem_algorithm<sierra::nalu::GeometryInteriorAlg>(
+    sierra::nalu::INTERIOR, partVec_[0], "geometry");
+
+  geomAlgDriver.execute();
+
+  const double tol = 1.0e-16;
+  stk::mesh::Selector sel = meta_.universal_part();
+
+  // Dual volume check
+  {
+    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+
+    int counter = 0;
+    for (const auto* b: bkts)
+      for (const auto node: *b) {
+        const double* dVol = stk::mesh::field_data(*dnvField_, node);
+        EXPECT_NEAR(0.125, dVol[0], tol);
+        counter++;
+      }
+    EXPECT_EQ(counter, 8);
+  }
+
+  // Element volume check
+  {
+    const auto& bkts = bulk_.get_buckets(stk::topology::ELEM_RANK, sel);
+
+    int counter = 0;
+    for (const auto* b: bkts)
+      for (const auto elem: *b) {
+        const double* dVol = stk::mesh::field_data(*elementVolume_, elem);
+        EXPECT_NEAR(1.0, dVol[0], tol);
+        counter++;
+      }
+    EXPECT_EQ(counter, 1);
+  }
+
+  // Edge area vector check
+  {
+    const auto& bkts = bulk_.get_buckets(stk::topology::EDGE_RANK, sel);
+    const double aMagSqrGold = 0.25 * 0.25;
+
+    int counter = 0;
+    for (const auto* b: bkts)
+      for (const auto edge: *b) {
+        const double* areaVec = stk::mesh::field_data(*edgeAreaVec_, edge);
+        double aMagSqr = 0.0;
+        for (int i=0; i < 3; i++)
+          aMagSqr += areaVec[i] * areaVec[i];
+
+        EXPECT_NEAR(aMagSqrGold, aMagSqr, tol);
+        counter++;
+      }
+    EXPECT_EQ(counter, 12);
+  }
+}
+
+TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
+{
+  // Only execute for 1 processor runs
+  if (bulk_.parallel_size() > 1) return;
+
+  const bool doPerturb = false;
+  const bool generateSidesets = true;
+  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+
+  // zero out fields
+  stk::mesh::field_fill(0.0, *exposedAreaVec_);
+
+  unit_test_utils::HelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+
+  auto* part = meta_.get_part("surface_5");
+  auto* surfPart = part->subsets()[0];
+  sierra::nalu::GeometryAlgDriver geomAlgDriver(helperObjs.realm);
+  geomAlgDriver.register_face_algorithm<sierra::nalu::GeometryBoundaryAlg>(
+    sierra::nalu::WALL, surfPart, "geometry");
+
+  geomAlgDriver.execute();
+
+  // Edge area vector check
+  {
+    stk::mesh::Selector sel(*part);
+    const auto& bkts = bulk_.get_buckets(stk::topology::FACE_RANK, sel);
+    const double aMagSqrGold = 0.25 * 0.25;
+
+    const double tol = 1.0e-16;
+    for (const auto* b: bkts)
+      for (const auto face: *b) {
+        const double* areaVec = stk::mesh::field_data(*exposedAreaVec_, face);
+        for (int ip=0; ip < sierra::nalu::AlgTraitsQuad4::numFaceIp_; ++ip) {
+          double aMagSqr = 0.0;
+          for (int i=0; i < 3; i++) {
+            const double av = areaVec[ip * sierra::nalu::AlgTraitsQuad4::nDim_ + i];
+            aMagSqr += av * av;
+          }
+
+          EXPECT_NEAR(aMagSqrGold, aMagSqr, tol);
+        }
+      }
+  }
+}
+
+TEST_F(KsgsKernelHex8Mesh, NGP_geometry_wall_func)
+{
+  // Only execute for 1 processor runs
+  if (bulk_.parallel_size() > 1) return;
+
+  const bool doPerturb = false;
+  const bool generateSidesets = true;
+  LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
+
+  // zero out fields
+  stk::mesh::field_fill(0.0, *wallNormDist_);
+  stk::mesh::field_fill(0.0, *wallArea_);
+
+  unit_test_utils::HelperObjects helperObjs(
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+
+  auto* part = meta_.get_part("surface_5");
+  auto* surfPart = part->subsets()[0];
+  sierra::nalu::GeometryAlgDriver geomAlgDriver(helperObjs.realm);
+  geomAlgDriver.register_wall_func_algorithm<sierra::nalu::WallFuncGeometryAlg>(
+    sierra::nalu::WALL, surfPart,
+    sierra::nalu::get_elem_topo(helperObjs.realm, *surfPart), "geometry");
+
+  geomAlgDriver.execute();
+
+  // Edge area vector check
+  {
+    stk::mesh::Selector sel(*part);
+    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const double wdistGold = 0.25;
+    const double wAreaGold = 0.25;
+
+    const double tol = 1.0e-16;
+    for (const auto* b: bkts)
+      for (const auto node: *b) {
+        const double* wdist = stk::mesh::field_data(*wallNormDist_, node);
+        const double* warea = stk::mesh::field_data(*wallArea_, node);
+        EXPECT_NEAR(wdistGold, wdist[0], tol);
+        EXPECT_NEAR(wAreaGold, warea[0], tol);
+      }
+  }
+}


### PR DESCRIPTION
Introduce two new algorithm drivers `GeometryAlgDriver` and `TKEWallFuncAlgDriver`. These drivers are necessary as the ABL _assembled wall area/normal distance_ and the TKE wall function NGP algorithms are templated on the element topology type. We have a situation where the results will be incorrect if the user had multiple topologies for the wall boundary, because the field gets reset at every invocation of the Algorithm. This commit moves the rest of fields and the parallel/periodic synchronizations to the driver `pre_work` and `post_work` so that the fields are updated correctly. 

This commit also introduces NGP versions of the volume/area computations. There are unit tests to test these new algorithms, but `Realm` continues to use the non-NGP algorithms as we need several master elements to have NGP versions of `determinant` before we can switch completely. At the minimum we need `Tri32D` to have NGP versions of the methods before we can switch to NGP for 3D geometries.