### PR TITLE
Improve unit-testing for sparse-matrix values.

### DIFF
--- a/unit_tests/UnitTestTpetraHelperObjects.h
+++ b/unit_tests/UnitTestTpetraHelperObjects.h
@@ -109,10 +109,16 @@ struct TpetraHelperObjectsBase {
 
     for(int i=0; i<localMatrix.numRows(); ++i) {
       KokkosSparse::SparseRowViewConst<MatrixType> constRowView = localMatrix.rowConst(i);
-
-      for(int j=0; j<constRowView.length; ++j) {
-        EXPECT_EQ(cols[rowOffsets[i]+j], constRowView.colidx(j));
-        EXPECT_NEAR(vals[rowOffsets[i]+j], constRowView.value(j), 1.e-14)<<"i: "<<i<<", j: "<<j;
+      for(int offset=rowOffsets[i]; offset<rowOffsets[i+1]; ++offset) {
+        int goldCol = cols[offset];
+        bool foundGoldCol = false;
+        for(int j=0; j<constRowView.length; ++j) {
+          if (constRowView.colidx(j) == goldCol) {
+            foundGoldCol = true;
+            EXPECT_NEAR(vals[offset], constRowView.value(j), 1.e-14)<<"i: "<<i<<", j: "<<j;
+          }
+        }
+        EXPECT_TRUE(foundGoldCol);
       }
 
       EXPECT_NEAR(rhs[i], localRhs(i,0), 1.e-14)<<"i: "<<i;

--- a/unit_tests/UnitTestTpetraHelperObjects.h
+++ b/unit_tests/UnitTestTpetraHelperObjects.h
@@ -14,6 +14,19 @@
 
 namespace unit_test_utils {
 
+inline
+bool find_col(int col,
+               const std::vector<int>& cols,
+               int begin, int end)
+{
+  for(int i=begin; i<end; ++i) {
+    if (cols[i] == col) {
+      return true;
+    }
+  }
+  return false;
+}
+
 struct TpetraHelperObjectsBase {
   TpetraHelperObjectsBase(stk::mesh::BulkData& bulk, int numDof)
   : yamlNode(unit_test_utils::get_default_inputs()),
@@ -116,6 +129,11 @@ struct TpetraHelperObjectsBase {
           if (constRowView.colidx(j) == goldCol) {
             foundGoldCol = true;
             EXPECT_NEAR(vals[offset], constRowView.value(j), 1.e-14)<<"i: "<<i<<", j: "<<j;
+          }
+          else if (!find_col(constRowView.colidx(j),
+                             cols, rowOffsets[i], rowOffsets[i+1]))
+          {
+            EXPECT_NEAR(0.0, constRowView.value(j), 1.e-14);
           }
         }
         EXPECT_TRUE(foundGoldCol);


### PR DESCRIPTION
It used to just compare each matrix column and coefficient to
the expected gold values, expecting position to match as well.
Now it searchs the matrix row for each gold column and checks
if the coefficient matches, and doesn't fail if there are extra
columns in the matrix.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
