### PR TITLE
Fix temperature flux and velBarAvg bug in issue 499

### DIFF
--- a/src/wind_energy/BdyLayerStatistics.C
+++ b/src/wind_energy/BdyLayerStatistics.C
@@ -392,7 +392,7 @@ BdyLayerStatistics::impl_compute_velocity_stats()
       int offset = ih * ndim;
       for (int d=0; d < ndim; ++d) {
         Kokkos::atomic_add(&d_velAvg(offset + d), (velocity.get(mi, d) * rho * dVol));
-        Kokkos::atomic_add(&d_velBarAvg(offset + d), (velTimeAvg.get(mi, d) * rho * dVol));
+        Kokkos::atomic_add(&d_velBarAvg(offset + d), (velTimeAvg.get(mi, d) * dVol));
       }
 
       // Stress computations
@@ -533,12 +533,12 @@ BdyLayerStatistics::impl_compute_temperature_stats()
       const int offset = ih * ndim;
       for (int d=0; d < ndim; ++d) {
         Kokkos::atomic_add(
-          &d_thetaSFSBarAvg(offset + d), (thetaSFS.get(mi, 0) * dVol));
+          &d_thetaSFSBarAvg(offset + d), (thetaSFS.get(mi, d) * dVol));
         Kokkos::atomic_add(
-          &d_thetaUjBarAvg(offset + d), (thetaUj.get(mi, 0) * dVol));
+          &d_thetaUjBarAvg(offset + d), (thetaUj.get(mi, d) * dVol));
         Kokkos::atomic_add(
           &d_thetaUjAvg(offset + d),
-          (rho * theta.get(mi, 0) * velocity.get(mi, 0) * dVol));
+          (rho * theta.get(mi, 0) * velocity.get(mi, d) * dVol));
       }
     });
 


### PR DESCRIPTION
**Pull-request type:**
- [X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Addresses bug seen in [issue 499](https://github.com/Exawind/nalu-wind/issues/499).  Changes `BdyLayerStatistics.C` so that the temperature flux can be computed correctly, and the velocity averages are handled the same as pre-NGP changes.

Note that additional testing & verification should be done to verify that all ABL statistics are consistent with pre-NGP calculations.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [X] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
