### PR TITLE
Step 2 of coeff-applier cleanup.

### DIFF
--- a/include/AssembleEdgeSolverAlgorithm.h
+++ b/include/AssembleEdgeSolverAlgorithm.h
@@ -64,8 +64,7 @@ public:
     const auto entityRank = entityRank_;
     const auto rhsSize = rhsSize_;
 
-    CoeffApplier* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
-    CoeffApplier* deviceCoeffApplier = coeffApplier->device_pointer();
+    CoeffApplier* deviceCoeffApplier = eqSystem_->linsys_->get_coeff_applier();
 
     const auto nodesPerEntity = nodesPerEntity_;
 
@@ -97,9 +96,6 @@ public:
               smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
           });
       });
-
-      coeffApplier->free_device_pointer();
-      delete coeffApplier;
   }
 
 protected:

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -80,11 +80,9 @@ public:
     LinearSolver *linearSolver);
 
   virtual ~LinearSystem() {
-    if (hostCoeffApplier != nullptr) {
+    if (hostCoeffApplier.get() != nullptr) {
       hostCoeffApplier->free_device_pointer();
       deviceCoeffApplier = nullptr;
-      delete hostCoeffApplier;
-      hostCoeffApplier = nullptr;
     }
   }
 
@@ -161,10 +159,10 @@ public:
   virtual CoeffApplier* get_coeff_applier()
   {
 #ifndef KOKKOS_ENABLE_CUDA
-    if (hostCoeffApplier == nullptr) {
-      hostCoeffApplier = new DefaultHostOnlyCoeffApplier(*this);
+    if (hostCoeffApplier.get() == nullptr) {
+      hostCoeffApplier.reset(new DefaultHostOnlyCoeffApplier(*this));
     }
-    return hostCoeffApplier;
+    return hostCoeffApplier.get();
 #else
     return nullptr;
 #endif
@@ -276,7 +274,7 @@ protected:
   bool recomputePreconditioner_;
   bool reusePreconditioner_;
 
-  CoeffApplier* hostCoeffApplier = nullptr;
+  std::unique_ptr<CoeffApplier> hostCoeffApplier;
   CoeffApplier* deviceCoeffApplier = nullptr;
 
 public:

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -89,8 +89,7 @@ AssembleElemSolverAlgorithm::execute()
 
   auto ngpKernels = nalu_ngp::create_ngp_view<Kernel>(activeKernels_);
 
-  CoeffApplier* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
-  CoeffApplier* deviceCoeffApplier = coeffApplier->device_pointer();
+  CoeffApplier* deviceCoeffApplier = eqSystem_->linsys_->get_coeff_applier();
 
   double diagRelaxFactor = diagRelaxFactor_;
   int rhsSize = rhsSize_;
@@ -124,9 +123,6 @@ AssembleElemSolverAlgorithm::execute()
                   smdata.scratchIds, smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
 #endif
     });
-
-  coeffApplier->free_device_pointer();
-  delete coeffApplier;
 }
 
 } // namespace nalu

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -92,8 +92,7 @@ AssembleFaceElemSolverAlgorithm::execute()
 
   const unsigned nodesPerEntity = nodesPerElem_;
   const unsigned numDof = numDof_;
-  CoeffApplier* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
-  CoeffApplier* deviceCoeffApplier = coeffApplier->device_pointer();
+  CoeffApplier* deviceCoeffApplier = eqSystem_->linsys_->get_coeff_applier();
   double diagRelaxFactor = diagRelaxFactor_;
 
   run_face_elem_algorithm(realm_.bulk_data(),
@@ -125,9 +124,6 @@ AssembleFaceElemSolverAlgorithm::execute()
         }
 #endif
     });
-
-    coeffApplier->free_device_pointer();
-    delete coeffApplier;
 }
 
 } // namespace nalu

--- a/src/AssembleNGPNodeSolverAlgorithm.C
+++ b/src/AssembleNGPNodeSolverAlgorithm.C
@@ -91,8 +91,7 @@ AssembleNGPNodeSolverAlgorithm::execute()
   const stk::mesh::EntityRank entityRank = stk::topology::NODE_RANK;
   const int rhsSize = rhsSize_;
 
-  CoeffApplier* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
-  CoeffApplier* deviceCoeffApplier = coeffApplier->device_pointer();
+  CoeffApplier* deviceCoeffApplier = eqSystem_->linsys_->get_coeff_applier();
 
   const int nodesPerEntity = 1;
   const int bytes_per_team = 0;
@@ -134,9 +133,6 @@ AssembleNGPNodeSolverAlgorithm::execute()
             smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
         });
     });
-
-    coeffApplier->free_device_pointer();
-    delete coeffApplier;
 }
 
 }  // nalu

--- a/src/FixPressureAtNodeAlgorithm.C
+++ b/src/FixPressureAtNodeAlgorithm.C
@@ -66,8 +66,7 @@ FixPressureAtNodeAlgorithm::execute()
   }
 
   // Reset LHS and RHS for this matrix
-  CoeffApplier* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
-  CoeffApplier* deviceCoeffApplier = coeffApplier->device_pointer();
+  CoeffApplier* deviceCoeffApplier = eqSystem_->linsys_->get_coeff_applier();
  
   ngp::Mesh ngpMesh = realm_.ngp_mesh();
   NGPDoubleFieldType ngpPressure = realm_.ngp_field_manager().get_field<double>(pressure_->mesh_meta_data_ordinal());
@@ -108,9 +107,6 @@ FixPressureAtNodeAlgorithm::execute()
       }
     });
   });
-
-  coeffApplier->free_device_pointer();
-  delete coeffApplier;
 }
 
 void

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1310,20 +1310,25 @@ void reset_rows(
 
 sierra::nalu::CoeffApplier* TpetraLinearSystem::get_coeff_applier()
 {
-  const bool extractDiagonal = equationSystem()->extractDiagonal_;
-  const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->get_diagonal_field() !=nullptr) ?
-                    equationSystem()->get_diagonal_field()->mesh_meta_data_ordinal() : 0;
-  
-  NGPDoubleFieldType diagField;
-  if (extractDiagonal) {
-    diagField = realm_.ngp_field_manager().get_field<double>(diagFieldOrdinal);
+  if (hostCoeffApplier == nullptr) {
+    const bool extractDiagonal = equationSystem()->extractDiagonal_;
+    const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->get_diagonal_field() !=nullptr) ?
+                      equationSystem()->get_diagonal_field()->mesh_meta_data_ordinal() : 0;
+    
+    NGPDoubleFieldType diagField;
+    if (extractDiagonal) {
+      diagField = realm_.ngp_field_manager().get_field<double>(diagFieldOrdinal);
+    }
+   
+    hostCoeffApplier = new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
+                                        ownedLocalRhs_, sharedNotOwnedLocalRhs_,
+                                        entityToLID_, entityToColLID_,
+                                        maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_,
+                                        extractDiagonal, diagField, realm_.ngp_mesh());
+    deviceCoeffApplier = hostCoeffApplier->device_pointer();
   }
 
-  return new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
-                                      ownedLocalRhs_, sharedNotOwnedLocalRhs_,
-                                      entityToLID_, entityToColLID_,
-                                      maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_,
-                                      extractDiagonal, diagField, realm_.ngp_mesh());
+  return deviceCoeffApplier;
 }
 
 KOKKOS_FUNCTION

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1310,7 +1310,7 @@ void reset_rows(
 
 sierra::nalu::CoeffApplier* TpetraLinearSystem::get_coeff_applier()
 {
-  if (hostCoeffApplier == nullptr) {
+  if (hostCoeffApplier.get() == nullptr) {
     const bool extractDiagonal = equationSystem()->extractDiagonal_;
     const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->get_diagonal_field() !=nullptr) ?
                       equationSystem()->get_diagonal_field()->mesh_meta_data_ordinal() : 0;
@@ -1320,11 +1320,11 @@ sierra::nalu::CoeffApplier* TpetraLinearSystem::get_coeff_applier()
       diagField = realm_.ngp_field_manager().get_field<double>(diagFieldOrdinal);
     }
    
-    hostCoeffApplier = new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
+    hostCoeffApplier.reset(new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
                                         ownedLocalRhs_, sharedNotOwnedLocalRhs_,
                                         entityToLID_, entityToColLID_,
                                         maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_,
-                                        extractDiagonal, diagField, realm_.ngp_mesh());
+                                        extractDiagonal, diagField, realm_.ngp_mesh()));
     deviceCoeffApplier = hostCoeffApplier->device_pointer();
   }
 

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -1179,7 +1179,7 @@ void reset_rows(
 
 sierra::nalu::CoeffApplier* TpetraSegregatedLinearSystem::get_coeff_applier()
 {
-  if (hostCoeffApplier == nullptr) {
+  if (hostCoeffApplier.get() == nullptr) {
     const bool extractDiagonal = equationSystem()->extractDiagonal_;
     const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->get_diagonal_field()!=nullptr) ?
                       equationSystem()->get_diagonal_field()->mesh_meta_data_ordinal() : 0;
@@ -1189,11 +1189,11 @@ sierra::nalu::CoeffApplier* TpetraSegregatedLinearSystem::get_coeff_applier()
       diagField = realm_.ngp_field_manager().get_field<double>(diagFieldOrdinal);
     }
   
-    hostCoeffApplier = new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
+    hostCoeffApplier.reset(new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
                                         ownedLocalRhs_, sharedNotOwnedLocalRhs_,
                                         entityToLID_, entityToColLID_,
                                         maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_,
-                                        extractDiagonal, diagField, realm_.ngp_mesh());
+                                        extractDiagonal, diagField, realm_.ngp_mesh()));
     deviceCoeffApplier = hostCoeffApplier->device_pointer();
   }
 

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -1179,20 +1179,25 @@ void reset_rows(
 
 sierra::nalu::CoeffApplier* TpetraSegregatedLinearSystem::get_coeff_applier()
 {
-  const bool extractDiagonal = equationSystem()->extractDiagonal_;
-  const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->get_diagonal_field()!=nullptr) ?
-                    equationSystem()->get_diagonal_field()->mesh_meta_data_ordinal() : 0;
-
-  NGPDoubleFieldType diagField;
-  if (extractDiagonal) {
-    diagField = realm_.ngp_field_manager().get_field<double>(diagFieldOrdinal);
+  if (hostCoeffApplier == nullptr) {
+    const bool extractDiagonal = equationSystem()->extractDiagonal_;
+    const unsigned diagFieldOrdinal = (extractDiagonal && equationSystem()->get_diagonal_field()!=nullptr) ?
+                      equationSystem()->get_diagonal_field()->mesh_meta_data_ordinal() : 0;
+  
+    NGPDoubleFieldType diagField;
+    if (extractDiagonal) {
+      diagField = realm_.ngp_field_manager().get_field<double>(diagFieldOrdinal);
+    }
+  
+    hostCoeffApplier = new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
+                                        ownedLocalRhs_, sharedNotOwnedLocalRhs_,
+                                        entityToLID_, entityToColLID_,
+                                        maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_,
+                                        extractDiagonal, diagField, realm_.ngp_mesh());
+    deviceCoeffApplier = hostCoeffApplier->device_pointer();
   }
 
-  return new TpetraLinSysCoeffApplier(ownedLocalMatrix_, sharedNotOwnedLocalMatrix_,
-                                      ownedLocalRhs_, sharedNotOwnedLocalRhs_,
-                                      entityToLID_, entityToColLID_,
-                                      maxOwnedRowId_, maxSharedNotOwnedRowId_, numDof_,
-                                      extractDiagonal, diagField, realm_.ngp_mesh());
+  return deviceCoeffApplier;
 }
 
 KOKKOS_FUNCTION


### PR DESCRIPTION
Make coeff-applier pointers be owned/managed by
LinearSystem. By default, get_coeff_applier returns a device pointer.
This also makes sense when running a non-cuda build, since the
host is the same as the device.
If we need a host pointer when running a cuda build, we can add a
get_host_coeff_applier.

Next step will be to try to move the extract-diagonal code into
something (a functor?) owned by SolverAlgorithm, and also put
the fix-overset code in that.