### PR TITLE
add  alias for processing all blocks in a mesh

### DIFF
--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -560,7 +560,8 @@ Initial conditions
 .. inpfile:: initial_conditions.target_name
 
    A list of element blocks (*parts*) where this initial condition must be
-   applied.
+   applied.  Using the alias ``all_blocks`` is equivalent to listing all
+   element blocks in the mesh.
 
 Boundary Conditions
 ```````````````````
@@ -742,7 +743,8 @@ Material Properties
 
    A list of element blocks (*parts*) where the material properties are applied.
    This list should ideally include all the parts that are referenced by
-   :inpfile:`initial_conditions.target_name`.
+   :inpfile:`initial_conditions.target_name`. Using the alias ``all_blocks`` is 
+   equivalent to listing all element blocks in the mesh.
 
 .. inpfile:: material_properties.constant_specification
 

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -676,10 +676,13 @@ class Realm {
    */
   bool hypreIsActive_{false};
 
+  std::vector<std::string> handle_all_element_part_alias(const std::vector<std::string>& names) const;
+
 protected:
   std::unique_ptr<NgpMeshInfo> meshInfo_;
 
   unsigned meshModCount_{0};
+  const std::string allElementPartAlias{"all_blocks"};
 
 };
 

--- a/reg_tests/test_files/cvfemHC/cvfemHC.i
+++ b/reg_tests/test_files/cvfemHC/cvfemHC.i
@@ -35,12 +35,12 @@ realms:
 
     initial_conditions:
       - user_function: ic_1
-        target_name: [block_1, block_2, block_3, block_4, block_5, block_6, block_7, block_8, block_9, block_10, block_11, block_12, block_13, block_14, block_15, block_16, block_17, block_18, block_19]
+        target_name: all_blocks
         user_function_name:
          temperature: steady_3d_thermal
 
     material_properties:
-      target_name: [block_1, block_2, block_3, block_4, block_5, block_6, block_7, block_8, block_9, block_10, block_11, block_12, block_13, block_14, block_15, block_16, block_17, block_18, block_19]
+      target_name: all_blocks
       specifications:
         - name: density
           type: constant

--- a/src/MaterialPropertys.C
+++ b/src/MaterialPropertys.C
@@ -87,6 +87,7 @@ MaterialPropertys::load(const YAML::Node & node)
         targetNames_[i] = targets[i].as<std::string>() ;
       }
     }
+    targetNames_ = realm_.handle_all_element_part_alias(targetNames_);
     
     // has a table?
     if ( y_material_propertys["table_file_name"] ) {

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1176,7 +1176,7 @@ Realm::setup_initial_conditions()
   for (size_t j_ic = 0; j_ic < initialConditions_.size(); ++j_ic) {
     InitialCondition& initCond = *initialConditions_[j_ic];
 
-    const std::vector<std::string> targetNames = initCond.targetNames_;
+    const std::vector<std::string> targetNames = handle_all_element_part_alias(initCond.targetNames_);
 
     for (size_t itarget=0; itarget < targetNames.size(); ++itarget) {
       const std::string targetName = physics_part_name(targetNames[itarget]);
@@ -4546,6 +4546,7 @@ Realm::physics_part_name(std::string name) const
 std::vector<std::string>
 Realm::physics_part_names(std::vector<std::string> names) const
 {
+  names = handle_all_element_part_alias(names);
   if (doPromotion_) {
     std::transform(names.begin(), names.end(), names.begin(), [&](const std::string& name) {
       return super_element_part_name(name);
@@ -4841,6 +4842,27 @@ bool
 {
   // for now, adaptivity only; load-balance in the future?
   return solutionOptions_->activateAdaptivity_;
+}
+
+std::vector<std::string>
+Realm::handle_all_element_part_alias(const std::vector<std::string>& names) const
+{
+  if (names.size() == 1u && names.front() == allElementPartAlias) {
+    std::vector<std::string> new_names;
+    for (const auto* part : meta_data().get_mesh_parts()) {
+      ThrowRequire(part);
+      if (part->topology().rank() == stk::topology::ELEMENT_RANK) {
+        new_names.push_back(part->name());
+      }
+    }
+    return new_names;
+  }
+
+  if (std::find(names.begin(), names.end(), allElementPartAlias) != names.end()) {
+    NaluEnv::self().naluOutputP0() << "Part alias " << allElementPartAlias
+        << " present with other parts; " << allElementPartAlias << " must be a valid mesh part" << std::endl;
+  }
+  return names;
 }
 
 


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

The "usability breakout session" during the Q1 meeting requested an alias for specifying all blocks on a mesh, since there can be a lot of them generated with tools like percept.  This adds a special-case for specifying "all_blocks" as the equivalent of listing all element-ranked mesh blocks.  

Another possibility here would instead to have an "omit_targets: " syntax as an alternative way of specifying the target parts of the mesh.  That would better support the use case where there are a lot of physics blocks but a couple of post-processing blocks that the user wants to omit.  I'm not sure which way is better.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [x] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [x] New regression tests exercising the new code
