### PR TITLE
Using Tpetra default types to define Nalu's types, see issue #475

### DIFF
--- a/include/LinearSolver.h
+++ b/include/LinearSolver.h
@@ -16,6 +16,7 @@
 #include <LinearSolverConfig.h>
 
 #include <Kokkos_DefaultNode.hpp>
+#include <Tpetra_Details_DefaultTypes.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Teuchos_GlobalMPISession.hpp>
@@ -25,11 +26,11 @@
 
 // Header files defining default types for template parameters.
 // These headers must be included after other MueLu/Xpetra headers.
-typedef double                                                        Scalar;
-typedef long                                                          GlobalOrdinal;
-typedef int                                                           LocalOrdinal;
-typedef Tpetra::Map<LocalOrdinal, GlobalOrdinal>::node_type           Node;
-typedef Teuchos::ScalarTraits<Scalar> STS;
+using Scalar        = sierra::nalu::LinSys::Scalar;
+using GlobalOrdinal = sierra::nalu::LinSys::GlobalOrdinal;
+using LocalOrdinal  = sierra::nalu::LinSys::LocalOrdinal;
+using Node          = Tpetra::Map<LocalOrdinal, GlobalOrdinal>::node_type;
+using STS           = Teuchos::ScalarTraits<Scalar>;
 
 // MueLu main header: include most common header files in one line
 #include <MueLu.hpp>
@@ -58,8 +59,8 @@ class Simulation;
 
 const LocalOrdinal INVALID = std::numeric_limits<LocalOrdinal>::max();
 
-typedef typename LinSys::LocalGraph::row_map_type::non_const_type RowPointers;
-typedef typename LinSys::LocalGraph::entries_type::non_const_type ColumnIndices;
+using RowPointers    = typename LinSys::LocalGraph::row_map_type::non_const_type;
+using ColumnIndices  = typename LinSys::LocalGraph::entries_type::non_const_type;
 
 /** LocalGraphArrays is a helper class for building the arrays describing
  * the local csr graph, rowPointers and colIndices. These arrays are passed

--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -13,6 +13,7 @@
 #define LinearSolverTypes_h
 
 #include <KokkosInterface.h>
+#include <Tpetra_Details_DefaultTypes.hpp>
 #include <Tpetra_CrsGraph.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 #include <Tpetra_Vector.hpp>
@@ -63,35 +64,35 @@ class TpetraLinearSolver;
 
 struct LinSys {
 
-typedef long   GlobalOrdinal; // MUST be signed
-typedef int    LocalOrdinal;  // MUST be signed
-typedef double Scalar;
+  using Scalar        = Tpetra::Details::DefaultTypes::scalar_type;
+  using GlobalOrdinal = Tpetra::Details::DefaultTypes::global_ordinal_type;
+  using LocalOrdinal  = Tpetra::Details::DefaultTypes::local_ordinal_type;
 
-typedef Kokkos::DualView<size_t*, DeviceSpace>                             RowLengths;
-typedef RowLengths::t_dev                                                  DeviceRowLengths;
-typedef RowLengths::t_host                                                 HostRowLengths;
-typedef Tpetra::Map<LocalOrdinal, GlobalOrdinal>::node_type                Node;
-typedef Tpetra::CrsGraph< LocalOrdinal, GlobalOrdinal, Node>               Graph;
-typedef typename Graph::local_graph_type                                   LocalGraph;
-typedef Teuchos::MpiComm<int>                                              Comm;
-typedef Tpetra::Export< LocalOrdinal, GlobalOrdinal, Node >                Export;
-typedef Tpetra::Import< LocalOrdinal, GlobalOrdinal, Node >                Import;
-typedef Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node>                       Map;
-typedef Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>        MultiVector;
-typedef Teuchos::ArrayRCP<Scalar >                                         OneDVector;
-typedef Teuchos::ArrayRCP<const Scalar >                                   ConstOneDVector;
-typedef MultiVector::dual_view_type::t_host                                LocalVector;
-typedef Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>       Matrix;
-typedef Matrix::local_matrix_type                                          LocalMatrix;
-typedef Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>        Operator;
-typedef Belos::MultiVecTraits<Scalar, MultiVector>                         MultiVectorTraits;
-typedef Belos::OperatorTraits<Scalar,MultiVector, Operator>                OperatorTraits;
-typedef Belos::LinearProblem<Scalar, MultiVector, Operator>                LinearProblem;
-typedef Belos::SolverManager<Scalar, MultiVector, Operator>                SolverManager;
-typedef Belos::TpetraSolverFactory<Scalar, MultiVector, Operator>          SolverFactory;
-typedef Ifpack2::Preconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node> Preconditioner;
+  using RowLengths        = Kokkos::DualView<size_t*, DeviceSpace>;
+  using DeviceRowLengths  = RowLengths::t_dev;
+  using HostRowLengths    = RowLengths::t_host;
+  using Node              = Tpetra::Map<LocalOrdinal, GlobalOrdinal>::node_type;
+  using Graph             = Tpetra::CrsGraph< LocalOrdinal, GlobalOrdinal, Node>;
+  using LocalGraph        = typename Graph::local_graph_type;
+  using Comm              = Teuchos::MpiComm<int>;
+  using Export            = Tpetra::Export< LocalOrdinal, GlobalOrdinal, Node >;
+  using Import            = Tpetra::Import< LocalOrdinal, GlobalOrdinal, Node >;
+  using Map               = Tpetra::Map<LocalOrdinal,GlobalOrdinal,Node>;
+  using MultiVector       = Tpetra::MultiVector<Scalar,LocalOrdinal,GlobalOrdinal,Node>;
+  using OneDVector        = Teuchos::ArrayRCP<Scalar >;
+  using ConstOneDVector   = Teuchos::ArrayRCP<const Scalar >;
+  using LocalVector       = MultiVector::dual_view_type::t_host;
+  using Matrix            = Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+  using LocalMatrix       = Matrix::local_matrix_type;
+  using Operator          = Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+  using MultiVectorTraits = Belos::MultiVecTraits<Scalar, MultiVector>;
+  using OperatorTraits    = Belos::OperatorTraits<Scalar,MultiVector, Operator>;
+  using LinearProblem     = Belos::LinearProblem<Scalar, MultiVector, Operator>;
+  using SolverManager     = Belos::SolverManager<Scalar, MultiVector, Operator>;
+  using SolverFactory     = Belos::TpetraSolverFactory<Scalar, MultiVector, Operator>;
+  using Preconditioner    = Ifpack2::Preconditioner<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
 
-using EntityToLIDView = Kokkos::View<LocalOrdinal*,Kokkos::LayoutRight,LinSysMemSpace>;
+  using EntityToLIDView = Kokkos::View<LocalOrdinal*, Kokkos::LayoutRight, LinSysMemSpace>;
 };
 
 

--- a/unit_tests/UnitTestTpetraHelperObjects.h
+++ b/unit_tests/UnitTestTpetraHelperObjects.h
@@ -46,10 +46,10 @@ struct TpetraHelperObjectsBase {
 
     using MatrixType = sierra::nalu::LinSys::LocalMatrix;
     const MatrixType& localMatrix = linsys->getOwnedMatrix()->getLocalMatrix();
-  
+
     using VectorType = sierra::nalu::LinSys::LocalVector;
     const VectorType& localRhs = linsys->getOwnedRhs()->getLocalView<sierra::nalu::DeviceSpace>();
-  
+
     int localProc = realm.bulkData_->parallel_rank();
 
     std::string suffix = std::string("_P")+std::to_string(localProc);
@@ -82,7 +82,7 @@ struct TpetraHelperObjectsBase {
       os<<(i<localMatrix.numRows()-1?", ":"");
     }
     os<<"};"<<std::endl;
-    
+
     os<<"\nstatic const std::vector<double> rhs"<<suffix<<" = {";
     for(int i=0; i<localMatrix.numRows(); ++i) {
       os<<localRhs(i,0)<<(i<localMatrix.numRows()-1 ? ", ":"");
@@ -99,14 +99,14 @@ struct TpetraHelperObjectsBase {
   {
     using MatrixType = sierra::nalu::LinSys::LocalMatrix;
     const MatrixType& localMatrix = linsys->getOwnedMatrix()->getLocalMatrix();
-  
+
     using VectorType = sierra::nalu::LinSys::LocalVector;
     const VectorType& localRhs = linsys->getOwnedRhs()->getLocalView<sierra::nalu::DeviceSpace>();
-  
+
     EXPECT_EQ(rowOffsets.size()-1, localMatrix.numRows());
     EXPECT_EQ(rhs.size(), localRhs.size());
     EXPECT_EQ(rhs.size(), localMatrix.numRows());
-  
+
     for(int i=0; i<localMatrix.numRows(); ++i) {
       KokkosSparse::SparseRowViewConst<MatrixType> constRowView = localMatrix.rowConst(i);
 
@@ -124,31 +124,31 @@ struct TpetraHelperObjectsBase {
   {
     using MatrixType = sierra::nalu::LinSys::LocalMatrix;
     const MatrixType& localMatrix = linsys->getOwnedMatrix()->getLocalMatrix();
-  
+
     using VectorType = sierra::nalu::LinSys::LocalVector;
     const VectorType& localRhs = linsys->getOwnedRhs()->getLocalView<sierra::nalu::DeviceSpace>();
-  
+
     EXPECT_EQ(rhsSize, localMatrix.numRows());
     EXPECT_EQ(rhsSize, localRhs.size());
-  
+
     stk::mesh::Entity elem = realm.bulkData_->get_entity(stk::topology::ELEM_RANK, 1);
     const stk::mesh::Entity* elemNodes = realm.bulkData_->begin_nodes(elem);
     unsigned numElemNodes = realm.bulkData_->num_nodes(elem);
     EXPECT_EQ(rhsSize, numElemNodes*linsys->numDof());
-  
+
     for(unsigned i=0; i<numElemNodes; ++i) {
       int rowId = linsys->getRowLID(elemNodes[i]);
       for(unsigned d=0; d<linsys->numDof(); ++d) {
         KokkosSparse::SparseRowViewConst<MatrixType> constRowView = localMatrix.rowConst(rowId+d);
         EXPECT_EQ(rhsSize, constRowView.length);
-  
+
         for(unsigned j=0; j<numElemNodes; ++j) {
           int colId = linsys->getColLID(elemNodes[j]);
           for(unsigned dd=0; dd<linsys->numDof(); ++dd) {
             EXPECT_NEAR(lhs[i][j], constRowView.value(colId+dd), 1.e-14);
           }
         }
-  
+
         EXPECT_NEAR(rhs[i], localRhs(rowId+d,0), 1.e-14);
       }
     }
@@ -207,7 +207,7 @@ struct TpetraHelperObjectsFaceElem : public TpetraHelperObjectsBase {
     linsys->finalizeLinearSystem();
     assembleFaceElemSolverAlg->execute();
     for (auto kern: assembleFaceElemSolverAlg->activeKernels_)
-      kern->free_on_device();  
+      kern->free_on_device();
     assembleFaceElemSolverAlg->activeKernels_.clear();
   }
   sierra::nalu::AssembleFaceElemSolverAlgorithm* assembleFaceElemSolverAlg;
@@ -253,4 +253,3 @@ struct TpetraHelperObjectsEdge : public TpetraHelperObjectsBase {
 }
 
 #endif
-

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -13,6 +13,8 @@
 
 #include "UnitTestUtils.h"
 
+#include "Tpetra_Details_DefaultTypes.hpp"
+
 #include "SolutionOptions.h"
 #include "kernel/Kernel.h"
 #include "ElemDataRequests.h"
@@ -322,8 +324,8 @@ public:
   stk::mesh::PartVector partVec_;
 
   sierra::nalu::SolutionOptions solnOpts_;
-  typedef long   GlobalOrdinal;
-  typedef stk::mesh::Field<GlobalOrdinal> TpetIDFieldType;
+  using GlobalOrdinal   = Tpetra::Details::DefaultTypes::global_ordinal_type;
+  using TpetIDFieldType = stk::mesh::Field<GlobalOrdinal>;
 
   const VectorFieldType* coordinates_{nullptr};
   GlobalIdFieldType* naluGlobalId_{nullptr};

--- a/unit_tests/kernels/UnitTestScalarAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestScalarAdvDiffElem.C
@@ -42,7 +42,7 @@ namespace advection_diffusion {
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion)
 {
   // FIXME: only test on one core
-  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) 
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
     return;
 
   fill_mesh_and_init_fields(true);
@@ -78,11 +78,11 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion)
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion_tpetra)
 {
   // FIXME: only test on one core
-  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) 
+  if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
     return;
 
   fill_mesh_and_init_fields(true);
-  
+
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
   solnOpts_.meshDeformation_ = false;
@@ -109,4 +109,3 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion_tpetra)
   namespace gold_values = hex8_golds::advection_diffusion;
   helperObjs.check_against_dense_gold_values(8, gold_values::lhs, gold_values::rhs);
 }
-


### PR DESCRIPTION
I am not sure why the types need to be defined twice: in LinearSolver.h and in LinearSolverTypes.h but in any case everything is now working.


**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request
The types defined in Nalu: `Scalar`, `GlobalOrdinal` and `LocalOrdinal` are now aligned with Tpetra's default types.
This should remove any issues related to the build configuration of Trilinos and the types used in Nalu.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors