### PR TITLE
Provide Kokkos configuration and Teuchos Timer output

### DIFF
--- a/nalu.C
+++ b/nalu.C
@@ -27,6 +27,7 @@
 
 // Kokkos
 #include <Kokkos_Core.hpp>
+#include <Teuchos_TimeMonitor.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -238,6 +239,10 @@ int main( int argc, char ** argv )
                               false, naluEnv.parallel_comm());
 
   stk::diag::deleteRootTimer(sierra::nalu::Simulation::rootTimer());
+
+  // Write out Trilinos timers
+  Teuchos::TimeMonitor::summarize(
+    naluEnv.naluOutputP0(), false, true, false, Teuchos::Union);
   }
   Kokkos::finalize_all();
   // all done  

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -195,6 +195,12 @@ void Simulation::high_level_banner() {
   NaluEnv::self().naluOutputP0() << "-----------------------------------------------------------------" << std::endl;
   NaluEnv::self().naluOutputP0() << std::endl;
 
+  if (!std::is_same<DeviceSpace, Kokkos::Serial>::value) {
+    // Save output from the master proc in the log file
+    Kokkos::DefaultExecutionSpace::print_configuration(NaluEnv::self().naluOutputP0());
+    // But have everyone print out to standard error for debugging purposes
+    Kokkos::DefaultExecutionSpace::print_configuration(std::cerr);
+  }
 }
 } // namespace nalu
 } // namespace Sierra


### PR DESCRIPTION
For NGP runs print out Kokkos configuration for debugging purposes. Always
output Teuchos timers to get Trilinos solver timings based on settings.