### PR TITLE
Fix memory leak in ActuatorDisk

### DIFF
--- a/src/actuator/ActuatorFAST.C
+++ b/src/actuator/ActuatorFAST.C
@@ -435,6 +435,8 @@ ActuatorFAST::initialize()
   // create the ActuatorLineFASTPointInfo
   create_actuator_point_info_map();
 
+  create_point_info_map_class_specific();
+
   // coarse search
   determine_elems_to_ghost();
 
@@ -443,8 +445,6 @@ ActuatorFAST::initialize()
 
   // complete filling in the set of elements connected to the centroid
   complete_search();
-
-  update(); // Update location of actuator points, ghosting etc.
 
 }
 
@@ -1405,7 +1405,6 @@ ActuatorFAST::update_actuator_point_info_map()
       }
     }
   }
-   create_point_info_map_class_specific(); 
 }
 
 /// This function computes the index map such that actuator points can be


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

**1.  Stop creating actuatorPoints every iteration**
- When these redundant points were created one of the node_vec's is not populated/gets a stale pointer
- This leads to an invalid pointer being referenced when the `spread_actuator_force_to_node_vec` method is called.
- Actuator disk regression test now passes clang 7.0 build with asan turned on

**2.  Remove unnecessary re-construction of actuatorMap during initialization**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
