### PR TITLE
Convert LinearSystem::sync_field to NGP

### DIFF
--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -116,56 +116,56 @@ public:
     EquationSystems& equationSystems);
   virtual ~MomentumEquationSystem();
 
-  virtual void initial_work();
+  virtual void initial_work() override;
 
   virtual void register_nodal_fields(
-    stk::mesh::Part *part);
+    stk::mesh::Part *part) override;
 
   virtual void register_edge_fields(
-    stk::mesh::Part *part);
+    stk::mesh::Part *part) override;
 
   virtual void register_element_fields(
     stk::mesh::Part *part,
-    const stk::topology &theTopo);
+    const stk::topology &theTopo) override;
 
   virtual void register_interior_algorithm(
-    stk::mesh::Part *part);
+    stk::mesh::Part *part) override;
 
   virtual void register_inflow_bc(
     stk::mesh::Part *part,
     const stk::topology &theTopo,
-    const InflowBoundaryConditionData &inflowBCData);
+    const InflowBoundaryConditionData &inflowBCData) override;
 
   virtual void register_open_bc(
     stk::mesh::Part *part,
     const stk::topology &partTopo,
-    const OpenBoundaryConditionData &openBCData);
+    const OpenBoundaryConditionData &openBCData) override;
 
   virtual void register_wall_bc(
     stk::mesh::Part *part,
     const stk::topology &partTopo,
-    const WallBoundaryConditionData &wallBCData);
+    const WallBoundaryConditionData &wallBCData) override;
     
   virtual void register_symmetry_bc(
     stk::mesh::Part *part,
     const stk::topology &partTopo,
-    const SymmetryBoundaryConditionData &symmetryBCData);
+    const SymmetryBoundaryConditionData &symmetryBCData) override;
 
   virtual void register_abltop_bc(
     stk::mesh::Part *part,
     const stk::topology &partTopo,
-    const ABLTopBoundaryConditionData &ablTopBCData);
+    const ABLTopBoundaryConditionData &ablTopBCData) override;
 
   virtual void register_non_conformal_bc(
     stk::mesh::Part *part,
-    const stk::topology &theTopo);
+    const stk::topology &theTopo) override;
 
-  virtual void register_overset_bc();
+  virtual void register_overset_bc() override;
 
-  virtual void initialize();
-  virtual void reinitialize_linear_system();
+  virtual void initialize() override;
+  virtual void reinitialize_linear_system() override;
   
-  virtual void predict_state();
+  virtual void predict_state() override;
 
   void compute_wall_function_params();
 
@@ -177,22 +177,22 @@ public:
     const std::vector<stk::mesh::Entity>&,
     const std::vector<int>&,
     const std::vector<double>&
-  );
+  ) override;
 
   virtual void save_diagonal_term(
     unsigned,
     const stk::mesh::Entity*,
     const SharedMemView<const double**>&
-  );
+  ) override;
 
   virtual void save_diagonal_term(
     unsigned,
     const ngp::Mesh::ConnectedNodes&,
     const SharedMemView<const double**,DeviceShmem>&
-  );
+  ) override;
 
   virtual void assemble_and_solve(
-    stk::mesh::FieldBase *deltaSolution);
+    stk::mesh::FieldBase *deltaSolution) override;
 
   void compute_turbulence_parameters();
 

--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -32,6 +32,8 @@
 #include <stk_topology/topology.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
 
+#include "stk_ngp/NgpFieldParallel.hpp"
+
 #include <Teuchos_VerboseObject.hpp>
 #include <Teuchos_FancyOStream.hpp>
 
@@ -123,9 +125,12 @@ LinearSystem *LinearSystem::create(Realm& realm, const unsigned numDof, Equation
 
 void LinearSystem::sync_field(const stk::mesh::FieldBase *field)
 {
-  std::vector< const stk::mesh::FieldBase *> fields(1,field);
-  stk::mesh::BulkData& bulkData = realm_.bulk_data();
-  stk::mesh::copy_owned_to_shared( bulkData, fields);
+  const auto& fieldMgr = realm_.ngp_field_manager();
+  const std::vector<NGPDoubleFieldType*> ngpFields{
+    &fieldMgr.get_field<double>(field->mesh_meta_data_ordinal())
+  };
+
+  ngp::copy_owned_to_shared(realm_.bulk_data(), ngpFields);
 }
 
 #ifndef KOKKOS_ENABLE_CUDA


### PR DESCRIPTION
- Fix owned/share field synchronization when running on GPUs over multiple MPI ranks - see #370 
- Fix inconsistent override warnings from #413. 