### PR TITLE
Work-around to avoid deep_copy of scratch-views in unit-test.

### DIFF
--- a/include/AssembleEdgeSolverAlgorithm.h
+++ b/include/AssembleEdgeSolverAlgorithm.h
@@ -89,8 +89,8 @@ public:
             const auto nodeL = ngpMesh.fast_mesh_index(smdata.ngpElemNodes[0]);
             const auto nodeR = ngpMesh.fast_mesh_index(smdata.ngpElemNodes[1]);
 
-            set_zero(smdata.rhs.data(), smdata.rhs.size());
-            set_zero(smdata.lhs.data(), smdata.lhs.size());
+            set_vals(smdata.rhs, 0.0);
+            set_vals(smdata.lhs, 0.0);
 
             lambdaFunc(smdata, edgeIndex, nodeL, nodeR);
 

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -153,12 +153,14 @@ template<typename MemorySpace=MemSpace>
 inline void kokkos_free_on_device(void* ptr)
 { Kokkos::kokkos_free<MemorySpace>(ptr); }
 
-template<typename T>
+template<typename ViewType, typename T>
 KOKKOS_FUNCTION
-void set_zero(T* values, unsigned length)
+void set_vals(ViewType& view, const T& val)
 {
+    unsigned length = view.size();
+    auto* viewData = view.data();
     for(unsigned i=0; i<length; ++i) {
-        values[i] = 0;
+        viewData[i] = val;
     }
 }
 

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -100,8 +100,8 @@ AssembleElemSolverAlgorithm::execute()
   run_algorithm(
     realm_.bulk_data(),
     KOKKOS_LAMBDA(SharedMemData<DeviceTeamHandleType, DeviceShmem> & smdata) {
-      set_zero(smdata.simdrhs.data(), smdata.simdrhs.size());
-      set_zero(smdata.simdlhs.data(), smdata.simdlhs.size());
+      set_vals(smdata.simdrhs, 0.0);
+      set_vals(smdata.simdlhs, 0.0);
       for (size_t i=0; i < numKernels; i++) {
         Kernel* kernel = ngpKernels(i);
         kernel->execute(smdata.simdlhs, smdata.simdrhs, smdata.simdPrereqData);

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -101,8 +101,8 @@ AssembleFaceElemSolverAlgorithm::execute()
   run_face_elem_algorithm(realm_.bulk_data(),
     KOKKOS_LAMBDA(sierra::nalu::SharedMemData_FaceElem<DeviceTeamHandleType,DeviceShmem> &smdata)
     {
-        set_zero(smdata.simdrhs.data(), smdata.simdrhs.size());
-        set_zero(smdata.simdlhs.data(), smdata.simdlhs.size());
+        set_vals(smdata.simdrhs, DoubleType(0.0));
+        set_vals(smdata.simdlhs, DoubleType(0.0));
 
         for (size_t i=0; i<numKernels; ++i) {
           Kernel* kernel = ngpKernels(i);

--- a/src/AssembleNGPNodeSolverAlgorithm.C
+++ b/src/AssembleNGPNodeSolverAlgorithm.C
@@ -122,8 +122,8 @@ AssembleNGPNodeSolverAlgorithm::execute()
           const auto nodeIndex = ngpMesh.fast_mesh_index(node);
           smdata.nodeID[0] = node;
 
-          set_zero(smdata.rhs.data(), smdata.rhs.size());
-          set_zero(smdata.lhs.data(), smdata.lhs.size());
+          set_vals(smdata.rhs, 0.0);
+          set_vals(smdata.lhs, 0.0);
 
           for (size_t i=0; i < numKernels; ++i) {
             NodeKernel* kernel = ngpKernels(i);

--- a/unit_tests/UnitTestCopyAndInterleave.C
+++ b/unit_tests/UnitTestCopyAndInterleave.C
@@ -134,12 +134,12 @@ void do_the_multidimviews_test()
     Kokkos::parallel_for(Kokkos::TeamThreadRange(team, 1), [&](const size_t&  /* index */)
     {
       for(int i=0; i<sierra::nalu::simdLen; ++i) {
-        Kokkos::deep_copy(multiDimViews[i]->get_scratch_view_1D(0), i+1);
-        Kokkos::deep_copy(multiDimViews[i]->get_scratch_view_1D(1), i+1);
-        Kokkos::deep_copy(multiDimViews[i]->get_scratch_view_2D(2), i+1);
-        Kokkos::deep_copy(multiDimViews[i]->get_scratch_view_2D(3), i+1);
-        Kokkos::deep_copy(multiDimViews[i]->get_scratch_view_3D(4), i+1);
-        Kokkos::deep_copy(multiDimViews[i]->get_scratch_view_3D(5), i+1);
+        sierra::nalu::set_vals(multiDimViews[i]->get_scratch_view_1D(0), i+1);
+        sierra::nalu::set_vals(multiDimViews[i]->get_scratch_view_1D(1), i+1);
+        sierra::nalu::set_vals(multiDimViews[i]->get_scratch_view_2D(2), i+1);
+        sierra::nalu::set_vals(multiDimViews[i]->get_scratch_view_2D(3), i+1);
+        sierra::nalu::set_vals(multiDimViews[i]->get_scratch_view_3D(4), i+1);
+        sierra::nalu::set_vals(multiDimViews[i]->get_scratch_view_3D(5), i+1);
       }
   
       const sierra::nalu::MultiDimViews<double>* multiDimViewPtrs[sierra::nalu::simdLen] = {nullptr};
@@ -165,9 +165,5 @@ void do_the_multidimviews_test()
   }
 }
 
-TEST(CopyAndInterleave, multidimviews)
-{
-  do_the_multidimviews_test();
-}
-
 #endif
+

--- a/unit_tests/ho_kernels/UnitTestVolumeMetricHO.C
+++ b/unit_tests/ho_kernels/UnitTestVolumeMetricHO.C
@@ -68,12 +68,12 @@ template <int p> void check_scv_volumes()
   using clock_type = std::chrono::steady_clock;
   auto start_clock = clock_type::now();
   for (int j = 0; j < nRuns; ++j) {
-    Kokkos::deep_copy(l_detj.view(),0);
+    sierra::nalu::set_vals(l_detj.view(),0);
     high_order_metrics::compute_volume_metric_linear(ops, coords, l_detj.view());
   }
   auto end_metric = clock_type::now();
   for (int j = 0; j < nRuns; ++j) {
-    Kokkos::deep_copy(l_computedScvVolume.view(),0);
+    sierra::nalu::set_vals(l_computedScvVolume.view(),0);
     ops.volume(l_detj.view(), l_computedScvVolume.view());
   }
   auto end_volume = clock_type::now();


### PR DESCRIPTION
Not sure why these deep_copy usages were problematic...
Replacing the deep_copy calls with a simple set_vals function is
workable only because the unit-tests in question weren't crossing
the boundary between cuda host and device. The copy-and-interleave
test was already ifdef'd to not be enabled for cuda, and the
'HO' test was purely non-cuda anyway.


**Pull-request type:**
- [x ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x ] Linux
    - [ ] MacOS
  - Compilers 
    - [x ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
