### PR TITLE
Make pyramid isInElement more robust

### DIFF
--- a/src/master_element/Pyr5CVFEM.C
+++ b/src/master_element/Pyr5CVFEM.C
@@ -34,22 +34,27 @@
 namespace sierra{
 namespace nalu{
 
+
+KOKKOS_FUNCTION double regularize_apex(double t_tmp)
+{
+  constexpr double eps = 10. * std::numeric_limits<double>::epsilon();
+  const double one_minus_t = 1.0 - t_tmp;
+  const double t = (std::fabs(one_minus_t) > eps) ? t_tmp : 1.0 + std::copysign(eps, one_minus_t);
+  return t;
+}
+
 template<typename ViewType>
 KOKKOS_FUNCTION void pyramid_shape_fcn(
   const int npts,
   const double* par_coord,
   ViewType& shape_fcn)
 {
-  const double eps = std::numeric_limits<double>::epsilon();
 
   for ( int j = 0; j < npts; ++j ) {
     const int k     = 3*j;
     const double r    = par_coord[k+0];
     const double s    = par_coord[k+1];
-    const double t_tmp    = par_coord[k+2];
-
-    const double one_minus_t = 1.0 - t_tmp;
-    const double t = (std::fabs(one_minus_t) > eps) ? t_tmp : 1.0 + std::copysign(eps, one_minus_t);
+    const double t    = regularize_apex(par_coord[k+2]);
     const double quarter_inv_tm1 = 0.25 / (1.0 - t);
 
     shape_fcn(j, 0) = (1.0 - r - t) * (1.0 - s - t) * quarter_inv_tm1;
@@ -90,17 +95,12 @@ void pyr_deriv(const int npts,
 {
   // d3d(c,s,j) = deriv[c + 3*(s + 5*j)] = deriv[c+3s+15j]
 
-  const double eps = std::numeric_limits<double>::epsilon();
-  
   for ( int j = 0; j < npts; ++j) {
     const int k = j*3;
     
     const double r = intgLoc[k+0];
     const double s = intgLoc[k+1];
-    const double t_tmp = intgLoc[k+2];
-    
-    const double one_minus_t = 1.0 - t_tmp;
-    const double t = (std::fabs(one_minus_t) > eps) ? t_tmp : 1.0 + std::copysign(eps, one_minus_t);
+    const double t = regularize_apex(intgLoc[k+2]);
     const double quarter_inv_tm1 = 0.25 / (1.0 - t);
     const double t_term = 4.0 * r * s * quarter_inv_tm1 * quarter_inv_tm1;
     
@@ -510,17 +510,12 @@ PyrSCV::pyr_shape_fcn(
   const double *par_coord, 
   double *shape_fcn)
 {
-  const double eps = std::numeric_limits<double>::epsilon();
-  
   for ( int j = 0; j < npts; ++j ) {
     const int fivej = 5*j;
     const int k     = 3*j;
     const double r    = par_coord[k+0];
     const double s    = par_coord[k+1];
-    const double t_tmp    = par_coord[k+2];
-    
-    const double one_minus_t = 1.0 - t_tmp;
-    const double t = (std::fabs(one_minus_t) > eps) ? t_tmp : 1.0 + std::copysign(eps, one_minus_t);
+    const double t    = regularize_apex(par_coord[k+2]);
     const double quarter_inv_tm1 = 0.25 / (1.0 - t);
     
     shape_fcn[0 + fivej] = (1.0 - r - t) * (1.0 - s - t) * quarter_inv_tm1;
@@ -1015,6 +1010,7 @@ double PyrSCS::isInElement(
   std::array<double, dim> delta;
   int iter = 0;
 
+  bool solve_failed = false;
   do {
     // interpolate coordinate at guess
     constexpr int nNodes = 5;
@@ -1027,6 +1023,11 @@ double PyrSCS::isInElement(
     error_vec[0] = pointCoord[0] - dot5(weights.data(), elemNodalCoord + 0 * nNodes);
     error_vec[1] = pointCoord[1] - dot5(weights.data(), elemNodalCoord + 1 * nNodes);
     error_vec[2] = pointCoord[2] - dot5(weights.data(), elemNodalCoord + 2 * nNodes);
+
+    // Break early if the error vector becomes nearly zero
+    if (vector_norm_sq(error_vec.data(), 3) < isInElemConverged) {
+      break;
+    }
 
     // update guess along gradient of mapping from physical-to-reference coordinates
     // transpose of the jacobian of the forward mapping
@@ -1050,7 +1051,12 @@ double PyrSCS::isInElement(
     }
 
     // apply its inverse on the error vector
-    solve33(jact.data(), error_vec.data(), delta.data());
+    auto status = solve33(jact.data(), error_vec.data(), delta.data());
+
+    if (status == SolveStatus::FAILED) {
+      solve_failed = true;
+      break;
+    }
 
     // update guess
     guess[0] += delta[0];
@@ -1066,7 +1072,7 @@ double PyrSCS::isInElement(
   isoParCoord[2] = std::numeric_limits<double>::max();
   double dist = std::numeric_limits<double>::max();
 
-  if (iter < N_MAX_ITER) {
+  if (iter < N_MAX_ITER && !solve_failed) {
     // output if succeeded:
     isoParCoord[0] = guess[0];
     isoParCoord[1] = guess[1];
@@ -1117,18 +1123,13 @@ void PyrSCS::pyr_derivative(
   double *deriv)
 {
   // d3d(c,s,j) = deriv[c + 3*(s + 5*j)] = deriv[c+3s+15j]
-  const double eps = std::numeric_limits<double>::epsilon();
-  
   for ( int j = 0; j < npts; ++j) {
     const int k = j*3;
     const int p = 15*j;
     
     const double r = intgLoc[k+0];
     const double s = intgLoc[k+1];
-    const double t_tmp = intgLoc[k+2];
-    
-    const double one_minus_t = 1.0 - t_tmp;
-    const double t = (std::fabs(one_minus_t) > eps) ? t_tmp : 1.0 + std::copysign(eps, one_minus_t);
+    const double t = regularize_apex(intgLoc[k+2]);
     const double quarter_inv_tm1 = 0.25 / (1.0 - t);
     const double t_term = 4.0 * r * s * quarter_inv_tm1 * quarter_inv_tm1;
     
@@ -1304,17 +1305,12 @@ PyrSCS::pyr_shape_fcn(
   const double *par_coord, 
   double *shape_fcn)
 {
-  const double eps = std::numeric_limits<double>::epsilon();
-  
   for ( int j = 0; j < npts; ++j ) {
     const int fivej = 5*j;
     const int k     = 3*j;
     const double r    = par_coord[k+0];
     const double s    = par_coord[k+1];
-    const double t_tmp    = par_coord[k+2];
-    
-    const double one_minus_t = 1.0 - t_tmp;
-    const double t = (std::fabs(one_minus_t) > eps) ? t_tmp : 1.0 + std::copysign(eps, one_minus_t);
+    const double t = regularize_apex(par_coord[k+2]);
     const double quarter_inv_tm1 = 0.25 / (1.0 - t);
     
     shape_fcn[0 + fivej] = (1.0 - r - t) * (1.0 - s - t) * quarter_inv_tm1;

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -13,6 +13,7 @@
 #include <master_element/MasterElement.h>
 #include <master_element/MasterElementFactory.h>
 #include <master_element/Quad42DCVFEM.h>
+#include <master_element/Pyr5CVFEM.h>
 #include <master_element/TensorOps.h>
 
 #include <memory>
@@ -21,6 +22,20 @@
 #include "UnitTestUtils.h"
 
 namespace {
+
+
+TEST(pyramid, is_in_element)
+{
+  std::array<double,15> coords = {
+      4.2, 4.2, 4.2, 4.2, 3.5,
+      5.6, 7.0, 7.0, 5.6, 6.3,
+      2.8, 2.8, 1.4, 1.4, 2.1
+  };
+  std::array<double,3> point = {3.5, 6.5, 1.5};
+  std::array<double,3> mePt;
+  auto dist = sierra::nalu::PyrSCS().isInElement(coords.data(), point.data(), mePt.data());
+  ASSERT_TRUE(std::isfinite(dist));
+}
 
 using VectorFieldType = stk::mesh::Field<double, stk::mesh::Cartesian>;
 //-------------------------------------------------------------------------
@@ -582,15 +597,6 @@ protected:
     sierra::nalu::MasterElement* meSV;
 };
 
-#define TEST_F_ALL_TOPOS_NO_PYR(x, y) \
-    TEST_F(x, tri##_##y)   { y(stk::topology::TRI_3_2D); }   \
-    TEST_F(x, quad4##_##y)  { y(stk::topology::QUAD_4_2D); } \
-    TEST_F(x, quad9##_##y)  { y(stk::topology::QUAD_9_2D); } \
-    TEST_F(x, tet##_##y)   { y(stk::topology::TET_4); }      \
-    TEST_F(x, wedge##_##y) { y(stk::topology::WEDGE_6); }    \
-    TEST_F(x, hex8##_##y)   { y(stk::topology::HEX_8); }     \
-    TEST_F(x, hex27##_##y)  { y(stk::topology::HEX_27); }
-
 #define TEST_F_ALL_TOPOS(x, y) \
     TEST_F(x, tri##_##y)   { y(stk::topology::TRI_3_2D); }   \
     TEST_F(x, quad4##_##y)  { y(stk::topology::QUAD_4_2D); } \
@@ -610,14 +616,14 @@ protected:
     TEST_F(x, hex8##_##y)   { y(stk::topology::HEX_8); }
 
 // Patch tests: pyramids fail
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scs_interpolation)
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scs_derivative)
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, scv_interpolation)
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, volume_integration)
+TEST_F_ALL_TOPOS(MasterElement, scs_interpolation)
+TEST_F_ALL_TOPOS(MasterElement, scs_derivative)
+TEST_F_ALL_TOPOS(MasterElement, scv_interpolation)
+TEST_F_ALL_TOPOS(MasterElement, volume_integration)
 
 // Pyramid fails since the reference element
 // since the constant Jacobian assumption is violated
-TEST_F_ALL_TOPOS_NO_PYR(MasterElement, is_in_element)
+TEST_F_ALL_TOPOS(MasterElement, is_in_element)
 
 // Pyramid works. Doesn't work for higher-order elements sicne they have more ips than nodes
 TEST_F_ALL_P1_TOPOS(MasterElement, scv_shifted_ips_are_nodal)

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -615,14 +615,11 @@ protected:
     TEST_F(x, pyr##_##y) { y(stk::topology::PYRAMID_5); }    \
     TEST_F(x, hex8##_##y)   { y(stk::topology::HEX_8); }
 
-// Patch tests: pyramids fail
+// Patch tests
 TEST_F_ALL_TOPOS(MasterElement, scs_interpolation)
 TEST_F_ALL_TOPOS(MasterElement, scs_derivative)
 TEST_F_ALL_TOPOS(MasterElement, scv_interpolation)
 TEST_F_ALL_TOPOS(MasterElement, volume_integration)
-
-// Pyramid fails since the reference element
-// since the constant Jacobian assumption is violated
 TEST_F_ALL_TOPOS(MasterElement, is_in_element)
 
 // Pyramid works. Doesn't work for higher-order elements sicne they have more ips than nodes


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

The pyramid basis functions are well-defined within the element but are singular on a surface outside the element.  During the newton solve in isInElement, the point may be outside of the element and near the singular surface, causing the inversion to produce a NAN or similar bad things to occur.

This tries to make the newton solve more robust, by increasing the tolerance on the `(1-t)` denominator when t approaches 1, providing an early out when the point is actually found, and providing an earlier failure mechanism when the Jacobian is zero.

Also activates the master element unit tests to pyramids, which haven't needed to be skipped in a while.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [x] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
