### PR TITLE
Begin deprecating boost_rtree search.

### DIFF
--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -1066,7 +1066,7 @@ Actuator
 
      actuator:
        type: ActLineFAST
-       search_method: boost_rtree
+       search_method: stk_kdtree
        search_target_part: Unspecified-2-HEX
 
        n_turbines_glob: 2
@@ -1108,7 +1108,7 @@ Actuator
 
 .. inpfile:: actuator.search_method
 
-   String specifying the type of search method used to identify the nodes within the search radius of the actuator points. Options are ``boost_rtree`` and ``stk_kdtree``. The default is ``stk_kdtree`` when the ``search_type`` is not specified.
+   String specifying the type of search method used to identify the nodes within the search radius of the actuator points. The recommended option is ``stk_kdtree``. The ``boost_rtree`` option is being deprecated by the STK search library.
 
 .. inpfile:: search_target_part
 

--- a/docs/source/user/nalu_run/turbine_modeling.rst
+++ b/docs/source/user/nalu_run/turbine_modeling.rst
@@ -11,7 +11,7 @@ Actuator Turbine Model
 
      actuator:
        type: ActLineFAST
-       search_method: boost_rtree
+       search_method: stk_kdtree
        search_target_part: Unspecified-2-HEX
 
        n_turbines_glob: 2
@@ -59,7 +59,7 @@ Actuator Turbine Model
 
 .. inpfile:: actuator.search_method
 
-   String specifying the type of search method used to identify the nodes within the search radius of the actuator points. Options are ``boost_rtree`` and ``stk_kdtree``. The default is ``stk_kdtree`` when the ``search_type`` is not specified.
+   String specifying the type of search method used to identify the nodes within the search radius of the actuator points. The recommended option is ``stk_kdtree``. The ``boost_rtree`` option is being deprecated by the STK search library.
 
 .. inpfile:: search_target_part
 

--- a/examples/turbine_uniform_inflow/alm_simulation.yaml
+++ b/examples/turbine_uniform_inflow/alm_simulation.yaml
@@ -118,7 +118,7 @@ realms:
 
   actuator:
     type: ActLineFAST
-    search_method: boost_rtree
+    search_method: stk_kdtree
     search_target_part: Unspecified-2-HEX
 
     n_turbines_glob: 2

--- a/examples/turbine_uniform_inflow/template_input_files/nrel5MWactuatorLine.i
+++ b/examples/turbine_uniform_inflow/template_input_files/nrel5MWactuatorLine.i
@@ -118,7 +118,7 @@ realms:
 
     actuator:
       type: ActLineFAST
-      search_method: boost_rtree
+      search_method: stk_kdtree
       search_target_part: Unspecified-2-HEX
 
       n_turbines_glob: 1

--- a/examples/wind_farm/case3/case_3_wind_farm.yaml
+++ b/examples/wind_farm/case3/case_3_wind_farm.yaml
@@ -266,7 +266,7 @@ realms:
 
   actuator:
     type: ActLineFAST
-    search_method: boost_rtree
+    search_method: stk_kdtree
     search_target_part: fluid_part
 
     n_turbines_glob: 2

--- a/examples/wind_farm/case3/template_input_files/wind_farm.yaml
+++ b/examples/wind_farm/case3/template_input_files/wind_farm.yaml
@@ -250,7 +250,7 @@ realms:
 
     actuator:
       type: ActLineFAST
-      search_method: boost_rtree
+      search_method: stk_kdtree
       search_target_part: fluid_part
 
       n_turbines_glob: 1

--- a/reg_tests/test_files/fluidsPmrChtPeriodic/fluidsPmrChtPeriodic.i
+++ b/reg_tests/test_files/fluidsPmrChtPeriodic/fluidsPmrChtPeriodic.i
@@ -102,7 +102,7 @@ realms:
       target_name: [surface_1, surface_2]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
+        search_method: stk_kdtree
 
     - wall_boundary_condition: bc_3
       target_name: surface_3
@@ -226,7 +226,7 @@ realms:
       target_name: [surface_1, surface_2]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
+        search_method: stk_kdtree
 
     - wall_boundary_condition: bc_inner
       target_name: surface_3
@@ -310,7 +310,7 @@ realms:
       target_name: [surface_3, surface_4]
       periodic_user_data:
         search_tolerance: 1.e-2
-        search_method: boost_rtree
+        search_method: stk_kdtree
 
     solution_options:
       name: myOptionsHC

--- a/reg_tests/test_files/heatedBackStep/heatedBackStep.i
+++ b/reg_tests/test_files/heatedBackStep/heatedBackStep.i
@@ -155,7 +155,7 @@ realms:
       target_name: [surface_6, surface_7]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
+        search_method: stk_kdtree
 
     - wall_boundary_condition: bc_top
       target_name: surface_8

--- a/reg_tests/test_files/nrel5MWactuatorLine/nrel5MWactuatorLine.i
+++ b/reg_tests/test_files/nrel5MWactuatorLine/nrel5MWactuatorLine.i
@@ -118,7 +118,7 @@ realms:
 
     actuator:
       type: ActLineFAST
-      search_method: boost_rtree
+      search_method: stk_kdtree
       search_target_part: Unspecified-2-HEX
 
       n_turbines_glob: 1

--- a/reg_tests/test_files/quad9HC/quad9HC.i
+++ b/reg_tests/test_files/quad9HC/quad9HC.i
@@ -60,13 +60,13 @@ realms:
       target_name: [surface_1, surface_2]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
+        search_method: stk_kdtree
 
     - periodic_boundary_condition: bc_top_bottom
       target_name: [surface_3, surface_4]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
+        search_method: stk_kdtree
 
     solution_options:
       name: myOptions

--- a/reg_tests/test_files/waleElemXflowMixFrac3.5m/waleElemXflowMixFrac3.5m.i
+++ b/reg_tests/test_files/waleElemXflowMixFrac3.5m/waleElemXflowMixFrac3.5m.i
@@ -106,7 +106,7 @@ realms:
       target_name: [leftWall, rightWall]
       periodic_user_data:
         search_tolerance: 1.e-5
-        search_method: boost_rtree
+        search_method: stk_kdtree
 
     - symmetry_boundary_condition: bc_top
       target_name: topWall

--- a/src/Actuator.C
+++ b/src/Actuator.C
@@ -69,8 +69,11 @@ Actuator::load(const YAML::Node& y_node)
       y_actuator, "search_method", searchMethodName, searchMethodName);
 
     // determine search method for this pair
-    if (searchMethodName == "boost_rtree")
+    if (searchMethodName == "boost_rtree") {
       searchMethod_ = stk::search::BOOST_RTREE;
+      NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree'"
+                 <<" is being deprecated, please switch to 'stk_kdtree'" << std::endl;
+    }
     else if (searchMethodName == "stk_kdtree")
       searchMethod_ = stk::search::KDTREE;
     else

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -86,7 +86,7 @@ NonConformalInfo::NonConformalInfo(
     currentPartVec_(currentPartVec),
     opposingPartVec_(opposingPartVec),
     expandBoxPercentage_(expandBoxPercentage),
-    searchMethod_(stk::search::BOOST_RTREE),
+    searchMethod_(stk::search::KDTREE),
     clipIsoParametricCoords_(clipIsoParametricCoords),
     searchTolerance_(searchTolerance),
     dynamicSearchTolAlg_(dynamicSearchTolAlg),
@@ -94,12 +94,15 @@ NonConformalInfo::NonConformalInfo(
     canReuse_(false)
 {
   // determine search method for this pair
-  if ( searchMethodName == "boost_rtree" )
+  if ( searchMethodName == "boost_rtree" ) {
     searchMethod_ = stk::search::BOOST_RTREE;
+    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' is being deprecated"
+           <<", please switch to 'stk_kdtree'" << std::endl;
+  }
   else if ( searchMethodName == "stk_kdtree" )
     searchMethod_ = stk::search::KDTREE;
   else
-    NaluEnv::self().naluOutputP0() << "NonConformalInfo::search method not declared; will use boost_rtree" << std::endl;
+    NaluEnv::self().naluOutputP0() << "NonConformalInfo::search method not declared; will use stk_kdtree" << std::endl;
 }
 
 //--------------------------------------------------------------------------

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -88,10 +88,13 @@ PeriodicManager::add_periodic_pair(
   SelectorPair periodicSelectorPair(masterSelect, slaveSelect);
   periodicSelectorPairs_.push_back(periodicSelectorPair);
 
-  // determine search method for this pair; default is boost_rtree
+  // determine search method for this pair; default is stk_kdtree
   stk::search::SearchMethod searchMethod = stk::search::KDTREE;
-  if ( searchMethodName == "boost_rtree" )
+  if ( searchMethodName == "boost_rtree" ) {
     searchMethod = stk::search::BOOST_RTREE;
+    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' is being deprecated"
+        <<", please swithc to 'stk_kdtree'" << std::endl;
+  }
   else if ( searchMethodName == "stk_kdtree" )
     searchMethod = stk::search::KDTREE;
   else

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -431,8 +431,11 @@ SolutionOptions::load(const YAML::Node & y_node)
           fix_pressure["search_target_part"].as<std::vector<std::string>>();
         if (fix_pressure["search_method"]) {
           std::string searchMethodName = fix_pressure["search_method"].as<std::string>();
-          if (searchMethodName == "boost_rtree")
+          if (searchMethodName == "boost_rtree") {
             fixPressureInfo_->searchMethod_ = stk::search::BOOST_RTREE;
+            NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' is being"
+              <<" deprecated. Please switch to 'stk_kdtree'." << std::endl;
+          }
           else if (searchMethodName == "stk_kdtree")
             fixPressureInfo_->searchMethod_ = stk::search::KDTREE;
           else

--- a/src/xfer/Transfer.C
+++ b/src/xfer/Transfer.C
@@ -356,8 +356,11 @@ void Transfer::allocate_stk_transfer() {
 
   // extract search type
   stk::search::SearchMethod searchMethod = stk::search::KDTREE;
-  if ( searchMethodName_ == "boost_rtree" )
+  if ( searchMethodName_ == "boost_rtree" ) {
     searchMethod = stk::search::BOOST_RTREE;
+    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' is being deprecated"
+          <<", please switch to 'stk_kdtree'" << std::endl;
+  }
   else if ( searchMethodName_ == "stk_kdtree" )
     searchMethod = stk::search::KDTREE;
   else


### PR DESCRIPTION
Initially, just change existing input files and also print a message
when the code encounters boost_rtree coming in from input.

Next step (after some grace period?) will be to either throw error when
boost_rtree is encountered, or automatically change it to stk_kdtree.