### PR TITLE
Fix segfaults on MacOS and implement all SolverAlgorithm::apply_coeff behavior for NGP runs

### DIFF
--- a/include/AssembleEdgeSolverAlgorithm.h
+++ b/include/AssembleEdgeSolverAlgorithm.h
@@ -64,7 +64,7 @@ public:
     const auto entityRank = entityRank_;
     const auto rhsSize = rhsSize_;
 
-    CoeffApplier* deviceCoeffApplier = eqSystem_->linsys_->get_coeff_applier();
+    auto coeffApplier = coeff_applier();
 
     const auto nodesPerEntity = nodesPerEntity_;
 
@@ -91,15 +91,7 @@ public:
 
             lambdaFunc(smdata, edgeIndex, nodeL, nodeR);
 
-#ifndef KOKKOS_ENABLE_CUDA
-            // TODO: Replace this with NGP version
-            if (realm_.hasOverset_)
-              reset_overset_rows(
-                realm_.meta_data(), eqSystem_->linsys_->numDof(), nodesPerEntity,
-                smdata.ngpElemNodes, smdata.rhs, smdata.lhs);
-#endif
-
-            (*deviceCoeffApplier)(
+            coeffApplier(
               nodesPerEntity, smdata.ngpElemNodes, smdata.scratchIds,
               smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
           });

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -19,8 +19,53 @@
 namespace sierra{
 namespace nalu{
 
+class CoeffApplier;
 class EquationSystem;
 class Realm;
+
+struct NGPApplyCoeff
+{
+  NGPApplyCoeff(EquationSystem*);
+
+  KOKKOS_INLINE_FUNCTION
+  NGPApplyCoeff() = default;
+
+  KOKKOS_INLINE_FUNCTION
+  ~NGPApplyCoeff() = default;
+
+  KOKKOS_FUNCTION
+  void operator()(
+    unsigned numMeshobjs,
+    const ngp::Mesh::ConnectedNodes& symMeshobjs,
+    const SharedMemView<int*,DeviceShmem> & scratchIds,
+    const SharedMemView<int*,DeviceShmem> & sortPermutation,
+    SharedMemView<double*,DeviceShmem> & rhs,
+    SharedMemView<double**,DeviceShmem> & lhs,
+    const char *trace_tag) const;
+
+  KOKKOS_FUNCTION
+  void extract_diagonal(
+    const unsigned nEntities,
+    const ngp::Mesh::ConnectedNodes& entities,
+    SharedMemView<double**, DeviceShmem>& lhs) const;
+
+  KOKKOS_FUNCTION
+  void reset_overset_rows(
+    const unsigned nEntities,
+    const ngp::Mesh::ConnectedNodes& entities,
+    SharedMemView<double*, DeviceShmem>&  rhs,
+    SharedMemView<double**, DeviceShmem>& lhs) const;
+
+  const ngp::Mesh ngpMesh_;
+  mutable ngp::Field<double> diagField_;
+  ngp::Field<int> iblankField_;
+
+  CoeffApplier* deviceSumInto_;
+
+  const unsigned nDim_{3};
+  const bool hasOverset_{false};
+  const bool extractDiagonal_{false};
+};
 
 class SolverAlgorithm : public Algorithm
 {
@@ -36,6 +81,9 @@ public:
   virtual void initialize_connectivity() = 0;
 
 protected:
+
+  NGPApplyCoeff coeff_applier()
+  { return NGPApplyCoeff(eqSystem_); }
 
   // Need to find out whether this ever gets called inside a modification cycle.
   void apply_coeff(

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -112,14 +112,6 @@ protected:
     const SharedMemView<const double**,DeviceShmem> & lhs,
     const char *trace_tag);
 
-  void reset_overset_rows(
-    const stk::mesh::MetaData& meta,
-    const size_t nDim,
-    const size_t nEntities,
-    const ngp::Mesh::ConnectedEntities& entities,
-    sierra::nalu::SharedMemView<double*, sierra::nalu::DeviceShmem>& rhs,
-    sierra::nalu::SharedMemView<double**, sierra::nalu::DeviceShmem>& lhs);
-
   EquationSystem *eqSystem_;
 };
 

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -173,9 +173,7 @@ public:
                              LinSys::LocalVector sharedNotOwnedLclRhs,
                              LinSys::EntityToLIDView entityLIDs,
                              LinSys::EntityToLIDView entityColLIDs,
-                             int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof,
-                             bool extractDiagonal, NGPDoubleFieldType& diagField,
-                             const ngp::Mesh& ngpMesh)
+                             int maxOwnedRowId, int maxSharedNotOwnedRowId, unsigned numDof)
     : ownedLocalMatrix_(ownedLclMatrix),
       sharedNotOwnedLocalMatrix_(sharedNotOwnedLclMatrix),
       ownedLocalRhs_(ownedLclRhs),
@@ -183,8 +181,6 @@ public:
       entityToLID_(entityLIDs),
       entityToColLID_(entityColLIDs),
       maxOwnedRowId_(maxOwnedRowId), maxSharedNotOwnedRowId_(maxSharedNotOwnedRowId), numDof_(numDof),
-      extractDiagonal_(extractDiagonal), diagField_(diagField),
-      ngpMesh_(ngpMesh),
       devicePointer_(nullptr)
     {}
 
@@ -219,9 +215,6 @@ public:
     LinSys::EntityToLIDView entityToColLID_;
     int maxOwnedRowId_, maxSharedNotOwnedRowId_;
     unsigned numDof_;
-    bool extractDiagonal_;
-    NGPDoubleFieldType diagField_;
-    ngp::Mesh ngpMesh_;
     TpetraLinSysCoeffApplier* devicePointer_;
   };
 

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -89,10 +89,10 @@ AssembleFaceElemSolverAlgorithm::execute()
 
   auto ngpKernels = nalu_ngp::create_ngp_view<Kernel>(activeKernels_);
   const size_t numKernels = activeKernels_.size();
+  auto coeffApplier = coeff_applier();
 
   const unsigned nodesPerEntity = nodesPerElem_;
   const unsigned numDof = numDof_;
-  CoeffApplier* deviceCoeffApplier = eqSystem_->linsys_->get_coeff_applier();
   double diagRelaxFactor = diagRelaxFactor_;
 
   run_face_elem_algorithm(realm_.bulk_data(),
@@ -103,35 +103,25 @@ AssembleFaceElemSolverAlgorithm::execute()
 
         for (size_t i=0; i<numKernels; ++i) {
           Kernel* kernel = ngpKernels(i);
-          kernel->execute( smdata.simdlhs, smdata.simdrhs, smdata.simdFaceViews, smdata.simdElemViews, smdata.elemFaceOrdinal );
+          kernel->execute(
+            smdata.simdlhs, smdata.simdrhs, smdata.simdFaceViews,
+            smdata.simdElemViews, smdata.elemFaceOrdinal);
         }
 
 #ifdef KOKKOS_ENABLE_CUDA
-        extract_vector_lane(smdata.simdrhs, 0, smdata.rhs);
-        extract_vector_lane(smdata.simdlhs, 0, smdata.lhs);
-        for (unsigned ir=0; ir < nodesPerEntity*numDof; ++ir)
-          smdata.lhs(ir, ir) /= diagRelaxFactor;
-        (*deviceCoeffApplier)(nodesPerEntity, smdata.ngpConnectedNodes[0],
-                    smdata.scratchIds, smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
+        const int simdIndex = 0;
 #else
-        for(int simdIndex=0; simdIndex<smdata.numSimdFaces; ++simdIndex) {
+        for(int simdIndex=0; simdIndex<smdata.numSimdFaces; ++simdIndex)
+#endif
+        {
           extract_vector_lane(smdata.simdrhs, simdIndex, smdata.rhs);
           extract_vector_lane(smdata.simdlhs, simdIndex, smdata.lhs);
           for (unsigned ir=0; ir < nodesPerElem_*numDof; ++ir)
             smdata.lhs(ir, ir) /= diagRelaxFactor;
 
-#ifndef KOKKOS_ENABLE_CUDA
-          // TODO: Replace this with NGP version
-          if (realm_.hasOverset_)
-            reset_overset_rows(
-              realm_.meta_data(), eqSystem_->linsys_->numDof(), nodesPerEntity,
-              smdata.ngpConnectedNodes[simdIndex], smdata.rhs, smdata.lhs);
-#endif
-
-          (*deviceCoeffApplier)(nodesPerEntity, smdata.ngpConnectedNodes[simdIndex],
+          coeffApplier(nodesPerEntity, smdata.ngpConnectedNodes[simdIndex],
                       smdata.scratchIds, smdata.sortPermutation, smdata.rhs, smdata.lhs, __FILE__);
         }
-#endif
     });
 }
 

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -116,7 +116,7 @@ AssembleFaceElemSolverAlgorithm::execute()
         {
           extract_vector_lane(smdata.simdrhs, simdIndex, smdata.rhs);
           extract_vector_lane(smdata.simdlhs, simdIndex, smdata.lhs);
-          for (unsigned ir=0; ir < nodesPerElem_*numDof; ++ir)
+          for (unsigned ir=0; ir < nodesPerEntity*numDof; ++ir)
             smdata.lhs(ir, ir) /= diagRelaxFactor;
 
           coeffApplier(nodesPerEntity, smdata.ngpConnectedNodes[simdIndex],

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -128,7 +128,7 @@ NGPApplyCoeff::reset_overset_rows(
 
   for (unsigned in=0u; in < nEntities; ++in) {
     const int ibl = iblankField_.get(ngpMesh_, entities[in], 0);
-    const double mask  = std::max(0.0, static_cast<double>(ibl));
+    const double mask = max(0.0, static_cast<double>(ibl));
     const unsigned ix = in * nDim_;
 
     for (unsigned d=0; d < nDim_; ++d) {

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -230,33 +230,5 @@ SolverAlgorithm::apply_coeff(
     eqSystem_->save_diagonal_term(numMeshobjs, symMeshobjs, lhs);
 }
 
-void SolverAlgorithm::reset_overset_rows(
-  const stk::mesh::MetaData& meta,
-  const size_t nDim,
-  const size_t nEntities,
-  const ngp::Mesh::ConnectedEntities& entities,
-  sierra::nalu::SharedMemView<double*, sierra::nalu::DeviceShmem>& rhs,
-  sierra::nalu::SharedMemView<double**, sierra::nalu::DeviceShmem>& lhs)
-{
-  using ScalarIntFieldType = sierra::nalu::ScalarIntFieldType;
-  const size_t numRows = nEntities * nDim;
-
-  ScalarIntFieldType* iblank = meta.get_field<ScalarIntFieldType>(
-    stk::topology::NODE_RANK, "iblank");
-
-  for (size_t in=0; in < nEntities; in++) {
-    const int* ibl = stk::mesh::field_data(*iblank, entities[in]);
-    double mask = std::max(0.0, static_cast<double>(ibl[0]));
-    size_t ix = in * nDim;
-
-    for (size_t d=0; d < nDim; d++) {
-      size_t ir = ix + d;
-
-      rhs(ir) *= mask;
-      for (size_t c=0; c < numRows; c++)
-        lhs(ir, c) *= mask;
-    }
-  }
-}
 } // namespace nalu
 } // namespace Sierra

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -128,7 +128,7 @@ NGPApplyCoeff::reset_overset_rows(
 
   for (unsigned in=0u; in < nEntities; ++in) {
     const int ibl = iblankField_.get(ngpMesh_, entities[in], 0);
-    const double mask = max(0.0, static_cast<double>(ibl));
+    const double mask = stk::math::max(0.0, static_cast<double>(ibl));
     const unsigned ix = in * nDim_;
 
     for (unsigned d=0; d < nDim_; ++d) {

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -12,6 +12,8 @@
 #include <LinearSystem.h>
 #include <KokkosInterface.h>
 
+#include "ngp_utils/NgpFieldUtils.h"
+
 #include <stk_mesh/base/Entity.hpp>
 
 #include <vector>
@@ -81,18 +83,83 @@ void fix_overset_rows(
 namespace sierra{
 namespace nalu{
 
-class Realm;
-class EquationSystem;
+NGPApplyCoeff::NGPApplyCoeff(EquationSystem* eqSystem)
+  : ngpMesh_(eqSystem->realm_.ngp_mesh()),
+    deviceSumInto_(eqSystem->linsys_->get_coeff_applier()),
+    nDim_(eqSystem->linsys_->numDof()),
+    hasOverset_(eqSystem->realm_.hasOverset_),
+    extractDiagonal_(eqSystem->extractDiagonal_)
+{
+  if (extractDiagonal_) {
+    diagField_ = nalu_ngp::get_ngp_field(
+      eqSystem->realm_.mesh_info(), eqSystem->get_diagonal_field()->name());
+  }
 
-//==========================================================================
-// Class Definition
-//==========================================================================
-// SolverAlgorithm - base class for algorithm with expectations of solver
-//                   contributions
-//==========================================================================
-//--------------------------------------------------------------------------
-//-------- constructor -----------------------------------------------------
-//--------------------------------------------------------------------------
+  if (hasOverset_) {
+    iblankField_ = nalu_ngp::get_ngp_field<int>(eqSystem->realm_.mesh_info(), "iblank");
+  }
+}
+
+void NGPApplyCoeff::extract_diagonal(
+  const unsigned int nEntities,
+  const ngp::Mesh::ConnectedNodes& entities,
+  SharedMemView<double**, DeviceShmem>& lhs) const
+{
+  constexpr bool forceAtomic = std::is_same<
+    sierra::nalu::DeviceSpace, Kokkos::DefaultExecutionSpace>::value;
+
+  for (unsigned i=0u; i < nEntities; ++i) {
+    auto ix = i * nDim_;
+    if (forceAtomic)
+      Kokkos::atomic_add(&diagField_.get(ngpMesh_, entities[i], 0), lhs(ix, ix));
+    else
+      diagField_.get(ngpMesh_, entities[i], 0) += lhs(ix, ix);
+  }
+}
+
+void
+NGPApplyCoeff::reset_overset_rows(
+  const unsigned int nEntities,
+  const ngp::Mesh::ConnectedNodes& entities,
+  SharedMemView<double*, DeviceShmem>& rhs,
+  SharedMemView<double**, DeviceShmem>& lhs) const
+{
+  const unsigned numRows = nEntities * nDim_;
+
+  for (unsigned in=0u; in < nEntities; ++in) {
+    const int ibl = iblankField_.get(ngpMesh_, entities[in], 0);
+    const double mask  = std::max(0.0, static_cast<double>(ibl));
+    const unsigned ix = in * nDim_;
+
+    for (unsigned d=0; d < nDim_; ++d) {
+      const unsigned ir = ix + d;
+
+      rhs(ir) *= mask;
+      for (unsigned ic=0; ic < numRows; ++ic)
+        lhs(ir, ic) *= mask;
+    }
+  }
+}
+
+void NGPApplyCoeff::operator()(
+  unsigned numMeshobjs,
+  const ngp::Mesh::ConnectedNodes& symMeshobjs,
+  const SharedMemView<int*,DeviceShmem> & scratchIds,
+  const SharedMemView<int*,DeviceShmem> & sortPermutation,
+  SharedMemView<double*,DeviceShmem> & rhs,
+  SharedMemView<double**,DeviceShmem> & lhs,
+  const char *trace_tag) const
+{
+  if (hasOverset_)
+    reset_overset_rows(numMeshobjs, symMeshobjs, rhs, lhs);
+
+  (*deviceSumInto_)(
+    numMeshobjs, symMeshobjs, scratchIds, sortPermutation, rhs, lhs, trace_tag);
+
+  if (extractDiagonal_)
+    extract_diagonal(numMeshobjs, symMeshobjs, lhs);
+}
+
 SolverAlgorithm::SolverAlgorithm(
   Realm &realm,
   stk::mesh::Part *part,

--- a/unit_tests/kernels/UnitTestContinuityInflowElem.C
+++ b/unit_tests/kernels/UnitTestContinuityInflowElem.C
@@ -15,7 +15,7 @@ namespace {
 namespace hex8_golds {
 
 static constexpr double rhs[4] = {
-  0, 0, -0.20225424859374, -0.20225424859374,
+  0, 0.11888206453689, 0.11888206453689, 0
 };
 
 }
@@ -37,7 +37,7 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_inflow)
   solnOpts_.mdotInterpRhoUTogether_ = true;
   solnOpts_.activateOpenMdotCorrection_ = true;
 
-  auto* part = meta_.get_part("surface_1");
+  auto* part = meta_.get_part("surface_2");
   unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::QUAD_4, 1, part);
 
   sierra::nalu::TimeIntegrator timeIntegrator;


### PR DESCRIPTION
This pull request introduces the following changes:

- Fix [segfaults on MacOS builds](https://my.cdash.org/viewTest.php?onlyfailed&buildid=1728070) introduced by pull requests #432 and #434. The segfaults were caused by Tpetra CoeffApplier storing an instance of `ngp::Mesh` which was being deleted after `stk::mesh::BulkData` was deleted within `Realm` destructor. The `ngp::Mesh` instance was only needed to enable diagonal field extraction from momentum matrices, this was removed as part of the larger cleanup

- The logic of `reset_overset_rows` and `extract_diagonal` was removed for the NGP algorithms as part of the transition effort. The changes introduced in #432 implemented it for only TpetraLinearSystem and left the HypreLinearSystem incomplete for momentum solves when using the new timestepping algorithm. This pull request restores the original behavior of Tpetra CoeffApplier – it only does what the original TpetraLinearSystem::sumInto performed. The behavior of `SolverAlgorithm::apply_coeff` is restored by introducing an NGP safe functor that performs the same function as `apply_coeff`. This restores original behavior for both Trilinos and Hypre solvers on CPUs. 