### PR TITLE
Fixing more clang warning from the dashboard.

### DIFF
--- a/src/kernel/MomentumSSTTAMSForcingElemKernel.C
+++ b/src/kernel/MomentumSSTTAMSForcingElemKernel.C
@@ -253,9 +253,10 @@ MomentumSSTTAMSForcingElemKernel<AlgTraits>::execute(
     const DoubleType F_target =
       forceFactor_ * stk::math::sqrt(alphaScv * v2Scv) / T_alpha;
 
-    const DoubleType prod_r_temp =
-      (F_target * dt_) *
-      (h[0] * w_fluctUScv[0] + h[1] * w_fluctUScv[1] + h[2] * w_fluctUScv[2]);
+    DoubleType prod_r_temp = 0.0;
+    for (int d = 0; d < AlgTraits::nDim_; d++)
+      prod_r_temp += h[d] * w_fluctUScv[d];
+    prod_r_temp *= (F_target * dt_);
 
     const DoubleType prod_r_sgn =
       stk::math::if_then_else(prod_r_temp < 0.0, -1.0, 1.0);


### PR DESCRIPTION
**Pull-request type:**
- [X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

This fixes clang warnings appeared on the dashboard that didn't appear on my local clang build.

## Checklist

- [X] Builds successfully
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [X] GCC
    - [X] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors
