### PR TITLE
Disable Hypre for mom w/h strong sym

### DIFF
--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -82,6 +82,7 @@
 #include <wind_energy/ABLForcingAlgorithm.h>
 #include <FixPressureAtNodeAlgorithm.h>
 #include <FixPressureAtNodeInfo.h>
+#include <HypreLinearSystem.h>
 
 // template for kernels
 #include <AlgTraits.h>
@@ -2156,7 +2157,10 @@ MomentumEquationSystem::register_symmetry_bc(
      beginPos = 2;
      break;
   }
-
+  if(dynamic_cast<HypreLinearSystem*>(linsys_) != nullptr){
+    throw std::runtime_error(
+      "Hypre is not supported for a momentum solver when using strong_symmetry bc's.");
+  }
   endPos = beginPos + 1;
   if(!symmBCData.userData_.useProjections_){
     notProjectedDir_[beginPos].push_back(part);


### PR DESCRIPTION
Inconsistencies with how hypre handles the dirichlet bc
make it incompatible with the strong_symmetry bc's.
First pass at fixing the issues in HypreLinearSystem.C
were not successful.

Throw for now.