### PR TITLE
add parser option to rebalance mesh using stk_balance

### DIFF
--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -403,6 +403,13 @@ Common options
    A boolean flag indicating whether memory diagnostics are activated during
    simulation. Default value is ``no``.
 
+.. inpfile:: rebalance_mesh
+
+   A boolean flag indicating whether to rebalance mesh using stk_balance. The 
+   default value is ``no``. If this parameter is activated, it requires that
+   ``stk_rebalance_method`` is also set to specify the decomposition method to be 
+   used for rebalance, e.g., RIB, RCB, etc. 
+
 .. inpfile:: balance_nodes
 
    A boolean flag indicating whether node balancing is performed during

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -521,6 +521,11 @@ class Realm {
   // automatic mesh decomposition; None, rib, rcb, multikl, etc.
   std::string autoDecompType_;
 
+  // STK rebalance options
+  bool rebalanceMesh_{false};
+  
+  std::string rebalanceMethod_;
+   
   // allow aura to be optional
   bool activateAura_;
 

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -499,6 +499,11 @@ Realm::initialize()
 
   // rebalance mesh using stk_balance
   if (rebalanceMesh_) {
+#ifndef HAVE_ZOLTAN2_PARMETIS
+  if (rebalanceMethod_ == "parmetis")
+    throw std::runtime_error("Zoltan2 is not built with parmetis enabled, "
+                             "try a geometric balance method instead (rcb or rib)");
+#endif
     stk::balance::GraphCreationSettings rebalanceSettings;
     rebalanceSettings.setDecompMethod(rebalanceMethod_);
     stk::balance::balanceStkMesh(rebalanceSettings, *bulkData_);

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -475,10 +475,6 @@ Realm::initialize()
   timerPopulateMesh_ += time;
   NaluEnv::self().naluOutputP0() << "Realm::ioBroker_->populate_mesh() End" << std::endl;
 
-  if (doBalanceNodes_) {
-    balance_nodes();
-  }
-
   // If we want to create all internal edges, we want to do it before
   // field-data is allocated because that allows better performance in
   // the create-edges code.
@@ -506,6 +502,10 @@ Realm::initialize()
     stk::balance::GraphCreationSettings rebalanceSettings;
     rebalanceSettings.setDecompMethod(rebalanceMethod_);
     stk::balance::balanceStkMesh(rebalanceSettings, *bulkData_);
+  }
+
+  if (doBalanceNodes_) {
+    balance_nodes();
   }
 
   if (doPromotion_) {


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

This change adds the parser option to turn on rebalance using stk_balance with the input file parameter ``rebalance_mesh``. Users need to provide a decomposition method ``stk_rebalance_method`` in the input file as well. 

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x ] Linux
    - [ ] MacOS
  - Compilers 
    - [x ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x ] NVIDIA CUDA
- [x ] Compiles without warnings
- [x ] Passes all unit tests
- [x ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [x ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
