### PR TITLE
GPU version of GradP open boundary algorithm.

### DIFF
--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -403,6 +403,13 @@ Common options
    A boolean flag indicating whether memory diagnostics are activated during
    simulation. Default value is ``no``.
 
+.. inpfile:: rebalance_mesh
+
+   A boolean flag indicating whether to rebalance mesh using stk_balance. The 
+   default value is ``no``. If this parameter is activated, it requires that
+   ``stk_rebalance_method`` is also set to specify the decomposition method to be 
+   used for rebalance, e.g., RIB, RCB, etc. 
+
 .. inpfile:: balance_nodes
 
    A boolean flag indicating whether node balancing is performed during

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -520,6 +520,11 @@ class Realm {
   // automatic mesh decomposition; None, rib, rcb, multikl, etc.
   std::string autoDecompType_;
 
+  // STK rebalance options
+  bool rebalanceMesh_{false};
+  
+  std::string rebalanceMethod_;
+   
   // allow aura to be optional
   bool activateAura_;
 

--- a/include/ngp_algorithms/GeometryInteriorAlg.h
+++ b/include/ngp_algorithms/GeometryInteriorAlg.h
@@ -40,7 +40,6 @@ public:
   virtual ~GeometryInteriorAlg() = default;
 
   virtual void execute() override;
-  virtual void pre_work() override;
 
   void impl_compute_edge_area_vector();
   void impl_compute_dual_nodal_volume();

--- a/include/ngp_algorithms/GeometryInteriorAlg.h
+++ b/include/ngp_algorithms/GeometryInteriorAlg.h
@@ -40,6 +40,7 @@ public:
   virtual ~GeometryInteriorAlg() = default;
 
   virtual void execute() override;
+  virtual void pre_work() override;
 
   void impl_compute_edge_area_vector();
   void impl_compute_dual_nodal_volume();

--- a/include/ngp_algorithms/NodalGradPOpenBoundaryAlg.h
+++ b/include/ngp_algorithms/NodalGradPOpenBoundaryAlg.h
@@ -1,0 +1,55 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2019 National Renewable Energy Laboratory.                  */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+
+#ifndef NODALGRADPOPENBOUNDARYALG_H
+#define NODALGRADPOPENBOUNDARYALG_H
+
+#include<Algorithm.h>
+#include<FieldTypeDef.h>
+#include<ElemDataRequests.h>
+
+#include "stk_mesh/base/Types.hpp"
+
+namespace sierra{
+namespace nalu{
+
+template<typename AlgTraits>
+class NodalGradPOpenBoundary : public Algorithm
+{
+public:
+  NodalGradPOpenBoundary(
+    Realm &,
+    stk::mesh::Part *,
+    const bool useShifted);
+
+  virtual ~NodalGradPOpenBoundary() = default;
+
+  virtual void execute() override;
+
+  const bool useShifted_;
+  const bool zeroGrad_;
+  const bool massCorr_;
+
+  const unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
+  const unsigned dualNodalVol_   {stk::mesh::InvalidOrdinal};
+  const unsigned exposedPressureField_ {stk::mesh::InvalidOrdinal};
+  const unsigned pressureField_  {stk::mesh::InvalidOrdinal};
+  const unsigned gradP_          {stk::mesh::InvalidOrdinal};
+  const unsigned coordinates_    {stk::mesh::InvalidOrdinal};
+
+  MasterElement* meFC_ {nullptr};
+  MasterElement* meSCS_{nullptr};
+
+  ElemDataRequests faceData_;
+  ElemDataRequests elemData_;
+};
+
+} // namespace nalu
+} // namespace Sierra
+
+#endif

--- a/reg_tests/test_files/BoussinesqNonIso/norms.py
+++ b/reg_tests/test_files/BoussinesqNonIso/norms.py
@@ -1,11 +1,11 @@
 import os
 import math
 import os.path
-
+import subprocess 
 
 def exit_if_file_does_not_exist(fname):
     if not os.path.exists(fname):
-        print 'No file: ' + fname
+        print ('No file: ' + fname)
         exit(1)
 
 
@@ -25,7 +25,11 @@ def num_lines_output(fname):
 
 def tail(fname, n):
     exit_if_file_does_not_exist(fname)
-    stdin, stdout = os.popen2("tail -n " + str(n) + " " + fname)
+    p = subprocess.Popen("tail -n " + str(n) + " " + fname, 
+        shell=True, 
+        stdin=subprocess.PIPE, 
+        stdout=subprocess.PIPE, close_fds=True)
+    (stdin, stdout) = (p.stdin, p.stdout)
     stdin.close()
     lines = stdout.readlines()
     stdout.close()
@@ -48,11 +52,11 @@ def compute_and_check_ooas(basep_name, numResolutions, dim, min_ooas):
     linesToRead = num_lines_output(first_name)
     nodes0, norm0 = extract_norm(tail(first_name, linesToRead))
 
-    for j in xrange(numResolutions - 1):
+    for j in range(numResolutions - 1):
         name = basep_name + "_R" + str(j + 1) + ".dat"
         nodes1, norm1 = extract_norm(tail(name, linesToRead))
         order = {}
-        for varname, norm in norm1.iteritems():
+        for varname, norm in norm1.items():
             num_ratio = math.log(float(norm1[varname]) / float(norm0[varname]))
             order[varname] = num_ratio / math.log(2.0)
 
@@ -61,11 +65,12 @@ def compute_and_check_ooas(basep_name, numResolutions, dim, min_ooas):
 
         output_string = "R" + str(j + 1) + "-" + str(j)
 
-        for varname, ooa in order.iteritems():
-            output_string += " " + varname + ": " + str(ooa)
-            if ooa > min_ooas[varname]:
-                print 'Bad convergence'
-                print output_string
+        for varname, ooa in order.items():
+            name = varname.decode('utf-8')
+            output_string += " " + name + ": " + str(ooa)
+            if ooa > min_ooas[name]:
+                print ('Bad convergence')
+                print (output_string)
                 exit(1)
 
 

--- a/src/AssembleNodalGradPOpenBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradPOpenBoundaryAlgorithm.C
@@ -169,7 +169,7 @@ AssembleNodalGradPOpenBoundaryAlgorithm::execute()
           pOpp += oppShapeFns[ic] * p_elemPressure[ic];
         }
 
-        double press_div_vol = (zeroGrad_ ? pOpp : pIp) / volNN;
+        const double press_div_vol = (zeroGrad_ ? pOpp : pIp) / volNN;
         for ( int j = 0; j < nDim; ++j ) {
           gradQNN[j] += press_div_vol * areav[j];
         }

--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -912,11 +912,20 @@ DataProbePostProcessing::provide_output_txt(
         if ( processorId == NaluEnv::self().parallel_rank()) {    
 
 	  // Get the path to the file name, and create any directories necessary
-	  size_t pathfound;
-	  pathfound = fileName.find_last_of("/");
-	  const std::string path = fileName.substr(0, pathfound);
-	  if (!boost::filesystem::exists(path)) {
-	    boost::filesystem::create_directories(path);
+	  boost::filesystem::path pathdir{fileName};
+	  if (pathdir.has_parent_path()) { 
+	    if (!boost::filesystem::exists(pathdir.parent_path().string())) 
+	      {
+		try{ 
+		  boost::filesystem::create_directories(pathdir.parent_path().string());
+		} catch(const boost::filesystem::filesystem_error& e) {
+		  NaluEnv::self().naluOutputP0() 
+		    << "Error creating "<< pathdir.parent_path().string() <<std::endl;
+		  NaluEnv::self().naluOutputP0()  
+		    << e.code().message()<<std::endl;
+		  throw std::runtime_error(e.code().message());
+		}
+	      }
 	  }
           
           // one banner per file 
@@ -996,13 +1005,20 @@ DataProbePostProcessing::provide_output_txt(
 	      const int pointsPerPlane = N1*N2;
 
 	      // Get the path to the file name, and create any directories necessary
-	      // - Get the path
-	      size_t pathfound; 
-	      pathfound = fileName.find_last_of("/");
-	      const std::string path = fileName.substr(0, pathfound);
-	      // - Create the path, if necessary
-	      if (!boost::filesystem::exists(path)) {
-		boost::filesystem::create_directories(path);
+	      boost::filesystem::path pathdir{fileName};
+	      if (pathdir.has_parent_path()) { 
+		if (!boost::filesystem::exists(pathdir.parent_path().string())) 
+		  {
+		    try{ 
+		      boost::filesystem::create_directories(pathdir.parent_path().string());
+		    } catch(const boost::filesystem::filesystem_error& e) {
+		      NaluEnv::self().naluOutputP0() 
+			<< "Error creating "<< pathdir.parent_path().string() <<std::endl;
+		      NaluEnv::self().naluOutputP0()  
+			<< e.code().message()<<std::endl;
+		      throw std::runtime_error(e.code().message());
+		    }
+		  }
 	      }
 
 	      myfile.open(fileName.c_str(), std::ios_base::out); // std::ios_base::app

--- a/src/ngp_algorithms/CMakeLists.txt
+++ b/src/ngp_algorithms/CMakeLists.txt
@@ -24,6 +24,7 @@ target_sources(nalu PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/GeometryBoundaryAlg.C
   ${CMAKE_CURRENT_SOURCE_DIR}/SDRLowReWallAlg.C
   ${CMAKE_CURRENT_SOURCE_DIR}/SDRWallFuncAlg.C
+  ${CMAKE_CURRENT_SOURCE_DIR}/NodalGradPOpenBoundaryAlg.C
 
   # Algorithm Drivers
   ${CMAKE_CURRENT_SOURCE_DIR}/FieldUpdateAlgDriver.C

--- a/src/ngp_algorithms/GeometryBoundaryAlg.C
+++ b/src/ngp_algorithms/GeometryBoundaryAlg.C
@@ -63,9 +63,10 @@ void GeometryBoundaryAlg<AlgTraits>::execute()
       const auto& meViews = scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
       const auto& v_area = meViews.scs_areav;
 
-      for (int ip = 0; ip < AlgTraits::numFaceIp_; ++ip)
+      for (int ip = 0; ip < AlgTraits::numFaceIp_; ++ip) {
         for (int d=0; d < AlgTraits::nDim_; ++d)
           areaVecOps(edata, ip * AlgTraits::nDim_ + d) = v_area(ip, d);
+      }
     });
 
   exposedAreaVec.modify_on_device();

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -20,10 +20,6 @@
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
 
-#include "stk_mesh/base/Field.hpp"
-#include "stk_mesh/base/FieldParallel.hpp"
-#include "stk_mesh/base/FieldBLAS.hpp"
-#include "stk_mesh/base/MetaData.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -54,21 +50,6 @@ GeometryInteriorAlg<AlgTraits>::GeometryInteriorAlg(
   }
 }
 
-template<typename AlgTraits>
-void GeometryInteriorAlg<AlgTraits>::pre_work()
-{
-  const auto& meta     = realm_.meta_data();
-  const auto& meshInfo = realm_.mesh_info();
-  const auto  ngpMesh  = meshInfo.ngp_mesh();
-  const auto& fieldMgr = meshInfo.ngp_field_manager();
-
-  auto *dualVol = meta.template get_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
-  auto ngpDualVol = fieldMgr.template get_field<double>(dualVol->mesh_meta_data_ordinal());
-
-  stk::mesh::field_fill(0.0, *dualVol);
-  ngpDualVol.set_all(ngpMesh, 0.0);
-}
-
 template <typename AlgTraits>
 void GeometryInteriorAlg<AlgTraits>::execute()
 {
@@ -88,7 +69,6 @@ void GeometryInteriorAlg<AlgTraits>::impl_compute_dual_nodal_volume()
   const auto ngpMesh = meshInfo.ngp_mesh();
   const auto& fieldMgr = meshInfo.ngp_field_manager();
   auto dualVol = fieldMgr.template get_field<double>(dualNodalVol_);
-  dualVol.set_all(ngpMesh, 0.0);
   auto elemVol = fieldMgr.template get_field<double>(elemVol_);
   const auto dnvOps = nalu_ngp::simd_elem_nodal_field_updater(ngpMesh, dualVol);
   const auto elemVolOps = nalu_ngp::simd_elem_field_updater(ngpMesh, elemVol);

--- a/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
+++ b/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
@@ -1,0 +1,162 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
+
+#include "ngp_algorithms/NodalGradPOpenBoundaryAlg.h"
+#include "Algorithm.h"
+
+#include "BuildTemplates.h"
+#include "master_element/MasterElement.h"
+#include "master_element/MasterElementFactory.h"
+#include "ngp_algorithms/ViewHelper.h"
+#include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpFieldOps.h"
+#include "Realm.h"
+#include "ScratchViews.h"
+#include "SolutionOptions.h"
+#include "utils/StkHelpers.h"
+
+namespace sierra{
+namespace nalu{
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// NodalGradPOpenBoundary - adds in boundary contribution
+//                                      for elem/edge proj nodal gradient
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+template <typename AlgTraits>
+NodalGradPOpenBoundary<AlgTraits>::NodalGradPOpenBoundary(
+  Realm &realm,
+  stk::mesh::Part *part,
+  const bool useShifted)
+  : Algorithm(realm, part),
+    useShifted_(useShifted),
+    zeroGrad_(realm_.solutionOptions_->explicitlyZeroOpenPressureGradient_),
+    massCorr_(realm_.solutionOptions_->activateOpenMdotCorrection_),
+    exposedAreaVec_ (get_field_ordinal(realm_.meta_data(), "exposed_area_vector", realm.meta_data().side_rank())),
+    dualNodalVol_   (get_field_ordinal(realm_.meta_data(), "dual_nodal_volume")),
+    exposedPressureField_   (get_field_ordinal(realm_.meta_data(), (massCorr_ ? "pressure" : "pressure_bc"))),
+    pressureField_ (get_field_ordinal(realm_.meta_data(), "pressure")),
+    gradP_         (get_field_ordinal(realm_.meta_data(), "dpdx")),
+    coordinates_   (get_field_ordinal(realm_.meta_data(), realm.get_coordinates_name())),
+    meFC_  (MasterElementRepo::get_surface_master_element<typename AlgTraits::FaceTraits>()),
+    meSCS_ (MasterElementRepo::get_surface_master_element<typename AlgTraits::ElemTraits>()),
+    faceData_(realm.meta_data()),
+    elemData_(realm.meta_data())
+{
+  const int coordinates = get_field_ordinal(realm.meta_data(), realm.get_coordinates_name());
+  faceData_.add_coordinates_field(coordinates, AlgTraits::nDim_, CURRENT_COORDINATES);
+  elemData_.add_coordinates_field(coordinates, AlgTraits::nDim_, CURRENT_COORDINATES);
+  faceData_.add_cvfem_face_me   (meFC_);
+  elemData_.add_cvfem_surface_me(meSCS_);
+
+  faceData_.add_face_field(exposedAreaVec_, AlgTraits::numFaceIp_, AlgTraits::nDim_);
+  faceData_.add_gathered_nodal_field(dualNodalVol_,1);
+  faceData_.add_gathered_nodal_field(exposedPressureField_,1);
+  faceData_.add_gathered_nodal_field(pressureField_,1);
+  faceData_.add_gathered_nodal_field(gradP_,       AlgTraits::nodesPerFace_, AlgTraits::nDim_);
+  faceData_.add_coordinates_field   (coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
+
+  const ELEM_DATA_NEEDED fc_shape_fcn  = useShifted_ ?  FC_SHIFTED_SHAPE_FCN :  FC_SHAPE_FCN;
+  const ELEM_DATA_NEEDED scs_shape_fcn = useShifted_ ? SCS_SHIFTED_SHAPE_FCN : SCS_SHAPE_FCN;
+  faceData_.add_master_element_call( fc_shape_fcn, CURRENT_COORDINATES);
+  elemData_.add_master_element_call(scs_shape_fcn, CURRENT_COORDINATES);
+}
+
+
+
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+template <typename AlgTraits>
+void
+NodalGradPOpenBoundary<AlgTraits>::execute()
+{
+  using SimdDataType = nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+
+  const auto& meshInfo = realm_.mesh_info();
+  const auto& meta_data = meshInfo.meta();
+
+  const bool useShifted = useShifted_;
+  const bool zeroGrad   = zeroGrad_;
+
+  const unsigned exposedAreaVec       = exposedAreaVec_;
+  const unsigned dualNodalVol         = dualNodalVol_;
+  const unsigned exposedPressureField = exposedPressureField_;
+  const unsigned pressureField        = pressureField_;
+  const unsigned coordsID             = coordinates_;
+
+  const auto& fieldMgr = meshInfo.ngp_field_manager();
+  const auto   ngpMesh = meshInfo.ngp_mesh();
+  auto  gradP = fieldMgr.template get_field<double>(gradP_);
+  const auto gradPOps = nalu_ngp::simd_face_elem_nodal_field_updater(ngpMesh, gradP);
+
+  MasterElement* meFC  = meFC_;
+  MasterElement* meSCS = meSCS_;
+
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part() & stk::mesh::selectUnion(partVec_);
+
+  const std::string algName = "NodalGradPOpenBoundary_" +
+                              std::to_string(AlgTraits::faceTopo_) + "_" +
+                              std::to_string(AlgTraits::elemTopo_);
+
+  nalu_ngp::run_face_elem_algorithm(
+    algName, meshInfo, faceData_, elemData_, s_locally_owned_union,
+    KOKKOS_LAMBDA(SimdDataType& fdata) {
+
+      const int* ipNodeMap = meFC->ipNodeMap();
+
+      auto& faceView = fdata.simdFaceView;
+      const auto v_areav        = faceView.get_scratch_view_2D(exposedAreaVec);
+      const auto v_dnv          = faceView.get_scratch_view_1D(dualNodalVol);
+      const auto face_p_field   = faceView.get_scratch_view_1D(exposedPressureField);
+      const auto elem_p_field   = faceView.get_scratch_view_1D(pressureField);
+      const auto v_coord        = faceView.get_scratch_view_2D(coordsID);
+
+      const auto meFaceViews = fdata.simdFaceView.get_me_views(CURRENT_COORDINATES);
+      const auto meElemViews = fdata.simdElemView.get_me_views(CURRENT_COORDINATES);
+      const auto v_shape_fcn = useShifted ? meFaceViews.fc_shifted_shape_fcn :  meFaceViews.fc_shape_fcn;
+      const auto e_shape_fcn = useShifted ? meElemViews.scs_shifted_shape_fcn:  meElemViews.scs_shape_fcn;
+
+      const int faceOrdinal = fdata.faceOrd;
+
+      for (int ip = 0; ip < AlgTraits::numFaceIp_; ++ip) {
+        DoubleType pIp = 0.0;
+        if (zeroGrad) {
+          // evaluate pressure at opposing face.  If zeroGrad_ option is used, then
+          // we'll copy this value to the exposed face.  Otherwise, it's unused
+          const int oip = meSCS->opposingFace(faceOrdinal, ip);
+          for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
+            pIp += e_shape_fcn(oip,n) * elem_p_field(n);
+          }
+        } else {
+          for (int n = 0; n < AlgTraits::nodesPerFace_; ++n) {
+            pIp += v_shape_fcn(ip, n) * face_p_field(n);
+          }
+        }
+
+        const int node = ipNodeMap[ip];
+        const DoubleType vol = v_dnv(node);
+        const DoubleType press_div_vol = pIp / vol;
+
+        for ( int d = 0; d < AlgTraits::nDim_; ++d ) {
+          const DoubleType areav = v_areav(ip, d);
+          gradPOps(fdata, node, d) += areav * press_div_vol;
+        }
+      }
+    }
+  );
+}
+
+INSTANTIATE_KERNEL_FACE_ELEMENT(NodalGradPOpenBoundary)
+
+} // namespace nalu
+} // namespace Sierra

--- a/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
+++ b/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
@@ -1,5 +1,5 @@
 /*------------------------------------------------------------------------*/
-/*  Copyright 2014 Sandia Corporation.                                    */
+/*  Copyright 2019 Sandia Corporation.                                    */
 /*  This software is released under the license detailed                  */
 /*  in the file, LICENSE, which is located in the top-level Nalu          */
 /*  directory structure                                                   */
@@ -26,7 +26,7 @@ namespace nalu{
 // Class Definition
 //==========================================================================
 // NodalGradPOpenBoundary - adds in boundary contribution
-//                                      for elem/edge proj nodal gradient
+//                          for elem/edge proj nodal gradient
 //==========================================================================
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
@@ -131,8 +131,7 @@ NodalGradPOpenBoundary<AlgTraits>::execute()
       for (int ip = 0; ip < AlgTraits::numFaceIp_; ++ip) {
         DoubleType pIp = 0.0;
         if (zeroGrad) {
-          // evaluate pressure at opposing face.  If zeroGrad_ option is used, then
-          // we'll copy this value to the exposed face.  Otherwise, it's unused
+          // evaluate pressure at opposing face.  
           const int oip = meSCS->opposingFace(faceOrdinal, ip);
           for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
             pIp += e_shape_fcn(oip,n) * elem_p_field(n);

--- a/src/ngp_algorithms/WallFuncGeometryAlg.C
+++ b/src/ngp_algorithms/WallFuncGeometryAlg.C
@@ -5,7 +5,7 @@
 //
 // This software is released under the BSD 3-clause license. See LICENSE file
 // for more details.
-// 
+//
 
 
 #include "ngp_algorithms/WallFuncGeometryAlg.h"

--- a/src/ngp_algorithms/WallFuncGeometryAlg.C
+++ b/src/ngp_algorithms/WallFuncGeometryAlg.C
@@ -5,7 +5,7 @@
 //
 // This software is released under the BSD 3-clause license. See LICENSE file
 // for more details.
-//
+// 
 
 
 #include "ngp_algorithms/WallFuncGeometryAlg.h"

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTest1ElemCoordCheck.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestABLWallFunction.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestNodalGradPOpenBoundary.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestBasicKokkos.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestCopyAndInterleave.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestCreateOnDevice.C

--- a/unit_tests/UnitTestNodalGradPOpenBoundary.C
+++ b/unit_tests/UnitTestNodalGradPOpenBoundary.C
@@ -1,4 +1,3 @@
-#include <gtest/gtest.h>
 
 #include "memory"
 
@@ -60,69 +59,52 @@ struct HelperObjectsNodalGradPOpenBoundary {
 
 #ifndef KOKKOS_ENABLE_CUDA
 TEST_F(Hex8MeshWithNSOFields, nodal_grad_popen_boundary) {
-  fill_mesh_and_initialize_test_fields();
+  const std::string meshSpec = "generated:20x20x20";
+  fill_mesh_and_initialize_test_fields(meshSpec, true);
+  stk::mesh::Part* surface1 = meta.get_part("surface_1");
+  
+  const double dpdxref[6][3] = {{-0.25, 0.0,  -0.25},
+                                {-0.25, 0.0,   0.25},
+                                {-0.25,-0.25,  0.0},
+                                {-0.25, 0.25,  0.0},
+                                {-0.5,  0.0,   0.0},
+                                { 0.0,  0.0,   0.0}};
 
-  const double dpdxref[6][3] = {{-0.25, 0.125,-0.25},
-                                {-0.25, 0.125, 0.25},
-                                {-0.25,-0.25,  0.125},
-                                {-0.25, 0.25,  0.125},
-                                {-0.5,  0.25,  0.25},
-                                { 0.5,  0.5,   0.5}};
-
-  HelperObjectsNodalGradPOpenBoundary helperObjs(bulk, &meta.universal_part());
-
-  bulk.modification_begin();
-  stk::mesh::Part* block_1 = meta.get_part("block_1");
-  stk::mesh::PartVector allSurfaces = { &meta.declare_part("all_surfaces", meta.side_rank()) };
-  stk::mesh::create_all_sides(bulk, *block_1, allSurfaces, false);
-  bulk.modification_end();
-
+  HelperObjectsNodalGradPOpenBoundary helperObjs(bulk, surface1);
   helperObjs.computeGeomBoundAlg->execute();
 
-  {
-    ngp::Field<double> ngpDpDx(bulk, *dpdx);
-    stk::mesh::field_fill(0.0, *dpdx);
-    ngpDpDx.modify_on_host();
-    ngpDpDx.sync_to_device();
-  }
+  stk::mesh::field_fill(0.0, *dpdx);
   helperObjs.NodalGradPOpenBoundaryAlg->execute();
-
-  ngp::Field<double> ngpDpDx(bulk, *dpdx);
-  ngp::Field<double> ngpCord(bulk, *coordField);
-  ngpDpDx.modify_on_device();
-  ngpDpDx.sync_to_host();
-  ngpCord.modify_on_device();
-  ngpCord.sync_to_host();
 
   const stk::mesh::Selector all_local = meta.universal_part() & meta.locally_owned_part();
   const stk::mesh::BucketVector& nodeBuckets = bulk.get_buckets(stk::topology::NODE_RANK, all_local);
-   for (const stk::mesh::Bucket* b : nodeBuckets)
-   {
-     for (stk::mesh::Entity node : *b)
-     {
-       const double* dpdxData = stk::mesh::field_data(*dpdx, node);
-       const double* cordData = stk::mesh::field_data(*coordField, node);
-       int j=-1;
-       if (cordData[0] == 0) {
-         if      (cordData[2] ==  0 && (cordData[1] == 0 || cordData[1] == 20)) j = -1;
-         else if (cordData[2] == 20 && (cordData[1] == 0 || cordData[1] == 20)) j = -1;
-         else if (cordData[2] ==  0) j = 0;
-         else if (cordData[2] == 20) j = 1;
-         else if (cordData[1] ==  0) j = 2;
-         else if (cordData[1] == 20) j = 3;
-         else                        j = 4;
-       } else {
-         if (0<cordData[0]  && 0<cordData[1]  && 0<cordData[2] &&
-             cordData[0]<20 && cordData[1]<20 && cordData[2]<20)
-                                     j = 5;
-       }
-       if (-1 < j) {
-         for (int i=0; i<3; ++i) 
-           EXPECT_NEAR(dpdxref[j][i], dpdxData[i], tol);
-       }
-     }
-   }
-
+  for (const stk::mesh::Bucket* b : nodeBuckets)
+  {
+    for (stk::mesh::Entity node : *b)
+    {
+      const double* dpdxData = stk::mesh::field_data(*dpdx, node);
+      const double* cordData = stk::mesh::field_data(*coordField, node);
+      int j=-1;
+      if (cordData[0] == 0) {
+        if      (cordData[2] ==  0 && (cordData[1] == 0 || cordData[1] == 20)) j = -1;
+        else if (cordData[2] == 20 && (cordData[1] == 0 || cordData[1] == 20)) j = -1;
+        else if (cordData[2] ==  0) j = 0;
+        else if (cordData[2] == 20) j = 1;
+        else if (cordData[1] ==  0) j = 2;
+        else if (cordData[1] == 20) j = 3;
+        else                        j = 4;
+        if (stk::parallel_machine_size(comm)==2 && cordData[2] == 10) j = -1;
+      } else {
+        if (0<cordData[0]  && 0<cordData[1]  && 0<cordData[2] &&
+            cordData[0]<20 && cordData[1]<20 && cordData[2]<20)
+                                    j = 5;
+      }
+      if (-1 < j) {
+        for (int i=0; i<3; ++i) 
+          EXPECT_NEAR(dpdxref[j][i], dpdxData[i], tol);
+      }
+    }
+  }
 }
 
 #endif

--- a/unit_tests/UnitTestNodalGradPOpenBoundary.C
+++ b/unit_tests/UnitTestNodalGradPOpenBoundary.C
@@ -1,3 +1,9 @@
+/*------------------------------------------------------------------------*/
+/*  Copyright 2014 Sandia Corporation.                                    */
+/*  This software is released under the license detailed                  */
+/*  in the file, LICENSE, which is located in the top-level Nalu          */
+/*  directory structure                                                   */
+/*------------------------------------------------------------------------*/
 
 #include "memory"
 
@@ -5,17 +11,11 @@
 #include "UnitTestLinearSystem.h"
 #include "UnitTestUtils.h"
 
-#include "ABLProfileFunction.h"
-#include "AssembleElemSolverAlgorithm.h"
 #include "AssembleNodalGradPOpenBoundaryAlgorithm.h"
 #include "ComputeGeometryBoundaryAlgorithm.h"
-#include "EquationSystem.h"
 #include "SolutionOptions.h"
-#include "master_element/MasterElement.h"
 
 #include <stk_mesh/base/BulkData.hpp>
-#include <stk_mesh/base/FEMHelpers.hpp>
-#include <stk_mesh/base/SkinBoundary.hpp>
 #include <stk_topology/topology.hpp>
 
  
@@ -26,9 +26,9 @@ struct HelperObjectsNodalGradPOpenBoundary {
   HelperObjectsNodalGradPOpenBoundary(
     stk::mesh::BulkData& bulk, 
     stk::mesh::Part* part)
-  : yamlNode(unit_test_utils::get_default_inputs()),
+  : 
     realmDefaultNode(unit_test_utils::get_realm_default_node()),
-    naluObj(new unit_test_utils::NaluTest(yamlNode)),
+    naluObj(new unit_test_utils::NaluTest(unit_test_utils::get_default_inputs())),
     realm(naluObj->create_realm(realmDefaultNode, "multi_physics", false)),
     NodalGradPOpenBoundaryAlg(),
     computeGeomBoundAlg()
@@ -49,12 +49,11 @@ struct HelperObjectsNodalGradPOpenBoundary {
   HelperObjectsNodalGradPOpenBoundary() = delete;
   HelperObjectsNodalGradPOpenBoundary(const HelperObjectsNodalGradPOpenBoundary&) = delete;
 
-  const YAML::Node yamlNode;
   const YAML::Node realmDefaultNode;
   std::unique_ptr<unit_test_utils::NaluTest> naluObj;
   sierra::nalu::Realm& realm;
   std::unique_ptr<AssembleNodalGradPOpenBoundaryAlgorithm> NodalGradPOpenBoundaryAlg;
-  std::unique_ptr<ComputeGeometryBoundaryAlgorithm> computeGeomBoundAlg;
+  std::unique_ptr<ComputeGeometryBoundaryAlgorithm>        computeGeomBoundAlg;
 };
 
 #ifndef KOKKOS_ENABLE_CUDA

--- a/unit_tests/UnitTestNodalGradPOpenBoundary.C
+++ b/unit_tests/UnitTestNodalGradPOpenBoundary.C
@@ -1,0 +1,131 @@
+#include <gtest/gtest.h>
+
+#include "memory"
+
+#include "UnitTestRealm.h"
+#include "UnitTestLinearSystem.h"
+#include "UnitTestUtils.h"
+
+#include "ABLProfileFunction.h"
+#include "AssembleElemSolverAlgorithm.h"
+#include "AssembleNodalGradPOpenBoundaryAlgorithm.h"
+#include "ComputeGeometryBoundaryAlgorithm.h"
+#include "EquationSystem.h"
+#include "SolutionOptions.h"
+#include "master_element/MasterElement.h"
+
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/FEMHelpers.hpp>
+#include <stk_mesh/base/SkinBoundary.hpp>
+#include <stk_topology/topology.hpp>
+
+ 
+namespace sierra {
+namespace nalu{
+
+struct HelperObjectsNodalGradPOpenBoundary {
+  HelperObjectsNodalGradPOpenBoundary(
+    stk::mesh::BulkData& bulk, 
+    stk::mesh::Part* part)
+  : yamlNode(unit_test_utils::get_default_inputs()),
+    realmDefaultNode(unit_test_utils::get_realm_default_node()),
+    naluObj(new unit_test_utils::NaluTest(yamlNode)),
+    realm(naluObj->create_realm(realmDefaultNode, "multi_physics", false)),
+    NodalGradPOpenBoundaryAlg(),
+    computeGeomBoundAlg()
+  {
+    realm.metaData_ = &bulk.mesh_meta_data();
+    realm.bulkData_ = &bulk;
+    realm.solutionOptions_->activateOpenMdotCorrection_ = true;
+    NodalGradPOpenBoundaryAlg.reset(new AssembleNodalGradPOpenBoundaryAlgorithm(realm, part, false));
+    computeGeomBoundAlg.reset(new ComputeGeometryBoundaryAlgorithm(realm, part));
+  }
+
+  ~HelperObjectsNodalGradPOpenBoundary()
+  {
+    realm.metaData_ = nullptr;
+    realm.bulkData_ = nullptr;
+  }
+
+  HelperObjectsNodalGradPOpenBoundary() = delete;
+  HelperObjectsNodalGradPOpenBoundary(const HelperObjectsNodalGradPOpenBoundary&) = delete;
+
+  const YAML::Node yamlNode;
+  const YAML::Node realmDefaultNode;
+  std::unique_ptr<unit_test_utils::NaluTest> naluObj;
+  sierra::nalu::Realm& realm;
+  std::unique_ptr<AssembleNodalGradPOpenBoundaryAlgorithm> NodalGradPOpenBoundaryAlg;
+  std::unique_ptr<ComputeGeometryBoundaryAlgorithm> computeGeomBoundAlg;
+};
+
+#ifndef KOKKOS_ENABLE_CUDA
+TEST_F(Hex8MeshWithNSOFields, nodal_grad_popen_boundary) {
+  fill_mesh_and_initialize_test_fields();
+
+  const double dpdxref[6][3] = {{-0.25, 0.125,-0.25},
+                                {-0.25, 0.125, 0.25},
+                                {-0.25,-0.25,  0.125},
+                                {-0.25, 0.25,  0.125},
+                                {-0.5,  0.25,  0.25},
+                                { 0.5,  0.5,   0.5}};
+
+  HelperObjectsNodalGradPOpenBoundary helperObjs(bulk, &meta.universal_part());
+
+  bulk.modification_begin();
+  stk::mesh::Part* block_1 = meta.get_part("block_1");
+  stk::mesh::PartVector allSurfaces = { &meta.declare_part("all_surfaces", meta.side_rank()) };
+  stk::mesh::create_all_sides(bulk, *block_1, allSurfaces, false);
+  bulk.modification_end();
+
+  helperObjs.computeGeomBoundAlg->execute();
+
+  {
+    ngp::Field<double> ngpDpDx(bulk, *dpdx);
+    stk::mesh::field_fill(0.0, *dpdx);
+    ngpDpDx.modify_on_host();
+    ngpDpDx.sync_to_device();
+  }
+  helperObjs.NodalGradPOpenBoundaryAlg->execute();
+
+  ngp::Field<double> ngpDpDx(bulk, *dpdx);
+  ngp::Field<double> ngpCord(bulk, *coordField);
+  ngpDpDx.modify_on_device();
+  ngpDpDx.sync_to_host();
+  ngpCord.modify_on_device();
+  ngpCord.sync_to_host();
+
+  const stk::mesh::Selector all_local = meta.universal_part() & meta.locally_owned_part();
+  const stk::mesh::BucketVector& nodeBuckets = bulk.get_buckets(stk::topology::NODE_RANK, all_local);
+   for (const stk::mesh::Bucket* b : nodeBuckets)
+   {
+     for (stk::mesh::Entity node : *b)
+     {
+       const double* dpdxData = stk::mesh::field_data(*dpdx, node);
+       const double* cordData = stk::mesh::field_data(*coordField, node);
+       int j=-1;
+       if (cordData[0] == 0) {
+         if      (cordData[2] ==  0 && (cordData[1] == 0 || cordData[1] == 20)) j = -1;
+         else if (cordData[2] == 20 && (cordData[1] == 0 || cordData[1] == 20)) j = -1;
+         else if (cordData[2] ==  0) j = 0;
+         else if (cordData[2] == 20) j = 1;
+         else if (cordData[1] ==  0) j = 2;
+         else if (cordData[1] == 20) j = 3;
+         else                        j = 4;
+       } else {
+         if (0<cordData[0]  && 0<cordData[1]  && 0<cordData[2] &&
+             cordData[0]<20 && cordData[1]<20 && cordData[2]<20)
+                                     j = 5;
+       }
+       if (-1 < j) {
+         for (int i=0; i<3; ++i) 
+           EXPECT_NEAR(dpdxref[j][i], dpdxData[i], tol);
+       }
+     }
+   }
+
+}
+
+#endif
+
+}
+}

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -138,31 +138,43 @@ protected:
       Gju(&meta.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "Gju", 1/*num-states*/)), 
       velocity(&meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity", 3/*num-states*/)), 
       dpdx(&meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx", 3/*num-states*/)), 
+      exposedAreaVec(&meta.declare_field<GenericFieldType>(meta.side_rank(), "exposed_area_vector")),
       density(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density", 3/*num-states*/)), 
       viscosity(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity")),
       pressure(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure")),
-      udiag(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "momentum_diag"))
+      udiag(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "momentum_diag")),
+      dnvField(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume")) 
+
     {
-      double one = 1.0;
+      const double one = 1.0;
+      const double two = 2.0;
+      const double oneVecThree[3] = {one, one, one};
+      const double oneVecTwelve[12] = {one, one, one, one, one, one, one, one, one, one, one, one};
       sierra::nalu::HexSCS hex8SCS;
-      stk::mesh::put_field_on_mesh(*massFlowRate, meta.universal_part(), hex8SCS.num_integration_points(), &one);
-      stk::mesh::put_field_on_mesh(*Gju, meta.universal_part(), 3, &one);
-      stk::mesh::put_field_on_mesh(*velocity, meta.universal_part(), 3, &one);
-      stk::mesh::put_field_on_mesh(*dpdx, meta.universal_part(), 3, &one);
+      const std::vector<double> oneVecNInt(hex8SCS.num_integration_points(),one);
+      stk::mesh::put_field_on_mesh(*massFlowRate, meta.universal_part(), hex8SCS.num_integration_points(), oneVecNInt.data());
+      stk::mesh::put_field_on_mesh(*Gju, meta.universal_part(), 3, oneVecThree);
+      stk::mesh::put_field_on_mesh(*velocity, meta.universal_part(), 3, oneVecThree);
+      stk::mesh::put_field_on_mesh(*dpdx, meta.universal_part(), 3, oneVecThree);
+      const sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(stk::topology::QUAD_4);
+      stk::mesh::put_field_on_mesh(*exposedAreaVec, meta.universal_part(), 3*meFC->num_integration_points(), oneVecTwelve);
       stk::mesh::put_field_on_mesh(*density, meta.universal_part(), 1, &one);
       stk::mesh::put_field_on_mesh(*viscosity, meta.universal_part(), 1, &one);
       stk::mesh::put_field_on_mesh(*pressure, meta.universal_part(), 1, &one);
       stk::mesh::put_field_on_mesh(*udiag, meta.universal_part(), 1, &one);
+      stk::mesh::put_field_on_mesh(*dnvField, meta.universal_part(), 1, &two);
     }
 
     GenericFieldType* massFlowRate;
     GenericFieldType* Gju;
     VectorFieldType* velocity;
     VectorFieldType* dpdx;
+    GenericFieldType* exposedAreaVec;
     ScalarFieldType* density;
     ScalarFieldType* viscosity;
     ScalarFieldType* pressure;
     ScalarFieldType* udiag;
+    ScalarFieldType* dnvField;
 };
 
 class Hex8ElementWithBCFields : public ::testing::Test

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -147,7 +147,6 @@ protected:
       pressure(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure")),
       udiag(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "momentum_diag")),
       dnvField(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume")) 
-
     {
       const double one = 1.0;
       const double two = 2.0;

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -96,8 +96,11 @@ protected:
       unit_test_utils::fill_hex8_mesh(meshSpec, bulk);
     }
 
-    void fill_mesh_and_initialize_test_fields(const std::string& meshSpec = "generated:20x20x20")
+    void fill_mesh_and_initialize_test_fields(std::string meshSpec = "generated:20x20x20", 
+                                              const bool generateSidesets = false)
     {
+        if (generateSidesets) meshSpec += "|sideset:xXyYzZ";
+
         fill_mesh(meshSpec);
 
         partVec = {meta.get_part("block_1")};

--- a/unit_tests/edge_kernels/UnitTestContinuityOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityOpenEdge.C
@@ -38,9 +38,10 @@ TEST_F(ContinuityKernelHex8Mesh,NGP_open_edge)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // Setup solution options for velocityRTM queries
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/edge_kernels/UnitTestMomentumABLWallFuncEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumABLWallFuncEdge.C
@@ -20,9 +20,10 @@ TEST_F(MomentumABLKernelHex8Mesh, NGP_abl_wall_func)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
@@ -55,9 +55,10 @@ TEST_F(MomentumKernelHex8Mesh, NGP_open_edge)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
@@ -83,4 +83,5 @@ TEST_F(MomentumKernelHex8Mesh, NGP_open_edge)
   unit_test_kernel_utils::expect_all_near(
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<24>(
-    helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);}
+    helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
+}

--- a/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
@@ -55,9 +55,10 @@ TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
@@ -39,9 +39,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_edge_open_solver_alg)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
@@ -77,9 +78,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_open_edge)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   std::mt19937 rng;
   rng.seed(std::mt19937::default_seed);

--- a/unit_tests/kernels/UnitTestContinuityInflowElem.C
+++ b/unit_tests/kernels/UnitTestContinuityInflowElem.C
@@ -26,9 +26,10 @@ static constexpr double rhs[4] = {
 
 TEST_F(ContinuityKernelHex8Mesh, NGP_inflow)
 {
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/kernels/UnitTestContinuityOpenElem.C
+++ b/unit_tests/kernels/UnitTestContinuityOpenElem.C
@@ -25,9 +25,10 @@ static constexpr double rhs[8] = {
 
 TEST_F(ContinuityKernelHex8Mesh, open)
 {
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/kernels/UnitTestEnthalpyTGradBCElem.C
+++ b/unit_tests/kernels/UnitTestEnthalpyTGradBCElem.C
@@ -18,9 +18,10 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_tgrad_bc)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   auto* part = meta_.get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -379,6 +379,24 @@ public:
 
   virtual ~LowMachKernelHex8Mesh() {}
 
+  void fill_mesh(const std::string& meshSpec = "generated:20x20x20")
+  {
+    const double one = 1.0;
+    const double two = 2.0;
+    const double oneVecTwelve[12] = {one, one, one, one, one, one, one, one, one, one, one, one};
+    unit_test_utils::fill_hex8_mesh(meshSpec, bulk_);
+    stk::mesh::create_edges(bulk_, meta_.universal_part());
+    partVec_ = {meta_.get_part("block_1")};
+
+    coordinates_ = static_cast<const VectorFieldType*>(meta_.coordinate_field());
+
+    EXPECT_TRUE(coordinates_ != nullptr);
+
+    stk::mesh::field_fill(two, *dnvField_);
+    stk::mesh::field_fill(one, *pressure_);
+    stk::mesh::field_fill_component(oneVecTwelve, *exposedAreaVec_);
+  }
+
   virtual void fill_mesh_and_init_fields(
     bool doPerturb = false, bool generateSidesets = false) override
   {

--- a/unit_tests/kernels/UnitTestMomentumUpwAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestMomentumUpwAdvDiffElem.C
@@ -280,7 +280,8 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_upw_advection_diffusion)
 {
   if (bulk_.parallel_size() > 1) return;
 
-  fill_mesh_and_init_fields(false);
+  const std::string meshSpec;
+  fill_mesh_and_init_fields(meshSpec, false);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/kernels/UnitTestScalarAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestScalarAdvDiffElem.C
@@ -45,7 +45,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion)
   if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
     return;
 
-  fill_mesh_and_init_fields(true);
+  const std::string meshSpec;
+  fill_mesh_and_init_fields(meshSpec, true);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
@@ -81,7 +82,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_advection_diffusion_tpetra)
   if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
     return;
 
-  fill_mesh_and_init_fields(true);
+  const std::string meshSpec;
+  fill_mesh_and_init_fields(meshSpec, true);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/kernels/UnitTestScalarFluxBCElem.C
+++ b/unit_tests/kernels/UnitTestScalarFluxBCElem.C
@@ -18,9 +18,10 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_heat_flux_bc)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   auto* part = meta_.get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(

--- a/unit_tests/kernels/UnitTestScalarMassElem.C
+++ b/unit_tests/kernels/UnitTestScalarMassElem.C
@@ -62,7 +62,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_mass)
   if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) 
     return;
 
-  fill_mesh_and_init_fields(true);
+  const std::string meshSpec;
+  fill_mesh_and_init_fields(meshSpec, true);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
@@ -107,7 +108,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_time_derivative_lumped)
   if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1)
     return;
 
-  fill_mesh_and_init_fields(false);
+  const std::string meshSpec;
+  fill_mesh_and_init_fields(meshSpec, false);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/kernels/UnitTestScalarOpenElem.C
+++ b/unit_tests/kernels/UnitTestScalarOpenElem.C
@@ -39,9 +39,10 @@ TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
 {
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/kernels/UnitTestScalarUpwAdvDiffElem.C
+++ b/unit_tests/kernels/UnitTestScalarUpwAdvDiffElem.C
@@ -42,7 +42,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_upw_advection_diffusion)
 {
   if (bulk_.parallel_size() > 1) return;
 
-  fill_mesh_and_init_fields(false);
+  const std::string meshSpec;
+  fill_mesh_and_init_fields(meshSpec, false);
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;

--- a/unit_tests/ngp_algorithms/CMakeLists.txt
+++ b/unit_tests/ngp_algorithms/CMakeLists.txt
@@ -9,4 +9,5 @@ target_sources(${utest_ex_name} PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestTurbViscSSTAlg.C
   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestGeometryAlg.C
   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSDRWallAlg.C
+  ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestNodalGradPOpenBoundary.C
   )

--- a/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
@@ -108,9 +108,10 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // zero out fields
   stk::mesh::field_fill(0.0, *exposedAreaVec_);
@@ -163,9 +164,10 @@ TEST_F(KsgsKernelHex8Mesh, NGP_geometry_wall_func)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  LowMachKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  LowMachKernelHex8Mesh::fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   // zero out fields
   stk::mesh::field_fill(0.0, *wallNormDist_);

--- a/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
@@ -45,6 +45,8 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
   geomAlgDriver.register_elem_algorithm<sierra::nalu::GeometryInteriorAlg>(
     sierra::nalu::INTERIOR, partVec_[0], "geometry");
 
+  // Test that multiple executes are not fatal.
+  geomAlgDriver.execute();
   geomAlgDriver.execute();
 
   ngpElemVol.modify_on_device();
@@ -126,6 +128,8 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
   geomAlgDriver.register_face_algorithm<sierra::nalu::GeometryBoundaryAlg>(
     sierra::nalu::WALL, surfPart, "geometry");
 
+  // Test that multiple executes are not fatal.
+  geomAlgDriver.execute();
   geomAlgDriver.execute();
 
   ngpArea.modify_on_device();
@@ -177,6 +181,8 @@ TEST_F(KsgsKernelHex8Mesh, NGP_geometry_wall_func)
     sierra::nalu::WALL, surfPart,
     sierra::nalu::get_elem_topo(helperObjs.realm, *surfPart), "geometry");
 
+  // Test that multiple executes are not fatal.
+  geomAlgDriver.execute();
   geomAlgDriver.execute();
 
   const auto& fieldMgr = helperObjs.realm.mesh_info().ngp_field_manager();

--- a/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
@@ -108,9 +108,10 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_correction)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
 
   stk::mesh::field_fill(0.0, *openMassFlowRate_);
@@ -149,9 +150,10 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_inflow)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   stk::mesh::field_fill(1.0, *density_);
   stk::mesh::field_fill(1.0, *velocity_);
@@ -176,9 +178,10 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_edge)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   stk::mesh::field_fill(1.0, *density_);
   stk::mesh::field_fill(1.0, *velocity_);

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradAlg.C
@@ -328,9 +328,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   const double xCoeff = 2.0;
   const double yCoeff = 2.0;
@@ -378,9 +379,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry_shifted)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   const double xCoeff = 2.0;
   const double yCoeff = 2.0;
@@ -428,9 +430,10 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_bndry_elem_vec)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   const double xCoeff = 2.0;
   const double yCoeff = 2.0;

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
@@ -1,0 +1,107 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include "AlgTraits.h"
+
+#include "stk_mesh/base/CreateEdges.hpp"
+#include "kernels/UnitTestKernelUtils.h"
+
+#include "UnitTestHelperObjects.h"
+
+#include "ngp_algorithms/UnitTestNgpAlgUtils.h"
+#include "ngp_algorithms/NodalGradPOpenBoundaryAlg.h"
+#include "ngp_algorithms/GeometryBoundaryAlg.h"
+#include "ngp_algorithms/GeometryInteriorAlg.h"
+
+#include "ngp_algorithms/NodalGradAlgDriver.h"
+#include "ngp_algorithms/GeometryAlgDriver.h"
+
+#include <stk_mesh/base/SkinBoundary.hpp>
+
+TEST_F(LowMachKernelHex8Mesh, NGP_nodal_grad_popen)
+{
+  // Only execute for 1 processor runs
+  if (bulk_.parallel_size() > 1) return;
+
+  fill_mesh();
+
+  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  stk::mesh::field_fill(0.0, *dpdx_);
+
+  {
+    bulk_.modification_begin();
+    stk::mesh::Part* block_1 = meta_.get_part("block_1");
+    stk::mesh::PartVector allSurfaces = { &meta_.declare_part("surface_1", meta_.side_rank()) };
+    stk::mesh::create_all_sides(bulk_, *block_1, allSurfaces, false);
+    bulk_.modification_end();
+  }
+  auto* surfPart = meta_.get_part("surface_1");
+  {
+    sierra::nalu::GeometryAlgDriver geomAlgDriver(helperObjs.realm);
+    geomAlgDriver.register_face_algorithm<sierra::nalu::GeometryBoundaryAlg>(
+      sierra::nalu::WALL, surfPart, "geometry");
+    geomAlgDriver.execute();
+  }
+
+  stk::mesh::field_fill(2.0, *dnvField_);
+
+  {
+    helperObjs.realm.solutionOptions_->activateOpenMdotCorrection_ = true;
+    sierra::nalu::ScalarNodalGradAlgDriver algDriver(helperObjs.realm, "dpdx");
+    algDriver.register_face_elem_algorithm<sierra::nalu::NodalGradPOpenBoundary>(
+      sierra::nalu::OPEN, surfPart, stk::topology::HEX_8, "nodal_grad_pressure_open_boundary", false);
+    algDriver.execute();
+  }
+
+  {
+    const double dpdxref[6][3] = {{-0.25, 0.125,-0.25},
+                                  {-0.25, 0.125, 0.25},
+                                  {-0.25,-0.25,  0.125},
+                                  {-0.25, 0.25,  0.125},
+                                  {-0.5,  0.25,  0.25},
+                                  { 0.5,  0.5,   0.5}};
+
+    const double tol = 1.0e-16;
+
+    ngp::Field<double> ngpdpdx(bulk_, *dpdx_);
+    ngp::Field<double> ngpcord(bulk_, *coordinates_);
+    ngpdpdx.modify_on_device();
+    ngpdpdx.sync_to_host();
+    ngpcord.modify_on_device();
+    ngpcord.sync_to_host();
+    
+    stk::mesh::Selector sel = meta_.universal_part();
+    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+
+    for (const auto* b: bkts) {
+      for (const auto node: *b) {
+        const double* dpdx = stk::mesh::field_data(*dpdx_, node);
+        const double* cord = stk::mesh::field_data(*coordinates_, node);
+        int j=-1;
+        if (cord[0] == 0) {
+          if      (cord[2] ==  0 && (cord[1] == 0 || cord[1] == 20)) j = -1;
+          else if (cord[2] == 20 && (cord[1] == 0 || cord[1] == 20)) j = -1;
+          else if (cord[2] ==  0) j = 0;
+          else if (cord[2] == 20) j = 1;
+          else if (cord[1] ==  0) j = 2;
+          else if (cord[1] == 20) j = 3;
+          else                    j = 4;
+        } else {
+          if (0<cord[0]  && 0<cord[1]  && 0<cord[2] &&
+              cord[0]<20 && cord[1]<20 && cord[2]<20)
+                                  j = 5;
+        }
+        if (-1 < j) {
+          for (int i=0; i<3; ++i)
+            EXPECT_NEAR(dpdxref[j][i], dpdx[i], tol);
+        }
+      }
+    }
+  }
+}

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
@@ -1,4 +1,4 @@
-// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// Copyright 2019 National Technology & Engineering Solutions of Sandia, LLC
 // (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
 // Northwest Research Associates. Under the terms of Contract DE-NA0003525
 // with NTESS, the U.S. Government retains certain rights in this software.
@@ -7,9 +7,6 @@
 // for more details.
 //
 
-#include "AlgTraits.h"
-
-#include "stk_mesh/base/CreateEdges.hpp"
 #include "kernels/UnitTestKernelUtils.h"
 
 #include "UnitTestHelperObjects.h"
@@ -17,12 +14,8 @@
 #include "ngp_algorithms/UnitTestNgpAlgUtils.h"
 #include "ngp_algorithms/NodalGradPOpenBoundaryAlg.h"
 #include "ngp_algorithms/GeometryBoundaryAlg.h"
-#include "ngp_algorithms/GeometryInteriorAlg.h"
-
 #include "ngp_algorithms/NodalGradAlgDriver.h"
 #include "ngp_algorithms/GeometryAlgDriver.h"
-
-#include <stk_mesh/base/SkinBoundary.hpp>
 
 TEST_F(LowMachKernelHex8Mesh, NGP_nodal_grad_popen)
 {

--- a/unit_tests/ngp_algorithms/UnitTestSDRWallAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestSDRWallAlg.C
@@ -23,9 +23,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_lowRE)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   solnOpts_.initialize_turbulence_constants();
 
@@ -89,9 +90,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_func)
   // Only execute for 1 processor runs
   if (bulk_.parallel_size() > 1) return;
 
+  const std::string meshSpec;
   const bool doPerturb = false;
   const bool generateSidesets = true;
-  fill_mesh_and_init_fields(doPerturb, generateSidesets);
+  fill_mesh_and_init_fields(meshSpec, doPerturb, generateSidesets);
 
   solnOpts_.initialize_turbulence_constants();
 


### PR DESCRIPTION
First had to create a unit test for
AssembleNodalGradPOpenBoundaryAlgorithm to have a result
for before GPUing.

Then wrote the GPU version a couple of times before getting
that right and then more time to get the results of the
old and new unit tests to match.

The unit test might not be correct as the surface mesh part
seems to include too many faces.  But the old CPU and new GPU
versions of the algorithm give the same result which is something.

The unit tests pass but the other tests are failing for me for
what appears to be an unrelated problem having to do with matrix
assembly. Might need to update Trilinos.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ X] Feature enhancement

## Description of the pull-request

See NGP conversion of field update algorithms #336
Under "Static mesh airfoil/wing simulations"
Entry AssembleNodalGradPOpenBoundaryAlgorithm

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [X ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ X] Linux
    - [ ] MacOS 
  - Compilers 
    - [X ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA (compiles but link fails with boost::filesystem error)
- [ X] Compiles without warnings
- [ X] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [X ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
