### PR TITLE
Revert "Revert "Set stack size on GPU.""

### DIFF
--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -681,15 +681,8 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
   MasterElement*,
   MasterElement* meSCS,
   MasterElement* meSCV,
-  MasterElement*
-#ifndef KOKKOS_ENABLE_CUDA
-      meFEM
-#endif
-  ,
-  int
-#ifndef KOKKOS_ENABLE_CUDA
-     faceOrdinal
-#endif
+  MasterElement* meFEM,
+  int faceOrdinal
   )
 {
   for(unsigned i=0; i<dataEnums.size(); ++i) {
@@ -703,7 +696,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
          meSCS->determinant(*coordsView, scs_areav);
          break;
-#ifndef KOKKOS_ENABLE_CUDA
       case SCS_FACE_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_FACE_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_FACE_GRAD_OP requested.");
@@ -714,7 +706,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_SHIFTED_FACE_GRAD_OP requested.");
          meSCS->shifted_face_grad_op(faceOrdinal, *coordsView, dndx_shifted_fc_scs);
        break;
-#endif
       case SCS_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
@@ -755,7 +746,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_SHIFTED_GRAD_OP requested.");
         meSCV->shifted_grad_op(*coordsView, dndx_scv_shifted, deriv_scv);
         break;
-#ifndef KOKKOS_ENABLE_CUDA
       case FEM_GRAD_OP:
          NGP_ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
@@ -766,7 +756,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
          meFEM->shifted_grad_op_fem(*coordsView, dndx_fem, deriv_fem, det_j_fem);
          break;
-#endif
 
       default: break;
     }

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -699,12 +699,12 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
       case SCS_FACE_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_FACE_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_FACE_GRAD_OP requested.");
-         meSCS->face_grad_op(faceOrdinal, *coordsView, dndx_fc_scs);
+         meSCS->face_grad_op(faceOrdinal, *coordsView, dndx_fc_scs, deriv_fc_scs);
        break;
       case SCS_SHIFTED_FACE_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_SHIFTED_FACE_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_SHIFTED_FACE_GRAD_OP requested.");
-         meSCS->shifted_face_grad_op(faceOrdinal, *coordsView, dndx_shifted_fc_scs);
+         meSCS->shifted_face_grad_op(faceOrdinal, *coordsView, dndx_shifted_fc_scs, deriv_fc_scs);
        break;
       case SCS_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -52,6 +52,9 @@ public:
 
   static bool debug_;
   int serializedIOGroupSize_;
+private:
+  size_t    default_stack_size;
+  const size_t nalu_stack_size=4096;
 };
 
 } // namespace nalu

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -54,7 +54,7 @@ public:
   int serializedIOGroupSize_;
 private:
   size_t    default_stack_size;
-  const size_t nalu_stack_size=4096;
+  const size_t nalu_stack_size=16384;
 };
 
 } // namespace nalu

--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -367,7 +367,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void Mij(
     SharedMemView<DoubleType**, DeviceShmem>& coords,

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -211,12 +211,14 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void shifted_grad_op(
     SharedMemView<DoubleType**, DeviceShmem>&coords,
@@ -497,11 +499,12 @@ private:
 
 private :
 
-  KOKKOS_FUNCTION void face_grad_op(
+  template<bool shifted>
+  KOKKOS_FUNCTION void face_grad_op_t(
     const int face_ordinal,
-    const bool shifted,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop);
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv);
 };
     
 //-------- hex8_derivative -------------------------------------------------

--- a/include/master_element/HexPCVFEM.h
+++ b/include/master_element/HexPCVFEM.h
@@ -160,7 +160,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   virtual const double* integration_locations() const final {
     return intgLoc_.data();

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -75,14 +75,16 @@ public:
   KOKKOS_FUNCTION virtual void face_grad_op(
     int /* face_ordinal */,
     SharedMemView<DoubleType**, DeviceShmem>& /* coords */,
-    SharedMemView<DoubleType***, DeviceShmem>& /* gradop */) {
+    SharedMemView<DoubleType***, DeviceShmem>& /* gradop */,
+    SharedMemView<DoubleType***, DeviceShmem>& /* deriv */) {
     NGP_ThrowErrorMsg("MasterElement::face_grad_op not implemented for element");
   }
 
   KOKKOS_FUNCTION virtual void shifted_face_grad_op(
     int /* face_ordinal */,
     SharedMemView<DoubleType**, DeviceShmem>& /* coords */,
-    SharedMemView<DoubleType***, DeviceShmem>& /* gradop */) {
+    SharedMemView<DoubleType***, DeviceShmem>& /* gradop */,
+    SharedMemView<DoubleType***, DeviceShmem>& /* deriv */) {
     NGP_ThrowErrorMsg("MasterElement::shifted_face_grad_op not implemented for element");
   }
 

--- a/include/master_element/MasterElementFunctions.h
+++ b/include/master_element/MasterElementFunctions.h
@@ -51,7 +51,9 @@ namespace nalu {
 
   template <typename AlgTraits, typename GradViewType, typename CoordViewType, typename OutputViewType>
   KOKKOS_FUNCTION
-  KOKKOS_FUNCTION void generic_grad_op(const GradViewType& referenceGradWeights, const CoordViewType& coords, OutputViewType& weights)
+  KOKKOS_FUNCTION void generic_grad_op(const GradViewType& referenceGradWeights, 
+                                       const CoordViewType& coords, 
+                                       OutputViewType& weights)
   {
     constexpr int dim = AlgTraits::nDim_;
 

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -273,7 +273,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,
@@ -286,7 +287,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void general_face_grad_op(
     const int face_ordinal,

--- a/include/master_element/Quad42DCVFEM.h
+++ b/include/master_element/Quad42DCVFEM.h
@@ -176,7 +176,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void face_grad_op(
     const int nelem,
@@ -189,7 +190,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,
@@ -355,7 +357,8 @@ private :
     const int face_ordinal,
     const bool shifted,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop);
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv);
 
   KOKKOS_FUNCTION
   void quad_shape_fcn(

--- a/include/master_element/Quad92DCVFEM.h
+++ b/include/master_element/Quad92DCVFEM.h
@@ -283,7 +283,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void face_grad_op(
     const int nelem,

--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -176,7 +176,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,
@@ -189,7 +190,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void gij(
     SharedMemView<DoubleType**, DeviceShmem>& coords,

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -181,7 +181,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void face_grad_op(
     const int nelem,
@@ -194,7 +195,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,

--- a/include/master_element/Wed6CVFEM.h
+++ b/include/master_element/Wed6CVFEM.h
@@ -185,7 +185,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,
@@ -198,7 +199,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void gij(
     SharedMemView<DoubleType**, DeviceShmem>& coords,

--- a/include/ngp_utils/NgpFieldBLAS.h
+++ b/include/ngp_utils/NgpFieldBLAS.h
@@ -42,6 +42,7 @@ inline void field_axpby(
   using MeshIndex = typename Traits::MeshIndex;
 
   nalu_ngp::run_entity_algorithm(
+    "ngp_field_axpby",
     ngpMesh, rank, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       for (unsigned d=0; d < numComponents; ++d)
@@ -67,6 +68,7 @@ inline void field_copy(
   using MeshIndex = typename Traits::MeshIndex;
 
   nalu_ngp::run_entity_algorithm(
+    "ngp_field_copy",
     ngpMesh, rank, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       for (unsigned d=0; d < numComponents; ++d)

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -886,6 +886,7 @@ LowMachEquationSystem::project_nodal_velocity()
       ((!stk::mesh::selectUnion(momentumEqSys_->notProjectedPart_)) &
        stk::mesh::selectField(*continuityEqSys_->dpdx_));
     nalu_ngp::run_entity_algorithm(
+      "nodal_velocity_projection",
       ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const MeshIndex& mi) {
         // Scaling factor
@@ -898,6 +899,7 @@ LowMachEquationSystem::project_nodal_velocity()
     const stk::mesh::Selector selX =
       (stk::mesh::selectUnion(momentumEqSys_->notProjectedDir_[0]));
     nalu_ngp::run_entity_algorithm(
+      "nodal_velocity_projection_strongX",
       ngpMesh, stk::topology::NODE_RANK, selX,
       KOKKOS_LAMBDA(const MeshIndex& mi) {
         // Scaling factor
@@ -908,6 +910,7 @@ LowMachEquationSystem::project_nodal_velocity()
     const stk::mesh::Selector selY =
       (stk::mesh::selectUnion(momentumEqSys_->notProjectedDir_[1]));
     nalu_ngp::run_entity_algorithm(
+      "nodal_velocity_project_strongY",
       ngpMesh, stk::topology::NODE_RANK, selY,
       KOKKOS_LAMBDA(const MeshIndex& mi) {
         // Scaling factor
@@ -919,6 +922,7 @@ LowMachEquationSystem::project_nodal_velocity()
       const stk::mesh::Selector selZ =
          (stk::mesh::selectUnion(momentumEqSys_->notProjectedDir_[2]));
       nalu_ngp::run_entity_algorithm(
+        "nodal_velocity_projection_strongZ",
            ngpMesh, stk::topology::NODE_RANK, selZ,
            KOKKOS_LAMBDA(const MeshIndex& mi) {
              // Scaling factor

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2683,6 +2683,7 @@ Realm::compute_vrtm()
   const stk::mesh::Selector sel = (
     metaData_->locally_owned_part() | metaData_->globally_shared_part());
   nalu_ngp::run_entity_algorithm(
+    "compute_vrtm",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       for (int d=0; d < nDim; ++d)

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -44,13 +44,21 @@ Simulation::Simulation(const YAML::Node& root_node) :
     transfers_(NULL),
     linearSolvers_(NULL),
     serializedIOGroupSize_(0)
-{}
+{
+#ifdef KOKKOS_ENABLE_CUDA
+  cudaDeviceGetLimit (&default_stack_size, cudaLimitStackSize);
+  cudaDeviceSetLimit (cudaLimitStackSize, nalu_stack_size);
+#endif
+}
 
 Simulation::~Simulation() {
   delete realms_;
   delete transfers_;
   delete timeIntegrator_;
   delete linearSolvers_;
+#ifdef KOKKOS_ENABLE_CUDA
+  cudaDeviceSetLimit (cudaLimitStackSize, default_stack_size);
+#endif
 }
 
 // Timers

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -2008,7 +2008,9 @@ void TpetraLinearSystem::copy_tpetra_to_stk(
 
   ngp::Mesh ngpMesh = realm_.ngp_mesh();
 
-  nalu_ngp::run_entity_algorithm(ngpMesh, stk::topology::NODE_RANK, selector,
+  nalu_ngp::run_entity_algorithm(
+    "TpetraLinSys::copy_tpetra_to_stk",
+    ngpMesh, stk::topology::NODE_RANK, selector,
   KOKKOS_LAMBDA(const MeshIndex& meshIdx)
   {
       stk::mesh::Entity node = (*meshIdx.bucket)[meshIdx.bucketOrd];

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -902,6 +902,7 @@ TurbKineticEnergyEquationSystem::initial_work()
     & stk::mesh::selectField(*tke_);
 
   nalu_ngp::run_entity_algorithm(
+    "clip_tke",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       if (ngpTke.get(mi, 0) < 0.0)
@@ -956,6 +957,7 @@ TurbKineticEnergyEquationSystem::update_and_clip()
     tke_->mesh_meta_data_ordinal());
 
   nalu_ngp::run_entity_par_reduce(
+    "tke_update_and_clip",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const Traits::MeshIndex& mi, size_t& nClip) {
       const double tmp = ngpTke.get(mi, 0) + ngpKTmp.get(mi, 0);

--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -746,6 +746,7 @@ TurbulenceAveragingPostProcessing::compute_averages(
     avInfo->reynoldsFieldVecPair_[0].second->mesh_meta_data_ordinal());
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::compute_averages",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       const double oldRhoRA = densityA.get(mi, 0);
@@ -838,6 +839,7 @@ TurbulenceAveragingPostProcessing::compute_tke(
   auto resTKE = nalu_ngp::get_ngp_field(meshInfo, resolvedTkeName);
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::compute_tke",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       double sum = 0.0;
@@ -877,6 +879,7 @@ TurbulenceAveragingPostProcessing::compute_reynolds_stress(
   const double currentTimeFilter = currentTimeFilter_;
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::compute_restress",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       int ic = 0;
@@ -932,6 +935,7 @@ TurbulenceAveragingPostProcessing::compute_favre_stress(
   const double currentTimeFilter = currentTimeFilter_;
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::compute_favre_stress",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       int ic = 0;
@@ -992,6 +996,7 @@ void TurbulenceAveragingPostProcessing::compute_temperature_resolved_flux(
   const double currentTimeFilter = currentTimeFilter_;
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::temp_res_flux",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       const double rho = density.get(mi, 0);
@@ -1040,6 +1045,7 @@ TurbulenceAveragingPostProcessing::compute_resolved_stress(
   const double currentTimeFilter = currentTimeFilter_;
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::resolved_stress",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       int ic = 0;
@@ -1103,6 +1109,7 @@ TurbulenceAveragingPostProcessing::compute_sfs_stress(
   const double currentTimeFilter = currentTimeFilter_;
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::sfs_stress",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       double divU = 0.0;
@@ -1175,6 +1182,7 @@ TurbulenceAveragingPostProcessing::compute_temperature_sfs_flux(
   auto tempSfsFlux = nalu_ngp::get_ngp_field(meshInfo, "temperature_sfs_flux");
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::temp_sfs_flux",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       const double nut = turbVisc.get(mi, 0);
@@ -1208,6 +1216,7 @@ TurbulenceAveragingPostProcessing::compute_vorticity(
   auto vort = nalu_ngp::get_ngp_field(meshInfo, "vorticity");
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::vorticity",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       for (int i=0; i < ndim; ++i) {
@@ -1239,6 +1248,7 @@ TurbulenceAveragingPostProcessing::compute_q_criterion(
   auto qcrit = nalu_ngp::get_ngp_field(meshInfo, "q_criterion");
 
   nalu_ngp::run_entity_algorithm(
+    "TurbPP::q_crit",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       double sij = 0.0;
@@ -1414,6 +1424,7 @@ TurbulenceAveragingPostProcessing::compute_mean_resolved_ke(
   nalu_ngp::ArrayDbl2 l_sum;
   Kokkos::Sum<nalu_ngp::ArrayDbl2> sum_reducer(l_sum);
   nalu_ngp::run_entity_par_reduce(
+    "TurbPP::mean_res_tke",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,
     KOKKOS_LAMBDA(const MeshIndex& mi, nalu_ngp::ArrayDbl2 pSum) {
       pSum.array_[0] += dualVol.get(mi, 0);

--- a/src/WallDistEquationSystem.C
+++ b/src/WallDistEquationSystem.C
@@ -442,6 +442,7 @@ WallDistEquationSystem::compute_wall_distance()
   const stk::mesh::Selector sel = stk::mesh::selectField(*wallDistPhi_);
 
   nalu_ngp::run_entity_algorithm(
+    "compute_wall_dist",
     ngpMesh, stk::topology::NODE_RANK, sel, KOKKOS_LAMBDA(const MeshIndex& mi) {
       double dpdxsq = 0.0;
 

--- a/src/master_element/Hex27CVFEM.C
+++ b/src/master_element/Hex27CVFEM.C
@@ -1491,7 +1491,8 @@ void Hex27SCS::face_grad_op(
 void Hex27SCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
   using traits = AlgTraitsQuad9Hex27;
   const int offset = traits::numFaceIp_ * face_ordinal;

--- a/src/master_element/Hex8CVFEM.C
+++ b/src/master_element/Hex8CVFEM.C
@@ -398,19 +398,15 @@ void HexSCS::shifted_grad_op(
 //--------------------------------------------------------------------------
 //-------- face_grad_op ----------------------------------------------------
 //--------------------------------------------------------------------------
-void HexSCS::face_grad_op(
+template<bool shifted>
+void HexSCS::face_grad_op_t(
   const int face_ordinal,
-  const bool shifted,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using traits = AlgTraitsQuad4Hex8;
   const double *exp_face = shifted ? &intgExpFaceShift_[0][0][0] : &intgExpFace_[0][0][0];
-
-  constexpr int derivSize = traits::numFaceIp_ * traits::nodesPerElement_ * traits::nDim_;
-  DoubleType psi[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, traits::numFaceIp_, traits::nodesPerElement_, traits::nDim_);
-
   const int offset = traits::numFaceIp_ * traits::nDim_ * face_ordinal;
   hex8_derivative(traits::numFaceIp_, &exp_face[offset], deriv);
   generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
@@ -419,10 +415,10 @@ void HexSCS::face_grad_op(
 void HexSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
-  constexpr bool shifted = false;
-  face_grad_op(face_ordinal, shifted, coords, gradop);
+  face_grad_op_t<false>(face_ordinal, coords, gradop, deriv);
 }
 
 void HexSCS::face_grad_op(
@@ -467,10 +463,10 @@ void HexSCS::face_grad_op(
 void HexSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
-  constexpr bool shifted = true;
-  face_grad_op(face_ordinal, shifted, coords, gradop);
+  face_grad_op_t<true>(face_ordinal, coords, gradop, deriv);
 }
 
 void HexSCS::shifted_face_grad_op(

--- a/src/master_element/HexPCVFEM.C
+++ b/src/master_element/HexPCVFEM.C
@@ -874,7 +874,8 @@ template <int p> void internal_face_grad_op(
 void HigherOrderHexSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
   switch(nodes1D_ - 1) {
     case 2: return internal_face_grad_op<2>(face_ordinal, expRefGradWeights_, coords, gradop);
@@ -888,6 +889,7 @@ void HigherOrderHexSCS::face_grad_op(
 void HigherOrderHexSCS::face_grad_op(
   int ,
   SharedMemView<DoubleType**, DeviceShmem>& ,
+  SharedMemView<DoubleType***, DeviceShmem>&,
   SharedMemView<DoubleType***, DeviceShmem>& )
 {}
 #endif

--- a/src/master_element/Pyr5CVFEM.C
+++ b/src/master_element/Pyr5CVFEM.C
@@ -892,17 +892,14 @@ void PyrSCS::face_grad_op(
 void PyrSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using tri_traits = AlgTraitsTri3Wed6;
   using quad_traits = AlgTraitsQuad4Wed6;
   constexpr int dim = 3;
 
-  constexpr int maxDerivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * dim;
-  NALU_ALIGNED DoubleType psi[maxDerivSize];
-
   const int numFaceIps = (face_ordinal == 4) ? quad_traits::numFaceIp_ : tri_traits::numFaceIp_;
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, numFaceIps, AlgTraitsPyr5::nodesPerElement_, dim);
 
   const int offset = tri_traits::numFaceIp_ * face_ordinal;
   pyr_deriv(numFaceIps, &intgExpFace_[dim * offset], deriv);
@@ -915,17 +912,14 @@ void PyrSCS::face_grad_op(
 void PyrSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using tri_traits = AlgTraitsTri3Wed6;
   using quad_traits = AlgTraitsQuad4Wed6;
   constexpr int dim = 3;
 
-  constexpr int maxDerivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * dim;
-  NALU_ALIGNED DoubleType psi[maxDerivSize];
-
   const int numFaceIps = (face_ordinal == 4) ? quad_traits::numFaceIp_ : tri_traits::numFaceIp_;
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, numFaceIps, AlgTraitsPyr5::nodesPerElement_, dim);
 
   const int offset = tri_traits::numFaceIp_ * face_ordinal;
   shifted_pyr_deriv(numFaceIps, &intgExpFaceShift_[dim * offset], deriv);

--- a/src/master_element/Quad42DCVFEM.C
+++ b/src/master_element/Quad42DCVFEM.C
@@ -544,13 +544,10 @@ void Quad42DSCS::face_grad_op(
   const int face_ordinal,
   const bool shifted,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using traits = AlgTraitsEdge2DQuad42D;
-
-  constexpr int derivSize = traits::numFaceIp_ * traits::nodesPerElement_ * traits::nDim_;
-  DoubleType psi[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, traits::numFaceIp_, traits::nodesPerElement_, traits::nDim_);
   const double *exp_face = shifted ? intgExpFaceShift_[face_ordinal][0]: intgExpFace_[face_ordinal][0];
   quad_derivative(exp_face, deriv);
   generic_grad_op<traits>(deriv, coords, gradop);
@@ -559,10 +556,11 @@ void Quad42DSCS::face_grad_op(
 void Quad42DSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   constexpr bool shifted = false;
-  face_grad_op(face_ordinal, shifted, coords, gradop);
+  face_grad_op(face_ordinal, shifted, coords, gradop, deriv);
 }
 
 void Quad42DSCS::face_grad_op(
@@ -607,10 +605,11 @@ void Quad42DSCS::face_grad_op(
 void Quad42DSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   constexpr bool shifted = true;
-  face_grad_op(face_ordinal, shifted, coords, gradop);
+  face_grad_op(face_ordinal, shifted, coords, gradop, deriv);
 }
 
 void Quad42DSCS::shifted_face_grad_op(

--- a/src/master_element/Quad92DCVFEM.C
+++ b/src/master_element/Quad92DCVFEM.C
@@ -1119,13 +1119,11 @@ void Quad92DSCS::shifted_grad_op(
 void Quad92DSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using traits = AlgTraitsEdge32DQuad92D;
 
-  constexpr int derivSize = traits::numFaceIp_ * traits::nodesPerElement_ * traits::nDim_;
-  DoubleType psi[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, traits::numFaceIp_, traits::nodesPerElement_, traits::nDim_);
   constexpr int offset = traits::nDim_*traits::numFaceIp_*traits::nodesPerElement_;
   const double* exp_face = &expFaceShapeDerivs_[offset*face_ordinal];
   for (int i=0,n=0; i<traits::numFaceIp_; ++i)

--- a/src/master_element/Tet4CVFEM.C
+++ b/src/master_element/Tet4CVFEM.C
@@ -602,17 +602,10 @@ void TetSCS::face_grad_op(
 void TetSCS::face_grad_op(
   int /*face_ordinal*/,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
-  using traits = AlgTraitsTri3Tet4;
-
-  // one ip at a time
-  constexpr int derivSize = traits::numFaceIp_ *  traits::nodesPerElement_ * traits::nDim_;
-
-  DoubleType wderiv[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(wderiv,traits::numFaceIp_, traits::nodesPerElement_,  traits::nDim_);
   tet_deriv(deriv);
-
   generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
 }
 
@@ -622,10 +615,11 @@ void TetSCS::face_grad_op(
 void TetSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   // no difference for regular face_grad_op
-  face_grad_op(face_ordinal, coords, gradop);
+  face_grad_op(face_ordinal, coords, gradop, deriv);
 }
 
 void TetSCS::shifted_face_grad_op(

--- a/src/master_element/Tri32DCVFEM.C
+++ b/src/master_element/Tri32DCVFEM.C
@@ -568,13 +568,10 @@ void Tri32DSCS::shifted_grad_op(
 void Tri32DSCS::face_grad_op(
   int /*face_ordinal*/,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using traits = AlgTraitsEdge2DTri32D;
-
-  constexpr int derivSize = traits::numFaceIp_ * traits::nodesPerElement_ * traits::nDim_;
-  DoubleType psi[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, traits::numFaceIp_, traits::nodesPerElement_, traits::nDim_);
   tri_derivative(deriv);
   generic_grad_op<AlgTraitsEdge2DTri32D>(deriv, coords, gradop);
 }
@@ -627,10 +624,11 @@ void Tri32DSCS::face_grad_op(
 void Tri32DSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   // same as regular face_grad_op
-  face_grad_op(face_ordinal, coords, gradop);
+  face_grad_op(face_ordinal, coords, gradop, deriv);
 }
 
 void Tri32DSCS::shifted_face_grad_op(

--- a/src/master_element/Wed6CVFEM.C
+++ b/src/master_element/Wed6CVFEM.C
@@ -676,17 +676,13 @@ WedSCS::face_grad_op(
 void WedSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using tri_traits = AlgTraitsTri3Wed6;
   using quad_traits = AlgTraitsQuad4Wed6;
   constexpr int dim = 3;
-
-  constexpr int maxDerivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * dim;
-  NALU_ALIGNED DoubleType psi[maxDerivSize];
   const int numFaceIps = (face_ordinal < 3) ? quad_traits::numFaceIp_ : tri_traits::numFaceIp_;
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, numFaceIps, AlgTraitsWed6::nodesPerElement_, dim);
-
   const int offset = quad_traits::numFaceIp_ * face_ordinal;
   wed_deriv(numFaceIps, &intgExpFace_[dim * offset], deriv);
   generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
@@ -697,17 +693,13 @@ void WedSCS::face_grad_op(
 void WedSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using tri_traits = AlgTraitsTri3Wed6;
   using quad_traits = AlgTraitsQuad4Wed6;
   constexpr int dim = 3;
-
-  constexpr int maxDerivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * dim;
-  NALU_ALIGNED DoubleType psi[maxDerivSize];
   const int numFaceIps = (face_ordinal < 3) ? quad_traits::numFaceIp_ : tri_traits::numFaceIp_;
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, numFaceIps, AlgTraitsWed6::nodesPerElement_, dim);
-
   const int offset = sideOffset_[face_ordinal];
   wed_deriv(numFaceIps, &intgExpFaceShift_[dim * offset], deriv);
   generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -196,8 +196,9 @@ void ABLWallFrictionVelAlg<BcAlgTraits>::execute()
   nalu_ngp::ArraySimdDouble2 utauSum(0.0);
   Kokkos::Sum<nalu_ngp::ArraySimdDouble2> utauReducer(utauSum);
 
+  const std::string algName = "ABLWallFrictionVelAlg_" + std::to_string(BcAlgTraits::topo_);
   nalu_ngp::run_elem_par_reduce(
-    meshInfo, realm_.meta_data().side_rank(), faceData_, sel,
+    algName, meshInfo, realm_.meta_data().side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdData& edata, nalu_ngp::ArraySimdDouble2& uSum) {
       // Unit normal vector
       NALU_ALIGNED DoubleType nx[BcAlgTraits::nDim_];

--- a/src/ngp_algorithms/EffDiffFluxCoeffAlg.C
+++ b/src/ngp_algorithms/EffDiffFluxCoeffAlg.C
@@ -59,6 +59,7 @@ EffDiffFluxCoeffAlg::execute()
 
   if (isTurbulent_) {
     nalu_ngp::run_entity_algorithm(
+      "EffDiffFluxCoeffAlg_turbulent",
       ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const Traits::MeshIndex& meshIdx) {
         evisc.get(meshIdx, 0) = (
@@ -67,6 +68,7 @@ EffDiffFluxCoeffAlg::execute()
       });
   } else {
     nalu_ngp::run_entity_algorithm(
+      "EffDiffFluxCoeffAlg_laminar",
       ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const Traits::MeshIndex& meshIdx) {
         evisc.get(meshIdx, 0) = visc.get(meshIdx, 0) * invSigmaLam;

--- a/src/ngp_algorithms/EffSSTDiffFluxCoeffAlg.C
+++ b/src/ngp_algorithms/EffSSTDiffFluxCoeffAlg.C
@@ -57,6 +57,7 @@ EffSSTDiffFluxCoeffAlg::execute()
   const DblType sigmaTwo = sigmaTwo_;
 
   nalu_ngp::run_entity_algorithm(
+    "EffSSTDiffFluxCoeffAlg",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const Traits::MeshIndex& meshIdx) {
       const DblType blendedConstant = fOneBlend.get(meshIdx, 0)*sigmaOne + (1.0-fOneBlend.get(meshIdx, 0))*sigmaTwo;

--- a/src/ngp_algorithms/EnthalpyEffDiffFluxCoeffAlg.C
+++ b/src/ngp_algorithms/EnthalpyEffDiffFluxCoeffAlg.C
@@ -61,6 +61,7 @@ EnthalpyEffDiffFluxCoeffAlg::execute()
   if (isTurbulent_) {
     const auto tvisc = fieldMgr.get_field<double>(tvisc_);
     nalu_ngp::run_entity_algorithm(
+      "EnthalpyEffDiffFluxCoeffAlg_turbulent",
       ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const Traits::MeshIndex& meshIdx) {
         evisc.get(meshIdx, 0) = (
@@ -69,6 +70,7 @@ EnthalpyEffDiffFluxCoeffAlg::execute()
       });
   } else {
     nalu_ngp::run_entity_algorithm(
+      "EnthalpyEffDiffFluxCoeffAlg_laminar",
       ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const Traits::MeshIndex& meshIdx) {
         evisc.get(meshIdx, 0) = (

--- a/src/ngp_algorithms/GeometryAlgDriver.C
+++ b/src/ngp_algorithms/GeometryAlgDriver.C
@@ -132,6 +132,7 @@ void GeometryAlgDriver::post_work()
     auto warea = fieldMgr.template get_field<double>(wallArea);
 
     sierra::nalu::nalu_ngp::run_entity_algorithm(
+      "GeometryAlgDriver_wdist_normalize",
       ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const MeshIndex& mi) {
         wdist.get(mi, 0) /= warea.get(mi, 0);

--- a/src/ngp_algorithms/GeometryBoundaryAlg.C
+++ b/src/ngp_algorithms/GeometryBoundaryAlg.C
@@ -52,8 +52,9 @@ void GeometryBoundaryAlg<AlgTraits>::execute()
   const stk::mesh::Selector sel = meta.locally_owned_part()
     & stk::mesh::selectUnion(partVec_);
 
+  const std::string algName = "GeometryBoundaryAlg_" + std::to_string(AlgTraits::topo_);
   sierra::nalu::nalu_ngp::run_elem_algorithm(
-    meshInfo, meta.side_rank(), dataNeeded_, sel,
+    algName, meshInfo, meta.side_rank(), dataNeeded_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata) {
       auto& scrViews = edata.simdScrView;
       const auto& meViews = scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -75,8 +75,9 @@ void GeometryInteriorAlg<AlgTraits>::impl_compute_dual_nodal_volume()
     & stk::mesh::selectUnion(partVec_)
     & !(realm_.get_inactive_selector());
 
+  const std::string algName = "compute_dnv_" + std::to_string(AlgTraits::topo_);
   nalu_ngp::run_elem_algorithm(
-    meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
+    algName, meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType& edata){
       const int* ipNodeMap = meSCV->ipNodeMap();
       auto& scrView = edata.simdScrView;
@@ -110,8 +111,9 @@ void GeometryInteriorAlg<AlgTraits>::impl_compute_edge_area_vector()
     & stk::mesh::selectUnion(partVec_)
     & !(realm_.get_inactive_selector());
 
+  const std::string algName = "compute_edge_areav_" + std::to_string(AlgTraits::topo_);
   nalu_ngp::run_elem_algorithm(
-    meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
+    algName, meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType& edata) {
       const int* lrscv = meSCS->adjacentNodes();
       const int* scsIpEdgeMap = meSCS->scsIpEdgeOrd();

--- a/src/ngp_algorithms/MdotEdgeAlg.C
+++ b/src/ngp_algorithms/MdotEdgeAlg.C
@@ -65,6 +65,7 @@ MdotEdgeAlg::execute()
     & !(realm_.get_inactive_selector());
 
   nalu_ngp::run_edge_algorithm(
+    "compute_mdot_edge_interior",
     ngpMesh, sel,
     KOKKOS_LAMBDA(const EntityInfoType& einfo) {
       NALU_ALIGNED DblType av[NDimMax];

--- a/src/ngp_algorithms/NodalGradBndryElemAlg.C
+++ b/src/ngp_algorithms/NodalGradBndryElemAlg.C
@@ -76,8 +76,10 @@ void NodalGradBndryElemAlg<AlgTraits, PhiType, GradPhiType>::execute()
   const stk::mesh::Selector sel = meta.locally_owned_part()
     & stk::mesh::selectUnion(partVec_);
 
+  const std::string algName =
+    (meta.get_fields()[gradPhi_]->name() + "_bndry_" + std::to_string(AlgTraits::topo_));
   nalu_ngp::run_elem_algorithm(
-    meshInfo, meta.side_rank(), dataNeeded_, sel,
+    algName, meshInfo, meta.side_rank(), dataNeeded_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType& edata) {
       const int* ipNodeMap = meFC->ipNodeMap();
 

--- a/src/ngp_algorithms/NodalGradEdgeAlg.C
+++ b/src/ngp_algorithms/NodalGradEdgeAlg.C
@@ -55,8 +55,9 @@ void NodalGradEdgeAlg<PhiType, GradPhiType>::execute()
   const int dim1 = dim1_;
   const int dim2 = dim2_;
 
+  const std::string algName = meta.get_fields()[gradPhi_]->name() + "_edge";
   nalu_ngp::run_edge_algorithm(
-    ngpMesh, sel,
+    algName, ngpMesh, sel,
     KOKKOS_LAMBDA(const EntityInfoType& einfo) {
       NALU_ALIGNED DblType av[NDimMax];
 

--- a/src/ngp_algorithms/NodalGradElemAlg.C
+++ b/src/ngp_algorithms/NodalGradElemAlg.C
@@ -73,8 +73,10 @@ void NodalGradElemAlg<AlgTraits, PhiType, GradPhiType>::execute()
     & stk::mesh::selectUnion(partVec_)
     & !(realm_.get_inactive_selector());
 
+  const std::string algName =
+    (meta.get_fields()[gradPhi_]->name() + "_elem_" + std::to_string(AlgTraits::topo_));
   nalu_ngp::run_elem_algorithm(
-    meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
+    algName, meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType& edata) {
       const int* lrscv = meSCS->adjacentNodes();
 

--- a/src/ngp_algorithms/SDRLowReWallAlg.C
+++ b/src/ngp_algorithms/SDRLowReWallAlg.C
@@ -87,8 +87,12 @@ void SDRLowReWallAlg<BcAlgTraits>::execute()
   const stk::mesh::Selector sel = meta.locally_owned_part()
     & stk::mesh::selectUnion(partVec_);
 
+  const std::string algName = "SDRLowReWallAlg_" +
+                              std::to_string(BcAlgTraits::faceTopo_) + "_" +
+                              std::to_string(BcAlgTraits::elemTopo_);
+
   nalu_ngp::run_face_elem_algorithm(
-    meshInfo, faceData_, elemData_, sel,
+    algName, meshInfo, faceData_, elemData_, sel,
     KOKKOS_LAMBDA(SimdDataType& fdata) {
       auto& v_coord = fdata.simdElemView.get_scratch_view_2D(coordsID);
       auto& v_density = fdata.simdFaceView.get_scratch_view_1D(densityID);

--- a/src/ngp_algorithms/SDRWallFuncAlg.C
+++ b/src/ngp_algorithms/SDRWallFuncAlg.C
@@ -82,8 +82,12 @@ void SDRWallFuncAlg<BcAlgTraits>::execute()
   const stk::mesh::Selector sel = meta.locally_owned_part()
     & stk::mesh::selectUnion(partVec_);
 
+  const std::string algName = "SDRWallFuncAlg_" +
+    std::to_string(BcAlgTraits::faceTopo_) + "_" +
+    std::to_string(BcAlgTraits::elemTopo_);
+
   nalu_ngp::run_face_elem_algorithm(
-    meshInfo, faceData_, elemData_, sel,
+    algName, meshInfo, faceData_, elemData_, sel,
     KOKKOS_LAMBDA(SimdDataType& fdata) {
       auto& v_coord = fdata.simdElemView.get_scratch_view_2D(coordsID);
       auto& v_area = fdata.simdFaceView.get_scratch_view_2D(exposedAreaVecID);

--- a/src/ngp_algorithms/SDRWallFuncAlgDriver.C
+++ b/src/ngp_algorithms/SDRWallFuncAlgDriver.C
@@ -80,6 +80,7 @@ void SDRWallFuncAlgDriver::post_work()
     stk::mesh::selectField(*bcsdrF);
 
   nalu_ngp::run_entity_algorithm(
+    "SDRWallFuncAlgDriver_normalize",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       const double warea = wallArea.get(mi, 0);

--- a/src/ngp_algorithms/TKEWallFuncAlg.C
+++ b/src/ngp_algorithms/TKEWallFuncAlg.C
@@ -69,8 +69,9 @@ void TKEWallFuncAlg<BcAlgTraits>::execute()
   const stk::mesh::Selector sel = realm_.meta_data().locally_owned_part()
     & stk::mesh::selectUnion(partVec_);
 
+  const std::string algName = "TKEWallFuncAlg_" + std::to_string(BcAlgTraits::topo_);
   nalu_ngp::run_elem_algorithm(
-    meshInfo, realm_.meta_data().side_rank(), faceData_, sel,
+    algName, meshInfo, realm_.meta_data().side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdData& edata) {
 
       auto& scrViews = edata.simdScrView;

--- a/src/ngp_algorithms/TKEWallFuncAlgDriver.C
+++ b/src/ngp_algorithms/TKEWallFuncAlgDriver.C
@@ -73,6 +73,7 @@ void TKEWallFuncAlgDriver::post_work()
       stk::topology::NODE_RANK, "wall_model_tke_bc"));
 
   nalu_ngp::run_entity_algorithm(
+    "TKEWallFuncAlgDriver_normalize",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       const double warea = ngpWallArea.get(mi, 0);

--- a/src/ngp_algorithms/TurbViscKsgsAlg.C
+++ b/src/ngp_algorithms/TurbViscKsgsAlg.C
@@ -52,6 +52,7 @@ TurbViscKsgsAlg::execute()
   const DblType invNdim = 1.0 / meta.spatial_dimension();
 
   nalu_ngp::run_entity_algorithm(
+    "TurbViscKsgsAlg",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const Traits::MeshIndex& meshIdx) {
       const DblType filter = std::pow(dualNodalVolume.get(meshIdx, 0), invNdim);

--- a/src/ngp_algorithms/TurbViscSSTAlg.C
+++ b/src/ngp_algorithms/TurbViscSSTAlg.C
@@ -60,6 +60,7 @@ TurbViscSSTAlg::execute()
   const int nDim = meta.spatial_dimension();
 
   nalu_ngp::run_entity_algorithm(
+    "TurbViscSSTAlg",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const Traits::MeshIndex& meshIdx) {
       DblType sijMag = 0.0;

--- a/src/ngp_algorithms/WallFuncGeometryAlg.C
+++ b/src/ngp_algorithms/WallFuncGeometryAlg.C
@@ -80,8 +80,12 @@ void WallFuncGeometryAlg<BcAlgTraits>::execute()
   auto* meSCS = meSCS_;
   auto* meFC = meFC_;
 
+  const std::string algName = "WallFuncGeometryAlg_" +
+    std::to_string(BcAlgTraits::faceTopo_) + "_" +
+    std::to_string(BcAlgTraits::elemTopo_);
+
   nalu_ngp::run_face_elem_algorithm(
-    meshInfo, faceData_, elemData_, sel,
+    algName, meshInfo, faceData_, elemData_, sel,
     KOKKOS_LAMBDA(SimdDataType& fdata) {
       auto& v_coord = fdata.simdElemView.get_scratch_view_2D(coordsID);
       auto& v_area = fdata.simdFaceView.get_scratch_view_2D(exposedAreaVecID);

--- a/src/wind_energy/BdyLayerStatistics.C
+++ b/src/wind_energy/BdyLayerStatistics.C
@@ -374,6 +374,7 @@ BdyLayerStatistics::impl_compute_velocity_stats()
 
   const int ndim = nDim_;
   nalu_ngp::run_entity_algorithm(
+    "BLStats::velocity",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       const int ih = heightIndex.get(mi, 0);
@@ -512,6 +513,7 @@ BdyLayerStatistics::impl_compute_temperature_stats()
 
   const int ndim = nDim_;
   nalu_ngp::run_entity_algorithm(
+    "BLStats::temperature",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       const int ih = heightIndex.get(mi, 0);

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -642,6 +642,7 @@ void calc_mass_flow_rate_scs(
     ngpMesh, ngpMdot);
 
   sierra::nalu::nalu_ngp::run_elem_algorithm(
+    "unittest_calc_mdot_scs",
     meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdData& edata) {
       NALU_ALIGNED Traits::DblType rhoU[Hex8Traits::nDim_];
@@ -722,6 +723,7 @@ void calc_open_mass_flow_rate(
     ngpMesh, ngpMdot);
 
   sierra::nalu::nalu_ngp::run_elem_algorithm(
+    "unittest_calc_open_mdot",
     meshInfo, meta.side_rank(), dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdDataType& edata) {
       NALU_ALIGNED Traits::DblType rhoU[Quad4Traits::nDim_];
@@ -865,6 +867,7 @@ void calc_exposed_area_vec(
     ngpMesh, areaVec);
 
   sierra::nalu::nalu_ngp::run_elem_algorithm(
+    "unittest_calc_exposed_area_vec",
     meshInfo, meta.side_rank(), dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata) {
       auto& scrViews = edata.simdScrView;
@@ -1018,6 +1021,7 @@ void calc_projected_nodal_gradient_interior(
 
 
   sierra::nalu::nalu_ngp::run_elem_algorithm(
+    "unittest_calc_png_interior",
     meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdDataType& edata) {
       const int* lrscv = meSCS->adjacentNodes();

--- a/unit_tests/ngp_algorithms/UnitTestNgpAlgUtils.C
+++ b/unit_tests/ngp_algorithms/UnitTestNgpAlgUtils.C
@@ -28,6 +28,7 @@ linear_scalar_field(
   const stk::mesh::Selector sel = bulk.mesh_meta_data().universal_part();
 
   sierra::nalu::nalu_ngp::run_entity_algorithm(
+    "unittest_linear_scalar_field",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const typename Traits::MeshIndex& meshIdx) {
       ngpField.get(meshIdx, 0) =
@@ -57,6 +58,7 @@ linear_scalar_field(
   const stk::mesh::Selector sel = bulk.mesh_meta_data().universal_part();
 
   sierra::nalu::nalu_ngp::run_entity_algorithm(
+    "unittest_linear_vector_field",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const typename Traits::MeshIndex& meshIdx) {
       ngpField.get(meshIdx, 0) = coords.get(meshIdx, 0) * xCoeff;

--- a/unit_tests/ngp_algorithms/UnitTestSDRWallAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestSDRWallAlg.C
@@ -107,7 +107,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_func)
     sierra::nalu::WALL, surfPart,
     sierra::nalu::get_elem_topo(helperObjs.realm, *surfPart),
     "sdr_lowre_wall");
-
+   
   algDriver.execute();
 
   {

--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -81,6 +81,7 @@ void basic_node_loop(
   ngp::Field<double> ngpPressure(bulk, pressure);
 
   sierra::nalu::nalu_ngp::run_entity_algorithm(
+    "unittest_basic_node_loop",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const typename Traits::MeshIndex& meshIdx) {
       ngpPressure.get(meshIdx, 0) = presSet;
@@ -118,6 +119,7 @@ void basic_node_reduce(
 
   double reduceVal = 0.0;
   sierra::nalu::nalu_ngp::run_entity_par_reduce(
+    "unittest_basic_node_reduce1",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const typename Traits::MeshIndex& mi, double& pSum) {
       pSum += ngpPressure.get(mi, 0);
@@ -126,6 +128,7 @@ void basic_node_reduce(
   double reduceVal1 = 0.0;
   Kokkos::Sum<double> sum_reducer(reduceVal1);
   sierra::nalu::nalu_ngp::run_entity_par_reduce(
+    "unittest_basic_node_reduce2",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const typename Traits::MeshIndex& mi, double& pSum) {
       sum_reducer.join(pSum, ngpPressure.get(mi, 0));
@@ -163,6 +166,7 @@ void basic_node_reduce_minmax(
   value_type max;
   Kokkos::Max<double> max_reducer(max);
   sierra::nalu::nalu_ngp::run_entity_par_reduce(
+    "unittest_basic_node_reduce_max",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const typename Traits::MeshIndex& mi, value_type& pSum) {
       const double xcoord = ngpCoords.get(mi, 0);
@@ -173,6 +177,7 @@ void basic_node_reduce_minmax(
   value_type min;
   Kokkos::Min<double> min_reducer(min);
   sierra::nalu::nalu_ngp::run_entity_par_reduce(
+    "unittest_basic_node_reduce_min",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const typename Traits::MeshIndex& mi, value_type& pSum) {
       const double xcoord = ngpCoords.get(mi, 0);
@@ -200,6 +205,7 @@ void basic_elem_loop(
   stk::mesh::Selector sel = meta.universal_part();
 
   sierra::nalu::nalu_ngp::run_elem_algorithm(
+    "unittest_basic_elem_loop",
     ngpMesh, stk::topology::ELEMENT_RANK, sel,
     KOKKOS_LAMBDA(const sierra::nalu::nalu_ngp::EntityInfo<ngp::Mesh>& einfo) {
       ngpMassFlowRate.get(einfo.meshIdx, 0) = flowRate;
@@ -254,6 +260,7 @@ void basic_edge_loop(
   stk::mesh::Selector sel = meta.universal_part();
 
   sierra::nalu::nalu_ngp::run_edge_algorithm(
+    "unittest_basic_edge_loop",
     ngpMesh, sel,
     KOKKOS_LAMBDA(const sierra::nalu::nalu_ngp::EntityInfo<ngp::Mesh>& einfo) {
       ngpMassFlowRate.get(einfo.meshIdx, 0) = flowRate;
@@ -336,6 +343,7 @@ void elem_loop_scratch_views(
   volCheck.template sync<typename DoubleTypeView::execution_space>();
 
   sierra::nalu::nalu_ngp::run_elem_algorithm(
+    "unittest_elem_loop_scratchviews",
     meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdData & edata) {
       Traits::DblType test = 0.0;
@@ -425,6 +433,7 @@ void calc_mdot_elem_loop(
     ngpMesh, ngpMdot);
 
   sierra::nalu::nalu_ngp::run_elem_algorithm(
+    "unittest_calc_mdot_elem_loop",
     meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdData& edata) {
       NALU_ALIGNED Traits::DblType rhoU[Hex8Traits::nDim_];
@@ -521,6 +530,7 @@ void basic_face_elem_loop(
     ngpMesh, wDist);
 
   sierra::nalu::nalu_ngp::run_face_elem_algorithm(
+    "unittest_basic_face_elem_loop",
     meshInfo, faceData, elemData, sel,
     KOKKOS_LAMBDA(FaceSimdData& fdata) {
 
@@ -552,6 +562,7 @@ void basic_face_elem_loop(
     });
 
   sierra::nalu::nalu_ngp::run_entity_algorithm(
+    "unittest_basic_face_elem_nodal",
     ngpMesh, stk::topology::NODE_RANK, sel,
     KOKKOS_LAMBDA(const MeshIndex& mi) {
       wDist.get(mi, 0) /= wArea.get(mi, 0);
@@ -609,6 +620,7 @@ void elem_loop_par_reduce(
   Kokkos::Sum<DoubleType> pressureReducer(pressureSum);
 
   sierra::nalu::nalu_ngp::run_elem_par_reduce(
+    "unittest_elem_loop_par_reduce",
     meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdData& edata, DoubleType& pSum) {
       auto& scrViews = edata.simdScrView;


### PR DESCRIPTION
This reverts commit d4706afdc5c01aaa86853d82ba5dd1cb498bc2ac.

It was thought that the original commit broke the regression
tests but the cause was traced to something else.

Setting the stack size to something larger than the default
seems to be necessary but the size needed is hard to determine.
Too small and the runs seg fault, too large and the GPU will run
out of memory.