### PR TITLE
Nalu-Wind copyright update - Part 1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,93 @@
+# -*- mode: yaml -*-
+---
+Language:        Cpp
+AccessModifierOffset: -2
+AlignAfterOpenBracket: AlwaysBreak
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true 
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes: false
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        2
+UseTab:          Never
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug Report 
+about: Help us fix something that is broken 
+title: "Short title describing the bug/issue"
+labels: "type: bug"
+---
+
+## Detailed description of the bug 
+
+Please describe the error/issue you have observed. What was the expected
+behavior? Do you have any ideas on what might have caused this, and how it can
+be fixed?
+
+### Details to reproduce bug/build error
+
+1. SHA ID of the Nalu-Wind commit you are using 
+1. Configure command
+1. CMake configure output
+1. Output of make step
+1. Details of your simulation (input file, mesh description, etc.)
+1. Stack trace of the runtime error output 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,8 +14,8 @@ be fixed?
 ### Details to reproduce bug/build error
 
 1. SHA ID of the Nalu-Wind commit you are using 
-1. Configure command
-1. CMake configure output
-1. Output of make step
+1. Configure command [attach file]
+1. CMake configure output [attach file]
+1. Output of make step [attach file]
 1. Details of your simulation (input file, mesh description, etc.)
 1. Stack trace of the runtime error output 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature Request
+about: Request a new feature or enhancement in Nalu-Wind
+title: "Short title describing your request"
+labels: "type: enhancement"
+---
+
+Please describe the feature/enhancement you would like to see in Nalu-Wind. Is
+the request related to a problem? Describe the solution you would like to see.
+Are there any alternatives you have considered? Do you have any suggestions for
+implementation? Provide any additional context/information that might help the
+developers in addressing your request.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,8 @@
+---
+name: Ask a question
+about: What can we help you with?
+title: "Short title describing your question/concern"
+labels: "type: question"
+---
+
+Provide as much information as possible describing your problem.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+
+**Pull-request type:**
+- [ ] Bug fix 
+- [ ] Documentation update
+- [ ] Feature enhancement
+
+## Description of the pull-request
+
+*Provide a description of your proposed changes. If there is a related issue, please specify.*
+
+## Checklist
+
+*All pull requests*
+- [ ] Builds successfully (*must test on at least one system/compiler combination*)
+  - Operating systems 
+    - [ ] Linux
+    - [ ] MacOS
+  - Compilers 
+    - [ ] GCC
+    - [ ] LLVM/Clang
+    - [ ] Intel compilers
+    - [ ] NVIDIA CUDA
+- [ ] Compiles without warnings
+- [ ] Passes all unit tests
+- [ ] Passes all regression tests
+- [ ] Documentation builds without errors
+
+*For new code updates*
+- [ ] Documentation updates - additions to user, theory, and verification manuals
+- [ ] New unit tests providing coverage for new code, bug fixes etc.
+- [ ] New regression tests exercising the new code

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,14 @@
 
 ## Description of the pull-request
 
-*Provide a description of your proposed changes. If there is a related issue, please specify.*
+*Provide a description of your proposed changes. If there is a related issue, please specify.**
 
 ## Checklist
+
+**NOTE** The checklist below is a suggestion and not mandatory. You don't have
+to _check all boxes_ to submit a pull request. However, please add a brief
+explanation in your pull request summary explaining the omission for the benefit
+of reviewers and developers.
 
 *All pull requests*
 - [ ] Builds successfully (*must test on at least one system/compiler combination*)

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,17 @@
+AUTHORS (in alphabetical order)
+
+Ananthan, Shreyas (NREL) <shreyas.ananthan@nrel.gov>
+Barone, Matthew F. (SNL) <mbarone@sandia.gov>
+Churchfield, Matt (NREL) <matt.churchfield@nrel.gov>
+Domino, Stefan (SNL) <spdomin@sandia.gov>
+Henry de Frahan, Marc (NREL) <marc.henrydefrahan@nrel.gov>
+Knaus, Robert (SNL) <rcknaus@sandia.gov>
+Lund, Thomas (NWRA) <lund@nwra.com>
+Martinez, Luis (Tony) <luis.martinez@nrel.gov>
+Melvin, Jeremy (Univ. of Texas, Austin) <jmelvin@ices.utexas.edu>
+Overfelt, James R. (SNL) <joverf@sandia.gov>
+Rood, Jon (NREL) <jon.rood@nrel.gov>
+Sakievich, Philip (SNL) <psakiev@sandia.gov>
+Sharma, Ashesh (NREL) <ashesh.sharma@nrel.gov>
+Vijayakumar, Ganesh (NREL) <ganesh.vijayakumar@nrel.gov>
+Williams, Alan B. (SNL) <william@sandia.gov>

--- a/AUTHORS
+++ b/AUTHORS
@@ -7,7 +7,7 @@ Domino, Stefan (SNL) <spdomin@sandia.gov>
 Henry de Frahan, Marc (NREL) <marc.henrydefrahan@nrel.gov>
 Knaus, Robert (SNL) <rcknaus@sandia.gov>
 Lund, Thomas (NWRA) <lund@nwra.com>
-Martinez, Luis (Tony) <luis.martinez@nrel.gov>
+Martinez, Luis (Tony) (NREL) <luis.martinez@nrel.gov>
 Melvin, Jeremy (Univ. of Texas, Austin) <jmelvin@ices.utexas.edu>
 Overfelt, James R. (SNL) <joverf@sandia.gov>
 Rood, Jon (NREL) <jon.rood@nrel.gov>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,11 @@ manual](https://nalu-wind.readthedocs.io/en/latest/source/developer/index.html).
   updates to the documentation, supported by necessary verification and
   validation, as well as unit tests and regression tests
   
+- Where appropriate please use [Clang
+  format](https://clang.llvm.org/docs/ClangFormat.html) to format your code to
+  match the rest of Nalu-Wind. Only do that for sections you edit/add. Don't run
+  `clang-format` on the entire file if it is not a new file created by you.
+  
 Once a pull-request is submitted you will iterate with Nalu-Wind maintainers
 until your changes are in an acceptable state and can be merged in. You can push
 addditional commits to the branch used to create the pull-request to reflect the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ guidelines for contributing to the Nalu-Wind project.
 ## Reporting bugs
 
 This section guides you through the process of [submitting a bug
-report](https://github.com/exawind/nalu-wind/issues/new) for Nalu-Wind.
+report](https://github.com/exawind/nalu-wind/issues/new) for the Nalu-Wind project.
 Following these guidelines will help maintainers understand your issue,
 reproduce the behavior, and develop a fix in an expedient fashion. Before
 submitting your bug report, please perform a [cursory

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing to Nalu-Wind
+
+Thank you for considering contributing to Nalu-Wind project. Please follow these
+guidelines for contributing to Nalu-Wind project.
+
+## Reporting bugs
+
+This section guides you through the process of [submitting a bug
+report](https://github.com/exawind/nalu-wind/issues/new) for Nalu-Wind.
+Following these guidelines will help maintainers understand your issue,
+reproduce the behavior, and develop a fix in an expedient fashion. Before
+submitting your bug report, please perform a [cursory
+search](https://github.com/search?q=is%3Aissue+repo%3Aexawind%2Fnalu-wind) to
+see if the problem has been already reported. If it has been reported, and the
+issue is still open, add a comment to the existing issue instead of opening a
+new issue.
+
+### Tips for effective bug reporting
+
+- Use a clear descriptive title for the issue
+
+- Describe the steps to reproduce the problem, the behavior you observed after
+  following the steps, and the expected behavior
+
+- Provide the SHA ID of the git commit Nalu-Wind code that you are using, as
+  well as the SHA ID of the Trilinos build
+
+- Provide as much details as possible about the operating system, compiler
+  versions, and third-party libraries used to build Nalu-Wind
+  
+- Include output of the CMake configuration step 
+
+- For build errors, include the complete output when executing `make`
+
+- For runtime errors, provide a stack trace of the error output
+
+## Contributing code and documentation changes
+
+Contributions can take the form of bug fixes, feature enhancements,
+documentation updates. All updates to the repository is managed via [pull
+requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests).
+One of the easiest ways to get started is by looking at [open
+issues](https://github.com/Exawind/nalu-wind/issues) and contributing fixes,
+enhancements that address those issues. If your code contribution involves large
+changes or additions to the codebase, we recommend opening an issue first and
+discussing your proposed changes with the core development team to ensure that
+your efforts are well directed, and so that your submission can be reviewed and
+merged seamlessly by the maintenance team.
+
+Nalu-Wind can be developed locally. For instructions please consult the
+[developer
+manual](https://nalu-wind.readthedocs.io/en/latest/source/developer/index.html).
+
+### Guidelines for preparing and submitting pull-requests
+
+- Use a clear descriptive title for your pull-requests
+
+- Describe if your submission is a bugfix, documentation update, or a feature
+  enhancement. Provide a concise description of your proposed changes. 
+  
+- Provide references to open issues, if applicable, to provide the necessary
+  context to understand your pull request.
+  
+- Make sure that your pull-request merges cleanly with the `master` branch of
+  Nalu-Wind. When working on a feature, always create your feature branch off of
+  the latest `master` commit.
+  
+- Ensure that the code compiles without warnings, the unit tests and regression
+  tests all pass without errors, and the documentation builds properly with your
+  modifications.
+  
+- New physics models and code enhancements should be accompanied with relevant
+  updates to the documentation, supported by necessary verification and
+  validation, as well as unit tests and regression tests.
+  
+Once a pull-request is submitted you will iterate with Nalu-Wind maintainers
+until your changes are in an acceptable state and can be merged in. You can push
+addditional commits to the branch used to create the pull-request to reflect the
+feedback from maintainers and users of the code.
+  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Nalu-Wind
 
 Thank you for considering contributing to Nalu-Wind project. Please follow these
-guidelines for contributing to Nalu-Wind project.
+guidelines for contributing to the Nalu-Wind project.
 
 ## Reporting bugs
 
@@ -25,7 +25,7 @@ new issue.
 - Provide the SHA ID of the git commit Nalu-Wind code that you are using, as
   well as the SHA ID of the Trilinos build
 
-- Provide as much details as possible about the operating system, compiler
+- Provide as much detail as possible about the operating system, compiler
   versions, and third-party libraries used to build Nalu-Wind
   
 - Include output of the CMake configuration step 
@@ -37,7 +37,7 @@ new issue.
 ## Contributing code and documentation changes
 
 Contributions can take the form of bug fixes, feature enhancements,
-documentation updates. All updates to the repository is managed via [pull
+documentation updates. All updates to the repository are managed via [pull
 requests](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/proposing-changes-to-your-work-with-pull-requests).
 One of the easiest ways to get started is by looking at [open
 issues](https://github.com/Exawind/nalu-wind/issues) and contributing fixes,
@@ -59,19 +59,19 @@ manual](https://nalu-wind.readthedocs.io/en/latest/source/developer/index.html).
   enhancement. Provide a concise description of your proposed changes. 
   
 - Provide references to open issues, if applicable, to provide the necessary
-  context to understand your pull request.
+  context to understand your pull request
   
 - Make sure that your pull-request merges cleanly with the `master` branch of
   Nalu-Wind. When working on a feature, always create your feature branch off of
-  the latest `master` commit.
+  the latest `master` commit
   
 - Ensure that the code compiles without warnings, the unit tests and regression
   tests all pass without errors, and the documentation builds properly with your
-  modifications.
+  modifications
   
 - New physics models and code enhancements should be accompanied with relevant
   updates to the documentation, supported by necessary verification and
-  validation, as well as unit tests and regression tests.
+  validation, as well as unit tests and regression tests
   
 Once a pull-request is submitted you will iterate with Nalu-Wind maintainers
 until your changes are in an acceptable state and can be merged in. You can push

--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,9 @@
-************************************************************************
-     Nalu 1.0:  Copyright 2014 Sandia Corporation
+Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC (NTESS),
+National Renewable Energy Laboratory, University of Texas Austin,
+Northwest Research Associates.
 
-Under the terms of Contract DE-AC04-94AL85000 with Sandia Corporation,
-the U.S. Government retains certain rights in this software.
+Under the terms of Contract DE-NA0003525 with NTESS, the U.S. Government retains
+certain rights in this software.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -15,21 +16,20 @@ notice, this list of conditions and the following disclaimer.
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
-3. Neither the name of the Corporation nor the names of the
+3. Neither the name of the copyright holders nor the names of the
 contributors may be used to endorse or promote products derived from
 this software without specific prior written permission.
 
-THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-Questions? Contact Stefan Domino (spdomin@sandia.gov)
-************************************************************************
+Questions? Contact Michael A. Sprague <michael.a.sprague@nrel.gov> or
+Paul Crozier <pscrozi@sandia.gov>

--- a/README.md
+++ b/README.md
@@ -1,26 +1,97 @@
-Nalu-Wind, a generalized unstructured massively parallel low Mach flow code designed to support the Exawind ECP.
+# Nalu-Wind 
 
-The Department of Energy (DOE), by memo dated 05/13/2014, has granted Sandia permission to assert 
-its copyright in software entitled "Nalu v 1.0".
+[Website](https://www.exawind.org/) | [Documentation](https://nalu-wind.readthedocs.io) | [Nightly test dashboard](http://my.cdash.org/index.php?project=Nalu-Wind) 
 
-### Referencing Nalu-Wind
-When disseminating technical work that includes Nalu-Wind simulations, please reference the following citation:
+Nalu-Wind is a generalized, unstructured, massively-parallel, incompressible
+flow solver on wind turbine and wind farm simulations. The codebase is a
+wind-focused fork of [NaluCFD](https://github.com/NaluCFD/Nalu) developed and
+maintained by Sandia National Laboratories. Nalu-Wind is being actively
+developed and maintained by a dedicated, multi-institutional team from [National
+Renewable Energy Laboratory](https://nrel.gov), [Sandia National
+Laboratories](https://sandia.gov), [Univ. of Texas Austin](https://utexas.edu).
 
-	Domino, S. "Sierra Low Mach Module: Nalu Theory Manual 1.0", SAND2015-3107W, Sandia National Laboratories Unclassified Unlimited Release (UUR), 2015. https://github.com/NaluCFD/NaluDoc
-	
-This document can be found under the [Nalu-Wind Documentation](http://nalu-wind.readthedocs.io/en/latest/source/theory/index.html).
+Nalu-Wind is developed as an open-source code with the following objectives: an
+open, documented implementation of the state-of-the-art computational models for
+modeling wind farm flow physics at various fidelities that are backed by a
+comprehensive verification and validation (V&V) process, be capable of
+performing the highest-fidelity simulations of flowfields within wind farms, and
+being able to leverage the high-performance leadership class computating
+facilities available at DOE national laboratories. We hope that this community
+developed model will be used by research laboratories, academia, and industry to
+develop the next-generation of wind farm technologies.
 
-### Nalu-Wind Documentation
+We welcome the wind energy community to use Nalu-Wind in their research. When
+disseminating technical work that includes Nalu-Wind simulations please
+reference the following citation:
 
-The Nalu-Wind documentation website is located [here](http://nalu-wind.readthedocs.io/en/latest/).
+    Sprague, M. A., Ananthan, S., Vijayakumar, G., Robinson, M., "ExaWind: A multifidelity modeling and simulation environment for wind energy", NAWEA/WindTech 2019 Conference, Amherst, MA, 2019.
 
-### Building Nalu-Wind
+## Documentation
 
-Detailed build instructions for Nalu and the accompanied required TPLs, e.g., Trilinos, YAML, etc.,
-can be found in the [Nalu-Wind Documentation](http://nalu-wind.readthedocs.io/en/latest/).
+Documentation is available online at https://nalu-wind.readthedocs.io/ and is
+split into the following sections:
 
-### Nightly Testing Status
+- [User manual](https://nalu-wind.readthedocs.io/en/latest/source/user/index.html):
+  The user manual contains detailed instructions on building the code, along
+  with the required third-party libraries (TPLs) and usage.
+  
+- [Theory manual](https://nalu-wind.readthedocs.io/en/latest/source/theory/index.html):
+  This section provides a detailed overview of the supported equation sets, the
+  discretization and time-integration schemes, turbulence models available, etc.
+  
+- [Verification manual](https://nalu-wind.readthedocs.io/en/latest/source/verification/index.html):
+  This section documents the results from verification studies of the spatial
+  and temporal schemes available in Nalu-Wind.
+  
+All documentation is maintained alongside the source code within the git
+repository and automatically deployed to ReadTheDocs website upon new commits.
+  
+## Compilation and usage
 
-[![CDash Logo](https://github.com/NaluCFD/Nalu/wiki/images/cDashLogo.gif)](http://my.cdash.org/index.php?project=Nalu-Wind)
+Nalu-Wind is primarily built upon the packages provided by the [Trilinos
+project](https://trilinos.org), which in turn depends on several third-party
+libraries (MPI, HDF5, NetCDF, parallel NetCDF), and YAML-CPP. In addition, it
+has the following optional dependencies: hypre, TIOGA, and OpenFAST. Detailed
+build instructions are available in the [user
+manual](https://nalu-wind.readthedocs.io/en/latest/source/user/building.html).
+We recommend using [Spack](https://spack.io/) package manager to install
+Nalu-Wind on your system.
 
-Nightly testing results can be seen by clicking the CDash logo above. More details on testing can be found [here](http://nalu-wind.readthedocs.io/en/latest/source/developer/testing.html).
+### Testing and quality assurance
+
+Nalu-Wind comes with a comprehensive unit test and regression test suite that
+exercise almost all major components of the code. The `master` branch is
+compiled and run through a regression test suite different compilers
+([GCC](https://gcc.gnu.org/), [LLVM/Clang](https://clang.llvm.org/), and
+[Intel](https://software.intel.com/en-us/compilers)) on Linux and MacOS
+operating systems, against both the `master` and `develop` branches of
+[Trilinos](https://github.com/trilinos/Trilinos). The results of the nightly
+testing are publicly available on
+[CDash dashboard](http://my.cdash.org/index.php?project=Nalu-Wind).
+
+### Help and reporting bugs
+
+To report issues or bugs please [create a new
+issue](https://github.com/Exawind/nalu-wind/issues/new) on GitHub.
+
+## Contributing
+
+We welcome contributions from the community in form of bug fixes, feature
+enhancements, documentation updates, etc. All contributions are processed
+through pull-requests on GitHub. Please follow our [contributing
+guidelines](https://github.com/Exawind/nalu-wind/blob/master/CONTRIBUTING.md)
+when submitting pull-requests.
+  
+## License
+
+Nalu-Wind is licensed under [BSD 3-clause
+license](https://github.com/Exawind/nalu-wind/blob/master/LICENSE).
+
+## Acknowledgements 
+
+Nalu-Wind is currently being developed with funding from Department of Energy's
+(DOE) Office of Science [Exascale Computing Project
+(ECP)](https://www.exascaleproject.org/) and Energy Efficiency and Renewable
+Energy (EERE) Wind Energy Technology Office (WETO). Please see [authors
+file](https://github.com/Exawind/nalu-wind/blob/master/AUTHORS) for a 
+list of contributors to Nalu-Wind. 

--- a/README.md
+++ b/README.md
@@ -2,39 +2,41 @@
 
 [Website](https://www.exawind.org/) | [Documentation](https://nalu-wind.readthedocs.io) | [Nightly test dashboard](http://my.cdash.org/index.php?project=Nalu-Wind) 
 
-Nalu-Wind is a generalized, unstructured, massively-parallel, incompressible
-flow solver on wind turbine and wind farm simulations. The codebase is a
-wind-focused fork of [NaluCFD](https://github.com/NaluCFD/Nalu) developed and
-maintained by Sandia National Laboratories. Nalu-Wind is being actively
+Nalu-Wind is a generalized, unstructured, massively parallel, incompressible
+flow solver for wind turbine and wind farm simulations. The codebase is a
+wind-focused fork of [NaluCFD](https://github.com/NaluCFD/Nalu); NaluCFD is developed 
+and maintained by Sandia National Laboratories. Nalu-Wind is being actively
 developed and maintained by a dedicated, multi-institutional team from [National
 Renewable Energy Laboratory](https://nrel.gov), [Sandia National
-Laboratories](https://sandia.gov), [Univ. of Texas Austin](https://utexas.edu).
+Laboratories](https://sandia.gov), and [Univ. of Texas Austin](https://utexas.edu).
 
-Nalu-Wind is developed as an open-source code with the following objectives: an
-open, documented implementation of the state-of-the-art computational models for
-modeling wind farm flow physics at various fidelities that are backed by a
-comprehensive verification and validation (V&V) process, be capable of
-performing the highest-fidelity simulations of flowfields within wind farms, and
-being able to leverage the high-performance leadership class computating
-facilities available at DOE national laboratories. We hope that this community
-developed model will be used by research laboratories, academia, and industry to
-develop the next-generation of wind farm technologies.
+Nalu-Wind is developed as an open-source code with the following objectives: 
 
-We welcome the wind energy community to use Nalu-Wind in their research. When
-disseminating technical work that includes Nalu-Wind simulations please
-reference the following citation:
+- an open, well-documented implementation of the state-of-the-art computational
+  models for modeling wind farm flow physics at various fidelities that are
+  backed by a comprehensive verification and validation (V&V) process;
 
-    Sprague, M. A., Ananthan, S., Vijayakumar, G., Robinson, M., "ExaWind: A multifidelity modeling and simulation environment for wind energy", NAWEA/WindTech 2019 Conference, Amherst, MA, 2019.
+- be capable of performing the highest-fidelity simulations of flowfields within
+  wind farms; and 
+
+- be able to leverage the high-performance leadership class computating
+  facilities available at DOE national laboratories.
+
+We hope that this community developed model will be used by research
+laboratories, academia, and industry to develop the next-generation of wind farm
+technologies. We welcome the wind energy community to use Nalu-Wind in their
+research. When disseminating technical work that includes Nalu-Wind simulations
+please reference the following citation:
+
+    Sprague, M. A., Ananthan, S., Vijayakumar, G., Robinson, M., "ExaWind: A multifidelity 
+    modeling and simulation environment for wind energy", NAWEA/WindTech 2019 Conference, 
+    Amherst, MA, 2019.
 
 ## Documentation
 
 Documentation is available online at https://nalu-wind.readthedocs.io/ and is
 split into the following sections:
 
-- [User manual](https://nalu-wind.readthedocs.io/en/latest/source/user/index.html):
-  The user manual contains detailed instructions on building the code, along
-  with the required third-party libraries (TPLs) and usage.
-  
 - [Theory manual](https://nalu-wind.readthedocs.io/en/latest/source/theory/index.html):
   This section provides a detailed overview of the supported equation sets, the
   discretization and time-integration schemes, turbulence models available, etc.
@@ -42,6 +44,10 @@ split into the following sections:
 - [Verification manual](https://nalu-wind.readthedocs.io/en/latest/source/verification/index.html):
   This section documents the results from verification studies of the spatial
   and temporal schemes available in Nalu-Wind.
+  
+- [User manual](https://nalu-wind.readthedocs.io/en/latest/source/user/index.html):
+  The user manual contains detailed instructions on building the code, along
+  with the required third-party libraries (TPLs) and usage.
   
 All documentation is maintained alongside the source code within the git
 repository and automatically deployed to ReadTheDocs website upon new commits.
@@ -61,20 +67,19 @@ Nalu-Wind on your system.
 
 Nalu-Wind comes with a comprehensive unit test and regression test suite that
 exercise almost all major components of the code. The `master` branch is
-compiled and run through a regression test suite different compilers
+compiled and run through a regression test suite with different compilers
 ([GCC](https://gcc.gnu.org/), [LLVM/Clang](https://clang.llvm.org/), and
 [Intel](https://software.intel.com/en-us/compilers)) on Linux and MacOS
 operating systems, against both the `master` and `develop` branches of
-[Trilinos](https://github.com/trilinos/Trilinos). The results of the nightly
-testing are publicly available on
-[CDash dashboard](http://my.cdash.org/index.php?project=Nalu-Wind).
+[Trilinos](https://github.com/trilinos/Trilinos). Tests are performed both using
+flat MPI and hybrid MPI-GPU hardware configurations. The results of the nightly
+testing are publicly available on [CDash
+dashboard](http://my.cdash.org/index.php?project=Nalu-Wind).
 
-### Help and reporting bugs
+### Contributing, reporting bugs, and requesting help
 
 To report issues or bugs please [create a new
 issue](https://github.com/Exawind/nalu-wind/issues/new) on GitHub.
-
-## Contributing
 
 We welcome contributions from the community in form of bug fixes, feature
 enhancements, documentation updates, etc. All contributions are processed
@@ -84,8 +89,9 @@ when submitting pull-requests.
   
 ## License
 
-Nalu-Wind is licensed under [BSD 3-clause
-license](https://github.com/Exawind/nalu-wind/blob/master/LICENSE).
+Nalu-Wind is licensed under BSD 3-clause license. Please see the
+[LICENSE](https://github.com/Exawind/nalu-wind/blob/master/LICENSE) included in
+the source code repository for more details.
 
 ## Acknowledgements 
 


### PR DESCRIPTION
**Background**: The ExaWind and A2e HFM project teams have been working on a joint-copyright assertion for the Nalu-Wind code to reflect the multi-institutional authorship of the codes. After a long process, we finally got this approved by Sandia Copyright Admin on Nov 14, 2019. 

This pull request is the first of a series to update the codebase to reflect the joint copyright assertion and updating documentation to let developers know how to add copyright notices on the new source code files created within the repository. As part of the process, Mike, Paul, and I thought it would be a good opportunity to also update the README and other files to more reflect Nalu-Wind. Since there are over 1000 files in the repo that will change copyright notices, I decided to split the commit into two. This pull request updates files in the root directory, and the next pull request will do the boilerplate changes across all the headers and C++ source files in the repo. 

Summary of updates in this pull request:

- Update LICENSE file with the new copyright notice and update contact information 

- Updates README with a more detailed introduction of Nalu-Wind, a more recent citation for referring to Nalu-Wind and an acknowledgements section

- Adds an AUTHORS file with all the current authors deemed to have significant contributions. This is intended to be a living document that will get updated when new authors add new functionality/enhancements to the codebase. 

- Adds a contributors guideline file and associated GitHub templates following those found in Trilinos and OpenFAST repositories. 

- Adds a `.clang-format` file that has been configured to match the formatting used in the source code. Please refer to [clang format documentation](https://clang.llvm.org/docs/ClangFormat.html) to configure your editors to use this capability.  