### PR TITLE
Revert 98bc2ac and update master elements.

### DIFF
--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -681,15 +681,8 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
   MasterElement*,
   MasterElement* meSCS,
   MasterElement* meSCV,
-  MasterElement*
-#ifndef KOKKOS_ENABLE_CUDA
-      meFEM
-#endif
-  ,
-  int
-#ifndef KOKKOS_ENABLE_CUDA
-     faceOrdinal
-#endif
+  MasterElement* meFEM,
+  int faceOrdinal
   )
 {
   for(unsigned i=0; i<dataEnums.size(); ++i) {
@@ -703,18 +696,16 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_AREAV requested.");
          meSCS->determinant(*coordsView, scs_areav);
          break;
-#ifndef KOKKOS_ENABLE_CUDA
       case SCS_FACE_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_FACE_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_FACE_GRAD_OP requested.");
-         meSCS->face_grad_op(faceOrdinal, *coordsView, dndx_fc_scs);
+         meSCS->face_grad_op(faceOrdinal, *coordsView, dndx_fc_scs, deriv_fc_scs);
        break;
       case SCS_SHIFTED_FACE_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_SHIFTED_FACE_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_SHIFTED_FACE_GRAD_OP requested.");
-         meSCS->shifted_face_grad_op(faceOrdinal, *coordsView, dndx_shifted_fc_scs);
+         meSCS->shifted_face_grad_op(faceOrdinal, *coordsView, dndx_shifted_fc_scs, deriv_fc_scs);
        break;
-#endif
       case SCS_GRAD_OP:
          NGP_ThrowRequireMsg(meSCS != nullptr, "ERROR, meSCS needs to be non-null if SCS_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCS_GRAD_OP requested.");
@@ -755,7 +746,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
         NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but SCV_SHIFTED_GRAD_OP requested.");
         meSCV->shifted_grad_op(*coordsView, dndx_scv_shifted, deriv_scv);
         break;
-#ifndef KOKKOS_ENABLE_CUDA
       case FEM_GRAD_OP:
          NGP_ThrowRequireMsg(meFEM != nullptr, "ERROR, meFEM needs to be non-null if FEM_GRAD_OP is requested.");
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
@@ -766,7 +756,6 @@ void MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_master_element_views_new
          NGP_ThrowRequireMsg(coordsView != nullptr, "ERROR, coords null but FEM_GRAD_OP requested.");
          meFEM->shifted_grad_op_fem(*coordsView, dndx_fem, deriv_fem, det_j_fem);
          break;
-#endif
 
       default: break;
     }

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -52,6 +52,9 @@ public:
 
   static bool debug_;
   int serializedIOGroupSize_;
+private:
+  size_t    default_stack_size;
+  const size_t nalu_stack_size=16384;
 };
 
 } // namespace nalu

--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -367,7 +367,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void Mij(
     SharedMemView<DoubleType**, DeviceShmem>& coords,

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -211,12 +211,14 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void shifted_grad_op(
     SharedMemView<DoubleType**, DeviceShmem>&coords,
@@ -497,11 +499,12 @@ private:
 
 private :
 
-  KOKKOS_FUNCTION void face_grad_op(
+  template<bool shifted>
+  KOKKOS_FUNCTION void face_grad_op_t(
     const int face_ordinal,
-    const bool shifted,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop);
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv);
 };
     
 //-------- hex8_derivative -------------------------------------------------

--- a/include/master_element/HexPCVFEM.h
+++ b/include/master_element/HexPCVFEM.h
@@ -160,7 +160,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   virtual const double* integration_locations() const final {
     return intgLoc_.data();

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -75,14 +75,16 @@ public:
   KOKKOS_FUNCTION virtual void face_grad_op(
     int /* face_ordinal */,
     SharedMemView<DoubleType**, DeviceShmem>& /* coords */,
-    SharedMemView<DoubleType***, DeviceShmem>& /* gradop */) {
+    SharedMemView<DoubleType***, DeviceShmem>& /* gradop */,
+    SharedMemView<DoubleType***, DeviceShmem>& /* deriv */) {
     NGP_ThrowErrorMsg("MasterElement::face_grad_op not implemented for element");
   }
 
   KOKKOS_FUNCTION virtual void shifted_face_grad_op(
     int /* face_ordinal */,
     SharedMemView<DoubleType**, DeviceShmem>& /* coords */,
-    SharedMemView<DoubleType***, DeviceShmem>& /* gradop */) {
+    SharedMemView<DoubleType***, DeviceShmem>& /* gradop */,
+    SharedMemView<DoubleType***, DeviceShmem>& /* deriv */) {
     NGP_ThrowErrorMsg("MasterElement::shifted_face_grad_op not implemented for element");
   }
 

--- a/include/master_element/MasterElementFunctions.h
+++ b/include/master_element/MasterElementFunctions.h
@@ -51,7 +51,9 @@ namespace nalu {
 
   template <typename AlgTraits, typename GradViewType, typename CoordViewType, typename OutputViewType>
   KOKKOS_FUNCTION
-  KOKKOS_FUNCTION void generic_grad_op(const GradViewType& referenceGradWeights, const CoordViewType& coords, OutputViewType& weights)
+  KOKKOS_FUNCTION void generic_grad_op(const GradViewType& referenceGradWeights, 
+                                       const CoordViewType& coords, 
+                                       OutputViewType& weights)
   {
     constexpr int dim = AlgTraits::nDim_;
 

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -273,7 +273,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,
@@ -286,7 +287,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void general_face_grad_op(
     const int face_ordinal,

--- a/include/master_element/Quad42DCVFEM.h
+++ b/include/master_element/Quad42DCVFEM.h
@@ -176,7 +176,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void face_grad_op(
     const int nelem,
@@ -189,7 +190,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,
@@ -355,7 +357,8 @@ private :
     const int face_ordinal,
     const bool shifted,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop);
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv);
 
   KOKKOS_FUNCTION
   void quad_shape_fcn(

--- a/include/master_element/Quad92DCVFEM.h
+++ b/include/master_element/Quad92DCVFEM.h
@@ -283,7 +283,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void face_grad_op(
     const int nelem,

--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -176,7 +176,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,
@@ -189,7 +190,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void gij(
     SharedMemView<DoubleType**, DeviceShmem>& coords,

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -181,7 +181,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void face_grad_op(
     const int nelem,
@@ -194,7 +195,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,

--- a/include/master_element/Wed6CVFEM.h
+++ b/include/master_element/Wed6CVFEM.h
@@ -185,7 +185,8 @@ public:
   KOKKOS_FUNCTION void face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   void shifted_face_grad_op(
     const int nelem,
@@ -198,7 +199,8 @@ public:
   KOKKOS_FUNCTION void shifted_face_grad_op(
     int face_ordinal,
     SharedMemView<DoubleType**, DeviceShmem>& coords,
-    SharedMemView<DoubleType***, DeviceShmem>& gradop) final;
+    SharedMemView<DoubleType***, DeviceShmem>& gradop,
+    SharedMemView<DoubleType***, DeviceShmem>& deriv) final;
 
   KOKKOS_FUNCTION void gij(
     SharedMemView<DoubleType**, DeviceShmem>& coords,

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -44,13 +44,21 @@ Simulation::Simulation(const YAML::Node& root_node) :
     transfers_(NULL),
     linearSolvers_(NULL),
     serializedIOGroupSize_(0)
-{}
+{
+#ifdef KOKKOS_ENABLE_CUDA
+  cudaDeviceGetLimit (&default_stack_size, cudaLimitStackSize);
+  cudaDeviceSetLimit (cudaLimitStackSize, nalu_stack_size);
+#endif
+}
 
 Simulation::~Simulation() {
   delete realms_;
   delete transfers_;
   delete timeIntegrator_;
   delete linearSolvers_;
+#ifdef KOKKOS_ENABLE_CUDA
+  cudaDeviceSetLimit (cudaLimitStackSize, default_stack_size);
+#endif
 }
 
 // Timers

--- a/src/master_element/Hex27CVFEM.C
+++ b/src/master_element/Hex27CVFEM.C
@@ -1491,7 +1491,8 @@ void Hex27SCS::face_grad_op(
 void Hex27SCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
   using traits = AlgTraitsQuad9Hex27;
   const int offset = traits::numFaceIp_ * face_ordinal;

--- a/src/master_element/Hex8CVFEM.C
+++ b/src/master_element/Hex8CVFEM.C
@@ -398,19 +398,15 @@ void HexSCS::shifted_grad_op(
 //--------------------------------------------------------------------------
 //-------- face_grad_op ----------------------------------------------------
 //--------------------------------------------------------------------------
-void HexSCS::face_grad_op(
+template<bool shifted>
+void HexSCS::face_grad_op_t(
   const int face_ordinal,
-  const bool shifted,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using traits = AlgTraitsQuad4Hex8;
   const double *exp_face = shifted ? &intgExpFaceShift_[0][0][0] : &intgExpFace_[0][0][0];
-
-  constexpr int derivSize = traits::numFaceIp_ * traits::nodesPerElement_ * traits::nDim_;
-  DoubleType psi[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, traits::numFaceIp_, traits::nodesPerElement_, traits::nDim_);
-
   const int offset = traits::numFaceIp_ * traits::nDim_ * face_ordinal;
   hex8_derivative(traits::numFaceIp_, &exp_face[offset], deriv);
   generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
@@ -419,10 +415,10 @@ void HexSCS::face_grad_op(
 void HexSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
-  constexpr bool shifted = false;
-  face_grad_op(face_ordinal, shifted, coords, gradop);
+  face_grad_op_t<false>(face_ordinal, coords, gradop, deriv);
 }
 
 void HexSCS::face_grad_op(
@@ -467,10 +463,10 @@ void HexSCS::face_grad_op(
 void HexSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
-  constexpr bool shifted = true;
-  face_grad_op(face_ordinal, shifted, coords, gradop);
+  face_grad_op_t<true>(face_ordinal, coords, gradop, deriv);
 }
 
 void HexSCS::shifted_face_grad_op(

--- a/src/master_element/HexPCVFEM.C
+++ b/src/master_element/HexPCVFEM.C
@@ -874,7 +874,8 @@ template <int p> void internal_face_grad_op(
 void HigherOrderHexSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
   switch(nodes1D_ - 1) {
     case 2: return internal_face_grad_op<2>(face_ordinal, expRefGradWeights_, coords, gradop);
@@ -888,6 +889,7 @@ void HigherOrderHexSCS::face_grad_op(
 void HigherOrderHexSCS::face_grad_op(
   int ,
   SharedMemView<DoubleType**, DeviceShmem>& ,
+  SharedMemView<DoubleType***, DeviceShmem>&,
   SharedMemView<DoubleType***, DeviceShmem>& )
 {}
 #endif

--- a/src/master_element/Pyr5CVFEM.C
+++ b/src/master_element/Pyr5CVFEM.C
@@ -892,17 +892,14 @@ void PyrSCS::face_grad_op(
 void PyrSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using tri_traits = AlgTraitsTri3Wed6;
   using quad_traits = AlgTraitsQuad4Wed6;
   constexpr int dim = 3;
 
-  constexpr int maxDerivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * dim;
-  NALU_ALIGNED DoubleType psi[maxDerivSize];
-
   const int numFaceIps = (face_ordinal == 4) ? quad_traits::numFaceIp_ : tri_traits::numFaceIp_;
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, numFaceIps, AlgTraitsPyr5::nodesPerElement_, dim);
 
   const int offset = tri_traits::numFaceIp_ * face_ordinal;
   pyr_deriv(numFaceIps, &intgExpFace_[dim * offset], deriv);
@@ -915,17 +912,14 @@ void PyrSCS::face_grad_op(
 void PyrSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using tri_traits = AlgTraitsTri3Wed6;
   using quad_traits = AlgTraitsQuad4Wed6;
   constexpr int dim = 3;
 
-  constexpr int maxDerivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * dim;
-  NALU_ALIGNED DoubleType psi[maxDerivSize];
-
   const int numFaceIps = (face_ordinal == 4) ? quad_traits::numFaceIp_ : tri_traits::numFaceIp_;
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, numFaceIps, AlgTraitsPyr5::nodesPerElement_, dim);
 
   const int offset = tri_traits::numFaceIp_ * face_ordinal;
   shifted_pyr_deriv(numFaceIps, &intgExpFaceShift_[dim * offset], deriv);

--- a/src/master_element/Quad42DCVFEM.C
+++ b/src/master_element/Quad42DCVFEM.C
@@ -544,13 +544,10 @@ void Quad42DSCS::face_grad_op(
   const int face_ordinal,
   const bool shifted,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using traits = AlgTraitsEdge2DQuad42D;
-
-  constexpr int derivSize = traits::numFaceIp_ * traits::nodesPerElement_ * traits::nDim_;
-  DoubleType psi[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, traits::numFaceIp_, traits::nodesPerElement_, traits::nDim_);
   const double *exp_face = shifted ? intgExpFaceShift_[face_ordinal][0]: intgExpFace_[face_ordinal][0];
   quad_derivative(exp_face, deriv);
   generic_grad_op<traits>(deriv, coords, gradop);
@@ -559,10 +556,11 @@ void Quad42DSCS::face_grad_op(
 void Quad42DSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   constexpr bool shifted = false;
-  face_grad_op(face_ordinal, shifted, coords, gradop);
+  face_grad_op(face_ordinal, shifted, coords, gradop, deriv);
 }
 
 void Quad42DSCS::face_grad_op(
@@ -607,10 +605,11 @@ void Quad42DSCS::face_grad_op(
 void Quad42DSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   constexpr bool shifted = true;
-  face_grad_op(face_ordinal, shifted, coords, gradop);
+  face_grad_op(face_ordinal, shifted, coords, gradop, deriv);
 }
 
 void Quad42DSCS::shifted_face_grad_op(

--- a/src/master_element/Quad92DCVFEM.C
+++ b/src/master_element/Quad92DCVFEM.C
@@ -1119,13 +1119,11 @@ void Quad92DSCS::shifted_grad_op(
 void Quad92DSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using traits = AlgTraitsEdge32DQuad92D;
 
-  constexpr int derivSize = traits::numFaceIp_ * traits::nodesPerElement_ * traits::nDim_;
-  DoubleType psi[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, traits::numFaceIp_, traits::nodesPerElement_, traits::nDim_);
   constexpr int offset = traits::nDim_*traits::numFaceIp_*traits::nodesPerElement_;
   const double* exp_face = &expFaceShapeDerivs_[offset*face_ordinal];
   for (int i=0,n=0; i<traits::numFaceIp_; ++i)

--- a/src/master_element/Tet4CVFEM.C
+++ b/src/master_element/Tet4CVFEM.C
@@ -602,17 +602,10 @@ void TetSCS::face_grad_op(
 void TetSCS::face_grad_op(
   int /*face_ordinal*/,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
-  using traits = AlgTraitsTri3Tet4;
-
-  // one ip at a time
-  constexpr int derivSize = traits::numFaceIp_ *  traits::nodesPerElement_ * traits::nDim_;
-
-  DoubleType wderiv[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(wderiv,traits::numFaceIp_, traits::nodesPerElement_,  traits::nDim_);
   tet_deriv(deriv);
-
   generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
 }
 
@@ -622,10 +615,11 @@ void TetSCS::face_grad_op(
 void TetSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   // no difference for regular face_grad_op
-  face_grad_op(face_ordinal, coords, gradop);
+  face_grad_op(face_ordinal, coords, gradop, deriv);
 }
 
 void TetSCS::shifted_face_grad_op(

--- a/src/master_element/Tri32DCVFEM.C
+++ b/src/master_element/Tri32DCVFEM.C
@@ -568,13 +568,10 @@ void Tri32DSCS::shifted_grad_op(
 void Tri32DSCS::face_grad_op(
   int /*face_ordinal*/,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using traits = AlgTraitsEdge2DTri32D;
-
-  constexpr int derivSize = traits::numFaceIp_ * traits::nodesPerElement_ * traits::nDim_;
-  DoubleType psi[derivSize];
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, traits::numFaceIp_, traits::nodesPerElement_, traits::nDim_);
   tri_derivative(deriv);
   generic_grad_op<AlgTraitsEdge2DTri32D>(deriv, coords, gradop);
 }
@@ -627,10 +624,11 @@ void Tri32DSCS::face_grad_op(
 void Tri32DSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   // same as regular face_grad_op
-  face_grad_op(face_ordinal, coords, gradop);
+  face_grad_op(face_ordinal, coords, gradop, deriv);
 }
 
 void Tri32DSCS::shifted_face_grad_op(

--- a/src/master_element/Wed6CVFEM.C
+++ b/src/master_element/Wed6CVFEM.C
@@ -676,17 +676,13 @@ WedSCS::face_grad_op(
 void WedSCS::face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using tri_traits = AlgTraitsTri3Wed6;
   using quad_traits = AlgTraitsQuad4Wed6;
   constexpr int dim = 3;
-
-  constexpr int maxDerivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * dim;
-  NALU_ALIGNED DoubleType psi[maxDerivSize];
   const int numFaceIps = (face_ordinal < 3) ? quad_traits::numFaceIp_ : tri_traits::numFaceIp_;
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, numFaceIps, AlgTraitsWed6::nodesPerElement_, dim);
-
   const int offset = quad_traits::numFaceIp_ * face_ordinal;
   wed_deriv(numFaceIps, &intgExpFace_[dim * offset], deriv);
   generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
@@ -697,17 +693,13 @@ void WedSCS::face_grad_op(
 void WedSCS::shifted_face_grad_op(
   int face_ordinal,
   SharedMemView<DoubleType**, DeviceShmem>& coords,
-  SharedMemView<DoubleType***, DeviceShmem>& gradop)
+  SharedMemView<DoubleType***, DeviceShmem>& gradop,
+  SharedMemView<DoubleType***, DeviceShmem>& deriv)
 {
   using tri_traits = AlgTraitsTri3Wed6;
   using quad_traits = AlgTraitsQuad4Wed6;
   constexpr int dim = 3;
-
-  constexpr int maxDerivSize = quad_traits::numFaceIp_ *  quad_traits::nodesPerElement_ * dim;
-  NALU_ALIGNED DoubleType psi[maxDerivSize];
   const int numFaceIps = (face_ordinal < 3) ? quad_traits::numFaceIp_ : tri_traits::numFaceIp_;
-  SharedMemView<DoubleType***, DeviceShmem> deriv(psi, numFaceIps, AlgTraitsWed6::nodesPerElement_, dim);
-
   const int offset = sideOffset_[face_ordinal];
   wed_deriv(numFaceIps, &intgExpFaceShift_[dim * offset], deriv);
   generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);


### PR DESCRIPTION
It was pointed out that some of the master element calls used
local scratch when it would be better to pass in a Kokkos View
to save stack space.