### PR TITLE
Step 1 of cleaning up CoeffApplier.

### DIFF
--- a/include/AssembleEdgeSolverAlgorithm.h
+++ b/include/AssembleEdgeSolverAlgorithm.h
@@ -64,10 +64,8 @@ public:
     const auto entityRank = entityRank_;
     const auto rhsSize = rhsSize_;
 
-#ifdef KOKKOS_ENABLE_CUDA
     CoeffApplier* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
     CoeffApplier* deviceCoeffApplier = coeffApplier->device_pointer();
-#endif
 
     const auto nodesPerEntity = nodesPerEntity_;
 
@@ -94,23 +92,14 @@ public:
 
             lambdaFunc(smdata, edgeIndex, nodeL, nodeR);
 
-#ifndef KOKKOS_ENABLE_CUDA
-            // TODO: scratchIds and sort permutations could be optimized away for edge based
-            this->apply_coeff(
-              nodesPerEntity, smdata.ngpElemNodes, smdata.scratchIds,
-              smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
-#else
             (*deviceCoeffApplier)(
               nodesPerEntity, smdata.ngpElemNodes, smdata.scratchIds,
               smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
-#endif
           });
       });
 
-#ifdef KOKKOS_ENABLE_CUDA
       coeffApplier->free_device_pointer();
       delete coeffApplier;
-#endif
   }
 
 protected:

--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -353,7 +353,7 @@ public:
   std::string dofName_{"undefined"};
 
   bool extractDiagonal_{false};
-  ScalarFieldType* Udiag_{nullptr};
+  virtual ScalarFieldType* get_diagonal_field() { return nullptr; }
 
   // owner equation system
   /*EquationSystem *ownerEqs_;*/

--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -353,6 +353,7 @@ public:
   std::string dofName_{"undefined"};
 
   bool extractDiagonal_{false};
+  ScalarFieldType* Udiag_{nullptr};
 
   // owner equation system
   /*EquationSystem *ownerEqs_;*/

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -140,10 +140,7 @@ public:
                             const SharedMemView<int*,DeviceShmem> & sortPermutation,
                             const SharedMemView<const double*,DeviceShmem> & rhs,
                             const SharedMemView<const double**,DeviceShmem> & lhs,
-                            const char * trace_tag)
-    {
-      linSys_.sumInto(numEntities, entities, rhs, lhs, localIds, sortPermutation, trace_tag);
-    }
+                            const char * trace_tag);
 
     void free_device_pointer() {}
 
@@ -242,6 +239,9 @@ public:
   double get_timer_precond();
   void zero_timer_precond();
   bool useSegregatedSolver() const;
+
+  EquationSystem* equationSystem() { return eqSys_; }
+
 protected:
   virtual void beginLinearSystemConstruction()=0;
   virtual void checkError(

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -222,6 +222,11 @@ public:
   // saved of mesh parts that are not to be projected
   std::vector<stk::mesh::Part *> notProjectedPart_;
   std::array<std::vector<stk::mesh::Part*>,3> notProjectedDir_;
+
+  ScalarFieldType* get_diagonal_field() override { return Udiag_; }
+
+private:
+  ScalarFieldType* Udiag_;
 };
 
 class ContinuityEquationSystem : public EquationSystem {

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -207,7 +207,6 @@ public:
   ScalarFieldType *visc_;
   ScalarFieldType *tvisc_;
   ScalarFieldType *evisc_;
-  ScalarFieldType* Udiag_{nullptr};
 
   VectorNodalGradAlgDriver nodalGradAlgDriver_;
   WallFricVelAlgDriver wallFuncAlgDriver_;

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -12,6 +12,7 @@
 #include <LinearSystem.h>
 
 #include <KokkosInterface.h>
+#include <FieldTypeDef.h>
 
 #include <Kokkos_DefaultNode.hpp>
 #include <Tpetra_MultiVector.hpp>
@@ -172,7 +173,9 @@ public:
                              LinSys::LocalVector sharedNotOwnedLclRhs,
                              LinSys::EntityToLIDView entityLIDs,
                              LinSys::EntityToLIDView entityColLIDs,
-                             int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof)
+                             int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof,
+                             bool extractDiagonal, NGPDoubleFieldType& diagField,
+                             const ngp::Mesh& ngpMesh)
     : ownedLocalMatrix_(ownedLclMatrix),
       sharedNotOwnedLocalMatrix_(sharedNotOwnedLclMatrix),
       ownedLocalRhs_(ownedLclRhs),
@@ -180,6 +183,8 @@ public:
       entityToLID_(entityLIDs),
       entityToColLID_(entityColLIDs),
       maxOwnedRowId_(maxOwnedRowId), maxSharedNotOwnedRowId_(maxSharedNotOwnedRowId), numDof_(numDof),
+      extractDiagonal_(extractDiagonal), diagField_(diagField),
+      ngpMesh_(ngpMesh),
       devicePointer_(nullptr)
     {}
 
@@ -214,6 +219,9 @@ public:
     LinSys::EntityToLIDView entityToColLID_;
     int maxOwnedRowId_, maxSharedNotOwnedRowId_;
     unsigned numDof_;
+    bool extractDiagonal_;
+    NGPDoubleFieldType diagField_;
+    ngp::Mesh ngpMesh_;
     TpetraLinSysCoeffApplier* devicePointer_;
   };
 

--- a/include/TpetraSegregatedLinearSystem.h
+++ b/include/TpetraSegregatedLinearSystem.h
@@ -12,6 +12,7 @@
 #include <LinearSystem.h>
 
 #include <KokkosInterface.h>
+#include <FieldTypeDef.h>
 
 #include <Kokkos_DefaultNode.hpp>
 #include <Tpetra_MultiVector.hpp>
@@ -163,7 +164,9 @@ public:
                              LinSys::LocalVector sharedNotOwnedLclRhs,
                              LinSys::EntityToLIDView entityLIDs,
                              LinSys::EntityToLIDView entityColLIDs,
-                             int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof)
+                             int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof,
+                             bool extractDiagonal, NGPDoubleFieldType& diagField,
+                             const ngp::Mesh& ngpMesh)
     : ownedLocalMatrix_(ownedLclMatrix),
       sharedNotOwnedLocalMatrix_(sharedNotOwnedLclMatrix),
       ownedLocalRhs_(ownedLclRhs),
@@ -171,6 +174,8 @@ public:
       entityToLID_(entityLIDs),
       entityToColLID_(entityColLIDs),
       maxOwnedRowId_(maxOwnedRowId), maxSharedNotOwnedRowId_(maxSharedNotOwnedRowId), numDof_(numDof),
+      extractDiagonal_(extractDiagonal), diagField_(diagField),
+      ngpMesh_(ngpMesh),
       devicePointer_(nullptr)
     {}
 
@@ -205,6 +210,9 @@ public:
     LinSys::EntityToLIDView entityToColLID_;
     int maxOwnedRowId_, maxSharedNotOwnedRowId_;
     unsigned numDof_;
+    bool extractDiagonal_;
+    NGPDoubleFieldType diagField_;
+    ngp::Mesh ngpMesh_;
     TpetraLinSysCoeffApplier* devicePointer_;
   };
 

--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -128,5 +128,22 @@ void LinearSystem::sync_field(const stk::mesh::FieldBase *field)
   stk::mesh::copy_owned_to_shared( bulkData, fields);
 }
 
+KOKKOS_FUNCTION
+void LinearSystem::DefaultHostOnlyCoeffApplier::operator()(
+                        unsigned numEntities,
+                        const ngp::Mesh::ConnectedNodes& entities,
+                        const SharedMemView<int*,DeviceShmem> & localIds,
+                        const SharedMemView<int*,DeviceShmem> & sortPermutation,
+                        const SharedMemView<const double*,DeviceShmem> & rhs,
+                        const SharedMemView<const double**,DeviceShmem> & lhs,
+                        const char * trace_tag)
+{
+  linSys_.sumInto(numEntities, entities, rhs, lhs, localIds, sortPermutation, trace_tag);
+
+  if (linSys_.equationSystem()->extractDiagonal_) {
+    linSys_.equationSystem()->save_diagonal_term(numEntities, entities, lhs);
+  }
+}
+
 } // namespace nalu
 } // namespace Sierra

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -856,7 +856,7 @@ LowMachEquationSystem::project_nodal_velocity()
   const auto dpdx = fieldMgr.get_field<double>(
     continuityEqSys_->dpdx_->mesh_meta_data_ordinal());
   const auto Udiag = fieldMgr.get_field<double>(
-    momentumEqSys_->Udiag_->mesh_meta_data_ordinal());
+    momentumEqSys_->get_diagonal_field()->mesh_meta_data_ordinal());
   const auto velNp1 = fieldMgr.get_field<double>(
     momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1)
       .mesh_meta_data_ordinal());

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1311,8 +1311,8 @@ void reset_rows(
 sierra::nalu::CoeffApplier* TpetraLinearSystem::get_coeff_applier()
 {
   const bool extractDiagonal = equationSystem()->extractDiagonal_;
-  const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->Udiag_!=nullptr) ?
-                    equationSystem()->Udiag_->mesh_meta_data_ordinal() : 0;
+  const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->get_diagonal_field() !=nullptr) ?
+                    equationSystem()->get_diagonal_field()->mesh_meta_data_ordinal() : 0;
   
   NGPDoubleFieldType diagField;
   if (extractDiagonal) {

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1310,10 +1310,20 @@ void reset_rows(
 
 sierra::nalu::CoeffApplier* TpetraLinearSystem::get_coeff_applier()
 {
+  const bool extractDiagonal = equationSystem()->extractDiagonal_;
+  const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->Udiag_!=nullptr) ?
+                    equationSystem()->Udiag_->mesh_meta_data_ordinal() : 0;
+  
+  NGPDoubleFieldType diagField;
+  if (extractDiagonal) {
+    diagField = realm_.ngp_field_manager().get_field<double>(diagFieldOrdinal);
+  }
+
   return new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
                                       ownedLocalRhs_, sharedNotOwnedLocalRhs_,
                                       entityToLID_, entityToColLID_,
-                                      maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_);
+                                      maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_,
+                                      extractDiagonal, diagField, realm_.ngp_mesh());
 }
 
 KOKKOS_FUNCTION
@@ -1348,23 +1358,43 @@ void TpetraLinearSystem::TpetraLinSysCoeffApplier::operator()(unsigned numEntiti
       entityToLID_, entityToColLID_,
       maxOwnedRowId_, maxSharedNotOwnedRowId_,
       numDof_);
+
+  if (extractDiagonal_) {
+    constexpr bool forceAtomic = !std::is_same<sierra::nalu::DeviceSpace, Kokkos::Serial>::value;
+    unsigned nDim = ngpMesh_.get_spatial_dimension();
+    for(unsigned i=0; i<numEntities; ++i) {
+      size_t idx = i*nDim;
+      if (forceAtomic) {
+        Kokkos::atomic_add(&diagField_.get(ngpMesh_, entities[i], 0), lhs(idx,idx));
+      }
+      else {
+        diagField_.get(ngpMesh_, entities[i], 0) += lhs(idx,idx);
+      }
+    }
+  }
 }
 
 void TpetraLinearSystem::TpetraLinSysCoeffApplier::free_device_pointer()
 {
+#ifdef KOKKOS_ENABLE_CUDA
   if (this != devicePointer_) {
     sierra::nalu::kokkos_free_on_device(devicePointer_);
     devicePointer_ = nullptr;
   }
+#endif
 }
 
 sierra::nalu::CoeffApplier* TpetraLinearSystem::TpetraLinSysCoeffApplier::device_pointer()
 {
+#ifdef KOKKOS_ENABLE_CUDA
   if (devicePointer_ != nullptr) {
     sierra::nalu::kokkos_free_on_device(devicePointer_);
     devicePointer_ = nullptr;
   }
   devicePointer_ = sierra::nalu::create_device_expression(*this);
+#else
+  devicePointer_ = this;
+#endif
   return devicePointer_;
 }
 

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -1179,10 +1179,20 @@ void reset_rows(
 
 sierra::nalu::CoeffApplier* TpetraSegregatedLinearSystem::get_coeff_applier()
 {
+  const bool extractDiagonal = equationSystem()->extractDiagonal_;
+  const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->Udiag_!=nullptr) ?
+                    equationSystem()->Udiag_->mesh_meta_data_ordinal() : 0;
+
+  NGPDoubleFieldType diagField;
+  if (extractDiagonal) {
+    diagField = realm_.ngp_field_manager().get_field<double>(diagFieldOrdinal);
+  }
+
   return new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
                                       ownedLocalRhs_, sharedNotOwnedLocalRhs_,
                                       entityToLID_, entityToColLID_,
-                                      maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_);
+                                      maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_,
+                                      extractDiagonal, diagField, realm_.ngp_mesh());
 }
 
 KOKKOS_FUNCTION
@@ -1216,23 +1226,43 @@ void TpetraSegregatedLinearSystem::TpetraLinSysCoeffApplier::operator() (unsigne
                       entityToLID_, entityToColLID_,
                       maxOwnedRowId_, maxSharedNotOwnedRowId_,
                       numDof_);
+
+  if (extractDiagonal_) {
+    constexpr bool forceAtomic = !std::is_same<sierra::nalu::DeviceSpace, Kokkos::Serial>::value;
+    unsigned nDim = ngpMesh_.get_spatial_dimension();
+    for(unsigned i=0; i<numEntities; ++i) {
+      size_t idx = i*nDim;
+      if (forceAtomic) {
+        Kokkos::atomic_add(&diagField_.get(ngpMesh_, entities[i], 0), lhs(idx,idx));
+      }
+      else {
+        diagField_.get(ngpMesh_, entities[i], 0) += lhs(idx,idx);
+      }
+    }
+  }
 }
 
 void TpetraSegregatedLinearSystem::TpetraLinSysCoeffApplier::free_device_pointer()
 {
+#ifdef KOKKOS_ENABLE_CUDA
   if (this != devicePointer_) {
     sierra::nalu::kokkos_free_on_device(devicePointer_);
     devicePointer_ = nullptr;
   }
+#endif
 }
 
 sierra::nalu::CoeffApplier* TpetraSegregatedLinearSystem::TpetraLinSysCoeffApplier::device_pointer()
 {
+#ifdef KOKKOS_ENABLE_CUDA
   if (devicePointer_ != nullptr) {
     sierra::nalu::kokkos_free_on_device(devicePointer_);
     devicePointer_ = nullptr;
   }
   devicePointer_ = sierra::nalu::create_device_expression(*this);
+#else
+  devicePointer_ = this;
+#endif
   return devicePointer_;
 }
 

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -1180,8 +1180,8 @@ void reset_rows(
 sierra::nalu::CoeffApplier* TpetraSegregatedLinearSystem::get_coeff_applier()
 {
   const bool extractDiagonal = equationSystem()->extractDiagonal_;
-  const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->Udiag_!=nullptr) ?
-                    equationSystem()->Udiag_->mesh_meta_data_ordinal() : 0;
+  const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->get_diagonal_field()!=nullptr) ?
+                    equationSystem()->get_diagonal_field()->mesh_meta_data_ordinal() : 0;
 
   NGPDoubleFieldType diagField;
   if (extractDiagonal) {


### PR DESCRIPTION
This commit makes CoeffApplier handle extracting/saving the diagonal.

Still more things to do:
1. Resolve coeffApplier vs deviceCoeffApplier usage. Algs shouldn't
need to get coeffApplier and then ask it to produce deviceCoeffApplier.
2. Handle the 'fix_overset_rows' functionality?
3. reduce duplication between TpetraLinearSystem and
TpetraSegregatedLinearSystem