### PR TITLE
Fix promoted element ioss writer when p != 2

### DIFF
--- a/include/element_promotion/HexNElementDescription.h
+++ b/include/element_promotion/HexNElementDescription.h
@@ -14,6 +14,7 @@
 #include <map>
 #include <memory>
 #include <vector>
+#include <array>
 
 namespace sierra {
 namespace nalu {
@@ -46,6 +47,7 @@ public:
   const int newNodesPerEdge;
   const int newNodesPerFace;
   const int newNodesPerVolume;
+  const int subElementsPerElement;
 private:
   void set_subelement_connectivity();
   std::vector<int> edge_node_ordinals();

--- a/include/element_promotion/PromotedElementIO.h
+++ b/include/element_promotion/PromotedElementIO.h
@@ -83,14 +83,10 @@ private:
     const stk::mesh::PartVector& baseParts,
     const std::vector<stk::mesh::EntityId>& entityIds);
 
-  void write_sideset_connectivity(
-      const stk::mesh::PartVector& baseParts);
-
   size_t sub_element_global_id() const;
   void write_node_block_definitions(
       const stk::mesh::PartVector& superElemParts);
   void write_elem_block_definitions(const stk::mesh::PartVector& baseParts);
-  void write_sideset_definitions(const stk::mesh::PartVector& baseParts);
   void write_coordinate_list(const stk::mesh::PartVector& superElemParts);
 
   template<typename T> void

--- a/src/element_promotion/HexNElementDescription.C
+++ b/src/element_promotion/HexNElementDescription.C
@@ -104,7 +104,8 @@ HexNElementDescription::HexNElementDescription(int p)
   nodesPerElement(nodes1D*nodes1D*nodes1D),
   newNodesPerEdge(polyOrder - 1),
   newNodesPerFace(newNodesPerEdge * newNodesPerEdge),
-  newNodesPerVolume(newNodesPerEdge * newNodesPerEdge * newNodesPerEdge)
+  newNodesPerVolume(newNodesPerEdge * newNodesPerEdge * newNodesPerEdge),
+  subElementsPerElement((nodes1D-1)*(nodes1D-1)*(nodes1D-1))
 {
   set_edge_node_connectivities();
   set_face_node_connectivities();
@@ -629,7 +630,7 @@ void HexNElementDescription::set_tensor_product_node_mappings()
 void
 HexNElementDescription::set_subelement_connectivites()
 {
-  subElementConnectivity.resize((nodes1D-1)*(nodes1D-1)*(nodes1D-1));
+  subElementConnectivity.resize(subElementsPerElement);
   for (int k = 0; k < nodes1D-1; ++k) {
     for (int j = 0; j < nodes1D-1; ++j) {
       for (int i = 0; i < nodes1D-1; ++i) {


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Fixes a bug I introduced in #472 where the promoted element ioss writer was not writing enough elements when p > 2.   Also gets rid of sideset definitions that were written but unused.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
