### PR TITLE
Reinstate fix_overset_rows for CPU only runs

### DIFF
--- a/include/AssembleEdgeSolverAlgorithm.h
+++ b/include/AssembleEdgeSolverAlgorithm.h
@@ -91,6 +91,14 @@ public:
 
             lambdaFunc(smdata, edgeIndex, nodeL, nodeR);
 
+#ifndef KOKKOS_ENABLE_CUDA
+            // TODO: Replace this with NGP version
+            if (realm_.hasOverset_)
+              reset_overset_rows(
+                realm_.meta_data(), eqSystem_->linsys_->numDof(), nodesPerEntity,
+                smdata.ngpElemNodes, smdata.rhs, smdata.lhs);
+#endif
+
             (*deviceCoeffApplier)(
               nodesPerEntity, smdata.ngpElemNodes, smdata.scratchIds,
               smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -64,6 +64,14 @@ protected:
     const SharedMemView<const double**,DeviceShmem> & lhs,
     const char *trace_tag);
 
+  void reset_overset_rows(
+    const stk::mesh::MetaData& meta,
+    const size_t nDim,
+    const size_t nEntities,
+    const ngp::Mesh::ConnectedEntities& entities,
+    sierra::nalu::SharedMemView<double*, sierra::nalu::DeviceShmem>& rhs,
+    sierra::nalu::SharedMemView<double**, sierra::nalu::DeviceShmem>& lhs);
+
   EquationSystem *eqSystem_;
 };
 

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -119,6 +119,15 @@ AssembleFaceElemSolverAlgorithm::execute()
           extract_vector_lane(smdata.simdlhs, simdIndex, smdata.lhs);
           for (unsigned ir=0; ir < nodesPerElem_*numDof; ++ir)
             smdata.lhs(ir, ir) /= diagRelaxFactor;
+
+#ifndef KOKKOS_ENABLE_CUDA
+          // TODO: Replace this with NGP version
+          if (realm_.hasOverset_)
+            reset_overset_rows(
+              realm_.meta_data(), eqSystem_->linsys_->numDof(), nodesPerEntity,
+              smdata.ngpConnectedNodes[simdIndex], smdata.rhs, smdata.lhs);
+#endif
+
           (*deviceCoeffApplier)(nodesPerEntity, smdata.ngpConnectedNodes[simdIndex],
                       smdata.scratchIds, smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
         }

--- a/src/AssembleNGPNodeSolverAlgorithm.C
+++ b/src/AssembleNGPNodeSolverAlgorithm.C
@@ -128,6 +128,14 @@ AssembleNGPNodeSolverAlgorithm::execute()
             kernel->execute(smdata.lhs, smdata.rhs, nodeIndex);
           }
 
+#ifndef KOKKOS_ENABLE_CUDA
+          // TODO: Replace this with NGP version
+          if (realm_.hasOverset_)
+            reset_overset_rows(
+              realm_.meta_data(), eqSystem_->linsys_->numDof(), nodesPerEntity,
+              smdata.ngpNodes, smdata.rhs, smdata.lhs);
+#endif
+
           (*deviceCoeffApplier)(
             nodesPerEntity, smdata.ngpNodes, smdata.scratchIds,
             smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -163,5 +163,33 @@ SolverAlgorithm::apply_coeff(
     eqSystem_->save_diagonal_term(numMeshobjs, symMeshobjs, lhs);
 }
 
+void SolverAlgorithm::reset_overset_rows(
+  const stk::mesh::MetaData& meta,
+  const size_t nDim,
+  const size_t nEntities,
+  const ngp::Mesh::ConnectedEntities& entities,
+  sierra::nalu::SharedMemView<double*, sierra::nalu::DeviceShmem>& rhs,
+  sierra::nalu::SharedMemView<double**, sierra::nalu::DeviceShmem>& lhs)
+{
+  using ScalarIntFieldType = sierra::nalu::ScalarIntFieldType;
+  const size_t numRows = nEntities * nDim;
+
+  ScalarIntFieldType* iblank = meta.get_field<ScalarIntFieldType>(
+    stk::topology::NODE_RANK, "iblank");
+
+  for (size_t in=0; in < nEntities; in++) {
+    const int* ibl = stk::mesh::field_data(*iblank, entities[in]);
+    double mask = std::max(0.0, static_cast<double>(ibl[0]));
+    size_t ix = in * nDim;
+
+    for (size_t d=0; d < nDim; d++) {
+      size_t ir = ix + d;
+
+      rhs(ir) *= mask;
+      for (size_t c=0; c < numRows; c++)
+        lhs(ir, c) *= mask;
+    }
+  }
+}
 } // namespace nalu
 } // namespace Sierra


### PR DESCRIPTION
This fix is needed for some of the turbine production runs that are breaking with the latest master. Eventually this will be handled by the CoeffApplier like logic for NGP simulations. 