### PR TITLE
Replace boost::program_options with stk command-line-parsing

### DIFF
--- a/nalu.C
+++ b/nalu.C
@@ -22,8 +22,9 @@
 #include <stk_util/environment/perf_util.hpp>
 #include <stk_util/parallel/ParallelReduce.hpp>
 
-// boost for input params
-#include <boost/program_options.hpp>
+// input params
+#include <stk_util/environment/OptionsSpecification.hpp> 
+#include <stk_util/environment/ParseCommandLineArgs.hpp> 
 
 // yaml for parsing..
 #include <yaml-cpp/yaml.h>
@@ -89,39 +90,34 @@ int main( int argc, char ** argv )
     ? (version::NaluVersionTag + "-dirty")
     : version::NaluVersionTag;
 
-  boost::program_options::options_description desc("Nalu Supported Options");
+  stk::OptionsSpecification desc("Nalu Supported Options");
+  std::string naluVout = naluVersion.c_str();
   desc.add_options()
     ("help,h","Help message")
     ("version,v", naluVersion.c_str())
-    ("input-deck,i", boost::program_options::value<std::string>(&inputFileName)->default_value("nalu.i"),
-        "Analysis input file")
-    ("log-file,o", boost::program_options::value<std::string>(&logFileName),
-        "Analysis log file")
-    ("serialized-io-group-size,s",
-     boost::program_options::value<int>(&serializedIOGroupSize)->default_value(0),
-        "Specifies the number of processors which can concurrently perform I/O. Specifying zero disables serialization.")
-    ("debug,D", "debug print on")
-    ("pprint,p", "parallel print on");
+    ("input-deck,i", "Analysis input file", stk::DefaultValue<std::string>("nalu.i"), stk::TargetPointer<std::string>(&inputFileName))
+    ("log-file,o", "Analysis log file", stk::TargetPointer<std::string>(&logFileName))
+    ("serialized-io-group-size,s", "Specifies the number of processors that can concurrently perform I/O. Specifying zero disables serialization.", stk::DefaultValue<int>(0), stk::TargetPointer<int>(&serializedIOGroupSize))
+    ("debug,D","Debug output to the log file")
+    ("pprint,p","Parallel output to the number of mpi rank log files ");
 
-  boost::program_options::variables_map vm;
-  boost::program_options::store(boost::program_options::parse_command_line(argc, argv, desc), vm);
-
-  boost::program_options::notify(vm);
+  stk::ParsedOptions parsedOptions;
+  stk::parse_command_line_args(argc, const_cast<const char**>(argv), desc, parsedOptions);
 
   // deal with some default parameters
-  if ( vm.count("help") ) {
+  if ( parsedOptions.count("help") ) {
     if (!naluEnv.parallel_rank())
       std::cerr << desc << std::endl;
     return 0;
   }
 
-  if (vm.count("version")) {
+  if (parsedOptions.count("version")) {
     if (!naluEnv.parallel_rank())
       std::cerr << "Version: " << naluVersion << std::endl;
     return 0;
   }
 
-  if (vm.count("debug")) {
+  if (parsedOptions.count("debug")) {
     debug = true;
   }
 
@@ -133,7 +129,7 @@ int main( int argc, char ** argv )
   }
 
   // deal with logfile name; if none supplied, go with inputFileName.log
-  if (!vm.count("log-file")) {
+  if (!parsedOptions.count("log-file")) {
     int dotPos = inputFileName.rfind(".");
     if ( -1 == dotPos ) {  
       // lacking extension
@@ -146,7 +142,7 @@ int main( int argc, char ** argv )
   }
 
   bool pprint = false;
-  if (vm.count("pprint")) {
+  if (parsedOptions.count("pprint")) {
     pprint = true;
   }
   // deal with log file stream


### PR DESCRIPTION
This fixes a link error that started when stk_search stopped
depending on 'BoostLib' which is the non-header-only boost libraries.

Blatently copied (i.e., "leveraged") from Stefan's conversion of the nalu-cfd command-line-parsing.

**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x ] Linux
    - [ ] MacOS
  - Compilers 
    - [ x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x ] Compiles without warnings
- [x ] Passes all unit tests
- [ x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
