### PR TITLE
Check for nvcc compiler in preprocessor to avoid unreachable statement warnings

### DIFF
--- a/include/utils/LinearInterpolation.h
+++ b/include/utils/LinearInterpolation.h
@@ -114,7 +114,10 @@ linear_interp(
     switch (oob) {
     case OutOfBounds::ERROR:
       throw std::runtime_error("Out of bounds error in interpolation");
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
       break;
+#endif
 
     case OutOfBounds::WARN:
       std::cout

--- a/src/BoundaryConditions.C
+++ b/src/BoundaryConditions.C
@@ -100,7 +100,10 @@ BoundaryCondition * BoundaryCondition::load(const YAML::Node & node)
   else {
     throw std::runtime_error("parser error BoundaryConditions::load: no such bc type");
   }
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
   return 0;
+#endif
 }
 
   Simulation* BoundaryCondition::root() { return parent()->root(); }

--- a/src/InitialConditions.C
+++ b/src/InitialConditions.C
@@ -55,7 +55,10 @@ InitialCondition * InitialCondition::load(const YAML::Node & node)
   }
   else
     throw std::runtime_error("parser error InitialConditions::load; unsupported IC type");
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
   return 0;
+#endif
 }
 
   Simulation* InitialCondition::root() { return parent()->root(); }

--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -99,11 +99,17 @@ LinearSystem *LinearSystem::create(Realm& realm, const unsigned numDof, Equation
   switch(solver->getType()) {
   case PT_TPETRA:
     return new TpetraLinearSystem(realm, numDof, eqSys, solver);
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
     break;
+#endif
 
   case PT_TPETRA_SEGREGATED:
     return new TpetraSegregatedLinearSystem(realm, numDof, eqSys, solver);
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
     break;
+#endif
 
 #ifdef NALU_USES_HYPRE
   case PT_HYPRE:
@@ -120,7 +126,10 @@ LinearSystem *LinearSystem::create(Realm& realm, const unsigned numDof, Equation
   default:
     throw std::logic_error("create lin sys");
   }
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
   return 0;
+#endif
 }
 
 void LinearSystem::sync_field(const stk::mesh::FieldBase *field)

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -2139,7 +2139,10 @@ MomentumEquationSystem::register_symmetry_bc(
         }
       }
      return;
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
      break;
+#endif
    case SYMMTYPES::X_DIR_STRONG:
      pickTheType = AlgorithmType::X_SYM_STRONG;
      beginPos = 0;

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -184,13 +184,19 @@ namespace sierra
           throw std::runtime_error(
             "TIOGA TPL support not enabled during compilation phase.");
 #endif
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
           break;
+#endif
 
         case OversetBoundaryConditionData::OVERSET_NONE:
         default:
           throw std::runtime_error(
             "Invalid overset connectivity setting in input file.");
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
           break;
+#endif
       }
     }
 

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -180,13 +180,14 @@ namespace sierra
         case OversetBoundaryConditionData::TPL_TIOGA:
 #ifdef NALU_USES_TIOGA
           oversetBC.userData_.oversetBlocks_ = oversetUserData;
+          break;
 #else
           throw std::runtime_error(
             "TIOGA TPL support not enabled during compilation phase.");
-#endif
 // Avoid nvcc unreachable statement warnings
 #ifndef __CUDACC__
           break;
+#endif
 #endif
 
         case OversetBoundaryConditionData::OVERSET_NONE:

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -620,7 +620,10 @@ Realm::look_ahead_and_creation(const YAML::Node & node)
 #else
 	throw std::runtime_error("look_ahead_and_create::error: Requested actuator type: " + ActuatorTypeName + ", but was not enabled at compile time");
 #endif
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
 	break;
+#endif
       }
       case ActuatorType::ActDiskFAST : {
 #ifdef NALU_USES_OPENFAST
@@ -628,11 +631,17 @@ Realm::look_ahead_and_creation(const YAML::Node & node)
 #else
 	throw std::runtime_error("look_ahead_and_create::error: Requested actuator type: " + ActuatorTypeName + ", but was not enabled at compile time");
 #endif
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
 	break;
+#endif
       }
       default : {
         throw std::runtime_error("look_ahead_and_create::error: unrecognized actuator type: " + ActuatorTypeName);
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
         break;
+#endif
       }
       }
     }
@@ -3089,12 +3098,18 @@ Realm::setup_overset_bc(
       // should not get here... we should have thrown error in input file processing stage
       throw std::runtime_error("TIOGA TPL support not enabled during compilation phase");
 #endif
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
       break;
+#endif
 
     case OversetBoundaryConditionData::OVERSET_NONE:
     default:
       throw std::runtime_error("Invalid setting for overset connectivity");
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
       break;
+#endif
     }
   }   
 }

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -617,23 +617,25 @@ Realm::look_ahead_and_creation(const YAML::Node & node)
       case ActuatorType::ActLineFAST : {
 #ifdef NALU_USES_OPENFAST
 	actuator_ =  new ActuatorLineFAST(*this, *foundActuator[0]);
+	break;
 #else
 	throw std::runtime_error("look_ahead_and_create::error: Requested actuator type: " + ActuatorTypeName + ", but was not enabled at compile time");
-#endif
 // Avoid nvcc unreachable statement warnings
 #ifndef __CUDACC__
 	break;
+#endif
 #endif
       }
       case ActuatorType::ActDiskFAST : {
 #ifdef NALU_USES_OPENFAST
 	actuator_ =  new ActuatorDiskFAST(*this, *foundActuator[0]);
+	break;
 #else
 	throw std::runtime_error("look_ahead_and_create::error: Requested actuator type: " + ActuatorTypeName + ", but was not enabled at compile time");
-#endif
 // Avoid nvcc unreachable statement warnings
 #ifndef __CUDACC__
 	break;
+#endif
 #endif
       }
       default : {

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -2127,10 +2127,12 @@ int getDofStatus_impl(stk::mesh::Entity node, const Realm& realm)
   }
 
   // still got here? problem...
-  if (1)
-    throw std::logic_error("bad status2");
+  throw std::logic_error("bad status2");
 
+// Avoid nvcc unreachable statement warnings
+#ifndef __CUDACC__
   return DS_SkippedDOF;
+#endif
 }
 
 } // namespace nalu


### PR DESCRIPTION
This doesn't get rid of all the warnings, but should stop most of these `unreachable statement` warnings. It seems `nvcc` uses an older GCC because these warnings are deprecated in more recent versions of GCC.