### PR TITLE
Disable copy/assignment construction of `MeshInfo` object

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -27,7 +27,6 @@
 #include <stk_ngp/NgpFieldManager.hpp>
 
 #include "ngp_utils/NgpMeshInfo.h"
-#include "ngp_algorithms/GeometryAlgDriver.h"
 
 // standard c++
 #include <map>
@@ -54,7 +53,7 @@ namespace nalu{
 class Algorithm;
 class AlgorithmDriver;
 class AuxFunctionAlgorithm;
-class ComputeGeometryAlgorithmDriver;
+class GeometryAlgDriver;
 
 class NonConformalManager;
 class ErrorIndicatorAlgorithmDriver;
@@ -419,8 +418,7 @@ class Realm {
   GlobalIdFieldType *naluGlobalId_;
 
   // algorithm drivers managed by region
-  ComputeGeometryAlgorithmDriver *computeGeometryAlgDriver_;
-  std::unique_ptr<GeometryAlgDriver> geometryAlgDriver_{nullptr};
+  std::unique_ptr<GeometryAlgDriver> geometryAlgDriver_;
   ErrorIndicatorAlgorithmDriver *errorIndicatorAlgDriver_;
 # if defined (NALU_USES_PERCEPT)  
   Adapter *adapter_;

--- a/include/ngp_utils/NgpMeshInfo.h
+++ b/include/ngp_utils/NgpMeshInfo.h
@@ -42,6 +42,10 @@ public:
 
   ~MeshInfo() = default;
 
+  MeshInfo() = delete;
+  MeshInfo(const MeshInfo&) = delete;
+  MeshInfo& operator=(const MeshInfo&) = delete;
+
   inline const stk::mesh::BulkData& bulk() const { return bulk_; }
 
   inline const stk::mesh::MetaData& meta() const { return meta_; }

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -191,7 +191,6 @@ namespace nalu{
     ioBroker_(NULL),
     resultsFileIndex_(99),
     restartFileIndex_(99),
-    computeGeometryAlgDriver_(0),
     errorIndicatorAlgDriver_(0),
 #if defined (NALU_USES_PERCEPT)
     adapter_(0),
@@ -280,8 +279,6 @@ Realm::~Realm()
   delete metaData_;
   delete ioBroker_;
 
-  delete computeGeometryAlgDriver_;
-
   if ( NULL != errorIndicatorAlgDriver_)
     delete errorIndicatorAlgDriver_;
 
@@ -344,7 +341,6 @@ Realm::~Realm()
 void
 Realm::breadboard()
 {
-  computeGeometryAlgDriver_ = new ComputeGeometryAlgorithmDriver(*this);
   geometryAlgDriver_.reset(new GeometryAlgDriver(*this));
   equationSystems_.breadboard();
 }

--- a/src/ngp_algorithms/GeometryBoundaryAlg.C
+++ b/src/ngp_algorithms/GeometryBoundaryAlg.C
@@ -42,7 +42,7 @@ void GeometryBoundaryAlg<AlgTraits>::execute()
 {
   using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
 
-  auto meshInfo = realm_.mesh_info();
+  const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();
   const auto ngpMesh = meshInfo.ngp_mesh();
   const auto& fieldMgr = meshInfo.ngp_field_manager();

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -61,7 +61,7 @@ void GeometryInteriorAlg<AlgTraits>::impl_compute_dual_nodal_volume()
 {
   using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
 
-  auto meshInfo = realm_.mesh_info();
+  const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();
   const auto ngpMesh = meshInfo.ngp_mesh();
   const auto& fieldMgr = meshInfo.ngp_field_manager();
@@ -99,7 +99,7 @@ void GeometryInteriorAlg<AlgTraits>::impl_compute_edge_area_vector()
 {
   using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
 
-  auto meshInfo = realm_.mesh_info();
+  const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();
   const auto ngpMesh = meshInfo.ngp_mesh();
   const auto& fieldMgr = meshInfo.ngp_field_manager();

--- a/src/ngp_algorithms/NodalGradElemAlg.C
+++ b/src/ngp_algorithms/NodalGradElemAlg.C
@@ -55,7 +55,7 @@ void NodalGradElemAlg<AlgTraits, PhiType, GradPhiType>::execute()
   using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
   using ViewHelperType = nalu_ngp::ViewHelper<ElemSimdDataType, PhiType>;
 
-  auto meshInfo = realm_.mesh_info();
+  const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();
   const auto ngpMesh = meshInfo.ngp_mesh();
   const auto& fieldMgr = meshInfo.ngp_field_manager();

--- a/unit_tests/UnitTestTpetra.C
+++ b/unit_tests/UnitTestTpetra.C
@@ -56,7 +56,7 @@ create_algorithm(sierra::nalu::Realm& realm, stk::mesh::Part& part)
   EXPECT_TRUE(solverAlgResult.second);
   ThrowRequireMsg(solverAlgResult.first != nullptr,"Error, failed to obtain non-null solver-algorithm object.");
 
-  if (realm.computeGeometryAlgDriver_ == nullptr) {
+  if (realm.geometryAlgDriver_ == nullptr) {
     realm.breadboard();
   }
   realm.register_interior_algorithm(&part);


### PR DESCRIPTION
Disabling to prevent creating accidental copy of `ngp::FieldManager` object so as to ensure that we always get the same instance of `ngp::Field` that have already been instantiated on device. 