### PR TITLE
Make get_entity_master more forgiving for ghost entities.

### DIFF
--- a/include/TpetraLinearSystemHelpers.h
+++ b/include/TpetraLinearSystemHelpers.h
@@ -55,7 +55,8 @@ void fill_owned_and_shared_then_nonowned_ordered_by_proc(std::vector<LinSys::Glo
 
 stk::mesh::Entity get_entity_master(const stk::mesh::BulkData& bulk,
                                     stk::mesh::Entity entity,
-                                    stk::mesh::EntityId naluId);
+                                    stk::mesh::EntityId naluId,
+                                    bool throwIfMasterNotFound = true);
 
 size_t get_neighbor_index(const std::vector<int>& neighborProcs, int proc);
 

--- a/src/TpetraLinearSystemHelpers.C
+++ b/src/TpetraLinearSystemHelpers.C
@@ -99,14 +99,15 @@ void fill_owned_and_shared_then_nonowned_ordered_by_proc(std::vector<LinSys::Glo
 
 stk::mesh::Entity get_entity_master(const stk::mesh::BulkData& bulk,
                                     stk::mesh::Entity entity,
-                                    stk::mesh::EntityId naluId)
+                                    stk::mesh::EntityId naluId,
+                                    bool throwIfMasterNotFound)
 {
   bool thisEntityIsMaster = (bulk.identifier(entity) == naluId);
   if (thisEntityIsMaster) {
     return entity;
   }
   stk::mesh::Entity master = bulk.get_entity(stk::topology::NODE_RANK, naluId);
-  if (!bulk.is_valid(master)) {
+  if (throwIfMasterNotFound && !bulk.is_valid(master)) {
     std::ostringstream os;
     const stk::mesh::Entity* elems = bulk.begin_elements(entity);
     unsigned numElems = bulk.num_elements(entity);


### PR DESCRIPTION
Added a flag so that get_entity_master can optionallly return an
invalid entity if master is not found, instead of throwing an exception.

In particular, when filling the entity_to_col_LID mapping-vector,
we traverse all of the entities (including ghosts) and occasionally
an entity won't have a local master. In those cases, this is a
location in the mapping-vector that won't be accessed anyway, so
we just set it to -1 and continue.