### PR TITLE
Some steps to more modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,17 @@ set(CMAKE_CXX_STANDARD 11)       # Set nalu-wind C++11 standard
 set(CMAKE_CXX_EXTENSIONS OFF)    # Do not enable GNU extensions
 set(CMAKE_CXX_STANDARD_REQUIRED) # Force error if C++11 standard is not supported
 
+# Create targets
+set(nalu_ex_name "naluX")
+set(utest_ex_name "unittestX")
+add_library(nalu "")
+add_executable(${nalu_ex_name} nalu.C)
+add_executable(${utest_ex_name} unit_tests.C)
+
 find_package(MPI REQUIRED)
-include_directories(SYSTEM ${MPI_C_INCLUDE_PATH})
-include_directories(SYSTEM ${MPI_CXX_INCLUDE_PATH})
-include_directories(SYSTEM ${MPI_Fortran_INCLUDE_PATH})
+target_include_directories(nalu SYSTEM PUBLIC ${MPI_C_INCLUDE_PATH})
+target_include_directories(nalu SYSTEM PUBLIC ${MPI_CXX_INCLUDE_PATH})
+target_include_directories(nalu SYSTEM PUBLIC ${MPI_Fortran_INCLUDE_PATH})
 
 if(ENABLE_OPENMP)
   find_package(OpenMP)
@@ -43,8 +50,8 @@ find_package(Trilinos REQUIRED)
 if(Trilinos_FOUND)
   message(STATUS "Found Trilinos = ${Trilinos_DIR}")
 endif()
-include_directories(SYSTEM ${Trilinos_INCLUDE_DIRS})
-include_directories(SYSTEM ${Trilinos_TPL_INCLUDE_DIRS})
+target_include_directories(nalu SYSTEM PUBLIC ${Trilinos_INCLUDE_DIRS})
+target_include_directories(nalu SYSTEM PUBLIC ${Trilinos_TPL_INCLUDE_DIRS})
 
 # Build Nalu as shared libraries if that is how Trilinos was built
 if(Trilinos_BUILD_SHARED_LIBS)
@@ -59,13 +66,13 @@ set(CMAKE_PREFIX_PATH ${YAML_DIR} ${CMAKE_PREFIX_PATH})
 find_package(YAML-CPP QUIET)
 if(YAML-CPP_FOUND)
   # YAML master branch is used
-  include_directories(SYSTEM ${YAML_CPP_INCLUDE_DIR})
+  target_include_directories(nalu SYSTEM PUBLIC ${YAML_CPP_INCLUDE_DIR})
 else()
   # YAML 0.5.3 is used
   find_library(YAML_CPP_LIBRARIES NAMES yaml-cpp PATHS ${YAML_DIR}/lib)
   find_path(YAML_CPP_INCLUDE_DIR yaml.h PATHS ${YAML_DIR}/include/yaml-cpp)
   if((DEFINED YAML_CPP_LIBRARIES) AND (DEFINED YAML_CPP_INCLUDE_DIR))
-    include_directories(SYSTEM ${YAML_CPP_INCLUDE_DIR}/..)
+    target_include_directories(nalu SYSTEM PUBLIC ${YAML_CPP_INCLUDE_DIR}/..)
     set(YAML-CPP_FOUND TRUE)
   endif()
 endif()
@@ -76,7 +83,7 @@ else()
 endif()
 
 if(ENABLE_CUDA)
-    add_definitions(-DUSE_STK_SIMD_NONE)
+    target_compile_definitions(nalu PUBLIC USE_STK_SIMD_NONE)
 endif()
 
 ############################ FFTW ######################################
@@ -86,8 +93,8 @@ if(ENABLE_FFTW)
   if(FFTW_FOUND)
     message(STATUS "Found FFTW = ${FFTW_DIR}")
   endif()
-  include_directories(${FFTW_INCLUDE_DIRS})
-  add_definitions("-DNALU_USES_FFTW")
+  target_include_directories(nalu SYSTEM PUBLIC ${FFTW_INCLUDE_DIRS})
+  target_compile_definitions(nalu PUBLIC NALU_USES_FFTW)
 endif(ENABLE_FFTW)
 
 ############################ HYPRE #####################################
@@ -97,8 +104,8 @@ if(ENABLE_HYPRE)
   if(HYPRE_FOUND)
     message(STATUS "Found HYPRE = ${HYPRE_DIR}")
   endif()
-  include_directories(SYSTEM ${HYPRE_INCLUDE_DIRS})
-  add_definitions("-DNALU_USES_HYPRE")
+  target_include_directories(nalu SYSTEM PUBLIC ${HYPRE_INCLUDE_DIRS})
+  target_compile_definitions(nalu PUBLIC NALU_USES_HYPRE)
 endif(ENABLE_HYPRE)
 
 ########################## OPENFAST ####################################
@@ -108,8 +115,8 @@ if(ENABLE_OPENFAST)
   if(OpenFAST_FOUND)
     message(STATUS "Found OpenFAST = ${OpenFAST_DIR}")
   endif()
-  include_directories(${OpenFAST_INCLUDE_DIRS})
-  add_definitions("-DNALU_USES_OPENFAST")
+  target_include_directories(nalu SYSTEM PUBLIC ${OpenFAST_INCLUDE_DIRS})
+  target_compile_definitions(nalu PUBLIC NALU_USES_OPENFAST)
 endif(ENABLE_OPENFAST)
 
 ############################ TIOGA #####################################
@@ -119,10 +126,10 @@ if(ENABLE_TIOGA)
   if(TIOGA_FOUND)
     message(STATUS "Found TIOGA = ${TIOGA_DIR}")
   endif()
-  include_directories(${TIOGA_INCLUDE_DIRS})
-  add_definitions("-DNALU_USES_TIOGA")
+  target_include_directories(nalu SYSTEM PUBLIC ${TIOGA_INCLUDE_DIRS})
+  target_compile_definitions(nalu PUBLIC NALU_USES_TIOGA)
   if(TIOGA_HAS_NODEGID)
-    add_definitions("-DTIOGA_HAS_NODEGID")
+    target_compile_definitions(nalu PUBLIC TIOGA_HAS_NODEGID)
   endif()
 endif()
 
@@ -199,7 +206,7 @@ if(ENABLE_HYPRE)
       "HYPRE does not enable 64-bit integer support; will fail on large problems!")
   endif()
   if (NALU_HYPRE_COGMRES)
-    add_definitions(-DHYPRE_COGMRES)
+    target_compile_definitions(nalu PUBLIC HYPRE_COGMRES)
   else()
     message(STATUS "Disabling HYPRE CO-GMRES interface")
   endif()
@@ -236,55 +243,44 @@ configure_file("${CMAKE_SOURCE_DIR}/cmake/NaluVersionInfo.h.in"
   "${CMAKE_BINARY_DIR}/include/NaluVersionInfo.h" @ONLY)
 #### END TAG VERSIONS
 
-include_directories(${CMAKE_SOURCE_DIR}/include)
-include_directories(${CMAKE_BINARY_DIR}/include)
-add_library(nalu ${NALU_SOURCES})
-target_link_libraries(nalu ${Trilinos_LIBRARIES})
-target_link_libraries(nalu ${YAML_CPP_LIBRARIES})
-target_link_libraries(nalu ${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_C_LIBRARIES})
+target_include_directories(nalu PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_include_directories(nalu PUBLIC ${CMAKE_BINARY_DIR}/include)
+target_link_libraries(nalu PUBLIC ${Trilinos_LIBRARIES})
+target_link_libraries(nalu PUBLIC ${YAML_CPP_LIBRARIES})
+target_link_libraries(nalu PUBLIC ${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_C_LIBRARIES})
 
 if(ENABLE_FFTW)
-  target_link_libraries(nalu ${FFTW_LIBRARIES})
+  target_link_libraries(nalu PUBLIC ${FFTW_LIBRARIES})
 endif()
 
 if(ENABLE_HYPRE)
-  target_link_libraries(nalu ${HYPRE_LIBRARIES})
+  target_link_libraries(nalu PUBLIC ${HYPRE_LIBRARIES})
 endif()
 
 if(ENABLE_OPENFAST)
-  target_link_libraries(nalu ${OpenFAST_LIBRARIES} ${OpenFAST_CPP_LIBRARIES})
+  target_link_libraries(nalu PUBLIC ${OpenFAST_LIBRARIES} ${OpenFAST_CPP_LIBRARIES})
 endif()
 
 if(ENABLE_TIOGA)
-  target_link_libraries(nalu ${TIOGA_LIBRARIES})
+  target_link_libraries(nalu PUBLIC ${TIOGA_LIBRARIES})
 endif()
 
 message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
-set(nalu_ex_name "naluX")
-add_executable(${nalu_ex_name} nalu.C)
-target_link_libraries(${nalu_ex_name} nalu)
+target_link_libraries(${nalu_ex_name} PRIVATE nalu)
 if(MPI_COMPILE_FLAGS)
   set_target_properties(${nalu_ex_name} PROPERTIES
     COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
 endif(MPI_COMPILE_FLAGS)
-if(MPI_LINK_FLAGS)
-  set_target_properties(${nalu_ex_name} PROPERTIES
-    LINK_FLAGS "${MPI_LINK_FLAGS}")
-endif(MPI_LINK_FLAGS)
+target_link_libraries(${nalu_ex_name} PRIVATE MPI::MPI_CXX MPI::MPI_Fortran)
 
-set(utest_ex_name "unittestX")
-add_executable(${utest_ex_name} unit_tests.C ${NALU_UNIT_SOURCES})
-target_link_libraries(${utest_ex_name} nalu)
-target_include_directories(${utest_ex_name} PUBLIC "${CMAKE_SOURCE_DIR}/unit_tests")
+target_link_libraries(${utest_ex_name} PRIVATE nalu)
+target_include_directories(${utest_ex_name} PRIVATE "${CMAKE_SOURCE_DIR}/unit_tests")
 if(MPI_COMPILE_FLAGS)
   set_target_properties(${utest_ex_name} PROPERTIES
     COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
 endif(MPI_COMPILE_FLAGS)
-if(MPI_LINK_FLAGS)
-  set_target_properties(${utest_ex_name} PROPERTIES
-    LINK_FLAGS "${MPI_LINK_FLAGS}")
-endif(MPI_LINK_FLAGS)
+target_link_libraries(${utest_ex_name} PRIVATE MPI::MPI_CXX MPI::MPI_Fortran)
 
 add_subdirectory(src)
 add_subdirectory(unit_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 ############################ BASE ######################################
-cmake_minimum_required (VERSION 3.13.0)
+cmake_minimum_required (VERSION 3.13.0 FATAL_ERROR)
 project(Nalu CXX Fortran)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,6 @@ add_executable(${nalu_ex_name} nalu.C)
 add_executable(${utest_ex_name} unit_tests.C)
 
 find_package(MPI REQUIRED)
-target_include_directories(nalu SYSTEM PUBLIC ${MPI_C_INCLUDE_PATH})
-target_include_directories(nalu SYSTEM PUBLIC ${MPI_CXX_INCLUDE_PATH})
-target_include_directories(nalu SYSTEM PUBLIC ${MPI_Fortran_INCLUDE_PATH})
 
 if(ENABLE_OPENMP)
   find_package(OpenMP)
@@ -45,7 +42,6 @@ endif()
 
 ########################## TRILINOS ####################################
 set(CMAKE_PREFIX_PATH ${Trilinos_DIR} ${CMAKE_PREFIX_PATH})
-set(CMAKE_PREFIX_PATH ${Trilinos_PATH} ${CMAKE_PREFIX_PATH})
 find_package(Trilinos REQUIRED)
 if(Trilinos_FOUND)
   message(STATUS "Found Trilinos = ${Trilinos_DIR}")
@@ -63,27 +59,15 @@ endif(Trilinos_BUILD_SHARED_LIBS)
 
 ############################ YAML ######################################
 set(CMAKE_PREFIX_PATH ${YAML_DIR} ${CMAKE_PREFIX_PATH})
-find_package(YAML-CPP QUIET)
-if(YAML-CPP_FOUND)
-  # YAML master branch is used
-  target_include_directories(nalu SYSTEM PUBLIC ${YAML_CPP_INCLUDE_DIR})
-else()
-  # YAML 0.5.3 is used
-  find_library(YAML_CPP_LIBRARIES NAMES yaml-cpp PATHS ${YAML_DIR}/lib)
-  find_path(YAML_CPP_INCLUDE_DIR yaml.h PATHS ${YAML_DIR}/include/yaml-cpp)
-  if((DEFINED YAML_CPP_LIBRARIES) AND (DEFINED YAML_CPP_INCLUDE_DIR))
-    target_include_directories(nalu SYSTEM PUBLIC ${YAML_CPP_INCLUDE_DIR}/..)
-    set(YAML-CPP_FOUND TRUE)
-  endif()
-endif()
+find_package(YAML-CPP 0.6.2 QUIET REQUIRED)
 if(YAML-CPP_FOUND)
   message(STATUS "Found YAML-CPP = ${YAML_DIR}")
-else()
-  message(FATAL_ERROR "YAML-CPP NOT FOUND")
 endif()
+target_include_directories(nalu SYSTEM PUBLIC ${YAML_CPP_INCLUDE_DIR})
 
+############################ CUDA ######################################
 if(ENABLE_CUDA)
-    target_compile_definitions(nalu PUBLIC USE_STK_SIMD_NONE)
+  target_compile_definitions(nalu PUBLIC USE_STK_SIMD_NONE)
 endif()
 
 ############################ FFTW ######################################
@@ -243,11 +227,16 @@ configure_file("${CMAKE_SOURCE_DIR}/cmake/NaluVersionInfo.h.in"
   "${CMAKE_BINARY_DIR}/include/NaluVersionInfo.h" @ONLY)
 #### END TAG VERSIONS
 
+# Set target options for libnalu
 target_include_directories(nalu PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(nalu PUBLIC ${CMAKE_BINARY_DIR}/include)
+target_include_directories(nalu SYSTEM PUBLIC MPI::MPI_CXX MPI::MPI_Fortran)
 target_link_libraries(nalu PUBLIC ${Trilinos_LIBRARIES})
 target_link_libraries(nalu PUBLIC ${YAML_CPP_LIBRARIES})
-target_link_libraries(nalu PUBLIC ${MPI_CXX_LIBRARIES} ${MPI_Fortran_LIBRARIES} ${MPI_C_LIBRARIES})
+target_link_libraries(nalu PUBLIC MPI::MPI_CXX MPI::MPI_Fortran)
+if(MPI_COMPILE_FLAGS)
+  set_target_properties(nalu PUBLIC PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
+endif(MPI_COMPILE_FLAGS)
 
 if(ENABLE_FFTW)
   target_link_libraries(nalu PUBLIC ${FFTW_LIBRARIES})
@@ -267,20 +256,10 @@ endif()
 
 message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
+# Most linking, etc, is set to PUBLIC for libnalu, so we merely link to libnalu for the exes
 target_link_libraries(${nalu_ex_name} PRIVATE nalu)
-if(MPI_COMPILE_FLAGS)
-  set_target_properties(${nalu_ex_name} PROPERTIES
-    COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
-endif(MPI_COMPILE_FLAGS)
-target_link_libraries(${nalu_ex_name} PRIVATE MPI::MPI_CXX MPI::MPI_Fortran)
-
 target_link_libraries(${utest_ex_name} PRIVATE nalu)
 target_include_directories(${utest_ex_name} PRIVATE "${CMAKE_SOURCE_DIR}/unit_tests")
-if(MPI_COMPILE_FLAGS)
-  set_target_properties(${utest_ex_name} PROPERTIES
-    COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
-endif(MPI_COMPILE_FLAGS)
-target_link_libraries(${utest_ex_name} PRIVATE MPI::MPI_CXX MPI::MPI_Fortran)
 
 add_subdirectory(src)
 add_subdirectory(unit_tests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ endif()
 # Add any extra flags based on compiler and/or OS
 message(STATUS "CMAKE_SYSTEM_NAME = ${CMAKE_SYSTEM_NAME}")
 message(STATUS "CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
+message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
 # Add -restrict to Intel compiler
 target_compile_options(nalu PUBLIC $<$<CXX_COMPILER_ID:Intel>:-restrict>)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ############################ BASE ######################################
-cmake_minimum_required (VERSION 3.10.0)
-project(Nalu CXX C Fortran)
+cmake_minimum_required (VERSION 3.13.0)
+project(Nalu CXX Fortran)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -236,22 +236,6 @@ configure_file("${CMAKE_SOURCE_DIR}/cmake/NaluVersionInfo.h.in"
   "${CMAKE_BINARY_DIR}/include/NaluVersionInfo.h" @ONLY)
 #### END TAG VERSIONS
 
-# Add all source files from source subdirectories
-function(add_sources target_list)
-   foreach(_source IN ITEMS ${ARGN})
-       if (IS_ABSOLUTE "${_source}")
-           set(_source_abs "${_source}")
-       else()
-           get_filename_component(_source_abs "${_source}" ABSOLUTE)
-       endif()
-       set_property(GLOBAL APPEND PROPERTY "${target_list}" "${_source_abs}")
-   endforeach()
-endfunction(add_sources)
-add_subdirectory(src)
-add_subdirectory(unit_tests)
-get_property(NALU_SOURCES GLOBAL PROPERTY GlobalSourceList)
-get_property(NALU_UNIT_SOURCES GLOBAL PROPERTY GlobalUnitSourceList)
-
 include_directories(${CMAKE_SOURCE_DIR}/include)
 include_directories(${CMAKE_BINARY_DIR}/include)
 add_library(nalu ${NALU_SOURCES})
@@ -301,6 +285,9 @@ if(MPI_LINK_FLAGS)
   set_target_properties(${utest_ex_name} PROPERTIES
     LINK_FLAGS "${MPI_LINK_FLAGS}")
 endif(MPI_LINK_FLAGS)
+
+add_subdirectory(src)
+add_subdirectory(unit_tests)
 
 set(nalu_ex_catalyst_name "naluXCatalyst")
 if(ENABLE_PARAVIEW_CATALYST)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ find_package(MPI REQUIRED)
 
 if(ENABLE_OPENMP)
   find_package(OpenMP)
+  target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${OpenMP_CXX_FLAGS}>)
+  target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${OpenMP_Fortran_FLAGS}>)
 endif()
 
 ########################## TRILINOS ####################################
@@ -68,6 +70,8 @@ target_include_directories(nalu SYSTEM PUBLIC ${YAML_CPP_INCLUDE_DIR})
 ############################ CUDA ######################################
 if(ENABLE_CUDA)
   target_compile_definitions(nalu PUBLIC USE_STK_SIMD_NONE)
+  target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${Trilinos_CXX_COMPILER_FLAGS}>)
+  target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:CXX>:--expt-relaxed-constexpr>)
 endif()
 
 ############################ FFTW ######################################
@@ -78,6 +82,7 @@ if(ENABLE_FFTW)
     message(STATUS "Found FFTW = ${FFTW_DIR}")
   endif()
   target_include_directories(nalu SYSTEM PUBLIC ${FFTW_INCLUDE_DIRS})
+  target_link_libraries(nalu PUBLIC ${FFTW_LIBRARIES})
   target_compile_definitions(nalu PUBLIC NALU_USES_FFTW)
 endif(ENABLE_FFTW)
 
@@ -89,95 +94,9 @@ if(ENABLE_HYPRE)
     message(STATUS "Found HYPRE = ${HYPRE_DIR}")
   endif()
   target_include_directories(nalu SYSTEM PUBLIC ${HYPRE_INCLUDE_DIRS})
+  target_link_libraries(nalu PUBLIC ${HYPRE_LIBRARIES})
   target_compile_definitions(nalu PUBLIC NALU_USES_HYPRE)
-endif(ENABLE_HYPRE)
 
-########################## OPENFAST ####################################
-if(ENABLE_OPENFAST)
-  set(CMAKE_PREFIX_PATH ${OpenFAST_DIR} ${CMAKE_PREFIX_PATH})
-  find_package(OpenFAST REQUIRED)
-  if(OpenFAST_FOUND)
-    message(STATUS "Found OpenFAST = ${OpenFAST_DIR}")
-  endif()
-  target_include_directories(nalu SYSTEM PUBLIC ${OpenFAST_INCLUDE_DIRS})
-  target_compile_definitions(nalu PUBLIC NALU_USES_OPENFAST)
-endif(ENABLE_OPENFAST)
-
-############################ TIOGA #####################################
-if(ENABLE_TIOGA)
-  set(CMAKE_PREFIX_PATH ${TIOGA_DIR} ${CMAKE_PREFIX_PATH})
-  find_package(TIOGA REQUIRED)
-  if(TIOGA_FOUND)
-    message(STATUS "Found TIOGA = ${TIOGA_DIR}")
-  endif()
-  target_include_directories(nalu SYSTEM PUBLIC ${TIOGA_INCLUDE_DIRS})
-  target_compile_definitions(nalu PUBLIC NALU_USES_TIOGA)
-  if(TIOGA_HAS_NODEGID)
-    target_compile_definitions(nalu PUBLIC TIOGA_HAS_NODEGID)
-  endif()
-endif()
-
-########################### NALU #####################################
-# Add any extra flags based on compiler and/or OS
-message(STATUS "CMAKE_SYSTEM_NAME = ${CMAKE_SYSTEM_NAME}")
-message(STATUS "CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-  set(EXTRA_CXX_FLAGS "")
-  set(EXTRA_Fortran_FLAGS "")
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  set(EXTRA_CXX_FLAGS "")
-  set(EXTRA_Fortran_FLAGS "")
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  set(EXTRA_CXX_FLAGS "")
-  set(EXTRA_Fortran_FLAGS "")
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-  set(EXTRA_CXX_FLAGS "-restrict")
-  set(EXTRA_Fortran_FLAGS "")
-endif()
-
-# Logic for showing and handling warnings
-if(ENABLE_ALL_WARNINGS)
-  # GCC, Clang, and Intel seem to accept these
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
-    if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
-      # ifort doesn't like -Wall
-      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Wall")
-    else()
-      # Intel always reports some diagnostics we don't necessarily care about
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -diag-disable:11074,11076")
-    endif()
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0)
-      # Avoid notes about -faligned-new with GCC > 7
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -faligned-new")
-    endif()
-endif()
-# Make warnings errors
-if(ENABLE_WERROR)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -Werror")
-endif()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CXX_FLAGS}")
-if (ENABLE_CUDA)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${Trilinos_CXX_COMPILER_FLAGS} --expt-relaxed-constexpr")
-endif()
-set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${EXTRA_Fortran_FLAGS}")
-
-if (OPENMP_FOUND)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
-endif()
-
-# Flags we have added
-message(STATUS "CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")
-message(STATUS "CMAKE_Fortran_FLAGS = ${CMAKE_Fortran_FLAGS}")
-
-# Build type flags in which CMake adds for us
-string(TOUPPER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
-message(STATUS "CMAKE_CXX_FLAGS_${BUILD_TYPE} = ${CMAKE_CXX_FLAGS_${BUILD_TYPE}}")
-message(STATUS "CMAKE_Fortran_FLAGS_${BUILD_TYPE} = ${CMAKE_Fortran_FLAGS_${BUILD_TYPE}}")
-
-if(ENABLE_HYPRE)
   include(CheckCXXSymbolExists)
   set(CMAKE_REQUIRED_INCLUDES "${HYPRE_INCLUDE_DIRS}")
   set(CMAKE_REQUIRED_LIBRARIES "${HYPRE_LIBRARIES}")
@@ -194,7 +113,64 @@ if(ENABLE_HYPRE)
   else()
     message(STATUS "Disabling HYPRE CO-GMRES interface")
   endif()
+endif(ENABLE_HYPRE)
+
+########################## OPENFAST ####################################
+if(ENABLE_OPENFAST)
+  set(CMAKE_PREFIX_PATH ${OpenFAST_DIR} ${CMAKE_PREFIX_PATH})
+  find_package(OpenFAST REQUIRED)
+  if(OpenFAST_FOUND)
+    message(STATUS "Found OpenFAST = ${OpenFAST_DIR}")
+  endif()
+  target_include_directories(nalu SYSTEM PUBLIC ${OpenFAST_INCLUDE_DIRS})
+  target_link_libraries(nalu PUBLIC ${OpenFAST_LIBRARIES} ${OpenFAST_CPP_LIBRARIES})
+  target_compile_definitions(nalu PUBLIC NALU_USES_OPENFAST)
+endif(ENABLE_OPENFAST)
+
+############################ TIOGA #####################################
+if(ENABLE_TIOGA)
+  set(CMAKE_PREFIX_PATH ${TIOGA_DIR} ${CMAKE_PREFIX_PATH})
+  find_package(TIOGA REQUIRED)
+  if(TIOGA_FOUND)
+    message(STATUS "Found TIOGA = ${TIOGA_DIR}")
+  endif()
+  target_include_directories(nalu SYSTEM PUBLIC ${TIOGA_INCLUDE_DIRS})
+  target_link_libraries(nalu PUBLIC ${TIOGA_LIBRARIES})
+  target_compile_definitions(nalu PUBLIC NALU_USES_TIOGA)
+  if(TIOGA_HAS_NODEGID)
+    target_compile_definitions(nalu PUBLIC TIOGA_HAS_NODEGID)
+  endif()
 endif()
+
+########################### NALU #####################################
+# Add any extra flags based on compiler and/or OS
+message(STATUS "CMAKE_SYSTEM_NAME = ${CMAKE_SYSTEM_NAME}")
+message(STATUS "CMAKE_CXX_COMPILER_ID = ${CMAKE_CXX_COMPILER_ID}")
+
+# Add -restrict to Intel compiler
+target_compile_options(nalu PUBLIC $<$<CXX_COMPILER_ID:Intel>:-restrict>)
+
+# Logic for handling warnings
+if(ENABLE_ALL_WARNINGS)
+  # GCC, Clang, and Intel seem to accept these
+  list(APPEND NALU_CXX_FLAGS "-Wall" "-Wextra" "-pedantic")
+  if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
+    # ifort doesn't like -Wall
+    list(APPEND NALU_Fortran_FLAGS "-Wall")
+  else()
+    # Intel always reports some diagnostics we don't necessarily care about
+    list(APPEND NALU_CXX_FLAGS "-diag-disable:11074,11076")
+  endif()
+  if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7.0)
+    # Avoid notes about -faligned-new with GCC > 7
+    list(APPEND NALU_CXX_FLAGS "-faligned-new")
+  endif()
+endif()
+
+# Add our flags according to language
+target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${NALU_CXX_FLAGS}>)
+target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:Fortran>:${NALU_Fortran_FLAGS}>)
+target_compile_options(nalu PUBLIC $<$<BOOL:${ENABLE_WERROR}>:-Werror>)
 
 ########################### TAG VERSIONS #####################################
 include(GetGitRevisionDescription)
@@ -230,31 +206,13 @@ configure_file("${CMAKE_SOURCE_DIR}/cmake/NaluVersionInfo.h.in"
 # Set target options for libnalu
 target_include_directories(nalu PUBLIC ${CMAKE_SOURCE_DIR}/include)
 target_include_directories(nalu PUBLIC ${CMAKE_BINARY_DIR}/include)
-target_include_directories(nalu SYSTEM PUBLIC MPI::MPI_CXX MPI::MPI_Fortran)
+target_include_directories(nalu SYSTEM PUBLIC ${MPI_CXX_INCLUDE_PATH} ${MPI_Fortran_INCLUDE_PATH})
 target_link_libraries(nalu PUBLIC ${Trilinos_LIBRARIES})
 target_link_libraries(nalu PUBLIC ${YAML_CPP_LIBRARIES})
 target_link_libraries(nalu PUBLIC MPI::MPI_CXX MPI::MPI_Fortran)
 if(MPI_COMPILE_FLAGS)
   set_target_properties(nalu PUBLIC PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
 endif(MPI_COMPILE_FLAGS)
-
-if(ENABLE_FFTW)
-  target_link_libraries(nalu PUBLIC ${FFTW_LIBRARIES})
-endif()
-
-if(ENABLE_HYPRE)
-  target_link_libraries(nalu PUBLIC ${HYPRE_LIBRARIES})
-endif()
-
-if(ENABLE_OPENFAST)
-  target_link_libraries(nalu PUBLIC ${OpenFAST_LIBRARIES} ${OpenFAST_CPP_LIBRARIES})
-endif()
-
-if(ENABLE_TIOGA)
-  target_link_libraries(nalu PUBLIC ${TIOGA_LIBRARIES})
-endif()
-
-message(STATUS "CMAKE_BUILD_TYPE = ${CMAKE_BUILD_TYPE}")
 
 # Most linking, etc, is set to PUBLIC for libnalu, so we merely link to libnalu for the exes
 target_link_libraries(${nalu_ex_name} PRIVATE nalu)
@@ -266,10 +224,7 @@ add_subdirectory(unit_tests)
 
 set(nalu_ex_catalyst_name "naluXCatalyst")
 if(ENABLE_PARAVIEW_CATALYST)
-   set(PARAVIEW_CATALYST_INSTALL_PATH
-       ""
-       CACHE
-       PATH
+   set(PARAVIEW_CATALYST_INSTALL_PATH "" CACHE PATH
        "Path to external installation of Trilinos Catalyst IOSS plugin.")
    configure_file(cmake/naluXCatalyst.in ${nalu_ex_catalyst_name} @ONLY)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    ABLProfileFunction.C
    Actuator.C
    Algorithm.C
@@ -147,13 +147,13 @@ add_sources(GlobalSourceList
 )
 
 if(ENABLE_FFTW)
-   add_sources(GlobalSourceList
+   target_sources(nalu PRIVATE
       AssembleMomentumEdgeABLTopBC.C
    )
 endif()
 
 if(ENABLE_OPENFAST)
-   add_sources(GlobalSourceList
+   target_sources(nalu PRIVATE
       ActuatorFAST.C
       ActuatorLineFAST.C
       ActuatorDiskFAST.C
@@ -161,7 +161,7 @@ if(ENABLE_OPENFAST)
 endif()
 
 if(ENABLE_HYPRE)
-   add_sources(GlobalSourceList
+   target_sources(nalu PRIVATE
       HypreDirectSolver.C
       HypreUVWSolver.C
       HypreLinearSolverConfig.C
@@ -171,7 +171,7 @@ if(ENABLE_HYPRE)
 endif()
 
 if(ENABLE_PARAVIEW_CATALYST)
-   add_sources(GlobalSourceList
+   target_sources(nalu PRIVATE
       Adapter.C
    )
 endif()

--- a/src/edge_kernels/CMakeLists.txt
+++ b/src/edge_kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
   # Edge kernels
   ContinuityEdgeSolverAlg.C
   MomentumEdgeSolverAlg.C

--- a/src/element_promotion/CMakeLists.txt
+++ b/src/element_promotion/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    ElementCondenser.C
    ElementDescription.C
    HexNElementDescription.C

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    ContinuityAdvElemKernel.C
    ContinuityInflowElemKernel.C
    ContinuityMassElemKernel.C

--- a/src/master_element/CMakeLists.txt
+++ b/src/master_element/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    CalculateBentHexVolume.F
    CalculateHexVolume.F
    CalculateOctohedronVolume.F

--- a/src/mesh_motion/CMakeLists.txt
+++ b/src/mesh_motion/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    AssembleMeshDisplacementElemSolverAlgorithm.C
    AssemblePressureForceBCSolverAlgorithm.C
    MeshDisplacementEquationSystem.C

--- a/src/ngp_algorithms/CMakeLists.txt
+++ b/src/ngp_algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
   # Algorithms
   NodalGradEdgeAlg.C
   NodalGradElemAlg.C

--- a/src/node_kernels/CMakeLists.txt
+++ b/src/node_kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
   ContinuityGclNodeKernel.C
   ContinuityMassBDFNodeKernel.C
   EnthalpyABLForceNodeKernel.C

--- a/src/nso/CMakeLists.txt
+++ b/src/nso/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    MomentumNSOElemKernel.C
    MomentumNSOElemSuppAlgDep.C
    MomentumNSOGradElemSuppAlg.C

--- a/src/overset/CMakeLists.txt
+++ b/src/overset/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    AssembleOversetPressureAlgorithm.C
    AssembleOversetSolverConstraintAlgorithm.C
    AssembleOversetWallDistAlgorithm.C
@@ -10,7 +10,7 @@ add_sources(GlobalSourceList
 )
 
 if(ENABLE_TIOGA)
-   add_sources(GlobalSourceList
+   target_sources(nalu PRIVATE
       OversetManagerTIOGA.C
       TiogaOptions.C
       TiogaBlock.C

--- a/src/pmr/CMakeLists.txt
+++ b/src/pmr/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    AssembleRadTransEdgeSolverAlgorithm.C
    AssembleRadTransEdgeUpwindSolverAlgorithm.C
    AssembleRadTransWallSolverAlgorithm.C

--- a/src/property_evaluator/CMakeLists.txt
+++ b/src/property_evaluator/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    ConstantPropertyEvaluator.C
    EnthalpyPropertyEvaluator.C
    GenericPropAlgorithm.C

--- a/src/tabular_props/CMakeLists.txt
+++ b/src/tabular_props/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    BSpline.C
    Converter.C
    Functions.C

--- a/src/user_functions/CMakeLists.txt
+++ b/src/user_functions/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    BoundaryLayerPerturbationAuxFunction.C
    BoussinesqNonIsoEnthalpySrcNodeSuppAlg.C
    BoussinesqNonIsoMomentumSrcNodeSuppAlg.C

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
   ComputeVectorDivergence.C
   StkHelpers.C
   )

--- a/src/wind_energy/CMakeLists.txt
+++ b/src/wind_energy/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
   ABLForcingAlgorithm.C
   BdyHeightAlgorithm.C
   BdyLayerStatistics.C

--- a/src/xfer/CMakeLists.txt
+++ b/src/xfer/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalSourceList
+target_sources(nalu PRIVATE
    Transfer.C
    Transfers.C
 )

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
    UnitTest1ElemCoordCheck.C
    UnitTestABLWallFunction.C
    UnitTestBasicKokkos.C
@@ -47,7 +47,7 @@ add_sources(GlobalUnitSourceList
 )
 
 if(ENABLE_OPENFAST)
-   add_sources(GlobalUnitSourceList
+   target_sources(${utest_ex_name} PRIVATE
       UnitTestActuatorDiskFAST.C
    )
 endif()

--- a/unit_tests/algorithms/CMakeLists.txt
+++ b/unit_tests/algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
    UnitTestAlgorithm.C
    UnitTestLESAlgorithms.C
    UnitTestSSTAlgorithms.C

--- a/unit_tests/edge_kernels/CMakeLists.txt
+++ b/unit_tests/edge_kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
   # Edge interior kernels
   UnitTestContinuityAdvEdge.C
   UnitTestMomentumAdvDiffEdge.C

--- a/unit_tests/ho_kernels/CMakeLists.txt
+++ b/unit_tests/ho_kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
    UnitTestDiffusionHO.C
    UnitTestDiffusionMetricHO.C
    UnitTestOperatorsHO.C

--- a/unit_tests/kernels/CMakeLists.txt
+++ b/unit_tests/kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
    UnitTestContinuityAdvElem.C
    UnitTestContinuityMassElem.C
    UnitTestContinuityInflowElem.C

--- a/unit_tests/mesh_motion/CMakeLists.txt
+++ b/unit_tests/mesh_motion/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
    UnitTestCompositeFrames.C
    UnitTestCompositeMotions.C
    UnitTestMotionTypes.C

--- a/unit_tests/ngp_algorithms/CMakeLists.txt
+++ b/unit_tests/ngp_algorithms/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
   UnitTestNgpAlgUtils.C
   UnitTestNodalGradAlg.C
   UnitTestDiffFluxCoeffAlg.C

--- a/unit_tests/ngp_kernels/CMakeLists.txt
+++ b/unit_tests/ngp_kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
   UnitTestNgpKernel.C
   UnitTestNgpLoops.C
   )

--- a/unit_tests/node_kernels/CMakeLists.txt
+++ b/unit_tests/node_kernels/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
   UnitTestContinuityGclNodeKernel.C
   UnitTestContinuityMassBDFNodeKernel.C
   UnitTestEnthalpyABLForceNode.C

--- a/unit_tests/utils/CMakeLists.txt
+++ b/unit_tests/utils/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_sources(GlobalUnitSourceList
+target_sources(${utest_ex_name} PRIVATE
    UnitTestComputeVectorDivergence.C
 )


### PR DESCRIPTION
This is a first step to localizing source and include files. This seems to work by merely removing the global source file property, enforcing CMake >= 3.13, and using `target_sources`.

@sayerhs I started to look at using `target_include_directories` in the `src` directory here, but since there is currently one large `include` directory, would we have to merge the `include` directory with the `src` directory to localize the include paths per directory? Or would we just cut off the directory prefixes and use relative paths in the `.C` `#include` lines and use the explicit paths in `target_include_directories` that pair each `src` subdirectory with its `include` subdirectory? Hard to explain my thought with that correctly I think.

I just realized we also don't seem to need a C compiler here so I removed that.