### PR TITLE
Fix continuity inflow unit test for NGP runs. 

### DIFF
--- a/unit_tests/kernels/UnitTestContinuityInflowElem.C
+++ b/unit_tests/kernels/UnitTestContinuityInflowElem.C
@@ -15,7 +15,7 @@ namespace {
 namespace hex8_golds {
 
 static constexpr double rhs[4] = {
-  0, 0, -0.20225424859374, -0.20225424859374,
+  0, 0.11888206453689, 0.11888206453689, 0
 };
 
 }
@@ -37,7 +37,7 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_inflow)
   solnOpts_.mdotInterpRhoUTogether_ = true;
   solnOpts_.activateOpenMdotCorrection_ = true;
 
-  auto* part = meta_.get_part("surface_1");
+  auto* part = meta_.get_part("surface_2");
   unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::QUAD_4, 1, part);
 
   sierra::nalu::TimeIntegrator timeIntegrator;


### PR DESCRIPTION
This unit test used `surface_1` as the sideset for the inflow computations. However, for historical reasons `surface_1` has all the boundary faces as shown in the code below. 

https://github.com/Exawind/nalu-wind/blob/c1ba146f2ed94e570aa3bf5c0dca1763d9db985a/unit_tests/UnitTestUtils.C#L77-L90

This was fine for CPU only runs since we ensure we always run with 1 OpenMP thread and so the faces were processed in the same order, and the test only considered the results from the first face. However, for GPU runs, this meant that the faces could run in arbitrary order and produce different results (due to the fact that the TestLinearSystem depends on the assumption of only having one face or element for element/face algorithms). 

This pull request changes the sideset from `surface_1` to `surface_2` (as surfaces 2-6 are created according to the mesh generation logic `generated|sideset:xXyYzZ` and will only have one face in them. 