### PR TITLE
Minimize inclusion of yaml-cpp and boost headers

### DIFF
--- a/include/AveragingInfo.h
+++ b/include/AveragingInfo.h
@@ -12,8 +12,6 @@
 #ifndef AveragingInfo_h
 #define AveragingInfo_h
 
-#include <NaluParsing.h>
-
 #include <string>
 #include <vector>
 

--- a/include/BoundaryConditions.h
+++ b/include/BoundaryConditions.h
@@ -14,9 +14,6 @@
 
 #include <Enums.h>
 
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-
 #include <map>
 #include <string>
 #include <vector>
@@ -66,25 +63,8 @@ class BoundaryCondition {
    }
  }
 
- BoundaryConditions* load(const YAML::Node & node) 
- {
-   BoundaryCondition tmp_boundary_condition(*this);
-   
-   if(node["boundary_conditions"]) {
-     const YAML::Node boundary_conditions = node["boundary_conditions"];
-     for ( size_t iboundary_condition = 0; iboundary_condition < boundary_conditions.size(); ++iboundary_condition ) {
-       const YAML::Node boundary_condition_node = boundary_conditions[iboundary_condition];
-       BoundaryCondition* bc = tmp_boundary_condition.load(boundary_condition_node);
-       boundaryConditionVector_.push_back(bc);
-     }
-   }
-   else {
-     throw std::runtime_error("parser error BoundaryConditions::load");
-   }
+   BoundaryConditions* load(const YAML::Node & node);
 
-   return this;
- }
- 
  void breadboard()
  {
    for ( size_t iboundary_condition = 0; iboundary_condition < boundaryConditionVector_.size(); ++iboundary_condition ) {

--- a/include/DataProbePostProcessing.h
+++ b/include/DataProbePostProcessing.h
@@ -12,7 +12,7 @@
 #ifndef DataProbePostProcessing_h
 #define DataProbePostProcessing_h
 
-#include <NaluParsing.h>
+#include "NaluParsedTypes.h"
 
 #include <string>
 #include <vector>
@@ -23,6 +23,8 @@
 #include <stk_mesh/base/Selector.hpp>
 
 #include <stk_io/StkMeshIoBroker.hpp>
+
+namespace YAML { class Node; }
 
 // stk forwards
 namespace stk {

--- a/include/EnthalpyEquationSystem.h
+++ b/include/EnthalpyEquationSystem.h
@@ -16,7 +16,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 #include "ngp_algorithms/NodalGradAlgDriver.h"
 #include "ngp_algorithms/EnthalpyEffDiffFluxCoeffAlg.h"

--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -13,7 +13,7 @@
 #define EquationSystem_h
 
 #include "KokkosInterface.h"
-#include "NaluParsing.h"
+#include "NaluParsedTypes.h"
 #include "Realm.h"
 #include "PecletFunction.h"
 #include "NGPInstance.h"
@@ -190,10 +190,7 @@ public:
   virtual void register_abltop_bc(
     stk::mesh::Part *part,
     const stk::topology &theTopo,
-    const ABLTopBoundaryConditionData &abltopBCData) {
-      SymmetryBoundaryConditionData simData(abltopBCData.boundaryConditions_);
-      register_symmetry_bc( part, theTopo, simData );
-    }
+    const ABLTopBoundaryConditionData &abltopBCData);
 
   virtual void register_periodic_bc(
     stk::mesh::Part * /* partMaster */,

--- a/include/EquationSystems.h
+++ b/include/EquationSystems.h
@@ -13,10 +13,7 @@
 #define EquationSystems_h
 
 #include <Enums.h>
-
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-#include<NaluParsing.h>
+#include "NaluParsedTypes.h"
 
 // stk
 namespace stk{
@@ -43,7 +40,6 @@ namespace nalu{
 
 class Realm;
 class EquationSystem;
-class PostProcessingData;
 class Simulation;
 class AlgorithmDriver;
 class UpdateOversetFringeAlgorithmDriver;

--- a/include/FieldTypeDef.h
+++ b/include/FieldTypeDef.h
@@ -16,7 +16,7 @@
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_ngp/Ngp.hpp>
 
-#include "LinearSolverTypes.h" // for GlobalOrdinal
+#include <Tpetra_Details_DefaultTypes.hpp>
 
 #ifdef NALU_USES_HYPRE
 #include "HYPRE_utilities.h"
@@ -51,7 +51,7 @@ typedef HYPRE_Int HypreIntType;
 typedef int HypreIntType;
 #endif
 
-typedef stk::mesh::Field<LinSys::GlobalOrdinal> TpetIDFieldType;
+typedef stk::mesh::Field<Tpetra::Details::DefaultTypes::global_ordinal_type> TpetIDFieldType;
 typedef stk::mesh::Field<HypreIntType> HypreIDFieldType;
 
 } // namespace nalu

--- a/include/HeatCondEquationSystem.h
+++ b/include/HeatCondEquationSystem.h
@@ -14,7 +14,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 #include <stk_mesh/base/FieldBase.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>

--- a/include/InitialConditions.h
+++ b/include/InitialConditions.h
@@ -14,9 +14,6 @@
 
 #include <Enums.h>
 
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-
 #include <map>
 #include <string>
 #include <vector>
@@ -67,25 +64,8 @@ class InitialCondition {
      }
    }
  
- InitialConditions* load(const YAML::Node & node) 
- {
-   InitialCondition tmp_initial_condition(*this);
-   
-   if(node["initial_conditions"]) {
-     const YAML::Node initial_conditions = node["initial_conditions"];
-     for ( size_t j_initial_condition = 0; j_initial_condition < initial_conditions.size(); ++j_initial_condition ) {
-       const YAML::Node initial_condition_node = initial_conditions[j_initial_condition];
-       InitialCondition* ic = tmp_initial_condition.load(initial_condition_node);
-       initialConditionVector_.push_back(ic);
-     }
-   }
-   else {
-     throw std::runtime_error("parser error InitialConditions::load");
-   }
+   InitialConditions* load(const YAML::Node & node);
 
-   return this;
- }
- 
  void breadboard()
  {
    for ( size_t j_initial_condition = 0; j_initial_condition < initialConditionVector_.size(); ++j_initial_condition ) {

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -15,11 +15,6 @@
 #include <LinearSolverTypes.h>
 #include <KokkosInterface.h>
 
-#include <Teuchos_RCP.hpp>
-
-#include <Teuchos_GlobalMPISession.hpp>
-#include <Teuchos_oblackholestream.hpp>
-
 #include <stk_ngp/Ngp.hpp>
 
 #include <vector>

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -16,7 +16,7 @@
 
 #include "EquationSystem.h"
 #include "FieldTypeDef.h"
-#include "NaluParsing.h"
+#include "NaluParsedTypes.h"
 #include "TAMSAlgDriver.h"
 
 #include "ngp_algorithms/NodalGradAlgDriver.h"

--- a/include/MassFractionEquationSystem.h
+++ b/include/MassFractionEquationSystem.h
@@ -14,7 +14,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 // c++
 #include <set>

--- a/include/MaterialProperty.h
+++ b/include/MaterialProperty.h
@@ -14,9 +14,6 @@
 
 #include <Enums.h>
 
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-
 #include <map>
 #include <string>
 #include <vector>

--- a/include/MaterialPropertys.h
+++ b/include/MaterialPropertys.h
@@ -14,9 +14,6 @@
 
 #include <Enums.h>
 
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-
 #include <map>
 #include <string>
 #include <vector>

--- a/include/MixtureFractionEquationSystem.h
+++ b/include/MixtureFractionEquationSystem.h
@@ -14,7 +14,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 namespace stk{
 struct topology;

--- a/include/NaluParsedTypes.h
+++ b/include/NaluParsedTypes.h
@@ -1,0 +1,170 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef NALUPARSEDTYPES_H
+#define NALUPARSEDTYPES_H
+
+#include <string>
+#include <vector>
+
+namespace YAML { class Node; }
+
+namespace sierra {
+namespace nalu {
+
+// our data types
+struct Velocity {
+  double ux_, uy_, uz_;
+  Velocity()
+    : ux_(0.0), uy_(0.0), uz_(0.0)
+  {}
+};
+
+struct Coordinates {
+  double x_, y_, z_;
+  Coordinates()
+    : x_(0.0), y_(0.0), z_(0.0)
+  {}
+};
+
+struct Pressure {
+  double pressure_;
+  Pressure()
+    : pressure_(0.0)
+  {}
+};
+
+struct TurbKinEnergy {
+  double turbKinEnergy_;
+  TurbKinEnergy()
+    : turbKinEnergy_(0.0)
+  {}
+};
+
+struct SpecDissRate {
+  double specDissRate_;
+  SpecDissRate()
+    : specDissRate_(0.0)
+  {}
+};
+
+struct Temperature {
+  double temperature_;
+  Temperature()
+    : temperature_(0.0)
+  {}
+};
+
+struct MixtureFraction {
+  double mixFrac_;
+  MixtureFraction()
+    : mixFrac_(0.0)
+  {}
+};
+
+struct MassFraction {
+  std::vector<double> massFraction_;
+  MassFraction()
+  {}
+};
+
+struct Emissivity {
+  double emissivity_;
+  Emissivity()
+    : emissivity_(1.0)
+  {}
+};
+
+struct Irradiation {
+  double irradiation_;
+  Irradiation()
+    : irradiation_(1.0)
+  {}
+};
+
+struct Transmissivity {
+  double transmissivity_;
+  Transmissivity()
+    : transmissivity_(0.0)
+  {}
+};
+
+struct EnvironmentalT {
+  double environmentalT_;
+  EnvironmentalT()
+    : environmentalT_(298.0)
+  {}
+};
+
+struct ReferenceTemperature {
+  double referenceTemperature_;
+  ReferenceTemperature()
+    : referenceTemperature_(298.0)
+  {}
+};
+
+struct HeatTransferCoefficient {
+  double heatTransferCoefficient_;
+  HeatTransferCoefficient()
+    : heatTransferCoefficient_(0.0)
+  {}
+};
+
+struct RobinCouplingParameter {
+  double robinCouplingParameter_;
+  RobinCouplingParameter()
+    : robinCouplingParameter_(0.0)
+  {}
+};
+
+
+struct NormalHeatFlux {
+  double qn_;
+  NormalHeatFlux()
+    : qn_(0.0)
+  {}
+};
+
+struct NormalTemperatureGradient {
+  double tempGradN_;
+  NormalTemperatureGradient()
+    : tempGradN_(0.0)
+  {}
+};
+
+struct RoughnessHeight {
+  double z0_;
+  RoughnessHeight()
+    :  z0_(0.1)
+  {}
+};
+
+struct MasterSlave {
+  std::string master_;
+  std::string slave_;
+  MasterSlave() {}
+};
+
+struct UserData;
+struct WallBoundaryConditionData;
+struct InflowBoundaryConditionData;
+struct OpenBoundaryConditionData;
+struct SymmetryBoundaryConditionData;
+struct ABLTopBoundaryConditionData;
+struct PeriodicBoundaryConditionData;
+struct OversetBoundaryConditionData;
+struct NonConformalBoundaryConditionData;
+class PostProcessingData;
+struct UserFunctionInitialConditionData;
+
+}  // nalu
+}  // sierra
+
+
+#endif /* NALUPARSEDTYPES_H */

--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -16,6 +16,7 @@
 #include <Enums.h>
 #include <InitialConditions.h>
 #include <MaterialPropertys.h>
+#include <NaluParsedTypes.h>
 #include <NaluParsingHelper.h>
 #include <NaluEnv.h>
 
@@ -29,111 +30,6 @@
 
 namespace sierra {
 namespace nalu {
-
-// our data types
-struct Velocity {
-  double ux_, uy_, uz_;
-  Velocity()
-    : ux_(0.0), uy_(0.0), uz_(0.0)
-  {}
-};
-
-struct Coordinates {
-  double x_, y_, z_;
-  Coordinates()
-    : x_(0.0), y_(0.0), z_(0.0)
-  {}
-};
-
-struct Pressure {
-  double pressure_;
-  Pressure()
-    : pressure_(0.0)
-  {}
-};
-
-struct TurbKinEnergy {
-  double turbKinEnergy_;
-  TurbKinEnergy()
-    : turbKinEnergy_(0.0)
-  {}
-};
-
-struct SpecDissRate {
-  double specDissRate_;
-  SpecDissRate()
-    : specDissRate_(0.0)
-  {}
-};
-
-struct Temperature {
-  double temperature_;
-  Temperature()
-    : temperature_(0.0)
-  {}
-};
-
-struct MixtureFraction {
-  double mixFrac_;
-  MixtureFraction()
-    : mixFrac_(0.0)
-  {}
-};
-
-struct MassFraction {
-  std::vector<double> massFraction_;
-  MassFraction()
-  {}
-};
-
-struct Emissivity {
-  double emissivity_;
-  Emissivity()
-    : emissivity_(1.0)
-  {}
-};
-
-struct Irradiation {
-  double irradiation_;
-  Irradiation()
-    : irradiation_(1.0)
-  {}
-};
-
-struct Transmissivity {
-  double transmissivity_;
-  Transmissivity()
-    : transmissivity_(0.0)
-  {}
-};
-
-struct EnvironmentalT {
-  double environmentalT_;
-  EnvironmentalT()
-    : environmentalT_(298.0)
-  {}
-};
-
-struct ReferenceTemperature {
-  double referenceTemperature_;
-  ReferenceTemperature()
-    : referenceTemperature_(298.0)
-  {}
-};
-
-struct HeatTransferCoefficient {
-  double heatTransferCoefficient_;
-  HeatTransferCoefficient()
-    : heatTransferCoefficient_(0.0)
-  {}
-};
-
-struct RobinCouplingParameter {
-  double robinCouplingParameter_;
-  RobinCouplingParameter()
-    : robinCouplingParameter_(0.0)
-  {}
-};
 
 // base class
 struct UserData 
@@ -151,32 +47,6 @@ struct UserData
 UserData() : tempSpec_(false), externalData_(false) {}
 };
 
-struct NormalHeatFlux {
-  double qn_;
-  NormalHeatFlux()
-    : qn_(0.0)
-  {}
-};
-
-struct NormalTemperatureGradient {
-  double tempGradN_;
-  NormalTemperatureGradient()
-    : tempGradN_(0.0)
-  {}
-};
-
-struct RoughnessHeight {
-  double z0_;
-  RoughnessHeight()
-    :  z0_(0.1)
-  {}
-};
-
-struct MasterSlave {
-  std::string master_;
-  std::string slave_;
-  MasterSlave() {}
-};
 
 // packaged
 struct WallUserData : public UserData {

--- a/include/OutputInfo.h
+++ b/include/OutputInfo.h
@@ -12,10 +12,10 @@
 #ifndef OutputInfo_h
 #define OutputInfo_h
 
-#include <NaluParsing.h>
-
 #include <string>
 #include <set>
+
+namespace YAML { class Node; }
 
 namespace Ioss{
   class PropertyManager;

--- a/include/PeriodicManager.h
+++ b/include/PeriodicManager.h
@@ -17,6 +17,7 @@
 //==============================================================================
 
 #include <FieldTypeDef.h>
+#include <KokkosInterface.h>
 
 // stk
 #include <stk_mesh/base/Part.hpp>

--- a/include/PostProcessingInfo.h
+++ b/include/PostProcessingInfo.h
@@ -12,7 +12,7 @@
 #ifndef PostProcessingInfo_h
 #define PostProcessingInfo_h
 
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 #include <string>
 #include <vector>

--- a/include/ProjectedNodalGradientEquationSystem.h
+++ b/include/ProjectedNodalGradientEquationSystem.h
@@ -15,7 +15,7 @@
 #include <Enums.h>
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 #include <stk_mesh/base/FieldBase.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -15,16 +15,14 @@
 #include <Enums.h>
 #include <FieldTypeDef.h>
 
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-
 #include <BoundaryConditions.h>
 #include <InitialConditions.h>
 #include <MaterialPropertys.h>
 #include <EquationSystems.h>
-#include <Teuchos_RCP.hpp>
 
-#include <stk_util/util/ParameterList.hpp>
+#if defined(NALU_USES_PERCEPT)
+#include <Teuchos_RCP.hpp>
+#endif
 
 #include <stk_ngp/NgpFieldManager.hpp>
 
@@ -34,7 +32,7 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <stdint.h>
+#include <memory>
 
 namespace stk {
 namespace mesh {
@@ -42,6 +40,10 @@ class Part;
 }
 namespace io {
   class StkMeshIoBroker;
+}
+
+namespace util {
+class ParameterList;
 }
 }
 
@@ -424,11 +426,11 @@ class Realm {
   ErrorIndicatorAlgorithmDriver *errorIndicatorAlgDriver_;
 # if defined (NALU_USES_PERCEPT)  
   Adapter *adapter_;
+  Teuchos::RCP<stk::mesh::Selector> activePartForIO_;
 #endif
   unsigned numInitialElements_;
   // for element, side, edge, node rank (node not used)
   stk::mesh::Selector adapterSelector_[4];
-  Teuchos::RCP<stk::mesh::Selector> activePartForIO_;
 
   TimeIntegrator *timeIntegrator_;
 
@@ -493,7 +495,7 @@ class Realm {
   bool hasFluids_;
 
   // global parameter list
-  stk::util::ParameterList globalParameters_;
+  std::unique_ptr<stk::util::ParameterList> globalParameters_;
 
   // part for all exposed surfaces in the mesh
   stk::mesh::Part *exposedBoundaryPart_;

--- a/include/Realms.h
+++ b/include/Realms.h
@@ -13,11 +13,7 @@
 #define Realms_h
 
 #include <Enums.h>
-
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
 #include <Realm.h>
-#include <NaluParsing.h>
 
 #include <map>
 #include <string>

--- a/include/ShearStressTransportEquationSystem.h
+++ b/include/ShearStressTransportEquationSystem.h
@@ -14,7 +14,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 namespace stk{
 struct topology;

--- a/include/SolutionNormPostProcessing.h
+++ b/include/SolutionNormPostProcessing.h
@@ -12,7 +12,7 @@
 #ifndef SolutionNormPostProcessing_h
 #define SolutionNormPostProcessing_h
 
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 #include <string>
 #include <vector>

--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -12,7 +12,6 @@
 #ifndef SolutionOptions_h
 #define SolutionOptions_h
 
-#include <NaluParsing.h>
 #include <Enums.h>
 
 // standard c++
@@ -20,6 +19,9 @@
 #include <map>
 #include <utility>
 #include <memory>
+#include <vector>
+
+namespace YAML { class Node; }
 
 namespace sierra{
 namespace nalu{

--- a/include/SpecificDissipationRateEquationSystem.h
+++ b/include/SpecificDissipationRateEquationSystem.h
@@ -14,7 +14,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 #include "ngp_algorithms/NodalGradAlgDriver.h"
 

--- a/include/TimeIntegrator.h
+++ b/include/TimeIntegrator.h
@@ -13,12 +13,10 @@
 #define TimeIntegrator_h
 
 #include <Enums.h>
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-
 #include <vector>
 #include <string>
 
+namespace YAML { class Node; }
 
 namespace sierra{
 namespace nalu{

--- a/include/TurbKineticEnergyEquationSystem.h
+++ b/include/TurbKineticEnergyEquationSystem.h
@@ -14,7 +14,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 #include "ngp_algorithms/NodalGradAlgDriver.h"
 #include "ngp_algorithms/TKEWallFuncAlgDriver.h"

--- a/include/TurbulenceAveragingPostProcessing.h
+++ b/include/TurbulenceAveragingPostProcessing.h
@@ -12,7 +12,7 @@
 #ifndef TurbulenceAveragingPostProcessing_h
 #define TurbulenceAveragingPostProcessing_h
 
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 #include <MovingAveragePostProcessor.h>
 
 #include <string>

--- a/include/actuator/Actuator.h
+++ b/include/actuator/Actuator.h
@@ -11,7 +11,7 @@
 #ifndef Actuator_h
 #define Actuator_h
 
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 #include <FieldTypeDef.h>
 
 // stk_mesh/base/fem

--- a/include/edge_kernels/AssembleTAMSEdgeKernelAlg.h
+++ b/include/edge_kernels/AssembleTAMSEdgeKernelAlg.h
@@ -11,13 +11,7 @@
 #ifndef ASSEMBLETAMSEDGEKERNEL_H
 #define ASSEMBLETAMSEDGEKERNEL_H
 
-#include "AssembleEdgeSolverAlgorithm.h"
-#include "MomentumSSTTAMSDiffEdgeKernel.h"
 #include "AssembleEdgeKernelAlg.h"
-#include "nalu_make_unique.h"
-
-#include <vector>
-#include <memory>
 
 namespace sierra {
 namespace nalu {

--- a/include/kernel/KernelBuilder.h
+++ b/include/kernel/KernelBuilder.h
@@ -15,6 +15,7 @@
 #include <AssembleFaceElemSolverAlgorithm.h>
 #include <EquationSystem.h>
 #include <AlgTraits.h>
+#include <NaluEnv.h>
 #include <kernel/KernelBuilderLog.h>
 
 #include <stk_mesh/base/BulkData.hpp>

--- a/include/mesh_motion/FrameBase.h
+++ b/include/mesh_motion/FrameBase.h
@@ -9,6 +9,8 @@
 #include "stk_mesh/base/Field.hpp"
 #include "stk_mesh/base/MetaData.hpp"
 
+namespace YAML { class Node; }
+
 namespace sierra{
 namespace nalu{
 

--- a/include/mesh_motion/MeshDisplacementEquationSystem.h
+++ b/include/mesh_motion/MeshDisplacementEquationSystem.h
@@ -14,7 +14,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 namespace stk{
 struct topology;

--- a/include/mesh_motion/MotionBase.h
+++ b/include/mesh_motion/MotionBase.h
@@ -1,13 +1,23 @@
 #ifndef MOTIONBASE_H
 #define MOTIONBASE_H
 
-#include <FieldTypeDef.h>
-
-#include "yaml-cpp/yaml.h"
-
 #include <algorithm>
 #include <cassert>
 #include <cfloat>
+#include <vector>
+#include <array>
+
+namespace YAML { class Node; }
+
+namespace stk {
+namespace mesh {
+class MetaData;
+class BulkData;
+class Part;
+
+typedef std::vector<Part*> PartVector;
+}
+}
 
 namespace sierra{
 namespace nalu{

--- a/include/mesh_motion/MotionPulsatingSphere.h
+++ b/include/mesh_motion/MotionPulsatingSphere.h
@@ -3,6 +3,8 @@
 
 #include "MotionBase.h"
 
+namespace YAML { class Node; }
+
 namespace sierra{
 namespace nalu{
 

--- a/include/mesh_motion/MotionScaling.h
+++ b/include/mesh_motion/MotionScaling.h
@@ -3,6 +3,12 @@
 
 #include "MotionBase.h"
 
+namespace stk {
+namespace mesh {
+class MetaData;
+}
+}
+
 namespace sierra{
 namespace nalu{
 

--- a/include/ngp_algorithms/NodalGradPOpenBoundaryAlg.h
+++ b/include/ngp_algorithms/NodalGradPOpenBoundaryAlg.h
@@ -11,7 +11,6 @@
 #define NODALGRADPOPENBOUNDARYALG_H
 
 #include<Algorithm.h>
-#include<FieldTypeDef.h>
 #include<ElemDataRequests.h>
 
 #include "stk_mesh/base/Types.hpp"

--- a/include/pmr/RadiativeTransportEquationSystem.h
+++ b/include/pmr/RadiativeTransportEquationSystem.h
@@ -14,7 +14,7 @@
 
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
-#include <NaluParsing.h>
+#include <NaluParsedTypes.h>
 
 namespace stk{
 struct topology;

--- a/include/utils/StkHelpers.h
+++ b/include/utils/StkHelpers.h
@@ -1,65 +1,23 @@
 #ifndef STKHELPERS_H
 #define STKHELPERS_H
 
-#include <element_promotion/PromotedPartHelper.h>
 
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
-#include <stk_mesh/base/Ghosting.hpp>
-#include <stk_util/util/SortAndUnique.hpp>
 #include <stk_topology/topology.hpp>
-
-#include <Realm.h>
 
 namespace sierra {
 namespace nalu {
 
-inline
-void populate_ghost_comm_procs(const stk::mesh::BulkData& bulk_data, stk::mesh::Ghosting& ghosting,
-                            std::vector<int>& ghostCommProcs)
-{
-    ghostCommProcs.clear();
+class Realm;
 
-    std::vector<stk::mesh::EntityProc> sendList;
-    ghosting.send_list(sendList);
+void
+populate_ghost_comm_procs(
+  const stk::mesh::BulkData& bulk_data,
+  stk::mesh::Ghosting& ghosting,
+  std::vector<int>& ghostCommProcs);
 
-    for(const stk::mesh::EntityProc& entProc : sendList) {
-        stk::util::insert_keep_sorted_and_unique(entProc.second, ghostCommProcs);
-    }
-
-    std::vector<stk::mesh::EntityKey> recvList;
-    ghosting.receive_list(recvList);
-
-    for(const stk::mesh::EntityKey& key : recvList) {
-        stk::mesh::Entity entity = bulk_data.get_entity(key);
-        stk::util::insert_keep_sorted_and_unique(bulk_data.parallel_owner_rank(entity), ghostCommProcs);
-    }
-}
-
-inline
-stk::topology get_elem_topo(const Realm& realm, const stk::mesh::Part& surfacePart)
-{
-  if (realm.doPromotion_) {
-    return get_promoted_elem_topo(realm.spatialDimension_, realm.promotionOrder_);
-  }
-
-  std::vector<const stk::mesh::Part*> blockParts = realm.meta_data().get_blocks_touching_surface(&surfacePart);
-
-  ThrowRequireMsg(blockParts.size() >= 1, "Error, expected at least 1 block for surface "<<surfacePart.name());
-
-  stk::topology elemTopo = blockParts[0]->topology();
-  if (blockParts.size() > 1) {
-    for(size_t i=1; i<blockParts.size(); ++i) {
-      ThrowRequireMsg(blockParts[i]->topology() == elemTopo,
-                 "Error, found blocks of different topology connected to surface '"
-                  <<surfacePart.name()<<"', "<<elemTopo<<" and "<<blockParts[i]->topology());
-    }
-  }
-
-  ThrowRequireMsg(elemTopo != stk::topology::INVALID_TOPOLOGY,
-                  "Error, didn't find valid topology block for surface "<<surfacePart.name());
-  return elemTopo;
-}
+stk::topology get_elem_topo(const Realm& realm, const stk::mesh::Part& surfacePart);
 
 void add_downward_relations(
   const stk::mesh::BulkData& bulk,

--- a/include/wind_energy/ABLForcingAlgorithm.h
+++ b/include/wind_energy/ABLForcingAlgorithm.h
@@ -2,7 +2,6 @@
 #ifndef ABLFORCINGALGORITHM_H
 #define ABLFORCINGALGORITHM_H
 
-#include "NaluParsing.h"
 #include "FieldTypeDef.h"
 #include "wind_energy/ABLSrcInterp.h"
 
@@ -14,6 +13,8 @@
 #include <sstream>
 #include <unordered_set>
 #include <memory>
+
+namespace YAML { class Node; }
 
 namespace sierra {
 namespace nalu {

--- a/include/wind_energy/BdyHeightAlgorithm.h
+++ b/include/wind_energy/BdyHeightAlgorithm.h
@@ -12,9 +12,10 @@
 #define BDYHEIGHTALGORITHM_H
 
 #include "FieldTypeDef.h"
-#include "NaluParsing.h"
 
 #include <vector>
+
+namespace YAML { class Node; }
 
 namespace sierra {
 namespace nalu {

--- a/include/wind_energy/BdyLayerStatistics.h
+++ b/include/wind_energy/BdyLayerStatistics.h
@@ -12,12 +12,13 @@
 #define BDYLAYERSTATISTICS_H
 
 #include "KokkosInterface.h"
-#include "NaluParsing.h"
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/Part.hpp"
 
 #include <memory>
+
+namespace YAML { class Node; }
 
 namespace sierra {
 namespace nalu {

--- a/include/xfer/Transfer.h
+++ b/include/xfer/Transfer.h
@@ -12,9 +12,6 @@
 #ifndef Transfer_h
 #define Transfer_h
 
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-
 #include <string>
 #include <vector>
 #include <utility>
@@ -22,6 +19,8 @@
 
 // stk_transfer related
 #include <stk_transfer/TransferBase.hpp>
+
+namespace YAML { class Node; }
 
 // stk
 namespace stk {

--- a/include/xfer/Transfers.h
+++ b/include/xfer/Transfers.h
@@ -14,9 +14,6 @@
 
 #include <Enums.h>
 
-// yaml for parsing..
-#include <yaml-cpp/yaml.h>
-
 #include <map>
 #include <string>
 #include <vector>

--- a/src/AssembleContinuityNonConformalSolverAlgorithm.C
+++ b/src/AssembleContinuityNonConformalSolverAlgorithm.C
@@ -15,6 +15,7 @@
 #include <DgInfo.h>
 #include <FieldTypeDef.h>
 #include <LinearSystem.h>
+#include <NaluEnv.h>
 #include <NonConformalInfo.h>
 #include <NonConformalManager.h>
 #include <Realm.h>

--- a/src/AssembleMomentumNonConformalSolverAlgorithm.C
+++ b/src/AssembleMomentumNonConformalSolverAlgorithm.C
@@ -15,6 +15,7 @@
 #include <DgInfo.h>
 #include <FieldTypeDef.h>
 #include <LinearSystem.h>
+#include <NaluEnv.h>
 #include <NonConformalInfo.h>
 #include <NonConformalManager.h>
 #include <Realm.h>

--- a/src/AssembleScalarDiffNonConformalSolverAlgorithm.C
+++ b/src/AssembleScalarDiffNonConformalSolverAlgorithm.C
@@ -15,6 +15,7 @@
 #include <DgInfo.h>
 #include <FieldTypeDef.h>
 #include <LinearSystem.h>
+#include <NaluEnv.h>
 #include <NonConformalInfo.h>
 #include <NonConformalManager.h>
 #include <Realm.h>

--- a/src/AssembleScalarEigenEdgeSolverAlgorithm.C
+++ b/src/AssembleScalarEigenEdgeSolverAlgorithm.C
@@ -15,6 +15,7 @@
 #include <EquationSystem.h>
 #include <FieldTypeDef.h>
 #include <LinearSystem.h>
+#include <NaluEnv.h>
 #include <PecletFunction.h>
 #include <Realm.h>
 #include <SolutionOptions.h>

--- a/src/AssembleScalarNonConformalSolverAlgorithm.C
+++ b/src/AssembleScalarNonConformalSolverAlgorithm.C
@@ -15,6 +15,7 @@
 #include <DgInfo.h>
 #include <FieldTypeDef.h>
 #include <LinearSystem.h>
+#include <NaluEnv.h>
 #include <NonConformalInfo.h>
 #include <NonConformalManager.h>
 #include <Realm.h>

--- a/src/BoundaryConditions.C
+++ b/src/BoundaryConditions.C
@@ -115,5 +115,25 @@ BoundaryCondition * BoundaryCondition::load(const YAML::Node & node)
   Simulation* BoundaryConditions::root() { return parent()->root(); }
   Realm *BoundaryConditions::parent() { return &realm_; }
 
+BoundaryConditions* BoundaryConditions::load(const YAML::Node &node)
+{
+  BoundaryCondition tmp_boundary_condition(*this);
+
+  if(node["boundary_conditions"]) {
+    const YAML::Node boundary_conditions = node["boundary_conditions"];
+    for ( size_t iboundary_condition = 0; iboundary_condition < boundary_conditions.size(); ++iboundary_condition ) {
+      const YAML::Node boundary_condition_node = boundary_conditions[iboundary_condition];
+      BoundaryCondition* bc = tmp_boundary_condition.load(boundary_condition_node);
+      boundaryConditionVector_.push_back(bc);
+    }
+  }
+  else {
+    throw std::runtime_error("parser error BoundaryConditions::load");
+  }
+
+  return this;
+}
+
+
 } // namespace nalu
 } // namespace Sierra

--- a/src/EquationSystem.C
+++ b/src/EquationSystem.C
@@ -560,5 +560,15 @@ void EquationSystem::solution_update(
     meshInfo, sel, delta_frac, delta, field_frac, field, numComponents, rank);
 }
 
+
+void EquationSystem::register_abltop_bc(
+  stk::mesh::Part *part,
+  const stk::topology &theTopo,
+  const ABLTopBoundaryConditionData &abltopBCData)
+{
+  SymmetryBoundaryConditionData simData(abltopBCData.boundaryConditions_);
+  register_symmetry_bc( part, theTopo, simData );
+}
+
 } // namespace nalu
 } // namespace Sierra

--- a/src/HeatCondEquationSystem.C
+++ b/src/HeatCondEquationSystem.C
@@ -38,6 +38,7 @@
 #include <LinearSystem.h>
 #include <master_element/MasterElement.h>
 #include <NaluEnv.h>
+#include <NaluParsing.h>
 #include <Realm.h>
 #include <Realms.h>
 #include <HeatCondMassBackwardEulerNodeSuppAlg.h>

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -14,6 +14,7 @@
 #include "EquationSystem.h"
 #include "LinearSolver.h"
 #include "PeriodicManager.h"
+#include "NaluEnv.h"
 #include "NonConformalManager.h"
 #include "overset/OversetManager.h"
 #include "overset/OversetInfo.h"

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -10,6 +10,7 @@
 
 #include "HypreUVWLinearSystem.h"
 #include "HypreUVWSolver.h"
+#include "NaluEnv.h"
 #include "Realm.h"
 #include "EquationSystem.h"
 

--- a/src/InitialConditions.C
+++ b/src/InitialConditions.C
@@ -70,5 +70,24 @@ InitialCondition * InitialCondition::load(const YAML::Node & node)
   Simulation* InitialConditions::root() { return parent()->root(); }
   Realm *InitialConditions::parent() { return &realm_; }
 
+InitialConditions* InitialConditions::load(const YAML::Node& node)
+{
+  InitialCondition tmp_initial_condition(*this);
+
+  if(node["initial_conditions"]) {
+    const YAML::Node initial_conditions = node["initial_conditions"];
+    for ( size_t j_initial_condition = 0; j_initial_condition < initial_conditions.size(); ++j_initial_condition ) {
+      const YAML::Node initial_condition_node = initial_conditions[j_initial_condition];
+      InitialCondition* ic = tmp_initial_condition.load(initial_condition_node);
+      initialConditionVector_.push_back(ic);
+    }
+  }
+  else {
+    throw std::runtime_error("parser error InitialConditions::load");
+  }
+
+  return this;
+}
+
 } // namespace nalu
 } // namespace Sierra

--- a/src/InputOutputRealm.C
+++ b/src/InputOutputRealm.C
@@ -10,6 +10,7 @@
 
 
 #include <InputOutputRealm.h>
+#include <NaluParsing.h>
 #include <Realm.h>
 #include <SolutionOptions.h>
 

--- a/src/MassFractionEquationSystem.C
+++ b/src/MassFractionEquationSystem.C
@@ -35,6 +35,7 @@
 #include <LinearSystem.h>
 #include <master_element/MasterElement.h>
 #include <NaluEnv.h>
+#include <NaluParsing.h>
 #include <Realm.h>
 #include <Realms.h>
 #include <ScalarMassElemSuppAlgDep.h>

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -10,6 +10,7 @@
 
 
 #include <PeriodicManager.h>
+#include <LinearSolverTypes.h>
 #include <NaluEnv.h>
 #include <Realm.h>
 #include <utils/StkHelpers.h>

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -117,6 +117,7 @@
 #include <stk_util/environment/WallTime.hpp>
 #include <stk_util/environment/perf_util.hpp>
 #include <stk_util/environment/FileUtils.hpp>
+#include <stk_util/util/ParameterList.hpp>
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
@@ -245,7 +246,7 @@ namespace nalu{
     periodicManager_(NULL),
     hasPeriodic_(false),
     hasFluids_(false),
-    globalParameters_(),
+    globalParameters_(new stk::util::ParameterList()),
     exposedBoundaryPart_(0),
     edgesPart_(0),
     checkForMissingBcs_(false),
@@ -1709,12 +1710,12 @@ Realm::initialize_global_variables()
   // other variables created on the fly during Eqs registration
   const bool needInOutput = false;
   const bool needInRestart = true;
-  globalParameters_.set_param("timeStepNm1", 1.0, needInOutput, needInRestart);
-  globalParameters_.set_param("timeStepCount", 1, needInOutput, needInRestart);
+  globalParameters_->set_param("timeStepNm1", 1.0, needInOutput, needInRestart);
+  globalParameters_->set_param("timeStepCount", 1, needInOutput, needInRestart);
 
   // consider pushing this parameter to some higher level design
   if ( NULL != turbulenceAveragingPostProcessing_ )
-    globalParameters_.set_param("currentTimeFilter", 0.0, needInOutput, needInRestart);
+    globalParameters_->set_param("currentTimeFilter", 0.0, needInOutput, needInRestart);
 }
 
 //--------------------------------------------------------------------------
@@ -2270,8 +2271,8 @@ Realm::create_restart_mesh()
     }
 
     // now global params
-    stk::util::ParameterMapType::const_iterator i = globalParameters_.begin();
-    stk::util::ParameterMapType::const_iterator iend = globalParameters_.end();
+    stk::util::ParameterMapType::const_iterator i = globalParameters_->begin();
+    stk::util::ParameterMapType::const_iterator iend = globalParameters_->end();
     for (; i != iend; ++i) {
       std::string parameterName = (*i).first;
       stk::util::Parameter parameter = (*i).second;
@@ -3269,15 +3270,15 @@ Realm::provide_restart_output()
 
       // push global variables for time step
       const double timeStepNm1 = timeIntegrator_->get_time_step();
-      globalParameters_.set_value("timeStepNm1", timeStepNm1);
-      globalParameters_.set_value("timeStepCount", timeStepCount);
+      globalParameters_->set_value("timeStepNm1", timeStepNm1);
+      globalParameters_->set_value("timeStepCount", timeStepCount);
 
       if ( NULL != turbulenceAveragingPostProcessing_ ) {
-        globalParameters_.set_value("currentTimeFilter", turbulenceAveragingPostProcessing_->currentTimeFilter_ );
+        globalParameters_->set_value("currentTimeFilter", turbulenceAveragingPostProcessing_->currentTimeFilter_ );
       }
 
-      stk::util::ParameterMapType::const_iterator i = globalParameters_.begin();
-      stk::util::ParameterMapType::const_iterator iend = globalParameters_.end();
+      stk::util::ParameterMapType::const_iterator i = globalParameters_->begin();
+      stk::util::ParameterMapType::const_iterator iend = globalParameters_->end();
       for (; i != iend; ++i)
       {
         std::string parameterName = (*i).first;

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -38,6 +38,7 @@
 // basic c++
 #include <cmath>
 #include <vector>
+#include <iomanip>
 
 // ngp
 #include "ngp_utils/NgpFieldBLAS.h"

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -12,6 +12,7 @@
 #include <SolutionOptions.h>
 #include <Enums.h>
 #include <NaluEnv.h>
+#include <NaluParsing.h>
 #include <FixPressureAtNodeInfo.h>
 
 // basic c++

--- a/src/TimeIntegrator.C
+++ b/src/TimeIntegrator.C
@@ -21,6 +21,7 @@
 #include <NaluParsing.h>
 
 #include <limits>
+#include <iomanip>
 
 namespace sierra{
 namespace nalu{

--- a/src/WallDistEquationSystem.C
+++ b/src/WallDistEquationSystem.C
@@ -23,6 +23,7 @@
 #include "LinearSolver.h"
 #include "LinearSolvers.h"
 #include "LinearSystem.h"
+#include "NaluParsing.h"
 #include "NonConformalManager.h"
 #include "Realm.h"
 #include "Realms.h"

--- a/src/actuator/ActuatorDiskFAST.C
+++ b/src/actuator/ActuatorDiskFAST.C
@@ -15,6 +15,8 @@
  */
 
 #include "actuator/ActuatorDiskFAST.h"
+#include "NaluEnv.h"
+#include "NaluParsing.h"
 #include <cmath>
 #include <algorithm>
 #include <functional>

--- a/src/edge_kernels/AssembleTAMSEdgeKernelAlg.C
+++ b/src/edge_kernels/AssembleTAMSEdgeKernelAlg.C
@@ -10,6 +10,7 @@
 
 #include "edge_kernels/AssembleTAMSEdgeKernelAlg.h"
 #include "edge_kernels/EdgeKernel.h"
+#include "edge_kernels/MomentumSSTTAMSDiffEdgeKernel.h"
 
 namespace sierra {
 namespace nalu {

--- a/src/mesh_motion/FrameBase.C
+++ b/src/mesh_motion/FrameBase.C
@@ -6,7 +6,8 @@
 #include "mesh_motion/MotionScaling.h"
 #include "mesh_motion/MotionTranslation.h"
 
-#include <NaluParsing.h>
+#include "NaluParsing.h"
+#include "FieldTypeDef.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/FieldBLAS.hpp>

--- a/src/mesh_motion/FrameInertial.C
+++ b/src/mesh_motion/FrameInertial.C
@@ -1,5 +1,6 @@
 
 #include "mesh_motion/FrameInertial.h"
+#include "FieldTypeDef.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/FieldBLAS.hpp>

--- a/src/mesh_motion/FrameNonInertial.C
+++ b/src/mesh_motion/FrameNonInertial.C
@@ -1,5 +1,6 @@
 
 #include "mesh_motion/FrameNonInertial.h"
+#include "FieldTypeDef.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/FieldBLAS.hpp>

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -16,6 +16,7 @@
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
 #include "ngp_utils/NgpReduceUtils.h"
+#include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"

--- a/src/ngp_algorithms/MdotAlgDriver.C
+++ b/src/ngp_algorithms/MdotAlgDriver.C
@@ -7,6 +7,8 @@
 // for more details.
 //
 
+#include <iomanip>
+
 #include "ngp_algorithms/MdotAlgDriver.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"

--- a/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
+++ b/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
@@ -12,7 +12,6 @@
 #include "BuildTemplates.h"
 #include "master_element/MasterElement.h"
 #include "master_element/MasterElementFactory.h"
-#include "ngp_algorithms/ViewHelper.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
 #include "Realm.h"

--- a/src/node_kernels/MomentumCoriolisNodeKernel.C
+++ b/src/node_kernels/MomentumCoriolisNodeKernel.C
@@ -9,6 +9,7 @@
 
 
 #include "node_kernels/MomentumCoriolisNodeKernel.h"
+#include "Realm.h"
 #include "utils/StkHelpers.h"
 
 namespace sierra {

--- a/src/node_kernels/WallDistNodeKernel.C
+++ b/src/node_kernels/WallDistNodeKernel.C
@@ -9,6 +9,7 @@
 
 
 #include "node_kernels/WallDistNodeKernel.h"
+#include "Realm.h"
 #include "utils/StkHelpers.h"
 
 namespace sierra {

--- a/src/overset/AssembleOversetPressureAlgorithm.C
+++ b/src/overset/AssembleOversetPressureAlgorithm.C
@@ -13,6 +13,7 @@
 #include "EquationSystem.h"
 #include "FieldTypeDef.h"
 #include "LinearSystem.h"
+#include "NaluEnv.h"
 #include "Realm.h"
 #include "SolverAlgorithm.h"
 #include "TimeIntegrator.h"

--- a/src/overset/AssembleOversetSolverConstraintAlgorithm.C
+++ b/src/overset/AssembleOversetSolverConstraintAlgorithm.C
@@ -14,6 +14,7 @@
 #include <EquationSystem.h>
 
 #include <LinearSystem.h>
+#include <NaluEnv.h>
 #include <Realm.h>
 #include <TimeIntegrator.h>
 

--- a/src/overset/AssembleOversetWallDistAlgorithm.C
+++ b/src/overset/AssembleOversetWallDistAlgorithm.C
@@ -13,6 +13,7 @@
 #include "EquationSystem.h"
 #include "FieldTypeDef.h"
 #include "LinearSystem.h"
+#include "NaluEnv.h"
 #include "Realm.h"
 #include "SolverAlgorithm.h"
 #include "TimeIntegrator.h"

--- a/src/pmr/RadTransAdvectionSUCVElemKernel.C
+++ b/src/pmr/RadTransAdvectionSUCVElemKernel.C
@@ -12,6 +12,7 @@
 #include "pmr/RadiativeTransportEquationSystem.h"
 #include "AlgTraits.h"
 #include "Enums.h"
+#include "NaluEnv.h"
 #include "SolutionOptions.h"
 #include "master_element/MasterElement.h"
 #include "master_element/MasterElementFactory.h"

--- a/src/pmr/RadiativeTransportEquationSystem.C
+++ b/src/pmr/RadiativeTransportEquationSystem.C
@@ -30,6 +30,7 @@
 #include <master_element/MasterElement.h>
 #include "master_element/MasterElementFactory.h"
 #include <NaluEnv.h>
+#include <NaluParsing.h>
 #include <Realm.h>
 #include <Realms.h>
 #include <Simulation.h>

--- a/src/property_evaluator/HDF5TablePropAlgorithm.C
+++ b/src/property_evaluator/HDF5TablePropAlgorithm.C
@@ -4,6 +4,7 @@
 
 #include <Algorithm.h>
 #include <FieldTypeDef.h>
+#include <NaluEnv.h>
 #include <Realm.h>
 
 #include <stk_mesh/base/BulkData.hpp>

--- a/src/utils/StkHelpers.C
+++ b/src/utils/StkHelpers.C
@@ -10,6 +10,14 @@
 
 #include "utils/StkHelpers.h"
 
+#include <element_promotion/PromotedPartHelper.h>
+#include <Realm.h>
+
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Ghosting.hpp>
+#include <stk_topology/topology.hpp>
+
 // stk_util
 #include "stk_util/parallel/ParallelReduce.hpp"
 #include "stk_util/parallel/CommSparse.hpp"
@@ -17,6 +25,55 @@
 
 namespace sierra {
 namespace nalu {
+
+void
+populate_ghost_comm_procs(
+  const stk::mesh::BulkData& bulk_data,
+  stk::mesh::Ghosting& ghosting,
+  std::vector<int>& ghostCommProcs)
+{
+  ghostCommProcs.clear();
+
+  std::vector<stk::mesh::EntityProc> sendList;
+  ghosting.send_list(sendList);
+
+  for(const stk::mesh::EntityProc& entProc : sendList) {
+    stk::util::insert_keep_sorted_and_unique(entProc.second, ghostCommProcs);
+  }
+
+  std::vector<stk::mesh::EntityKey> recvList;
+  ghosting.receive_list(recvList);
+
+  for(const stk::mesh::EntityKey& key : recvList) {
+    stk::mesh::Entity entity = bulk_data.get_entity(key);
+    stk::util::insert_keep_sorted_and_unique(bulk_data.parallel_owner_rank(entity), ghostCommProcs);
+  }
+}
+
+stk::topology
+get_elem_topo(const Realm& realm, const stk::mesh::Part& surfacePart)
+{
+  if (realm.doPromotion_) {
+    return get_promoted_elem_topo(realm.spatialDimension_, realm.promotionOrder_);
+  }
+
+  std::vector<const stk::mesh::Part*> blockParts = realm.meta_data().get_blocks_touching_surface(&surfacePart);
+
+  ThrowRequireMsg(blockParts.size() >= 1, "Error, expected at least 1 block for surface "<<surfacePart.name());
+
+  stk::topology elemTopo = blockParts[0]->topology();
+  if (blockParts.size() > 1) {
+    for(size_t i=1; i<blockParts.size(); ++i) {
+      ThrowRequireMsg(blockParts[i]->topology() == elemTopo,
+                      "Error, found blocks of different topology connected to surface '"
+                      <<surfacePart.name()<<"', "<<elemTopo<<" and "<<blockParts[i]->topology());
+    }
+  }
+
+  ThrowRequireMsg(elemTopo != stk::topology::INVALID_TOPOLOGY,
+                  "Error, didn't find valid topology block for surface "<<surfacePart.name());
+  return elemTopo;
+}
 
 void
 add_downward_relations(

--- a/src/wind_energy/ABLForcingAlgorithm.C
+++ b/src/wind_energy/ABLForcingAlgorithm.C
@@ -1,5 +1,6 @@
 
 #include "wind_energy/ABLForcingAlgorithm.h"
+#include "NaluParsing.h"
 #include "Realm.h"
 #include "xfer/Transfer.h"
 #include "xfer/Transfers.h"

--- a/src/wind_energy/BdyHeightAlgorithm.C
+++ b/src/wind_energy/BdyHeightAlgorithm.C
@@ -9,6 +9,7 @@
 
 
 #include "wind_energy/BdyHeightAlgorithm.h"
+#include "NaluParsing.h"
 #include "Realm.h"
 #include "utils/LinearInterpolation.h"
 

--- a/src/wind_energy/BdyLayerStatistics.C
+++ b/src/wind_energy/BdyLayerStatistics.C
@@ -12,6 +12,7 @@
 #include "wind_energy/BdyHeightAlgorithm.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldUtils.h"
+#include "NaluParsing.h"
 #include "Realm.h"
 #include "TurbulenceAveragingPostProcessing.h"
 #include "AveragingInfo.h"

--- a/unit_tests/UnitTestRealm.C
+++ b/unit_tests/UnitTestRealm.C
@@ -12,6 +12,7 @@
 #include "UnitTestRealm.h"
 #include "UnitTestUtils.h"
 
+#include "NaluEnv.h"
 #include "LinearSolvers.h"
 #include "Realms.h"
 #include "Realm.h"

--- a/unit_tests/UnitTestTpetra.C
+++ b/unit_tests/UnitTestTpetra.C
@@ -18,6 +18,7 @@
 #include "kernel/KernelBuilder.h"
 #include "SolverAlgorithmDriver.h"
 #include "AssembleElemSolverAlgorithm.h"
+#include "NaluEnv.h"
 #include "Realms.h"
 #include "Realm.h"
 #include "EquationSystem.h"

--- a/unit_tests/mesh_motion/UnitTestCompositeMotions.C
+++ b/unit_tests/mesh_motion/UnitTestCompositeMotions.C
@@ -1,6 +1,8 @@
 #include <gtest/gtest.h>
 #include <limits>
 
+#include "yaml-cpp/yaml.h"
+
 #include "mesh_motion/MotionRotation.h"
 #include "mesh_motion/MotionTranslation.h"
 


### PR DESCRIPTION
Remove `NaluParsing.h` from several of the most included headers. Split off
contents in `NaluParsing` with forward definitions for use in other headers.
Refactor Realm so that boost headers are not included when incuding `Realm.h`

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [x] MacOS
  - Compilers 
    - [x] GCC
    - [x] LLVM/Clang
    - [x] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
