### PR TITLE
Convert nalu-wind to use new stk::mesh::NgpMesh and stk::mesh::NgpField API

### DIFF
--- a/include/AssembleEdgeSolverAlgorithm.h
+++ b/include/AssembleEdgeSolverAlgorithm.h
@@ -60,7 +60,7 @@ public:
                               stk::mesh::selectUnion(partVec_) &
                               !(realm_.get_inactive_selector());
 
-    const auto& buckets = ngp::get_bucket_ids(bulk, entityRank_, sel);
+    const auto& buckets = stk::mesh::get_bucket_ids(bulk, entityRank_, sel);
     auto team_exec = get_device_team_policy(buckets.size(), bytes_per_team, bytes_per_thread);
 
     // Create local copies of class data for device capture

--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -20,6 +20,8 @@
 #include <SharedMemData.h>
 #include<CopyAndInterleave.h>
 #include<FieldTypeDef.h>
+#include <stk_mesh/base/NgpMesh.hpp>
+#include <ngp_utils/NgpFieldManager.h>
 
 namespace stk {
 namespace mesh {
@@ -54,8 +56,8 @@ public:
     const int lhsSize = rhsSize_*rhsSize_;
     const int scratchIdsSize = rhsSize_;
 
-    const ngp::Mesh& ngpMesh = realm_.ngp_mesh();
-    const ngp::FieldManager& fieldMgr = realm_.ngp_field_manager();
+    const stk::mesh::NgpMesh& ngpMesh = realm_.ngp_mesh();
+    const nalu_ngp::FieldManager& fieldMgr = realm_.ngp_field_manager();
     ElemDataRequestsGPU dataNeededNGP(
       fieldMgr, dataNeededByKernels_, meta_data.get_fields().size());
 
@@ -72,7 +74,7 @@ public:
                                        !realm_.get_inactive_selector();
 
     const auto& elem_buckets =
-      ngp::get_bucket_ids(bulk_data, entityRank_, elemSelector);
+      stk::mesh::get_bucket_ids(bulk_data, entityRank_, elemSelector);
 
     // Create local copies of class data
     const auto entityRank = entityRank_;

--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -19,6 +19,8 @@
 #include <SimdInterface.h>
 #include <SharedMemData.h>
 #include <CopyAndInterleave.h>
+#include <stk_mesh/base/NgpMesh.hpp>
+#include <ngp_utils/NgpFieldManager.h>
 #include <ngp_utils/NgpMEUtils.h>
 
 namespace stk {
@@ -56,8 +58,8 @@ public:
       int rhsSize = nodesPerElem_ * numDof_, lhsSize = rhsSize * rhsSize,
           scratchIdsSize = rhsSize;
 
-      const ngp::Mesh& ngpMesh = realm_.ngp_mesh();
-      const ngp::FieldManager& fieldMgr = realm_.ngp_field_manager();
+      const stk::mesh::NgpMesh& ngpMesh = realm_.ngp_mesh();
+      const nalu_ngp::FieldManager& fieldMgr = realm_.ngp_field_manager();
       ElemDataRequestsGPU faceDataNGP(fieldMgr, faceDataNeeded_, totalNumFields);
       ElemDataRequestsGPU elemDataNGP(fieldMgr, elemDataNeeded_, totalNumFields);
 
@@ -71,7 +73,7 @@ public:
         bulk.mesh_meta_data().locally_owned_part() &
         stk::mesh::selectUnion(partVec_);
       stk::mesh::EntityRank sideRank = bulk.mesh_meta_data().side_rank();
-      const auto& buckets = ngp::get_bucket_ids(bulk, sideRank, s_locally_owned_union);
+      const auto& buckets = stk::mesh::get_bucket_ids(bulk, sideRank, s_locally_owned_union);
 
       auto team_exec = sierra::nalu::get_device_team_policy(
         buckets.size(), bytes_per_team, bytes_per_thread);

--- a/include/ElemDataRequestsGPU.h
+++ b/include/ElemDataRequestsGPU.h
@@ -16,8 +16,8 @@
 #include <Kokkos_Core.hpp>
 #include <ElemDataRequests.h>
 #include <FieldTypeDef.h>
-#include <stk_ngp/Ngp.hpp>
-#include <stk_ngp/NgpFieldManager.hpp>
+#include <stk_mesh/base/Ngp.hpp>
+#include <ngp_utils/NgpFieldManager.h>
 
 namespace sierra{
 namespace nalu{
@@ -100,7 +100,7 @@ public:
   typedef Kokkos::View<FieldInfoType*, Kokkos::LayoutRight, MemSpace> FieldInfoView;
 
   ElemDataRequestsGPU(
-    const ngp::FieldManager& fieldMgr,
+    const nalu_ngp::FieldManager& fieldMgr,
     const ElemDataRequests& dataReq, unsigned totalFields);
 
   ~ElemDataRequestsGPU() {}
@@ -166,10 +166,10 @@ private:
   void fill_host_data_enums(const ElemDataRequests& dataReq, COORDS_TYPES ctype);
 
   void fill_host_fields(
-    const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr);
+    const ElemDataRequests& dataReq, const nalu_ngp::FieldManager& fieldMgr);
 
   void fill_host_coords_fields(
-    const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr);
+    const ElemDataRequests& dataReq, const nalu_ngp::FieldManager& fieldMgr);
 
   DataEnumView dataEnums[MAX_COORDS_TYPES];
   DataEnumView::HostMirror hostDataEnums[MAX_COORDS_TYPES];

--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -19,7 +19,8 @@
 #include "NGPInstance.h"
 #include "SimdInterface.h"
 
-#include <stk_ngp/Ngp.hpp>
+#include <stk_mesh/base/Ngp.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 namespace stk{
 struct topology;
@@ -318,7 +319,7 @@ public:
 
   virtual void save_diagonal_term(
     unsigned,
-    const ngp::Mesh::ConnectedNodes&,
+    const stk::mesh::NgpMesh::ConnectedNodes&,
     const SharedMemView<const double**,DeviceShmem>&
   ) {}
 

--- a/include/FieldTypeDef.h
+++ b/include/FieldTypeDef.h
@@ -14,7 +14,8 @@
 
 #include <stk_mesh/base/FieldBase.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
-#include <stk_ngp/Ngp.hpp>
+#include <stk_mesh/base/Ngp.hpp>
+#include <stk_mesh/base/NgpField.hpp>
 
 #include <Tpetra_Details_DefaultTypes.hpp>
 
@@ -29,9 +30,9 @@ namespace nalu{
 typedef stk::mesh::Field<double>  ScalarFieldType;
 typedef stk::mesh::Field<stk::mesh::EntityId> GlobalIdFieldType;
 typedef stk::mesh::Field<int>  ScalarIntFieldType;
-typedef ngp::Field<double>  NGPDoubleFieldType;
-typedef ngp::Field<stk::mesh::EntityId> NGPGlobalIdFieldType;
-typedef ngp::Field<int>  NGPScalarIntFieldType;
+typedef stk::mesh::NgpField<double>  NGPDoubleFieldType;
+typedef stk::mesh::NgpField<stk::mesh::EntityId> NGPGlobalIdFieldType;
+typedef stk::mesh::NgpField<int>  NGPScalarIntFieldType;
 
 // define vector field typedef; however, what is the value of Cartesian?
 typedef stk::mesh::Field<double, stk::mesh::Cartesian>  VectorFieldType;

--- a/include/FixPressureAtNodeAlgorithm.h
+++ b/include/FixPressureAtNodeAlgorithm.h
@@ -13,7 +13,7 @@
 
 #include "SolverAlgorithm.h"
 #include "FieldTypeDef.h"
-#include <stk_ngp/NgpMesh.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 #include <stk_mesh/base/Entity.hpp>
 
@@ -101,7 +101,7 @@ public:
   ScalarFieldType* pressure_{nullptr};
 
   //! List of nodes where pressure is referenced/fixed. Should be a list of size = 1
-  ngp::Mesh::ConnectedNodes refNodeList_;
+  stk::mesh::NgpMesh::ConnectedNodes refNodeList_;
   stk::mesh::Entity targetNode_;
 
   //! Track mesh motion for reinitialization

--- a/include/HypreLinearSystem.h
+++ b/include/HypreLinearSystem.h
@@ -15,6 +15,7 @@
 #include "XSDKHypreInterface.h"
 
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 #include "HYPRE_IJ_mv.h"
 #include "HYPRE_parcsr_ls.h"
@@ -110,7 +111,7 @@ public:
    */
   virtual void sumInto(
     unsigned numEntities,
-    const ngp::Mesh::ConnectedNodes& entities,
+    const stk::mesh::NgpMesh::ConnectedNodes& entities,
     const SharedMemView<const double*, DeviceShmem> & rhs,
     const SharedMemView<const double**, DeviceShmem> & lhs,
     const SharedMemView<int*, DeviceShmem> & localIds,

--- a/include/HypreUVWLinearSystem.h
+++ b/include/HypreUVWLinearSystem.h
@@ -12,6 +12,7 @@
 #define HYPREUVWLINEARSYSTEM_H
 
 #include "HypreLinearSystem.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 #include <vector>
 #include <array>
@@ -56,7 +57,7 @@ public:
    */
   virtual void sumInto(
     unsigned numEntities,
-    const ngp::Mesh::ConnectedNodes& entities,
+    const stk::mesh::NgpMesh::ConnectedNodes& entities,
     const SharedMemView<const double*, DeviceShmem> & rhs,
     const SharedMemView<const double**, DeviceShmem> & lhs,
     const SharedMemView<int*, DeviceShmem> & localIds,

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -15,7 +15,8 @@
 #include <LinearSolverTypes.h>
 #include <KokkosInterface.h>
 
-#include <stk_ngp/Ngp.hpp>
+#include <stk_mesh/base/Ngp.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 #include <vector>
 #include <string>
@@ -56,7 +57,7 @@ public:
 
   KOKKOS_FUNCTION
   virtual void operator()(unsigned numEntities,
-                          const ngp::Mesh::ConnectedNodes& entities,
+                          const stk::mesh::NgpMesh::ConnectedNodes& entities,
                           const SharedMemView<int*,DeviceShmem> & localIds,
                           const SharedMemView<int*,DeviceShmem> & sortPermutation,
                           const SharedMemView<const double*,DeviceShmem> & rhs,
@@ -108,7 +109,7 @@ public:
    *  sierra::nalu::FixPressureAtNodeAlgorithm for an example of this use case.
    */
   virtual void buildDirichletNodeGraph(const std::vector<stk::mesh::Entity>&) {}
-  virtual void buildDirichletNodeGraph(const ngp::Mesh::ConnectedNodes) {}
+  virtual void buildDirichletNodeGraph(const stk::mesh::NgpMesh::ConnectedNodes) {}
 
   // Matrix Assembly
   virtual void zeroSystem()=0;
@@ -138,7 +139,7 @@ public:
 
     KOKKOS_FUNCTION
     virtual void operator()(unsigned numEntities,
-                            const ngp::Mesh::ConnectedNodes& entities,
+                            const stk::mesh::NgpMesh::ConnectedNodes& entities,
                             const SharedMemView<int*,DeviceShmem> & localIds,
                             const SharedMemView<int*,DeviceShmem> & sortPermutation,
                             const SharedMemView<const double*,DeviceShmem> & rhs,
@@ -168,7 +169,7 @@ public:
 
   virtual void sumInto(
     unsigned numEntities,
-    const ngp::Mesh::ConnectedNodes& entities,
+    const stk::mesh::NgpMesh::ConnectedNodes& entities,
     const SharedMemView<const double*,DeviceShmem> & rhs,
     const SharedMemView<const double**,DeviceShmem> & lhs,
     const SharedMemView<int*,DeviceShmem> & localIds,

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -24,6 +24,8 @@
 #include "ngp_algorithms/EffDiffFluxCoeffAlg.h"
 #include "ngp_algorithms/CourantReAlgDriver.h"
 
+#include "stk_mesh/base/NgpMesh.hpp"
+
 namespace stk{
 struct topology;
 }
@@ -193,7 +195,7 @@ public:
 
   virtual void save_diagonal_term(
     unsigned,
-    const ngp::Mesh::ConnectedNodes&,
+    const stk::mesh::NgpMesh::ConnectedNodes&,
     const SharedMemView<const double**,DeviceShmem>&
   ) override;
 

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -24,9 +24,10 @@
 #include <Teuchos_RCP.hpp>
 #endif
 
-#include <stk_ngp/NgpFieldManager.hpp>
-
+#include <ngp_utils/NgpFieldManager.h>
 #include "ngp_utils/NgpMeshInfo.h"
+
+#include "stk_mesh/base/NgpMesh.hpp"
 
 // standard c++
 #include <map>
@@ -93,7 +94,7 @@ class PromotedElementIO;
  */
 class Realm {
  public:
-  using NgpMeshInfo = nalu_ngp::MeshInfo<ngp::Mesh, ngp::FieldManager>;
+  using NgpMeshInfo = nalu_ngp::MeshInfo<stk::mesh::NgpMesh, nalu_ngp::FieldManager>;
 
   Realm(Realms&, const YAML::Node & node);
   virtual ~Realm();
@@ -371,12 +372,12 @@ class Realm {
     return *meshInfo_;
   }
 
-  inline const ngp::Mesh& ngp_mesh()
+  inline const stk::mesh::NgpMesh& ngp_mesh()
   {
     return mesh_info().ngp_mesh();
   }
 
-  inline const ngp::FieldManager& ngp_field_manager()
+  inline const nalu_ngp::FieldManager& ngp_field_manager()
   {
     return mesh_info().ngp_field_manager();
   }

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -16,6 +16,7 @@
 #include <stk_mesh/base/FieldBase.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 #include <ElemDataRequestsGPU.h>
 #include <master_element/MasterElement.h>
@@ -254,7 +255,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   int total_bytes() const { return num_bytes_required; }
 
-  ngp::Mesh::ConnectedNodes elemNodes;
+  stk::mesh::NgpMesh::ConnectedNodes elemNodes;
 
   KOKKOS_INLINE_FUNCTION
         MultiDimViews<T,TEAMHANDLETYPE,SHMEM>& get_field_views()       { return fieldViews; }
@@ -841,7 +842,7 @@ int get_num_scalars_pre_req_data(
 template<typename T>
 KOKKOS_FUNCTION
 void fill_pre_req_data(const ElemDataRequestsGPU& dataNeeded,
-                       const ngp::Mesh& ngpMesh,
+                       const stk::mesh::NgpMesh& ngpMesh,
                        stk::mesh::EntityRank entityRank,
                        stk::mesh::Entity elem,
                        ScratchViews<T,DeviceTeamHandleType,DeviceShmem>& prereqData);

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -13,6 +13,7 @@
 #define SharedMemData_h
 
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 #include <KokkosInterface.h>
 #include <SimdInterface.h>
@@ -53,7 +54,7 @@ struct SharedMemData {
     KOKKOS_FUNCTION
     ~SharedMemData() = default;
 
-    ngp::Mesh::ConnectedNodes ngpElemNodes[simdLen];
+    stk::mesh::NgpMesh::ConnectedNodes ngpElemNodes[simdLen];
     int numSimdElems;
 #ifdef KOKKOS_ENABLE_CUDA
     ScratchViews<DoubleType,TEAMHANDLETYPE,SHMEM>* prereqData[1];
@@ -107,7 +108,7 @@ struct SharedMemData_FaceElem {
     KOKKOS_FUNCTION
     ~SharedMemData_FaceElem() = default;
 
-    ngp::Mesh::ConnectedNodes ngpConnectedNodes[simdLen];
+    stk::mesh::NgpMesh::ConnectedNodes ngpConnectedNodes[simdLen];
     int numSimdFaces;
     int elemFaceOrdinal;
 #ifdef KOKKOS_ENABLE_CUDA
@@ -141,7 +142,7 @@ struct SharedMemData_Edge {
     sortPermutation = get_shmem_view_1D<int,TEAMHANDLETYPE,SHMEM>(team, rhsSize);
   }
 
-  ngp::Mesh::ConnectedNodes ngpElemNodes;
+  stk::mesh::NgpMesh::ConnectedNodes ngpElemNodes;
   SharedMemView<double*,SHMEM> rhs;
   SharedMemView<double**,SHMEM> lhs;
 

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -16,7 +16,9 @@
 #include <KokkosInterface.h>
 
 #include <stk_mesh/base/Entity.hpp>
-#include <stk_ngp/Ngp.hpp>
+#include <stk_mesh/base/Ngp.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
+#include <stk_mesh/base/NgpField.hpp>
 #include <vector>
 
 namespace sierra{
@@ -39,7 +41,7 @@ struct NGPApplyCoeff
   KOKKOS_FUNCTION
   void operator()(
     unsigned numMeshobjs,
-    const ngp::Mesh::ConnectedNodes& symMeshobjs,
+    const stk::mesh::NgpMesh::ConnectedNodes& symMeshobjs,
     const SharedMemView<int*,DeviceShmem> & scratchIds,
     const SharedMemView<int*,DeviceShmem> & sortPermutation,
     SharedMemView<double*,DeviceShmem> & rhs,
@@ -49,19 +51,19 @@ struct NGPApplyCoeff
   KOKKOS_FUNCTION
   void extract_diagonal(
     const unsigned nEntities,
-    const ngp::Mesh::ConnectedNodes& entities,
+    const stk::mesh::NgpMesh::ConnectedNodes& entities,
     SharedMemView<double**, DeviceShmem>& lhs) const;
 
   KOKKOS_FUNCTION
   void reset_overset_rows(
     const unsigned nEntities,
-    const ngp::Mesh::ConnectedNodes& entities,
+    const stk::mesh::NgpMesh::ConnectedNodes& entities,
     SharedMemView<double*, DeviceShmem>&  rhs,
     SharedMemView<double**, DeviceShmem>& lhs) const;
 
-  const ngp::Mesh ngpMesh_;
-  mutable ngp::Field<double> diagField_;
-  ngp::Field<int> iblankField_;
+  const stk::mesh::NgpMesh ngpMesh_;
+  mutable stk::mesh::NgpField<double> diagField_;
+  stk::mesh::NgpField<int> iblankField_;
 
   CoeffApplier* deviceSumInto_;
 

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -26,7 +26,8 @@
 #include <stk_mesh/base/Entity.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
 
-#include <stk_ngp/Ngp.hpp>
+#include <stk_mesh/base/Ngp.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 #include <vector>
 #include <string>
@@ -81,7 +82,7 @@ public:
 
   void sumInto(
     unsigned numEntities,
-    const ngp::Mesh::ConnectedNodes& entities,
+    const stk::mesh::NgpMesh::ConnectedNodes& entities,
     const SharedMemView<const double*,DeviceShmem> & rhs,
     const SharedMemView<const double**,DeviceShmem> & lhs,
     const SharedMemView<int*,DeviceShmem> & localIds,
@@ -188,7 +189,7 @@ public:
 
     KOKKOS_FUNCTION
     virtual void operator()(unsigned numEntities,
-                            const ngp::Mesh::ConnectedNodes& entities,
+                            const stk::mesh::NgpMesh::ConnectedNodes& entities,
                             const SharedMemView<int*,DeviceShmem> & localIds,
                             const SharedMemView<int*,DeviceShmem> & sortPermutation,
                             const SharedMemView<const double*,DeviceShmem> & rhs,

--- a/include/TpetraSegregatedLinearSystem.h
+++ b/include/TpetraSegregatedLinearSystem.h
@@ -25,7 +25,8 @@
 #include <stk_mesh/base/Entity.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
 
-#include <stk_ngp/Ngp.hpp>
+#include <stk_mesh/base/Ngp.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 #include <vector>
 #include <string>
@@ -79,7 +80,7 @@ public:
 
   void sumInto(
     unsigned numEntities,
-    const ngp::Mesh::ConnectedNodes& entities,
+    const stk::mesh::NgpMesh::ConnectedNodes& entities,
     const SharedMemView<const double*,DeviceShmem> & rhs,
     const SharedMemView<const double**,DeviceShmem> & lhs,
     const SharedMemView<int*,DeviceShmem> & localIds,
@@ -178,7 +179,7 @@ public:
 
     KOKKOS_FUNCTION
     virtual void operator()(unsigned numEntities,
-                            const ngp::Mesh::ConnectedNodes& entities,
+                            const stk::mesh::NgpMesh::ConnectedNodes& entities,
                             const SharedMemView<int*,DeviceShmem> & localIds,
                             const SharedMemView<int*,DeviceShmem> & sortPermutation,
                             const SharedMemView<const double*,DeviceShmem> & rhs,

--- a/include/edge_kernels/EdgeKernel.h
+++ b/include/edge_kernels/EdgeKernel.h
@@ -22,8 +22,9 @@
 #include "ScratchViews.h"
 #include "SharedMemData.h"
 
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
 #include "stk_mesh/base/Entity.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/include/edge_kernels/MomentumSSTTAMSDiffEdgeKernel.h
+++ b/include/edge_kernels/MomentumSSTTAMSDiffEdgeKernel.h
@@ -14,7 +14,9 @@
 #include "edge_kernels/EdgeKernel.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -44,19 +46,19 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> edgeAreaVec_;
+  stk::mesh::NgpField<double> edgeAreaVec_;
 
-  ngp::Field<double> coordinates_;
-  ngp::Field<double> velocity_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> density_;
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> alpha_;
-  ngp::Field<double> nodalMij_;
-  ngp::Field<double> dudx_;
-  ngp::Field<double> avgVelocity_;
-  ngp::Field<double> avgDudx_;
+  stk::mesh::NgpField<double> coordinates_;
+  stk::mesh::NgpField<double> velocity_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> density_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> alpha_;
+  stk::mesh::NgpField<double> nodalMij_;
+  stk::mesh::NgpField<double> dudx_;
+  stk::mesh::NgpField<double> avgVelocity_;
+  stk::mesh::NgpField<double> avgDudx_;
 
   unsigned edgeAreaVecID_{stk::mesh::InvalidOrdinal};
   unsigned coordinatesID_{stk::mesh::InvalidOrdinal};

--- a/include/ngp_utils/NgpFieldBLAS.h
+++ b/include/ngp_utils/NgpFieldBLAS.h
@@ -14,6 +14,7 @@
 #include "ngp_utils/NgpTypes.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldUtils.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -21,7 +22,7 @@ namespace nalu_ngp {
 
 /** Operation: `y = alpha * x + beta * y`
  *
- *  @param ngpMesh Instance of ngp::Mesh
+ *  @param ngpMesh Instance of stk::mesh::NgpMesh
  *  @param sel Selector where the operation is applied
  */
 template<

--- a/include/ngp_utils/NgpFieldManager.h
+++ b/include/ngp_utils/NgpFieldManager.h
@@ -1,0 +1,64 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+
+#ifndef NGPFIELDMANAGER_H
+#define NGPFIELDMANAGER_H
+
+/** \file
+ *  \brief NGP Field Manager
+ */
+
+#include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/GetNgpField.hpp"
+
+namespace sierra {
+namespace nalu {
+namespace nalu_ngp {
+
+/** NGP Field Manager
+ *
+ *  This lightweight class wraps the new NgpField interface using the 
+ *  deprecated FieldManager workflow.
+*/
+class FieldManager
+{
+public:
+  FieldManager(const stk::mesh::BulkData & bulk)
+    : m_meta(bulk.mesh_meta_data())
+  {
+  }
+
+  ~FieldManager() {
+  }
+
+  FieldManager & operator=(const FieldManager & rhs) = delete;
+
+  FieldManager(const FieldManager & rhs) = delete;
+  FieldManager(FieldManager && rhs) = delete;
+
+  template <typename T>
+  stk::mesh::NgpField<T> & get_field(unsigned fieldOrdinal) const {
+    ThrowAssertMsg(m_meta.get_fields().size() > fieldOrdinal, "Invalid field ordinal.");
+    stk::mesh::FieldBase* stkField = m_meta.get_fields()[fieldOrdinal];
+    return stk::mesh::get_updated_ngp_field<T>(*stkField);
+  }
+
+private: 
+  const stk::mesh::MetaData& m_meta;
+};
+
+} 
+} 
+}
+
+
+#endif /* NGPFIELDMANAGER_H */

--- a/include/ngp_utils/NgpFieldOps.h
+++ b/include/ngp_utils/NgpFieldOps.h
@@ -22,7 +22,7 @@
 #include "ngp_utils/NgpScratchData.h"
 #include "SimdInterface.h"
 
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
 
 #include <type_traits>
 

--- a/include/ngp_utils/NgpFieldUtils.h
+++ b/include/ngp_utils/NgpFieldUtils.h
@@ -12,9 +12,12 @@
 #define NGPFIELDUTILS_H
 
 #include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/FieldBase.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
+#include "stk_mesh/base/NgpField.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -22,9 +25,9 @@ namespace nalu_ngp {
 
 template <
   typename T = double,
-  typename Mesh = ngp::Mesh,
-  typename FieldManager = ngp::FieldManager>
-inline ngp::Field<T>& get_ngp_field(
+  typename Mesh = stk::mesh::NgpMesh,
+  typename FieldManager = nalu_ngp::FieldManager>
+inline stk::mesh::NgpField<T>& get_ngp_field(
   const MeshInfo<Mesh, FieldManager>& meshInfo,
   const std::string& fieldName,
   const stk::mesh::EntityRank& rank = stk::topology::NODE_RANK)
@@ -35,9 +38,9 @@ inline ngp::Field<T>& get_ngp_field(
 
 template <
   typename T = double,
-  typename Mesh = ngp::Mesh,
-  typename FieldManager = ngp::FieldManager>
-inline ngp::Field<T>& get_ngp_field(
+  typename Mesh = stk::mesh::NgpMesh,
+  typename FieldManager = nalu_ngp::FieldManager>
+inline stk::mesh::NgpField<T>& get_ngp_field(
   const MeshInfo<Mesh, FieldManager>& meshInfo,
   const std::string& fieldName,
   const stk::mesh::FieldState state,

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -22,7 +22,7 @@
 #include "ScratchViews.h"
 
 #include "stk_mesh/base/Selector.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/include/ngp_utils/NgpMeshInfo.h
+++ b/include/ngp_utils/NgpMeshInfo.h
@@ -15,8 +15,9 @@
  *  \brief NGP mesh information objects
  */
 
-#include "stk_ngp/Ngp.hpp"
-#include "stk_ngp/NgpFieldManager.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
+#include "ngp_utils/NgpFieldManager.h"
 
 namespace sierra {
 namespace nalu {
@@ -25,10 +26,10 @@ namespace nalu_ngp {
 /** STK mesh object holder
  *
  *  This lightweight class carries information regarding the STK meshes both the
- *  non-NGP versions (MetaData/BulkData) as well as the `ngp::Mesh` and
- *  `ngp::FieldManager` instances.
+ *  non-NGP versions (MetaData/BulkData) as well as the `stk::mesh::NgpMesh` and
+ *  `nalu_ngp::FieldManager` instances.
  */
-template <typename Mesh = ngp::Mesh, typename FieldManager = ngp::FieldManager>
+template <typename Mesh = stk::mesh::NgpMesh, typename FieldManager = nalu_ngp::FieldManager>
 class MeshInfo
 {
 public:

--- a/include/ngp_utils/NgpTypes.h
+++ b/include/ngp_utils/NgpTypes.h
@@ -16,6 +16,7 @@
  */
 
 #include "ngp_utils/NgpMeshInfo.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 #include "SimdInterface.h"
 
 #include <memory>
@@ -38,7 +39,7 @@ constexpr int NDimMax = 3;
  *
  *  Depending on the bucket-loop, entity could be one of elem, edge, or face.
  */
-template<typename Mesh = ngp::Mesh>
+template<typename Mesh = stk::mesh::NgpMesh>
 struct EntityInfo
 {
   //! Bucket information
@@ -57,7 +58,7 @@ struct EntityInfo
  *  connected nodes are always for the parent element that owns the boundary
  *  face.
  */
-template<typename Mesh = ngp::Mesh>
+template<typename Mesh = stk::mesh::NgpMesh>
 struct BcFaceElemInfo
 {
   typename Mesh::MeshIndex meshIdx;
@@ -80,7 +81,7 @@ struct BcFaceElemInfo
 
 /** Traits for dealing with STK NGP meshes
  */
-template<typename Mesh=ngp::Mesh>
+template<typename Mesh=stk::mesh::NgpMesh>
 struct NGPMeshTraits
 {
   //! SIMD data type used in element data structures
@@ -90,7 +91,7 @@ struct NGPMeshTraits
   using FieldScalarType = double;
 
   using TeamPolicy =
-    Kokkos::TeamPolicy<typename Mesh::MeshExecSpace, ngp::ScheduleType>;
+    Kokkos::TeamPolicy<typename Mesh::MeshExecSpace, stk::mesh::ScheduleType>;
   using TeamHandleType = typename TeamPolicy::member_type;
   using ShmemType = typename Mesh::MeshExecSpace::scratch_memory_space;
   using MeshIndex = typename Mesh::MeshIndex;

--- a/include/node_kernels/ContinuityGclNodeKernel.h
+++ b/include/node_kernels/ContinuityGclNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -44,11 +46,11 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private: 
-  ngp::Field<double> densityNp1_;
-  ngp::Field<double> divV_;
-  ngp::Field<double> dualNdVolNm1_;
-  ngp::Field<double> dualNdVolN_;
-  ngp::Field<double> dualNdVolNp1_;
+  stk::mesh::NgpField<double> densityNp1_;
+  stk::mesh::NgpField<double> divV_;
+  stk::mesh::NgpField<double> dualNdVolNm1_;
+  stk::mesh::NgpField<double> dualNdVolN_;
+  stk::mesh::NgpField<double> dualNdVolNp1_;
 
   unsigned densityNp1ID_ {stk::mesh::InvalidOrdinal};
   unsigned divVID_ {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/ContinuityMassBDFNodeKernel.h
+++ b/include/node_kernels/ContinuityMassBDFNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -44,10 +46,10 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> densityNm1_;
-  ngp::Field<double> densityN_;
-  ngp::Field<double> densityNp1_;
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> densityNm1_;
+  stk::mesh::NgpField<double> densityN_;
+  stk::mesh::NgpField<double> densityNp1_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   unsigned densityNm1ID_ {stk::mesh::InvalidOrdinal};
   unsigned densityNID_ {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/EnthalpyABLForceNodeKernel.h
+++ b/include/node_kernels/EnthalpyABLForceNodeKernel.h
@@ -15,7 +15,9 @@
 #include "wind_energy/ABLSrcInterp.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -44,8 +46,8 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> coordinates_;
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> coordinates_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   ABLScalarInterpolator ablSrc_;
 

--- a/include/node_kernels/MomentumABLForceNodeKernel.h
+++ b/include/node_kernels/MomentumABLForceNodeKernel.h
@@ -15,7 +15,9 @@
 #include "wind_energy/ABLSrcInterp.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -44,8 +46,8 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> coordinates_;
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> coordinates_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   ABLVectorInterpolator ablSrc_;
 

--- a/include/node_kernels/MomentumActuatorNodeKernel.h
+++ b/include/node_kernels/MomentumActuatorNodeKernel.h
@@ -14,7 +14,9 @@
 #include "node_kernels/NodeKernel.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -39,9 +41,9 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> dualNodalVolume_;
-  ngp::Field<double> actuatorSrc_;
-  ngp::Field<double> actuatorSrcLHS_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> actuatorSrc_;
+  stk::mesh::NgpField<double> actuatorSrcLHS_;
   const int nDim_;
 
   const unsigned dualNodalVolumeID_ {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/MomentumBodyForceNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceNodeKernel.h
@@ -14,7 +14,9 @@
 #include "node_kernels/NodeKernel.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -41,7 +43,7 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   NALU_ALIGNED NodeKernelTraits::DblType forceVector_[NodeKernelTraits::NDimMax];
 

--- a/include/node_kernels/MomentumBoussinesqNodeKernel.h
+++ b/include/node_kernels/MomentumBoussinesqNodeKernel.h
@@ -14,7 +14,9 @@
 #include "node_kernels/NodeKernel.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -43,8 +45,8 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> dualNodalVolume_;
-  ngp::Field<double> temperature_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> temperature_;
   const int nDim_;
   NodeKernelTraits::DblType tRef_;
   NodeKernelTraits::DblType rhoRef_;

--- a/include/node_kernels/MomentumCoriolisNodeKernel.h
+++ b/include/node_kernels/MomentumCoriolisNodeKernel.h
@@ -15,7 +15,9 @@
 #include "CoriolisSrc.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -46,9 +48,9 @@ public:
 private:
   const CoriolisSrc cor_;
 
-  ngp::Field<double> dualNodalVolume_;
-  ngp::Field<double> densityNp1_;
-  ngp::Field<double> velocityNp1_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> densityNp1_;
+  stk::mesh::NgpField<double> velocityNp1_;
 
   unsigned dualNodalVolumeID_ {stk::mesh::InvalidOrdinal};
   unsigned densityNp1ID_ {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/MomentumGclSrcNodeKernel.h
+++ b/include/node_kernels/MomentumGclSrcNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -44,12 +46,12 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> velocityNp1_;
-  ngp::Field<double> densityNp1_;
-  ngp::Field<double> divV_;
-  ngp::Field<double> dualNdVolNm1_;
-  ngp::Field<double> dualNdVolN_;
-  ngp::Field<double> dualNdVolNp1_;
+  stk::mesh::NgpField<double> velocityNp1_;
+  stk::mesh::NgpField<double> densityNp1_;
+  stk::mesh::NgpField<double> divV_;
+  stk::mesh::NgpField<double> dualNdVolNm1_;
+  stk::mesh::NgpField<double> dualNdVolN_;
+  stk::mesh::NgpField<double> dualNdVolNp1_;
 
   unsigned velocityNp1ID_ {stk::mesh::InvalidOrdinal};
   unsigned densityNp1ID_ {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/MomentumMassBDFNodeKernel.h
+++ b/include/node_kernels/MomentumMassBDFNodeKernel.h
@@ -16,7 +16,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -44,14 +46,14 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> velocityNm1_;
-  ngp::Field<double> velocityN_;
-  ngp::Field<double> velocityNp1_;
-  ngp::Field<double> densityNm1_;
-  ngp::Field<double> densityN_;
-  ngp::Field<double> densityNp1_;
-  ngp::Field<double> dpdx_;
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> velocityNm1_;
+  stk::mesh::NgpField<double> velocityN_;
+  stk::mesh::NgpField<double> velocityNp1_;
+  stk::mesh::NgpField<double> densityNm1_;
+  stk::mesh::NgpField<double> densityN_;
+  stk::mesh::NgpField<double> densityNp1_;
+  stk::mesh::NgpField<double> dpdx_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   unsigned velocityNm1ID_ {stk::mesh::InvalidOrdinal};
   unsigned velocityNID_ {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/MomentumSSTTAMSForcingNodeKernel.h
+++ b/include/node_kernels/MomentumSSTTAMSForcingNodeKernel.h
@@ -14,7 +14,9 @@
 #include "node_kernels/NodeKernel.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -43,21 +45,21 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
-  ngp::Field<double> coordinates_;
-  ngp::Field<double> velocity_;
-  ngp::Field<double> viscosity_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> density_;
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> alpha_;
-  ngp::Field<double> Mij_;
-  ngp::Field<double> minDist_;
-  ngp::Field<double> avgVelocity_;
-  ngp::Field<double> avgTime_;
-  ngp::Field<double> avgResAdeq_;
+  stk::mesh::NgpField<double> coordinates_;
+  stk::mesh::NgpField<double> velocity_;
+  stk::mesh::NgpField<double> viscosity_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> density_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> alpha_;
+  stk::mesh::NgpField<double> Mij_;
+  stk::mesh::NgpField<double> minDist_;
+  stk::mesh::NgpField<double> avgVelocity_;
+  stk::mesh::NgpField<double> avgTime_;
+  stk::mesh::NgpField<double> avgResAdeq_;
 
   unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
   unsigned coordinatesID_{stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/NodeKernel.h
+++ b/include/node_kernels/NodeKernel.h
@@ -14,8 +14,9 @@
 #include "KokkosInterface.h"
 #include "NGPInstance.h"
 
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
 #include "stk_mesh/base/Entity.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/include/node_kernels/SDRSSTDESNodeKernel.h
+++ b/include/node_kernels/SDRSSTDESNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -42,16 +44,16 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> density_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> dudx_;
-  ngp::Field<double> dkdx_;
-  ngp::Field<double> dwdx_;
-  ngp::Field<double> dualNodalVolume_;
-  ngp::Field<double> fOneBlend_;
-  ngp::Field<double> cellLengthScale_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> density_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> dudx_;
+  stk::mesh::NgpField<double> dkdx_;
+  stk::mesh::NgpField<double> dwdx_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> fOneBlend_;
+  stk::mesh::NgpField<double> cellLengthScale_;
 
 
   unsigned tkeID_             {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/SDRSSTNodeKernel.h
+++ b/include/node_kernels/SDRSSTNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -42,15 +44,15 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> density_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> dudx_;
-  ngp::Field<double> dkdx_;
-  ngp::Field<double> dwdx_;
-  ngp::Field<double> dualNodalVolume_;
-  ngp::Field<double> fOneBlend_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> density_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> dudx_;
+  stk::mesh::NgpField<double> dkdx_;
+  stk::mesh::NgpField<double> dwdx_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> fOneBlend_;
 
   unsigned tkeID_             {stk::mesh::InvalidOrdinal};
   unsigned sdrID_             {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/SDRSSTTAMSNodeKernel.h
+++ b/include/node_kernels/SDRSSTTAMSNodeKernel.h
@@ -14,7 +14,9 @@
 #include "node_kernels/NodeKernel.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -41,19 +43,19 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
-  ngp::Field<double> coordinates_;
-  ngp::Field<double> viscosity_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> rho_;
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> alpha_;
-  ngp::Field<double> prod_;
-  ngp::Field<double> fOneBlend_;
-  ngp::Field<double> dkdx_;
-  ngp::Field<double> dwdx_;
+  stk::mesh::NgpField<double> coordinates_;
+  stk::mesh::NgpField<double> viscosity_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> rho_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> alpha_;
+  stk::mesh::NgpField<double> prod_;
+  stk::mesh::NgpField<double> fOneBlend_;
+  stk::mesh::NgpField<double> dkdx_;
+  stk::mesh::NgpField<double> dwdx_;
 
   unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
   unsigned coordinatesID_{stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/ScalarGclNodeKernel.h
+++ b/include/node_kernels/ScalarGclNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -45,12 +47,12 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> scalarQNp1_;
-  ngp::Field<double> densityNp1_;
-  ngp::Field<double> divV_;
-  ngp::Field<double> dualNdVolNm1_;
-  ngp::Field<double> dualNdVolN_;
-  ngp::Field<double> dualNdVolNp1_;
+  stk::mesh::NgpField<double> scalarQNp1_;
+  stk::mesh::NgpField<double> densityNp1_;
+  stk::mesh::NgpField<double> divV_;
+  stk::mesh::NgpField<double> dualNdVolNm1_;
+  stk::mesh::NgpField<double> dualNdVolN_;
+  stk::mesh::NgpField<double> dualNdVolNp1_;
 
   unsigned scalarQNp1ID_ {stk::mesh::InvalidOrdinal};
   unsigned densityNp1ID_ {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/ScalarMassBDFNodeKernel.h
+++ b/include/node_kernels/ScalarMassBDFNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -44,13 +46,13 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> scalarQNm1_;
-  ngp::Field<double> scalarQN_;
-  ngp::Field<double> scalarQNp1_;
-  ngp::Field<double> densityNm1_;
-  ngp::Field<double> densityN_;
-  ngp::Field<double> densityNp1_;
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> scalarQNm1_;
+  stk::mesh::NgpField<double> scalarQN_;
+  stk::mesh::NgpField<double> scalarQNp1_;
+  stk::mesh::NgpField<double> densityNm1_;
+  stk::mesh::NgpField<double> densityN_;
+  stk::mesh::NgpField<double> densityNp1_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   unsigned scalarQNm1ID_ {stk::mesh::InvalidOrdinal};
   unsigned scalarQNID_ {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/TKEKsgsNodeKernel.h
+++ b/include/node_kernels/TKEKsgsNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -42,12 +44,12 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> density_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> dudx_;
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> density_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> dudx_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   unsigned tkeID_             {stk::mesh::InvalidOrdinal};
   //unsigned sdrID_             {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/TKERodiNodeKernel.h
+++ b/include/node_kernels/TKERodiNodeKernel.h
@@ -13,7 +13,9 @@
 #define TKERODINODEKERNEL_H          
 
 #include "node_kernels/NodeKernel.h"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace stk{
 namespace mesh{
@@ -48,10 +50,10 @@ public:
 
 private:
 
-  ngp::Field<double> dhdx_;
-  ngp::Field<double> specificHeat_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> dhdx_;
+  stk::mesh::NgpField<double> specificHeat_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   const unsigned dhdxID_           {stk::mesh::InvalidOrdinal};
   const unsigned specificHeatID_   {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/TKESSTDESNodeKernel.h
+++ b/include/node_kernels/TKESSTDESNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -42,14 +44,14 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> density_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> dudx_;
-  ngp::Field<double> dualNodalVolume_;
-  ngp::Field<double> maxLenScale_;
-  ngp::Field<double> fOneBlend_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> density_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> dudx_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> maxLenScale_;
+  stk::mesh::NgpField<double> fOneBlend_;
 
   unsigned tkeID_             {stk::mesh::InvalidOrdinal};
   unsigned sdrID_             {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/TKESSTNodeKernel.h
+++ b/include/node_kernels/TKESSTNodeKernel.h
@@ -15,7 +15,9 @@
 #include "FieldTypeDef.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -42,12 +44,12 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> density_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> dudx_;
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> density_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> dudx_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   unsigned tkeID_             {stk::mesh::InvalidOrdinal};
   unsigned sdrID_             {stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/TKESSTTAMSNodeKernel.h
+++ b/include/node_kernels/TKESSTTAMSNodeKernel.h
@@ -14,7 +14,9 @@
 #include "node_kernels/NodeKernel.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -41,15 +43,15 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
-  ngp::Field<double> coordinates_;
-  ngp::Field<double> viscosity_;
-  ngp::Field<double> tvisc_;
-  ngp::Field<double> rho_;
-  ngp::Field<double> tke_;
-  ngp::Field<double> sdr_;
-  ngp::Field<double> prod_;
+  stk::mesh::NgpField<double> coordinates_;
+  stk::mesh::NgpField<double> viscosity_;
+  stk::mesh::NgpField<double> tvisc_;
+  stk::mesh::NgpField<double> rho_;
+  stk::mesh::NgpField<double> tke_;
+  stk::mesh::NgpField<double> sdr_;
+  stk::mesh::NgpField<double> prod_;
 
   unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
   unsigned coordinatesID_{stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/WallDistNodeKernel.h
+++ b/include/node_kernels/WallDistNodeKernel.h
@@ -14,7 +14,9 @@
 #include "node_kernels/NodeKernel.h"
 
 #include "stk_mesh/base/BulkData.hpp"
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -39,7 +41,7 @@ public:
     const stk::mesh::FastMeshIndex&) override;
 
 private:
-  ngp::Field<double> dualNodalVolume_;
+  stk::mesh::NgpField<double> dualNodalVolume_;
 
   unsigned dualNodalVolumeID_ {stk::mesh::InvalidOrdinal};
 };

--- a/src/AssembleNGPNodeSolverAlgorithm.C
+++ b/src/AssembleNGPNodeSolverAlgorithm.C
@@ -15,6 +15,7 @@
 #include "Realm.h"
 
 #include "node_kernels/NodeKernel.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -45,7 +46,7 @@ struct SharedMemData_Node {
   }
 
   stk::mesh::Entity nodeID[1];
-  ngp::Mesh::ConnectedNodes ngpNodes;
+  stk::mesh::NgpMesh::ConnectedNodes ngpNodes;
   SharedMemView<double*,SHMEM> rhs;
   SharedMemView<double**,SHMEM> lhs;
 
@@ -103,7 +104,7 @@ AssembleNGPNodeSolverAlgorithm::execute()
     & stk::mesh::selectUnion(partVec_)
     & !(stk::mesh::selectUnion(realm_.get_slave_part_vector()))
     & !(realm_.get_inactive_selector());
-  const auto& buckets = ngp::get_bucket_ids(realm_.bulk_data(), entityRank, sel);
+  const auto& buckets = stk::mesh::get_bucket_ids(realm_.bulk_data(), entityRank, sel);
 
   auto team_exec = get_device_team_policy(buckets.size(), bytes_per_team, bytes_per_thread);
 

--- a/src/ElemDataRequestsGPU.C
+++ b/src/ElemDataRequestsGPU.C
@@ -14,7 +14,7 @@ namespace sierra {
 namespace nalu {
 
 ElemDataRequestsGPU::ElemDataRequestsGPU(
-  const ngp::FieldManager& fieldMgr,
+  const nalu_ngp::FieldManager& fieldMgr,
   const ElemDataRequests& dataReq, unsigned totalFields)
   : dataEnums(),
     hostDataEnums(),
@@ -67,7 +67,7 @@ ElemDataRequestsGPU::fill_host_data_enums(
 }
 
 void ElemDataRequestsGPU::fill_host_fields(
-  const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr)
+  const ElemDataRequests& dataReq, const nalu_ngp::FieldManager& fieldMgr)
 {
   fields = FieldInfoView("Fields", dataReq.get_fields().size());
   hostFields = Kokkos::create_mirror_view(fields);
@@ -80,7 +80,7 @@ void ElemDataRequestsGPU::fill_host_fields(
 }
 
 void ElemDataRequestsGPU::fill_host_coords_fields(
-  const ElemDataRequests& dataReq, const ngp::FieldManager& fieldMgr)
+  const ElemDataRequests& dataReq, const nalu_ngp::FieldManager& fieldMgr)
 {
   coordsFields_ = FieldView("CoordsFields", dataReq.get_coordinates_map().size());
   coordsFieldsTypes_ = CoordsTypesView("CoordsFieldsTypes", dataReq.get_coordinates_map().size());

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -24,6 +24,7 @@
 #include "stk_mesh/base/MetaData.hpp"
 #include "stk_mesh/base/Field.hpp"
 #include "stk_mesh/base/FieldParallel.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 #include "stk_util/parallel/ParallelReduce.hpp"
 
 #include "HYPRE_IJ_mv.h"
@@ -383,7 +384,7 @@ HypreLinearSystem::zeroSystem()
 void
 HypreLinearSystem::sumInto(
   unsigned numEntities,
-  const ngp::Mesh::ConnectedNodes& entities,
+  const stk::mesh::NgpMesh::ConnectedNodes& entities,
   const SharedMemView<const double*, DeviceShmem>& rhs,
   const SharedMemView<const double**, DeviceShmem>& lhs,
   const SharedMemView<int*, DeviceShmem>&,

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -18,6 +18,7 @@
 #include "stk_mesh/base/MetaData.hpp"
 #include "stk_mesh/base/Field.hpp"
 #include "stk_mesh/base/FieldParallel.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 #include "stk_util/parallel/ParallelReduce.hpp"
 
 #include "HYPRE_IJ_mv.h"
@@ -146,7 +147,7 @@ HypreUVWLinearSystem::zeroSystem()
 void
 HypreUVWLinearSystem::sumInto(
   unsigned numEntities,
-  const ngp::Mesh::ConnectedNodes& entities,
+  const stk::mesh::NgpMesh::ConnectedNodes& entities,
   const SharedMemView<const double*, DeviceShmem>& rhs,
   const SharedMemView<const double**, DeviceShmem>& lhs,
   const SharedMemView<int*, DeviceShmem>&,

--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -32,10 +32,11 @@
 #include <stk_mesh/base/Selector.hpp>
 #include <stk_mesh/base/GetBuckets.hpp>
 #include <stk_mesh/base/Part.hpp>
+#include "stk_mesh/base/NgpMesh.hpp"
 #include <stk_topology/topology.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
 
-#include "stk_ngp/NgpFieldParallel.hpp"
+#include "stk_mesh/base/NgpFieldParallel.hpp"
 
 #include <Teuchos_VerboseObject.hpp>
 #include <Teuchos_FancyOStream.hpp>
@@ -142,14 +143,14 @@ void LinearSystem::sync_field(const stk::mesh::FieldBase *field)
     &fieldMgr.get_field<double>(field->mesh_meta_data_ordinal())
   };
 
-  ngp::copy_owned_to_shared(realm_.bulk_data(), ngpFields);
+  stk::mesh::copy_owned_to_shared(realm_.bulk_data(), ngpFields);
 }
 
 #ifndef KOKKOS_ENABLE_CUDA
 KOKKOS_FUNCTION
 void LinearSystem::DefaultHostOnlyCoeffApplier::operator()(
                         unsigned numEntities,
-                        const ngp::Mesh::ConnectedNodes& entities,
+                        const stk::mesh::NgpMesh::ConnectedNodes& entities,
                         const SharedMemView<int*,DeviceShmem> & localIds,
                         const SharedMemView<int*,DeviceShmem> & sortPermutation,
                         const SharedMemView<const double*,DeviceShmem> & rhs,

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -142,7 +142,7 @@
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldBLAS.h"
 #include "ngp_utils/NgpFieldUtils.h"
-#include "stk_ngp/NgpFieldParallel.hpp"
+#include "stk_mesh/base/NgpFieldParallel.hpp"
 
 // nso
 #include <nso/MomentumNSOElemKernel.h>
@@ -226,6 +226,7 @@
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/SkinMesh.hpp>
 #include <stk_mesh/base/Comm.hpp>
+#include "stk_mesh/base/NgpMesh.hpp"
 
 // stk_topo
 #include <stk_topology/topology.hpp>
@@ -2605,7 +2606,7 @@ MomentumEquationSystem::save_diagonal_term(
 void
 MomentumEquationSystem::save_diagonal_term(
   unsigned nEntities,
-  const ngp::Mesh::ConnectedNodes& entities,
+  const stk::mesh::NgpMesh::ConnectedNodes& entities,
   const SharedMemView<const double**,DeviceShmem>& lhs)
 {
   auto& bulk = realm_.bulk_data();
@@ -2627,7 +2628,7 @@ MomentumEquationSystem::save_diagonal_term(
 void
 MomentumEquationSystem::save_diagonal_term(
   unsigned,
-  const ngp::Mesh::ConnectedNodes&,
+  const stk::mesh::NgpMesh::ConnectedNodes&,
   const SharedMemView<const double**,DeviceShmem>&)
 {}
 #endif
@@ -2675,7 +2676,7 @@ MomentumEquationSystem::assemble_and_solve(
     // Sum up contributions on the nodes shared amongst processors
     const std::vector<NGPDoubleFieldType*> fVecNgp{&ngpUdiag};
     bool doFinalSyncBackToDevice = true;
-    ngp::parallel_sum(realm_.bulk_data(), fVecNgp, doFinalSyncBackToDevice);
+    stk::mesh::parallel_sum(realm_.bulk_data(), fVecNgp, doFinalSyncBackToDevice);
 
     const auto sel = stk::mesh::selectField(*Udiag_)
       & meta.locally_owned_part()

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -15,15 +15,19 @@
 #include <Realm.h>
 #include <utils/StkHelpers.h>
 #include <KokkosInterface.h>
+#include <ngp_utils/NgpFieldManager.h>
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_ngp/NgpFieldParallel.hpp>
+#include <stk_mesh/base/NgpFieldParallel.hpp>
 #include <stk_mesh/base/GetBuckets.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
+#include <stk_mesh/base/NgpField.hpp>
+#include <stk_mesh/base/Types.hpp>
 
 // stk_util
 #include <stk_util/parallel/ParallelReduce.hpp>
@@ -722,29 +726,29 @@ PeriodicManager::ngp_periodic_parallel_communicate_field(
   stk::mesh::FieldBase *theField)
 {
   if ( NULL != periodicGhosting_ ) {
-    const ngp::FieldManager& fieldMgr = realm_.ngp_field_manager();
+    const nalu_ngp::FieldManager& fieldMgr = realm_.ngp_field_manager();
     unsigned fieldOrd = theField->mesh_meta_data_ordinal();
 
     if (theField->type_is<double>()) {
       std::vector<NGPDoubleFieldType *> fieldVec(1, &fieldMgr.get_field<double>(fieldOrd));
-      ngp::communicate_field_data(*periodicGhosting_, fieldVec);
+      stk::mesh::communicate_field_data(*periodicGhosting_, fieldVec);
     }
     else if (theField->type_is<stk::mesh::EntityId>()) {
       std::vector<NGPGlobalIdFieldType *> fieldVec(1, &fieldMgr.get_field<stk::mesh::EntityId>(fieldOrd));
-      ngp::communicate_field_data(*periodicGhosting_, fieldVec);
+      stk::mesh::communicate_field_data(*periodicGhosting_, fieldVec);
     }
     else if (theField->type_is<int>()) {
       std::vector<NGPScalarIntFieldType *> fieldVec(1, &fieldMgr.get_field<int>(fieldOrd));
-      ngp::communicate_field_data(*periodicGhosting_, fieldVec);
+      stk::mesh::communicate_field_data(*periodicGhosting_, fieldVec);
     }
     else if (theField->type_is<LinSys::GlobalOrdinal>()) {
-      std::vector<ngp::Field<LinSys::GlobalOrdinal>*> fieldVec(1, &fieldMgr.get_field<LinSys::GlobalOrdinal>(fieldOrd));
-      ngp::communicate_field_data(*periodicGhosting_, fieldVec);
+      std::vector<stk::mesh::NgpField<LinSys::GlobalOrdinal>*> fieldVec(1, &fieldMgr.get_field<LinSys::GlobalOrdinal>(fieldOrd));
+      stk::mesh::communicate_field_data(*periodicGhosting_, fieldVec);
     }
 #ifdef NALU_USES_HYPRE
     else if (theField->type_is<HypreIntType>()) {
-      std::vector<ngp::Field<HypreIntType>*> fieldVec(1, &fieldMgr.get_field<HypreIntType>(fieldOrd));
-      ngp::communicate_field_data(*periodicGhosting_, fieldVec);
+      std::vector<stk::mesh::NgpField<HypreIntType>*> fieldVec(1, &fieldMgr.get_field<HypreIntType>(fieldOrd));
+      stk::mesh::communicate_field_data(*periodicGhosting_, fieldVec);
     }
 #endif
     else {
@@ -779,34 +783,34 @@ PeriodicManager::ngp_parallel_communicate_field(
   const stk::mesh::BulkData & bulk_data = realm_.bulk_data();
   const unsigned pSize = bulk_data.parallel_size();
   if ( pSize > 1 ) {
-    const ngp::FieldManager& fieldMgr = realm_.ngp_field_manager();
+    const nalu_ngp::FieldManager& fieldMgr = realm_.ngp_field_manager();
     unsigned fieldOrd = theField->mesh_meta_data_ordinal();
 
     if (theField->type_is<double>()) {
       std::vector<NGPDoubleFieldType *> fieldVec(1, &fieldMgr.get_field<double>(fieldOrd));
-      ngp::copy_owned_to_shared( bulk_data, fieldVec);
-      ngp::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
     else if (theField->type_is<stk::mesh::EntityId>()) {
       std::vector<NGPGlobalIdFieldType *> fieldVec(1, &fieldMgr.get_field<stk::mesh::EntityId>(fieldOrd));
-      ngp::copy_owned_to_shared( bulk_data, fieldVec);
-      ngp::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
     else if (theField->type_is<int>()) {
       std::vector<NGPScalarIntFieldType *> fieldVec(1, &fieldMgr.get_field<int>(fieldOrd));
-      ngp::copy_owned_to_shared( bulk_data, fieldVec);
-      ngp::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
     else if (theField->type_is<LinSys::GlobalOrdinal>()) {
-      std::vector<ngp::Field<LinSys::GlobalOrdinal>*> fieldVec(1, &fieldMgr.get_field<LinSys::GlobalOrdinal>(fieldOrd));
-      ngp::copy_owned_to_shared( bulk_data, fieldVec);
-      ngp::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
+      std::vector<stk::mesh::NgpField<LinSys::GlobalOrdinal>*> fieldVec(1, &fieldMgr.get_field<LinSys::GlobalOrdinal>(fieldOrd));
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
 #ifdef NALU_USES_HYPRE
     else if (theField->type_is<HypreIntType>()) {
-      std::vector<ngp::Field<HypreIntType>*> fieldVec(1, &fieldMgr.get_field<HypreIntType>(fieldOrd));
-      ngp::copy_owned_to_shared( bulk_data, fieldVec);
-      ngp::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
+      std::vector<stk::mesh::NgpField<HypreIntType>*> fieldVec(1, &fieldMgr.get_field<HypreIntType>(fieldOrd));
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
 #endif
     else {
@@ -992,7 +996,7 @@ PeriodicManager::ngp_add_slave_to_master(
   ThrowRequireMsg(theField->type_is<double>(), "Error in PeriodicManager::add_slave_to_master, theField ("<<theField->name()<<") is required to be double.");
 
   unsigned fieldSize = sizeOfField;
-  ngp::Mesh ngpMesh = realm_.ngp_mesh();
+  stk::mesh::NgpMesh ngpMesh = realm_.ngp_mesh();
   NGPDoubleFieldType ngpField = realm_.ngp_field_manager().get_field<double>(theField->mesh_meta_data_ordinal());
   KokkosEntityPairView deviceMasterSlaves = deviceMasterSlaves_;
 
@@ -1107,7 +1111,7 @@ PeriodicManager::ngp_set_slave_to_master(
   ThrowRequireMsg(theField->type_is<double>(), "Argh, theField ("<<theField->name()<<") is not double.");
 
   unsigned fieldSize = sizeOfField;
-  ngp::Mesh ngpMesh = realm_.ngp_mesh();
+  stk::mesh::NgpMesh ngpMesh = realm_.ngp_mesh();
   NGPDoubleFieldType ngpField = realm_.ngp_field_manager().get_field<double>(theField->mesh_meta_data_ordinal());
   KokkosEntityPairView deviceMasterSlaves = deviceMasterSlaves_;
 

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -98,6 +98,7 @@
 #include "ngp_utils/NgpTypes.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldBLAS.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "ngp_algorithms/GeometryAlgDriver.h"
 #include "ngp_algorithms/GeometryInteriorAlg.h"
 #include "ngp_algorithms/GeometryBoundaryAlg.h"
@@ -121,6 +122,7 @@
 #include <stk_mesh/base/CreateEdges.hpp>
 #include <stk_mesh/base/SkinBoundary.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 // stk_io
 #include <stk_io/StkMeshIoBroker.hpp>
@@ -1692,7 +1694,7 @@ Realm::pre_timestep_work()
     if ( hasOverset_ )
       initialize_overset();
 
-    // Reset the ngp::Mesh instance
+    // Reset the stk::mesh::NgpMesh instance
     meshInfo_.reset(new typename Realm::NgpMeshInfo(*bulkData_));
 
     // now re-initialize linear system
@@ -2370,7 +2372,7 @@ Realm::compute_vrtm(const std::string& velName)
   if (!solutionOptions_->meshMotion_ &&
       !solutionOptions_->externalMeshDeformation_) return;
 
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
   using MeshIndex = Traits::MeshIndex;
 
   const int nDim = metaData_->spatial_dimension();

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -10,6 +10,8 @@
 
 #include <ScratchViews.h>
 #include <ngp_utils/NgpMEUtils.h>
+#include <stk_mesh/base/NgpMesh.hpp>
+#include <stk_mesh/base/Types.hpp>
 
 #include <NaluEnv.h>
 
@@ -19,8 +21,8 @@ namespace nalu {
 template<typename ViewType>
 KOKKOS_INLINE_FUNCTION
 void gather_elem_node_field(const NGPDoubleFieldType& field,
-                            const ngp::Mesh& ngpMesh,
-                            const ngp::Mesh::ConnectedNodes& elemNodes,
+                            const stk::mesh::NgpMesh& ngpMesh,
+                            const stk::mesh::NgpMesh::ConnectedNodes& elemNodes,
                             ViewType& shmemView)
 {
   for(unsigned i=0; i<elemNodes.size(); ++i) {
@@ -31,11 +33,11 @@ void gather_elem_node_field(const NGPDoubleFieldType& field,
 template<typename ViewType>
 KOKKOS_INLINE_FUNCTION
 void gather_elem_node_tensor_field(const NGPDoubleFieldType& field,
-                            const ngp::Mesh& ngpMesh,
+                            const stk::mesh::NgpMesh& ngpMesh,
                             int numNodes,
                             int tensorDim1,
                             int tensorDim2,
-                            const ngp::Mesh::ConnectedNodes& elemNodes,
+                            const stk::mesh::NgpMesh::ConnectedNodes& elemNodes,
                             ViewType& shmemView)
 {
   NGP_ThrowRequireMsg(
@@ -82,8 +84,8 @@ void gather_elem_vector_field(const NGPDoubleFieldType& field,
 template<typename ViewType>
 KOKKOS_INLINE_FUNCTION
 void gather_elem_node_field_3D(const NGPDoubleFieldType& field,
-                               const ngp::Mesh& ngpMesh,
-                               const ngp::Mesh::ConnectedNodes& elemNodes,
+                               const stk::mesh::NgpMesh& ngpMesh,
+                               const stk::mesh::NgpMesh::ConnectedNodes& elemNodes,
                                ViewType& shmemView)
 {
   for(unsigned i=0; i<elemNodes.size(); ++i) {
@@ -96,9 +98,9 @@ void gather_elem_node_field_3D(const NGPDoubleFieldType& field,
 template<typename ViewType>
 KOKKOS_INLINE_FUNCTION
 void gather_elem_node_field(const NGPDoubleFieldType& field,
-                            const ngp::Mesh& ngpMesh,
+                            const stk::mesh::NgpMesh& ngpMesh,
                             int scalarsPerNode,
-                            const ngp::Mesh::ConnectedNodes& elemNodes,
+                            const stk::mesh::NgpMesh::ConnectedNodes& elemNodes,
                             ViewType& shmemView)
 {
   for(unsigned i=0; i<elemNodes.size(); ++i) {
@@ -111,7 +113,7 @@ void gather_elem_node_field(const NGPDoubleFieldType& field,
 inline
 void gather_elem_node_field(const stk::mesh::FieldBase& field,
                             int numNodes,
-                            const ngp::Mesh::ConnectedNodes& elemNodes,
+                            const stk::mesh::NgpMesh::ConnectedNodes& elemNodes,
                             SharedMemView<double*>& shmemView)
 {
   for(int i=0; i<numNodes; ++i) {
@@ -124,7 +126,7 @@ void gather_elem_node_tensor_field(const stk::mesh::FieldBase& field,
                             int numNodes,
                             int tensorDim1,
                             int tensorDim2,
-                            const ngp::Mesh::ConnectedNodes& elemNodes,
+                            const stk::mesh::NgpMesh::ConnectedNodes& elemNodes,
                             SharedMemView<double***>& shmemView)
 {
   for(int i=0; i<numNodes; ++i) {
@@ -157,7 +159,7 @@ void gather_elem_tensor_field(const stk::mesh::FieldBase& field,
 inline
 void gather_elem_node_field_3D(const stk::mesh::FieldBase& field,
                                int numNodes,
-                               const ngp::Mesh::ConnectedNodes& elemNodes,
+                               const stk::mesh::NgpMesh::ConnectedNodes& elemNodes,
                                SharedMemView<double**>& shmemView)
 {
   for(int i=0; i<numNodes; ++i) {
@@ -172,7 +174,7 @@ inline
 void gather_elem_node_field(const stk::mesh::FieldBase& field,
                             int numNodes,
                             int scalarsPerNode,
-                            const ngp::Mesh::ConnectedNodes& elemNodes,
+                            const stk::mesh::NgpMesh::ConnectedNodes& elemNodes,
                             SharedMemView<double**>& shmemView)
 {
   for(int i=0; i<numNodes; ++i) {
@@ -356,7 +358,7 @@ template<typename T>
 KOKKOS_FUNCTION
 void fill_pre_req_data(
   const ElemDataRequestsGPU& dataNeeded,
-  const ngp::Mesh& ngpMesh,
+  const stk::mesh::NgpMesh& ngpMesh,
   stk::mesh::EntityRank entityRank,
   stk::mesh::Entity entity,
   ScratchViews<T,DeviceTeamHandleType,DeviceShmem>& prereqData)
@@ -413,7 +415,7 @@ void fill_pre_req_data(
 template
 void fill_pre_req_data(
   const ElemDataRequestsGPU& dataNeeded,
-  const ngp::Mesh& ngpMesh,
+  const stk::mesh::NgpMesh& ngpMesh,
   stk::mesh::EntityRank entityRank,
   stk::mesh::Entity entity,
   ScratchViews<double, DeviceTeamHandleType,DeviceShmem>& prereqData);
@@ -421,7 +423,7 @@ void fill_pre_req_data(
 template
 void fill_pre_req_data(
   const ElemDataRequestsGPU& dataNeeded,
-  const ngp::Mesh& ngpMesh,
+  const stk::mesh::NgpMesh& ngpMesh,
   stk::mesh::EntityRank entityRank,
   stk::mesh::Entity entity,
   ScratchViews<DoubleType, DeviceTeamHandleType,DeviceShmem>& prereqData);

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -18,6 +18,7 @@
 #include "ngp_utils/NgpFieldUtils.h"
 
 #include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 #include <vector>
 
@@ -75,7 +76,7 @@ NGPApplyCoeff::NGPApplyCoeff(EquationSystem* eqSystem)
 
 void NGPApplyCoeff::extract_diagonal(
   const unsigned int nEntities,
-  const ngp::Mesh::ConnectedNodes& entities,
+  const stk::mesh::NgpMesh::ConnectedNodes& entities,
   SharedMemView<double**, DeviceShmem>& lhs) const
 {
   constexpr bool forceAtomic = std::is_same<
@@ -93,7 +94,7 @@ void NGPApplyCoeff::extract_diagonal(
 void
 NGPApplyCoeff::reset_overset_rows(
   const unsigned int nEntities,
-  const ngp::Mesh::ConnectedNodes& entities,
+  const stk::mesh::NgpMesh::ConnectedNodes& entities,
   SharedMemView<double*, DeviceShmem>& rhs,
   SharedMemView<double**, DeviceShmem>& lhs) const
 {
@@ -116,7 +117,7 @@ NGPApplyCoeff::reset_overset_rows(
 
 void NGPApplyCoeff::operator()(
   unsigned numMeshobjs,
-  const ngp::Mesh::ConnectedNodes& symMeshobjs,
+  const stk::mesh::NgpMesh::ConnectedNodes& symMeshobjs,
   const SharedMemView<int*,DeviceShmem> & scratchIds,
   const SharedMemView<int*,DeviceShmem> & sortPermutation,
   SharedMemView<double*,DeviceShmem> & rhs,

--- a/src/TAMSAlgDriver.C
+++ b/src/TAMSAlgDriver.C
@@ -15,7 +15,9 @@
 #include "utils/StkHelpers.h"
 #include "ngp_utils/NgpTypes.h"
 #include "ngp_utils/NgpFieldBLAS.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "ngp_algorithms/MetricTensorElemAlg.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -203,7 +205,7 @@ TAMSAlgDriver::initial_work()
 void
 TAMSAlgDriver::initial_production()
 {
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   // Initialize average_production (after tvisc)
   // We don't want to do this on restart where TAMS fields are present

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -26,6 +26,7 @@
 #include <utils/StkHelpers.h>
 #include <utils/CreateDeviceExpression.h>
 #include <ngp_utils/NgpLoopUtils.h>
+#include <ngp_utils/NgpFieldManager.h>
 
 #include <KokkosInterface.h>
 
@@ -47,6 +48,7 @@
 #include <stk_mesh/base/Part.hpp>
 #include <stk_topology/topology.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 // For Tpetra support
 #include <Kokkos_Serial.hpp>
@@ -1273,7 +1275,7 @@ KOKKOS_FUNCTION
 void
 TpetraLinearSystem::TpetraLinSysCoeffApplier::operator()(
   unsigned numEntities,
-  const ngp::Mesh::ConnectedNodes& entities,
+  const stk::mesh::NgpMesh::ConnectedNodes& entities,
   const SharedMemView<int*, DeviceShmem>& localIds,
   const SharedMemView<int*, DeviceShmem>& sortPermutation,
   const SharedMemView<const double*, DeviceShmem>& rhs,
@@ -1316,7 +1318,7 @@ sierra::nalu::CoeffApplier* TpetraLinearSystem::TpetraLinSysCoeffApplier::device
 }
 
 void TpetraLinearSystem::sumInto(unsigned numEntities,
-                                 const ngp::Mesh::ConnectedNodes& entities,
+                                 const stk::mesh::NgpMesh::ConnectedNodes& entities,
                                  const SharedMemView<const double*,DeviceShmem> & rhs,
                                  const SharedMemView<const double**,DeviceShmem> & lhs,
                                  const SharedMemView<int*,DeviceShmem> & localIds,
@@ -1429,7 +1431,7 @@ void TpetraLinearSystem::applyDirichletBCs(stk::mesh::FieldBase * solutionField,
   using Traits = nalu_ngp::NGPMeshTraits<>;
   using MeshIndex = typename Traits::MeshIndex;
 
-  ngp::Mesh ngpMesh = realm_.ngp_mesh();
+  stk::mesh::NgpMesh ngpMesh = realm_.ngp_mesh();
   NGPDoubleFieldType ngpSolutionField = realm_.ngp_field_manager().get_field<double>(solutionField->mesh_meta_data_ordinal());
   NGPDoubleFieldType ngpBCValuesField = realm_.ngp_field_manager().get_field<double>(bcValuesField->mesh_meta_data_ordinal());
 
@@ -1882,7 +1884,7 @@ void TpetraLinearSystem::copy_tpetra_to_stk(
 
   NGPDoubleFieldType ngpField = realm_.ngp_field_manager().get_field<double>(stkField->mesh_meta_data_ordinal());
 
-  ngp::Mesh ngpMesh = realm_.ngp_mesh();
+  stk::mesh::NgpMesh ngpMesh = realm_.ngp_mesh();
 
   nalu_ngp::run_entity_algorithm(
     "TpetraLinSys::copy_tpetra_to_stk",

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -46,6 +46,7 @@
 #include <stk_mesh/base/Part.hpp>
 #include <stk_topology/topology.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 // For Tpetra support
 #include <Kokkos_Serial.hpp>
@@ -1143,7 +1144,7 @@ void TpetraSegregatedLinearSystem::TpetraLinSysCoeffApplier::resetRows(unsigned 
 
 KOKKOS_FUNCTION
 void TpetraSegregatedLinearSystem::TpetraLinSysCoeffApplier::operator() (unsigned numEntities,
-                                                                         const ngp::Mesh::ConnectedNodes& entities,
+                                                                         const stk::mesh::NgpMesh::ConnectedNodes& entities,
                                                                          const SharedMemView<int*,DeviceShmem> & localIds,
                                                                          const SharedMemView<int*,DeviceShmem> & sortPermutation,
                                                                          const SharedMemView<const double*,DeviceShmem> & rhs,
@@ -1185,7 +1186,7 @@ sierra::nalu::CoeffApplier* TpetraSegregatedLinearSystem::TpetraLinSysCoeffAppli
 }
 
 void TpetraSegregatedLinearSystem::sumInto(unsigned numEntities,
-                                           const ngp::Mesh::ConnectedNodes& entities,
+                                           const stk::mesh::NgpMesh::ConnectedNodes& entities,
                                            const SharedMemView<const double*,DeviceShmem> & rhs,
                                            const SharedMemView<const double**,DeviceShmem> & lhs,
                                            const SharedMemView<int*,DeviceShmem> & localIds,

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -79,6 +79,7 @@
 #include <ngp_utils/NgpLoopUtils.h>
 #include <ngp_utils/NgpTypes.h>
 #include <ngp_utils/NgpFieldBLAS.h>
+#include <ngp_utils/NgpFieldManager.h>
 #include <ngp_algorithms/NodalGradEdgeAlg.h>
 #include <ngp_algorithms/NodalGradElemAlg.h>
 #include <ngp_algorithms/NodalGradBndryElemAlg.h>
@@ -108,6 +109,7 @@
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 // stk_io
 #include <stk_io/IossBridge.hpp>
@@ -920,7 +922,7 @@ TurbKineticEnergyEquationSystem::solve_and_update()
 void
 TurbKineticEnergyEquationSystem::initial_work()
 {
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
   using MeshIndex = typename Traits::MeshIndex;
 
   // do not let the user specify a negative field

--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -23,6 +23,7 @@
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldUtils.h"
 #include "ngp_utils/NgpReduceUtils.h"
+#include "ngp_utils/NgpFieldManager.h"
 
 // stk_util
 #include <stk_util/parallel/Parallel.hpp>
@@ -34,6 +35,8 @@
 #include <stk_mesh/base/GetBuckets.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
+#include <stk_mesh/base/NgpField.hpp>
 
 // basic c++
 #include <stdexcept>
@@ -701,7 +704,7 @@ TurbulenceAveragingPostProcessing::compute_averages(
   const double& zeroCurrent,
   const double& dt)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
   using FieldPair = Kokkos::pair<FieldInfoNGP, FieldInfoNGP>;
   using FieldInfoView = Kokkos::View<FieldPair*, Kokkos::LayoutRight, MemSpace>;
 
@@ -823,7 +826,7 @@ TurbulenceAveragingPostProcessing::compute_tke(
   const std::string &averageBlockName,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   // check for precise set of names
   const std::string velocityName = isReynolds
@@ -866,7 +869,7 @@ TurbulenceAveragingPostProcessing::compute_reynolds_stress(
   const double &dt,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.spatialDimension_;
   const std::string velocityAName = "velocity_ra_" + averageBlockName;
@@ -920,7 +923,7 @@ TurbulenceAveragingPostProcessing::compute_favre_stress(
   const double &dt,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.spatialDimension_;
   const std::string velocityAName = "velocity_fa_" + averageBlockName;
@@ -985,7 +988,7 @@ void TurbulenceAveragingPostProcessing::compute_temperature_resolved_flux(
   const double& dt,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.meta_data().spatial_dimension();
   const auto& meshInfo = realm_.mesh_info();
@@ -1036,7 +1039,7 @@ TurbulenceAveragingPostProcessing::compute_resolved_stress(
   const double &dt,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.spatialDimension_;
   const auto& meshInfo = realm_.mesh_info();
@@ -1082,7 +1085,7 @@ TurbulenceAveragingPostProcessing::compute_sfs_stress(
   const double &dt,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.spatialDimension_;
   const double twoDivDim = 2.0 / static_cast<double>(ndim);
@@ -1103,7 +1106,7 @@ TurbulenceAveragingPostProcessing::compute_sfs_stress(
 
   // If we have a turbulent_ke field, extract the NGP version for use in
   // computations
-  ngp::Field<double> turbKE;
+  stk::mesh::NgpField<double> turbKE;
   if (!computeSFSTKE) {
     turbKE = nalu_ngp::get_ngp_field(meshInfo, "turbulent_ke");
   }
@@ -1171,7 +1174,7 @@ TurbulenceAveragingPostProcessing::compute_temperature_sfs_flux(
   const double &dt,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.spatialDimension_;
   const auto& meshInfo = realm_.mesh_info();
@@ -1209,7 +1212,7 @@ TurbulenceAveragingPostProcessing::compute_vorticity(
   const std::string & /* averageBlockName */,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.spatialDimension_;
   const auto& meshInfo = realm_.mesh_info();
@@ -1241,7 +1244,7 @@ TurbulenceAveragingPostProcessing::compute_q_criterion(
   const std::string & /* averageBlockName */,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.spatialDimension_;
   const auto& meshInfo = realm_.mesh_info();
@@ -1415,7 +1418,7 @@ TurbulenceAveragingPostProcessing::compute_mean_resolved_ke(
   const std::string & /* averageBlockName */,
   stk::mesh::Selector s_all_nodes)
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const int ndim = realm_.spatialDimension_;
   const auto& meshInfo = realm_.mesh_info();

--- a/src/edge_kernels/AssembleEdgeKernelAlg.C
+++ b/src/edge_kernels/AssembleEdgeKernelAlg.C
@@ -10,6 +10,7 @@
 
 #include "edge_kernels/AssembleEdgeKernelAlg.h"
 #include "edge_kernels/EdgeKernel.h"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/edge_kernels/ContinuityEdgeSolverAlg.C
+++ b/src/edge_kernels/ContinuityEdgeSolverAlg.C
@@ -10,6 +10,8 @@
 
 #include "edge_kernels/ContinuityEdgeSolverAlg.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -51,7 +53,7 @@ ContinuityEdgeSolverAlg::execute()
   const DblType interpTogether = realm_.get_mdot_interp();
   const DblType om_interpTogether = (1.0 - interpTogether);
 
-  // STK ngp::Field instances for capture by lambda
+  // STK stk::mesh::NgpField instances for capture by lambda
   const auto& fieldMgr = realm_.ngp_field_manager();
   const auto coordinates = fieldMgr.get_field<double>(coordinates_);
   const auto velocity = fieldMgr.get_field<double>(velocityRTM_);

--- a/src/edge_kernels/MomentumEdgeSolverAlg.C
+++ b/src/edge_kernels/MomentumEdgeSolverAlg.C
@@ -14,6 +14,8 @@
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
 #include "edge_kernels/EdgeKernelUtils.h"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -65,7 +67,7 @@ MomentumEdgeSolverAlg::execute()
   const DblType om_alpha = 1.0 - alpha;
   const DblType om_alphaUpw = 1.0 - alphaUpw;
 
-  // STK ngp::Field instances for capture by lambda
+  // STK stk::mesh::NgpField instances for capture by lambda
   const auto& fieldMgr = realm_.ngp_field_manager();
   const auto coordinates = fieldMgr.get_field<double>(coordinates_);
   const auto vrtm = fieldMgr.get_field<double>(velocityRTM_);

--- a/src/edge_kernels/MomentumSSTTAMSDiffEdgeKernel.C
+++ b/src/edge_kernels/MomentumSSTTAMSDiffEdgeKernel.C
@@ -14,6 +14,7 @@
 #include "EigenDecomposition.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 #include "utils/TAMSUtils.h"
 #include <SimdInterface.h>

--- a/src/edge_kernels/ScalarEdgeSolverAlg.C
+++ b/src/edge_kernels/ScalarEdgeSolverAlg.C
@@ -14,6 +14,8 @@
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
 #include "edge_kernels/EdgeKernelUtils.h"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -60,7 +62,7 @@ ScalarEdgeSolverAlg::execute()
   const DblType om_alpha = 1.0 - alpha;
   const DblType om_alphaUpw = 1.0 - alphaUpw;
 
-  // STK ngp::Field instances for capture by lambda
+  // STK stk::mesh::NgpField instances for capture by lambda
   const auto& fieldMgr = realm_.ngp_field_manager();
   const auto coordinates = fieldMgr.get_field<double>(coordinates_);
   const auto vrtm = fieldMgr.get_field<double>(velocityRTM_);

--- a/src/edge_kernels/WallDistEdgeSolverAlg.C
+++ b/src/edge_kernels/WallDistEdgeSolverAlg.C
@@ -10,6 +10,7 @@
 
 #include "edge_kernels/WallDistEdgeSolverAlg.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -16,6 +16,7 @@
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
 #include "ngp_utils/NgpReduceUtils.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
@@ -23,6 +24,7 @@
 #include "wind_energy/MoninObukhov.h"
 
 #include "stk_mesh/base/Field.hpp"
+#include <stk_mesh/base/NgpMesh.hpp>
 
 namespace sierra {
 namespace nalu {
@@ -162,7 +164,7 @@ template<typename BcAlgTraits>
 void ABLWallFrictionVelAlg<BcAlgTraits>::execute()
 {
   namespace mo = abl_monin_obukhov;
-  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
   const auto& meshInfo = realm_.mesh_info();
   const auto ngpMesh = meshInfo.ngp_mesh();
   const auto& fieldMgr = meshInfo.ngp_field_manager();

--- a/src/ngp_algorithms/CourantReAlg.C
+++ b/src/ngp_algorithms/CourantReAlg.C
@@ -19,10 +19,12 @@
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
 #include "ngp_utils/NgpReduceUtils.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include <stk_mesh/base/NgpMesh.hpp>
 
 namespace sierra {
 namespace nalu {
@@ -64,7 +66,7 @@ CourantReAlg<AlgTraits>::CourantReAlg(
 template<typename AlgTraits>
 void CourantReAlg<AlgTraits>::execute()
 {
-  using ElemSimdDataType = nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& ngpMesh = meshInfo.ngp_mesh();

--- a/src/ngp_algorithms/EffDiffFluxCoeffAlg.C
+++ b/src/ngp_algorithms/EffDiffFluxCoeffAlg.C
@@ -11,10 +11,12 @@
 #include "ngp_algorithms/EffDiffFluxCoeffAlg.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include <stk_mesh/base/NgpMesh.hpp>
 
 namespace sierra {
 namespace nalu {
@@ -41,7 +43,7 @@ EffDiffFluxCoeffAlg::EffDiffFluxCoeffAlg(
 void
 EffDiffFluxCoeffAlg::execute()
 {
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
 

--- a/src/ngp_algorithms/EffSSTDiffFluxCoeffAlg.C
+++ b/src/ngp_algorithms/EffSSTDiffFluxCoeffAlg.C
@@ -11,10 +11,12 @@
 #include "ngp_algorithms/EffSSTDiffFluxCoeffAlg.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -40,7 +42,7 @@ EffSSTDiffFluxCoeffAlg::EffSSTDiffFluxCoeffAlg(
 void
 EffSSTDiffFluxCoeffAlg::execute()
 {
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
 

--- a/src/ngp_algorithms/EnthalpyEffDiffFluxCoeffAlg.C
+++ b/src/ngp_algorithms/EnthalpyEffDiffFluxCoeffAlg.C
@@ -11,10 +11,12 @@
 #include <ngp_algorithms/EnthalpyEffDiffFluxCoeffAlg.h>
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
 
 #include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 namespace sierra{
 namespace nalu{
@@ -45,7 +47,7 @@ EnthalpyEffDiffFluxCoeffAlg::EnthalpyEffDiffFluxCoeffAlg(
 void
 EnthalpyEffDiffFluxCoeffAlg::execute()
 {
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
 

--- a/src/ngp_algorithms/GeometryAlgDriver.C
+++ b/src/ngp_algorithms/GeometryAlgDriver.C
@@ -12,6 +12,7 @@
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldUtils.h"
 #include "ngp_utils/NgpReducers.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
 
@@ -19,7 +20,8 @@
 #include "stk_mesh/base/FieldParallel.hpp"
 #include "stk_mesh/base/FieldBLAS.hpp"
 #include "stk_mesh/base/MetaData.hpp"
-#include "stk_ngp/NgpFieldParallel.hpp"
+#include "stk_mesh/base/NgpFieldParallel.hpp"
+#include <stk_mesh/base/NgpMesh.hpp>
 
 namespace sierra {
 namespace nalu {
@@ -120,7 +122,7 @@ void GeometryAlgDriver::pre_work()
 
 void GeometryAlgDriver::post_work()
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& ngpMesh = realm_.ngp_mesh();
@@ -149,7 +151,7 @@ void GeometryAlgDriver::post_work()
   }
 
   bool doFinalSyncToDevice = false;
-  ngp::parallel_sum(realm_.bulk_data(), fields, doFinalSyncToDevice);
+  stk::mesh::parallel_sum(realm_.bulk_data(), fields, doFinalSyncToDevice);
 
   if (realm_.hasPeriodic_) {
     const auto& meta = realm_.meta_data();

--- a/src/ngp_algorithms/GeometryBoundaryAlg.C
+++ b/src/ngp_algorithms/GeometryBoundaryAlg.C
@@ -15,10 +15,12 @@
 #include "ngp_algorithms/ViewHelper.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 
 namespace sierra {
@@ -43,7 +45,7 @@ GeometryBoundaryAlg<AlgTraits>::GeometryBoundaryAlg(
 template<typename AlgTraits>
 void GeometryBoundaryAlg<AlgTraits>::execute()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -15,10 +15,12 @@
 #include "ngp_algorithms/ViewHelper.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 
 namespace sierra {
@@ -65,7 +67,7 @@ void GeometryInteriorAlg<AlgTraits>::execute()
 template <typename AlgTraits>
 void GeometryInteriorAlg<AlgTraits>::impl_compute_dual_nodal_volume()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();
@@ -105,7 +107,7 @@ void GeometryInteriorAlg<AlgTraits>::impl_compute_dual_nodal_volume()
 template<typename AlgTraits>
 void GeometryInteriorAlg<AlgTraits>::impl_negative_jacobian_check()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();
@@ -143,7 +145,7 @@ void GeometryInteriorAlg<AlgTraits>::impl_negative_jacobian_check()
 template <typename AlgTraits>
 void GeometryInteriorAlg<AlgTraits>::impl_compute_edge_area_vector()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();

--- a/src/ngp_algorithms/MdotDensityAccumAlg.C
+++ b/src/ngp_algorithms/MdotDensityAccumAlg.C
@@ -20,6 +20,7 @@
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -58,7 +59,7 @@ MdotDensityAccumAlg<AlgTraits>::MdotDensityAccumAlg(
 template<typename AlgTraits>
 void MdotDensityAccumAlg<AlgTraits>::execute()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
 

--- a/src/ngp_algorithms/MdotEdgeAlg.C
+++ b/src/ngp_algorithms/MdotEdgeAlg.C
@@ -11,8 +11,11 @@
 #include "ngp_algorithms/MdotEdgeAlg.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
+#include "stk_mesh/base/NgpField.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -38,7 +41,7 @@ MdotEdgeAlg::MdotEdgeAlg(
 void
 MdotEdgeAlg::execute()
 {
-  using EntityInfoType = nalu_ngp::EntityInfo<ngp::Mesh>;
+  using EntityInfoType = nalu_ngp::EntityInfo<stk::mesh::NgpMesh>;
   constexpr int NDimMax = 3;
   const auto& meta = realm_.meta_data();
   const int ndim = meta.spatial_dimension();
@@ -51,7 +54,7 @@ MdotEdgeAlg::execute()
   const DblType interpTogether = realm_.get_mdot_interp();
   const DblType om_interpTogether = (1.0 - interpTogether);
 
-  // STK ngp::Field instances for capture by lambda
+  // STK stk::mesh::NgpField instances for capture by lambda
   const auto ngpMesh = realm_.ngp_mesh();
   const auto& fieldMgr = realm_.ngp_field_manager();
   const auto coordinates = fieldMgr.get_field<double>(coordinates_);

--- a/src/ngp_algorithms/MdotInflowAlg.C
+++ b/src/ngp_algorithms/MdotInflowAlg.C
@@ -18,6 +18,7 @@
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -59,7 +60,7 @@ MdotInflowAlg<BcAlgTraits>::MdotInflowAlg(
 template<typename BcAlgTraits>
 void MdotInflowAlg<BcAlgTraits>::execute()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();

--- a/src/ngp_algorithms/MdotOpenCorrectorAlg.C
+++ b/src/ngp_algorithms/MdotOpenCorrectorAlg.C
@@ -12,8 +12,10 @@
 #include "ngp_algorithms/MdotAlgDriver.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -32,7 +34,7 @@ MdotOpenCorrectorAlg<BcAlgTraits>::MdotOpenCorrectorAlg(
 template<typename BcAlgTraits>
 void MdotOpenCorrectorAlg<BcAlgTraits>::execute()
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
 
   const auto& ngpMesh = realm_.ngp_mesh();
   const auto& fieldMgr = realm_.ngp_field_manager();

--- a/src/ngp_algorithms/MdotOpenEdgeAlg.C
+++ b/src/ngp_algorithms/MdotOpenEdgeAlg.C
@@ -15,10 +15,12 @@
 #include "ngp_utils/NgpFieldOps.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpReduceUtils.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -71,7 +73,7 @@ MdotOpenEdgeAlg<BcAlgTraits>::MdotOpenEdgeAlg(
 template <typename BcAlgTraits>
 void MdotOpenEdgeAlg<BcAlgTraits>::execute()
 {
-  using SimdDataType = nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+  using SimdDataType = nalu_ngp::FaceElemSimdData<stk::mesh::NgpMesh>;
   const auto& meta = realm_.meta_data();
   const auto& meshInfo = realm_.mesh_info();
   const auto& ngpMesh = meshInfo.ngp_mesh();

--- a/src/ngp_algorithms/MetricTensorElemAlg.C
+++ b/src/ngp_algorithms/MetricTensorElemAlg.C
@@ -16,10 +16,12 @@
 #include "ngp_algorithms/ViewHelper.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -52,7 +54,7 @@ template <typename AlgTraits>
 void
 MetricTensorElemAlg<AlgTraits>::execute()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();

--- a/src/ngp_algorithms/NodalGradAlgDriver.C
+++ b/src/ngp_algorithms/NodalGradAlgDriver.C
@@ -16,7 +16,7 @@
 #include "stk_mesh/base/FieldParallel.hpp"
 #include "stk_mesh/base/FieldBLAS.hpp"
 #include "stk_mesh/base/MetaData.hpp"
-#include "stk_ngp/NgpFieldParallel.hpp"
+#include "stk_mesh/base/NgpFieldParallel.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -65,7 +65,7 @@ void NodalGradAlgDriver<GradPhiType>::post_work()
 
   const std::vector<NGPDoubleFieldType*> fVec{&ngpGradPhi};
   bool doFinalSyncToDevice = false;
-  ngp::parallel_sum(bulk, fVec, doFinalSyncToDevice);
+  stk::mesh::parallel_sum(bulk, fVec, doFinalSyncToDevice);
 
   const int dim2 = meta.spatial_dimension();
   const int dim1 = std::is_same<VectorFieldType, GradPhiType>::value

--- a/src/ngp_algorithms/NodalGradBndryElemAlg.C
+++ b/src/ngp_algorithms/NodalGradBndryElemAlg.C
@@ -16,10 +16,12 @@
 #include "ngp_algorithms/ViewHelper.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -58,7 +60,7 @@ NodalGradBndryElemAlg<AlgTraits, PhiType, GradPhiType>::NodalGradBndryElemAlg(
 template <typename AlgTraits, typename PhiType, typename GradPhiType>
 void NodalGradBndryElemAlg<AlgTraits, PhiType, GradPhiType>::execute()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
   using ViewHelperType = nalu_ngp::ViewHelper<ElemSimdDataType, PhiType>;
 
   const auto& meshInfo = realm_.mesh_info();

--- a/src/ngp_algorithms/NodalGradEdgeAlg.C
+++ b/src/ngp_algorithms/NodalGradEdgeAlg.C
@@ -11,8 +11,10 @@
 #include "ngp_algorithms/NodalGradEdgeAlg.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -38,7 +40,7 @@ NodalGradEdgeAlg<PhiType, GradPhiType>::NodalGradEdgeAlg(
 template <typename PhiType, typename GradPhiType>
 void NodalGradEdgeAlg<PhiType, GradPhiType>::execute()
 {
-  using EntityInfoType = nalu_ngp::EntityInfo<ngp::Mesh>;
+  using EntityInfoType = nalu_ngp::EntityInfo<stk::mesh::NgpMesh>;
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();
   const auto ngpMesh = meshInfo.ngp_mesh();

--- a/src/ngp_algorithms/NodalGradElemAlg.C
+++ b/src/ngp_algorithms/NodalGradElemAlg.C
@@ -16,10 +16,12 @@
 #include "ngp_algorithms/ViewHelper.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -55,7 +57,7 @@ NodalGradElemAlg<AlgTraits, PhiType, GradPhiType>::NodalGradElemAlg(
 template <typename AlgTraits, typename PhiType, typename GradPhiType>
 void NodalGradElemAlg<AlgTraits, PhiType, GradPhiType>::execute()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
   using ViewHelperType = nalu_ngp::ViewHelper<ElemSimdDataType, PhiType>;
 
   const auto& meshInfo = realm_.mesh_info();

--- a/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
+++ b/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
@@ -14,10 +14,12 @@
 #include "master_element/MasterElementFactory.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -79,7 +81,7 @@ template <typename AlgTraits>
 void
 NodalGradPOpenBoundary<AlgTraits>::execute()
 {
-  using SimdDataType = nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+  using SimdDataType = nalu_ngp::FaceElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta_data = meshInfo.meta();

--- a/src/ngp_algorithms/SDRLowReWallAlg.C
+++ b/src/ngp_algorithms/SDRLowReWallAlg.C
@@ -13,8 +13,10 @@
 #include "master_element/MasterElementFactory.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -61,7 +63,7 @@ SDRLowReWallAlg<BcAlgTraits>::SDRLowReWallAlg(
 template<typename BcAlgTraits>
 void SDRLowReWallAlg<BcAlgTraits>::execute()
 {
-  using SimdDataType = nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+  using SimdDataType = nalu_ngp::FaceElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
 

--- a/src/ngp_algorithms/SDRWallFuncAlg.C
+++ b/src/ngp_algorithms/SDRWallFuncAlg.C
@@ -13,8 +13,10 @@
 #include "master_element/MasterElementFactory.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -58,7 +60,7 @@ SDRWallFuncAlg<BcAlgTraits>::SDRWallFuncAlg(
 template<typename BcAlgTraits>
 void SDRWallFuncAlg<BcAlgTraits>::execute()
 {
-  using SimdDataType = nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+  using SimdDataType = nalu_ngp::FaceElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
 

--- a/src/ngp_algorithms/SDRWallFuncAlgDriver.C
+++ b/src/ngp_algorithms/SDRWallFuncAlgDriver.C
@@ -19,7 +19,8 @@
 #include "stk_mesh/base/FieldParallel.hpp"
 #include "stk_mesh/base/FieldBLAS.hpp"
 #include "stk_mesh/base/MetaData.hpp"
-#include "stk_ngp/NgpFieldParallel.hpp"
+#include "stk_mesh/base/NgpFieldParallel.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -41,7 +42,7 @@ void SDRWallFuncAlgDriver::pre_work()
 
 void SDRWallFuncAlgDriver::post_work()
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
   const auto& ngpMesh = realm_.ngp_mesh();
 
   auto& bcsdr = nalu_ngp::get_ngp_field(realm_.mesh_info(), "wall_model_sdr_bc");
@@ -55,7 +56,7 @@ void SDRWallFuncAlgDriver::post_work()
   // Parallel synchronization
   const std::vector<NGPDoubleFieldType*> fields {&bcsdr, &wallArea};
   const bool doFinalSyncToDevice = true;
-  ngp::parallel_sum(realm_.bulk_data(), fields, doFinalSyncToDevice);
+  stk::mesh::parallel_sum(realm_.bulk_data(), fields, doFinalSyncToDevice);
 
   auto* bcsdrF = realm_.meta_data().get_field(
     stk::topology::NODE_RANK, "wall_model_sdr_bc");

--- a/src/ngp_algorithms/SSTMaxLengthScaleAlg.C
+++ b/src/ngp_algorithms/SSTMaxLengthScaleAlg.C
@@ -15,10 +15,12 @@
 #include "ngp_algorithms/ViewHelper.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 
 namespace sierra {
@@ -38,7 +40,7 @@ SSTMaxLengthScaleAlg<AlgTraits>::SSTMaxLengthScaleAlg(
 template <typename AlgTraits>
 void SSTMaxLengthScaleAlg<AlgTraits>::execute()
 {
-  using ElemInfoType = nalu_ngp::EntityInfo<ngp::Mesh>;
+  using ElemInfoType = nalu_ngp::EntityInfo<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();

--- a/src/ngp_algorithms/SSTMaxLengthScaleDriver.C
+++ b/src/ngp_algorithms/SSTMaxLengthScaleDriver.C
@@ -17,7 +17,7 @@
 #include "stk_mesh/base/FieldParallel.hpp"
 #include "stk_mesh/base/MetaData.hpp"
 #include "stk_mesh/base/FieldBLAS.hpp"
-#include "stk_ngp/NgpFieldParallel.hpp"
+#include "stk_mesh/base/NgpFieldParallel.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/ngp_algorithms/SSTTAMSAveragesAlg.C
+++ b/src/ngp_algorithms/SSTTAMSAveragesAlg.C
@@ -11,10 +11,12 @@
 #include "ngp_algorithms/SSTTAMSAveragesAlg.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 #include "EigenDecomposition.h"
 #include "utils/TAMSUtils.h"
 
@@ -51,7 +53,7 @@ SSTTAMSAveragesAlg::SSTTAMSAveragesAlg(Realm& realm, stk::mesh::Part* part)
 void
 SSTTAMSAveragesAlg::execute()
 {
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
   const DblType dt = realm_.get_time_step();

--- a/src/ngp_algorithms/TAMSAvgMdotEdgeAlg.C
+++ b/src/ngp_algorithms/TAMSAvgMdotEdgeAlg.C
@@ -11,8 +11,10 @@
 #include "ngp_algorithms/TAMSAvgMdotEdgeAlg.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -37,7 +39,7 @@ TAMSAvgMdotEdgeAlg::execute()
   const auto& meta = realm_.meta_data();
   const int ndim = meta.spatial_dimension();
 
-  using EntityInfoType = nalu_ngp::EntityInfo<ngp::Mesh>;
+  using EntityInfoType = nalu_ngp::EntityInfo<stk::mesh::NgpMesh>;
   const auto& ngpMesh = realm_.ngp_mesh();
   const auto& fieldMgr = realm_.ngp_field_manager();
 

--- a/src/ngp_algorithms/TAMSAvgMdotElemAlg.C
+++ b/src/ngp_algorithms/TAMSAvgMdotElemAlg.C
@@ -16,10 +16,12 @@
 #include "ngp_algorithms/ViewHelper.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -57,7 +59,7 @@ template <typename AlgTraits>
 void
 TAMSAvgMdotElemAlg<AlgTraits>::execute()
 {
-  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdDataType = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meshInfo = realm_.mesh_info();
   const auto& meta = meshInfo.meta();

--- a/src/ngp_algorithms/TKEWallFuncAlg.C
+++ b/src/ngp_algorithms/TKEWallFuncAlg.C
@@ -14,6 +14,7 @@
 #include "master_element/MasterElementFactory.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "ScratchViews.h"
 #include "SolutionOptions.h"
@@ -21,6 +22,7 @@
 
 #include "stk_mesh/base/Field.hpp"
 #include "stk_mesh/base/FieldParallel.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -54,7 +56,7 @@ TKEWallFuncAlg<BcAlgTraits>::TKEWallFuncAlg(Realm& realm, stk::mesh::Part* part)
 template<typename BcAlgTraits>
 void TKEWallFuncAlg<BcAlgTraits>::execute()
 {
-  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
   const auto& meshInfo = realm_.mesh_info();
   const auto ngpMesh = meshInfo.ngp_mesh();
   const auto& fieldMgr = meshInfo.ngp_field_manager();

--- a/src/ngp_algorithms/TKEWallFuncAlgDriver.C
+++ b/src/ngp_algorithms/TKEWallFuncAlgDriver.C
@@ -10,6 +10,7 @@
 
 #include "ngp_algorithms/TKEWallFuncAlgDriver.h"
 #include "ngp_utils/NgpLoopUtils.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
 
@@ -17,6 +18,7 @@
 #include "stk_mesh/base/FieldParallel.hpp"
 #include "stk_mesh/base/FieldBLAS.hpp"
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -45,7 +47,7 @@ void TKEWallFuncAlgDriver::pre_work()
 
 void TKEWallFuncAlgDriver::post_work()
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
   const auto& ngpMesh = realm_.ngp_mesh();
   const auto& fieldMgr = realm_.ngp_field_manager();
   auto ngpBcNodalTke = fieldMgr.get_field<double>(bcNodalTke_);

--- a/src/ngp_algorithms/TurbViscKsgsAlg.C
+++ b/src/ngp_algorithms/TurbViscKsgsAlg.C
@@ -11,10 +11,12 @@
 #include "ngp_algorithms/TurbViscKsgsAlg.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -35,7 +37,7 @@ TurbViscKsgsAlg::TurbViscKsgsAlg(
 void
 TurbViscKsgsAlg::execute()
 {
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
 

--- a/src/ngp_algorithms/TurbViscSSTAlg.C
+++ b/src/ngp_algorithms/TurbViscSSTAlg.C
@@ -11,10 +11,12 @@
 #include "ngp_algorithms/TurbViscSSTAlg.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpTypes.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra{
 namespace nalu{
@@ -40,7 +42,7 @@ TurbViscSSTAlg::TurbViscSSTAlg(
 void
 TurbViscSSTAlg::execute()
 {
-  using Traits = nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
 

--- a/src/ngp_algorithms/WallFuncGeometryAlg.C
+++ b/src/ngp_algorithms/WallFuncGeometryAlg.C
@@ -14,8 +14,10 @@
 #include "master_element/MasterElementFactory.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldOps.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -57,7 +59,7 @@ WallFuncGeometryAlg<BcAlgTraits>::WallFuncGeometryAlg(
 template<typename BcAlgTraits>
 void WallFuncGeometryAlg<BcAlgTraits>::execute()
 {
-  using SimdDataType = nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+  using SimdDataType = nalu_ngp::FaceElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meta = realm_.meta_data();
 

--- a/src/node_kernels/ContinuityGclNodeKernel.C
+++ b/src/node_kernels/ContinuityGclNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 namespace sierra{

--- a/src/node_kernels/ContinuityMassBDFNodeKernel.C
+++ b/src/node_kernels/ContinuityMassBDFNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 namespace sierra{

--- a/src/node_kernels/EnthalpyABLForceNodeKernel.C
+++ b/src/node_kernels/EnthalpyABLForceNodeKernel.C
@@ -15,6 +15,7 @@
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/node_kernels/MomentumABLForceNodeKernel.C
+++ b/src/node_kernels/MomentumABLForceNodeKernel.C
@@ -15,6 +15,7 @@
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/node_kernels/MomentumActuatorNodeKernel.C
+++ b/src/node_kernels/MomentumActuatorNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 #include "SolutionOptions.h"

--- a/src/node_kernels/MomentumBodyForceNodeKernel.C
+++ b/src/node_kernels/MomentumBodyForceNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 namespace sierra {

--- a/src/node_kernels/MomentumBoussinesqNodeKernel.C
+++ b/src/node_kernels/MomentumBoussinesqNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 #include "SolutionOptions.h"

--- a/src/node_kernels/MomentumCoriolisNodeKernel.C
+++ b/src/node_kernels/MomentumCoriolisNodeKernel.C
@@ -11,6 +11,7 @@
 #include "node_kernels/MomentumCoriolisNodeKernel.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/node_kernels/MomentumGclNodeKernel.C
+++ b/src/node_kernels/MomentumGclNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 namespace sierra{

--- a/src/node_kernels/MomentumMassBDFNodeKernel.C
+++ b/src/node_kernels/MomentumMassBDFNodeKernel.C
@@ -13,6 +13,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 namespace sierra{

--- a/src/node_kernels/MomentumSSTTAMSForcingNodeKernel.C
+++ b/src/node_kernels/MomentumSSTTAMSForcingNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 #include "SolutionOptions.h"
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 #include <SimdInterface.h>
 

--- a/src/node_kernels/SDRSSTDESNodeKernel.C
+++ b/src/node_kernels/SDRSSTDESNodeKernel.C
@@ -15,6 +15,7 @@
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/node_kernels/SDRSSTNodeKernel.C
+++ b/src/node_kernels/SDRSSTNodeKernel.C
@@ -15,6 +15,7 @@
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/node_kernels/SDRSSTTAMSNodeKernel.C
+++ b/src/node_kernels/SDRSSTTAMSNodeKernel.C
@@ -13,6 +13,7 @@
 #include "SolutionOptions.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 #include <SimdInterface.h>
 

--- a/src/node_kernels/ScalarGclNodeKernel.C
+++ b/src/node_kernels/ScalarGclNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 namespace sierra{

--- a/src/node_kernels/ScalarMassBDFNodeKernel.C
+++ b/src/node_kernels/ScalarMassBDFNodeKernel.C
@@ -12,6 +12,7 @@
 #include "Realm.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 
 namespace sierra{

--- a/src/node_kernels/TKEKsgsNodeKernel.C
+++ b/src/node_kernels/TKEKsgsNodeKernel.C
@@ -15,6 +15,7 @@
 #include "SimdInterface.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/node_kernels/TKERodiNodeKernel.C
+++ b/src/node_kernels/TKERodiNodeKernel.C
@@ -18,6 +18,7 @@
 #include <stk_mesh/base/MetaData.hpp>
 #include "utils/StkHelpers.h"
 #include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/Types.hpp>
 
 namespace sierra{
 namespace nalu{

--- a/src/node_kernels/TKESSTDESNodeKernel.C
+++ b/src/node_kernels/TKESSTDESNodeKernel.C
@@ -15,6 +15,7 @@
 #include "SimdInterface.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/node_kernels/TKESSTNodeKernel.C
+++ b/src/node_kernels/TKESSTNodeKernel.C
@@ -15,6 +15,7 @@
 #include "utils/StkHelpers.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/node_kernels/TKESSTTAMSNodeKernel.C
+++ b/src/node_kernels/TKESSTTAMSNodeKernel.C
@@ -13,6 +13,7 @@
 #include "SolutionOptions.h"
 
 #include "stk_mesh/base/MetaData.hpp"
+#include "stk_mesh/base/Types.hpp"
 #include "utils/StkHelpers.h"
 #include <SimdInterface.h>
 

--- a/src/node_kernels/WallDistNodeKernel.C
+++ b/src/node_kernels/WallDistNodeKernel.C
@@ -11,6 +11,7 @@
 #include "node_kernels/WallDistNodeKernel.h"
 #include "Realm.h"
 #include "utils/StkHelpers.h"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/wind_energy/BdyLayerStatistics.C
+++ b/src/wind_energy/BdyLayerStatistics.C
@@ -12,6 +12,7 @@
 #include "wind_energy/BdyHeightAlgorithm.h"
 #include "ngp_utils/NgpLoopUtils.h"
 #include "ngp_utils/NgpFieldUtils.h"
+#include "ngp_utils/NgpFieldManager.h"
 #include "NaluParsing.h"
 #include "Realm.h"
 #include "TurbulenceAveragingPostProcessing.h"
@@ -23,6 +24,7 @@
 #include "stk_mesh/base/BulkData.hpp"
 #include "stk_mesh/base/Field.hpp"
 #include "stk_util/parallel/ParallelReduce.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 #include "netcdf.h"
 
@@ -342,7 +344,7 @@ BdyLayerStatistics::interpolate_variable(
 void
 BdyLayerStatistics::impl_compute_velocity_stats()
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
   const auto& meshInfo = realm_.mesh_info();
   const auto& ngpMesh = realm_.ngp_mesh();
   const auto density = nalu_ngp::get_ngp_field(meshInfo, "density");
@@ -480,7 +482,7 @@ BdyLayerStatistics::impl_compute_velocity_stats()
 void
 BdyLayerStatistics::impl_compute_temperature_stats()
 {
-  using MeshIndex = nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
   const auto& meshInfo = realm_.mesh_info();
   const auto& ngpMesh = realm_.ngp_mesh();
 

--- a/unit_tests/UnitTestElemDataRequests.C
+++ b/unit_tests/UnitTestElemDataRequests.C
@@ -19,7 +19,7 @@ void do_the_test_gpu(const sierra::nalu::ElemDataRequests& dataReq,
                      stk::mesh::BulkData& bulk)
 {
   unsigned totalNumFields_guess = 10;
-  ngp::FieldManager fieldMgr(bulk);
+  sierra::nalu::nalu_ngp::FieldManager fieldMgr(bulk);
   sierra::nalu::ElemDataRequestsGPU ngpDataReq(fieldMgr, dataReq, totalNumFields_guess);
 
   unsigned numCorrectTests = 0;

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -9,6 +9,7 @@
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
 
 #include <master_element/MasterElementFactory.h>
 #include <stk_util/parallel/Parallel.hpp>
@@ -16,6 +17,7 @@
 
 #include <ElemDataRequests.h>
 #include <ScratchViews.h>
+#include <ngp_utils/NgpFieldManager.h>
 
 #include "UnitTestKokkosUtils.h"
 
@@ -40,7 +42,7 @@ void element_discrete_laplacian_kernel_3d(
       elemData.get_me_views(sierra::nalu::CURRENT_COORDINATES).scs_areav;
     sierra::nalu::SharedMemView<double***>& dndx =
       elemData.get_me_views(sierra::nalu::CURRENT_COORDINATES).dndx;
-    ngp::Mesh::ConnectedNodes elemNodes = elemData.elemNodes;
+    stk::mesh::NgpMesh::ConnectedNodes elemNodes = elemData.elemNodes;
 
     for (int ip = 0; ip < numScsIp; ++ip ) {
 
@@ -128,8 +130,8 @@ public:
   
       const stk::mesh::BucketVector& elemBuckets = bulkData_.get_buckets(stk::topology::ELEM_RANK, meta.locally_owned_part());
   
-      ngp::Mesh ngpMesh(bulkData_);
-      ngp::FieldManager fieldMgr(bulkData_);
+      stk::mesh::NgpMesh ngpMesh(bulkData_);
+      sierra::nalu::nalu_ngp::FieldManager fieldMgr(bulkData_);
 
       sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeededByKernels_, meta.get_fields().size());
       const int bytes_per_team = 0;

--- a/unit_tests/UnitTestLinearSystem.h
+++ b/unit_tests/UnitTestLinearSystem.h
@@ -14,6 +14,7 @@
 #include "LinearSystem.h"
 #include "EquationSystem.h"
 #include "utils/CreateDeviceExpression.h"
+#include "stk_mesh/base/NgpMesh.hpp"
 
 namespace unit_test_utils {
 
@@ -37,7 +38,7 @@ template<typename LHSView, typename RHSView>
 KOKKOS_FUNCTION
 void edgeSumInto(
     unsigned numEntities,
-    const ngp::Mesh::ConnectedNodes&  entities,
+    const stk::mesh::NgpMesh::ConnectedNodes&  entities,
     const sierra::nalu::SharedMemView<const double*,sierra::nalu::DeviceShmem> & rhs,
     const sierra::nalu::SharedMemView<const double**,sierra::nalu::DeviceShmem> & lhs,
     unsigned numDof,
@@ -98,7 +99,7 @@ void resetRows(unsigned /*numNodes*/,
 
   KOKKOS_FUNCTION
   void operator()(unsigned numEntities,
-                  const ngp::Mesh::ConnectedNodes& entities,
+                  const stk::mesh::NgpMesh::ConnectedNodes& entities,
                   const sierra::nalu::SharedMemView<int*, sierra::nalu::DeviceShmem> & /*localIds*/,
                   const sierra::nalu::SharedMemView<int*, sierra::nalu::DeviceShmem> & /*sortPermutation*/,
                   const sierra::nalu::SharedMemView<const double*, sierra::nalu::DeviceShmem> & rhs,
@@ -210,7 +211,7 @@ public:
 
   virtual void sumInto(
     unsigned  numEntities,
-    const ngp::Mesh::ConnectedNodes&  entities,
+    const stk::mesh::NgpMesh::ConnectedNodes&  entities,
     const sierra::nalu::SharedMemView<const double*,sierra::nalu::DeviceShmem> & rhs,
     const sierra::nalu::SharedMemView<const double**,sierra::nalu::DeviceShmem> & lhs,
     const sierra::nalu::SharedMemView<int*,sierra::nalu::DeviceShmem> &  /* localIds */,
@@ -314,7 +315,7 @@ public:
   using TestLinearSystem::sumInto;
   virtual void sumInto(
     unsigned numEntities,
-    const ngp::Mesh::ConnectedNodes&  entities,
+    const stk::mesh::NgpMesh::ConnectedNodes&  entities,
     const sierra::nalu::SharedMemView<const double*,sierra::nalu::DeviceShmem> & rhs,
     const sierra::nalu::SharedMemView<const double**,sierra::nalu::DeviceShmem> & lhs,
     const sierra::nalu::SharedMemView<int*,sierra::nalu::DeviceShmem> &  /* localIds */,

--- a/unit_tests/UnitTestNgpMesh1.C
+++ b/unit_tests/UnitTestNgpMesh1.C
@@ -3,6 +3,8 @@
 #include "stk_util/environment/WallTime.hpp"
 #include "stk_mesh/base/BulkData.hpp"
 #include "stk_mesh/base/GetEntities.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
+#include "stk_mesh/base/NgpField.hpp"
 
 #include "UnitTestUtils.h"
 #include "UnitTestRealm.h"
@@ -10,9 +12,10 @@
 #include "SimdInterface.h"
 #include "ElemDataRequests.h"
 
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/Types.hpp"
 
-void test_ngp_mesh_1(const stk::mesh::BulkData& bulk, const ngp::Mesh& ngpMesh)
+void test_ngp_mesh_1(const stk::mesh::BulkData& bulk, const stk::mesh::NgpMesh& ngpMesh)
 {
   stk::topology elemTopo = stk::topology::HEX_8;
 
@@ -36,7 +39,7 @@ void test_ngp_mesh_1(const stk::mesh::BulkData& bulk, const ngp::Mesh& ngpMesh)
 
   Kokkos::parallel_for(team_exec, KOKKOS_LAMBDA(const sierra::nalu::DeviceTeamHandleType& team)
   {
-    const ngp::Mesh::BucketType& b = ngpMesh.get_bucket(stk::topology::ELEM_RANK, team.league_rank());
+    const stk::mesh::NgpMesh::BucketType& b = ngpMesh.get_bucket(stk::topology::ELEM_RANK, team.league_rank());
     ++ngpResults(0);
 
     const size_t bucketLen   = b.size();
@@ -81,9 +84,9 @@ void test_ngp_mesh_field_values(const stk::mesh::BulkData& bulk,
   stk::mesh::Selector all_local = meta.universal_part() & meta.locally_owned_part();
   const stk::mesh::BucketVector& elemBuckets = bulk.get_buckets(stk::topology::ELEM_RANK, all_local);
 
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpVelocity(bulk, *velocity);
-  ngp::Field<double> ngpMassFlowRate(bulk, *massFlowRate);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpVelocity(bulk, *velocity);
+  stk::mesh::NgpField<double> ngpMassFlowRate(bulk, *massFlowRate);
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = 0;
@@ -96,7 +99,7 @@ void test_ngp_mesh_field_values(const stk::mesh::BulkData& bulk,
 
   Kokkos::parallel_for(team_exec, KOKKOS_LAMBDA(const sierra::nalu::DeviceTeamHandleType& team)
   {
-    const ngp::Mesh::BucketType& b = ngpMesh.get_bucket(stk::topology::ELEM_RANK, team.league_rank());
+    const stk::mesh::NgpMesh::BucketType& b = ngpMesh.get_bucket(stk::topology::ELEM_RANK, team.league_rank());
 
     const size_t bucketLen   = b.size();
     const size_t simdBucketLen = sierra::nalu::get_num_simd_groups(bucketLen);
@@ -110,7 +113,7 @@ void test_ngp_mesh_field_values(const stk::mesh::BulkData& bulk,
         stk::mesh::FastMeshIndex elemIndex = ngpMesh.fast_mesh_index(element);
         ngpMassFlowRate.get(elemIndex, 0) = flowRate;
 
-        ngp::Mesh::ConnectedNodes nodes = ngpMesh.get_nodes(stk::topology::ELEM_RANK, elemIndex);
+        stk::mesh::NgpMesh::ConnectedNodes nodes = ngpMesh.get_nodes(stk::topology::ELEM_RANK, elemIndex);
         for (unsigned n = 0; n < nodes.size(); ++n)
         {
           ngpVelocity.get(ngpMesh, nodes[n], 0) = xVel;

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -7,8 +7,8 @@
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
-#include <stk_ngp/NgpMesh.hpp>
-#include <stk_ngp/NgpFieldManager.hpp>
+#include <stk_mesh/base/NgpMesh.hpp>
+#include <ngp_utils/NgpFieldManager.h>
 
 #include <stk_util/parallel/Parallel.hpp>
 #include <Kokkos_Core.hpp>
@@ -121,8 +121,8 @@ public:
       //a topology would be available.
       dataNeededByKernels_.add_cvfem_surface_me(sierra::nalu::MasterElementRepo::get_surface_master_element(stk::topology::HEX_8));
 
-      ngp::Mesh ngpMesh(bulkData_);
-      ngp::FieldManager fieldMgr(bulkData_);
+      stk::mesh::NgpMesh ngpMesh(bulkData_);
+      sierra::nalu::nalu_ngp::FieldManager fieldMgr(bulkData_);
 
       sierra::nalu::ElemDataRequestsGPU dataNeededNGP(fieldMgr, dataNeededByKernels_, meta.get_fields().size());
       const int bytes_per_team = 0;

--- a/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
@@ -15,6 +15,7 @@
 #include "UnitTestTpetraHelperObjects.h"
 #include "FixPressureAtNodeInfo.h"
 #include "FixPressureAtNodeAlgorithm.h"
+#include "stk_mesh/base/NgpField.hpp"
 
 #include "edge_kernels/ScalarEdgeSolverAlg.h"
 
@@ -123,7 +124,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
     }
   }
 
-  //copy_stk_to_tpetra is not converted to ngp::Field yet, but this test still
+  //copy_stk_to_tpetra is not converted to stk::mesh::NgpField yet, but this test still
   //works due to tpetra using UVM space.
   helperObjs.linsys->copy_stk_to_tpetra(viscosity_, helperObjs.linsys->getOwnedRhs());
   helperObjs.linsys->copy_tpetra_to_stk(helperObjs.linsys->getOwnedRhs(), mixFraction_);

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -547,12 +547,32 @@ public:
     const double bcVel[3] = {0.0, 0.0, 0.0};
     MomentumKernelHex8Mesh::fill_mesh_and_init_fields(doPerturb, generateSidesets);
     stk::mesh::field_fill_component(vel, *velocity_);
+    velocity_->modify_on_host();
+    velocity_->sync_to_device();
+
     stk::mesh::field_fill_component(bcVel, *wallVelocityBC_);
+    wallVelocityBC_->modify_on_host();
+    wallVelocityBC_->sync_to_device();
+
     stk::mesh::field_fill(0.0, *bcHeatFlux_);
+    bcHeatFlux_->modify_on_host();
+    bcHeatFlux_->sync_to_device();
+
     stk::mesh::field_fill(1000.0, *specificHeat_);
+    specificHeat_->modify_on_host();
+    specificHeat_->sync_to_device();
+
     stk::mesh::field_fill(ustar_, *wallFricVel_);
+    wallFricVel_->modify_on_host();
+    wallFricVel_->sync_to_device();
+
     stk::mesh::field_fill(zh_, *wallNormDist_);
+    wallNormDist_->modify_on_host();
+    wallNormDist_->sync_to_device();
+
     stk::mesh::field_fill(-0.003, *tGradBC_);
+    tGradBC_->modify_on_host();
+    tGradBC_->sync_to_device();
   }
 
   VectorFieldType* wallVelocityBC_{nullptr};

--- a/unit_tests/ngp_algorithms/UnitTestCFLReAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestCFLReAlg.C
@@ -40,8 +40,16 @@ TEST_F(MomentumKernelHex8Mesh, NGP_courant_reynolds)
   const double cfl = velVal * dt;
 
   stk::mesh::field_fill(velVal, *velocity_);
+  velocity_->modify_on_host();
+  velocity_->sync_to_device();
+
   stk::mesh::field_fill(rhoVal, *density_);
+  density_->modify_on_host();
+  density_->sync_to_device();
+
   stk::mesh::field_fill(viscVal, *viscosity_);
+  viscosity_->modify_on_host();
+  viscosity_->sync_to_device();
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.timeStepN_ = dt;

--- a/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
@@ -37,10 +37,24 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_calc_edge)
   helperObjs.realm.interiorPartVec_.push_back(partVec_[0]);
 
   stk::mesh::field_fill(1.0, *density_);
+  density_->modify_on_host();
+  density_->sync_to_device();
+
   stk::mesh::field_fill(10.0, *velocity_);
+  velocity_->modify_on_host();
+  velocity_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *pressure_);
+  pressure_->modify_on_host();
+  pressure_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *dpdx_);
+  dpdx_->modify_on_host();
+  dpdx_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *massFlowRateEdge_);
+  massFlowRateEdge_->modify_on_host();
+  massFlowRateEdge_->sync_to_device();
 
   sierra::nalu::MdotEdgeAlg mdotAlg(helperObjs.realm, partVec_[0]);
   mdotAlg.execute();
@@ -81,7 +95,12 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_rho_accum)
   timeIntegrator.gamma3_ = 0.0;
 
   stk::mesh::field_fill(2.0, *density_);
+  density_->modify_on_host();
+  density_->sync_to_device();
+
   stk::mesh::field_fill(1.0, density_->field_of_state(stk::mesh::StateN));
+  density_->field_of_state(stk::mesh::StateN).modify_on_host();
+  density_->field_of_state(stk::mesh::StateN).sync_to_device();
 
   unit_test_utils::HelperObjects helperObjs(
     bulk_, stk::topology::HEX_8, 1, partVec_[0]);
@@ -154,7 +173,12 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_inflow)
   fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
   stk::mesh::field_fill(1.0, *density_);
+  density_->modify_on_host();
+  density_->sync_to_device();
+
   stk::mesh::field_fill(1.0, *velocity_);
+  velocity_->modify_on_host();
+  velocity_->sync_to_device();
 
   unit_test_utils::HelperObjects helperObjs(
     bulk_, stk::topology::HEX_8, 1, partVec_[0]);
@@ -181,9 +205,21 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_edge)
   fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
   stk::mesh::field_fill(1.0, *density_);
+  density_->modify_on_host();
+  density_->sync_to_device();
+
   stk::mesh::field_fill(1.0, *velocity_);
+  velocity_->modify_on_host();
+  velocity_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *pressure_);
+  pressure_->modify_on_host();
+  pressure_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *dpdx_);
+  dpdx_->modify_on_host();
+  dpdx_->sync_to_device();
+
 
   unit_test_utils::HelperObjects helperObjs(
     bulk_, stk::topology::HEX_8, 1, partVec_[0]);

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradAlg.C
@@ -85,7 +85,11 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_edge_vec)
     bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
+  velocity_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *dudx_);
+  dudx_->modify_on_host();
+  dudx_->sync_to_device();
 
   // Reference values from original AssembleNodalGradEdge
   // sierra::nalu::AssembleNodalGradUEdgeAlgorithm edgeAlg(
@@ -237,7 +241,11 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_vec)
     bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
+  velocity_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *dudx_);
+  dudx_->modify_on_host();
+  dudx_->sync_to_device();
 
   // Reference values from original AssembleNodalGradEdge
   // sierra::nalu::AssembleNodalGradUElemAlgorithm elemAlg(
@@ -288,7 +296,11 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_shifted_vec)
     bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
+  velocity_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *dudx_);
+  dudx_->modify_on_host();
+  dudx_->sync_to_device();
 
   // Reference values from original AssembleNodalGradEdge
   // sierra::nalu::AssembleNodalGradUEdgeAlgorithm edgeAlg(
@@ -442,7 +454,11 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_bndry_elem_vec)
     bulk_, stk::topology::QUAD_4, 1, part);
   unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
+  velocity_->sync_to_device();
+
   stk::mesh::field_fill(0.0, *dudx_);
+  dudx_->modify_on_host();
+  dudx_->sync_to_device();
 
   // Reference values from original
   // sierra::nalu::AssembleNodalGradUBoundaryAlgorithm elemAlg(

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
@@ -18,6 +18,7 @@
 #include "ngp_algorithms/GeometryBoundaryAlg.h"
 #include "ngp_algorithms/NodalGradAlgDriver.h"
 #include "ngp_algorithms/GeometryAlgDriver.h"
+#include "stk_mesh/base/NgpField.hpp"
 
 TEST_F(LowMachKernelHex8Mesh, NGP_nodal_grad_popen)
 {
@@ -66,7 +67,7 @@ TEST_F(LowMachKernelHex8Mesh, NGP_nodal_grad_popen)
       sierra::nalu::OPEN, surface1, stk::topology::HEX_8, "nodal_grad_pressure_open_boundary", useShifted);
     algDriver.execute();
 
-    ngp::Field<double> ngpdpdx(bulk_, *dpdx_);
+    stk::mesh::NgpField<double> ngpdpdx(bulk_, *dpdx_);
     ngpdpdx.modify_on_device();
     ngpdpdx.sync_to_host();
     

--- a/unit_tests/ngp_kernels/UnitTestNgpKernel.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpKernel.C
@@ -16,7 +16,7 @@
 
 #include "AlgTraits.h"
 
-#include "stk_ngp/Ngp.hpp"
+#include "stk_mesh/base/Ngp.hpp"
 
 #include <memory>
 

--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -16,6 +16,9 @@
 #include "ngp_utils/NgpFieldOps.h"
 #include "ngp_utils/NgpReduceUtils.h"
 #include "ngp_utils/NgpReducers.h"
+#include "ngp_utils/NgpFieldManager.h"
+#include "stk_mesh/base/NgpMesh.hpp"
+#include "stk_mesh/base/NgpField.hpp"
 
 #include <cmath>
 
@@ -76,13 +79,13 @@ void basic_node_loop(
   const stk::mesh::BulkData& bulk,
   ScalarFieldType& pressure)
 {
-  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
   const double presSet = 4.0;
 
   const auto& meta = bulk.mesh_meta_data();
   stk::mesh::Selector sel = meta.universal_part();
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpPressure(bulk, pressure);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpPressure(bulk, pressure);
 
   sierra::nalu::nalu_ngp::run_entity_algorithm(
     "unittest_basic_node_loop",
@@ -111,14 +114,14 @@ void basic_node_reduce(
   const stk::mesh::BulkData& bulk,
   ScalarFieldType& pressure)
 {
-  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
   const double presSet = 4.0;
 
   stk::mesh::field_fill(presSet, pressure);
   const auto& meta = bulk.mesh_meta_data();
   stk::mesh::Selector sel = meta.universal_part();
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpPressure(bulk, pressure);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpPressure(bulk, pressure);
 
 
   double reduceVal = 0.0;
@@ -158,13 +161,13 @@ void basic_node_reduce_minmax(
   const double minGold,
   const double maxGold)
 {
-  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   const auto& meta = bulk.mesh_meta_data();
   const auto& coords =  meta.coordinate_field();
   stk::mesh::Selector sel = meta.universal_part();
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpCoords(bulk, *coords);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpCoords(bulk, *coords);
 
   using value_type = Kokkos::Max<double>::value_type;
   value_type max;
@@ -197,13 +200,13 @@ void basic_node_reduce_minmax_alt(
   const double minGold,
   const double maxGold)
 {
-  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
 
   const auto& meta = bulk.mesh_meta_data();
   const auto& coords =  meta.coordinate_field();
   stk::mesh::Selector sel = meta.universal_part();
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpCoords(bulk, *coords);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpCoords(bulk, *coords);
 
   using value_type = Kokkos::MinMax<double>::value_type;
   value_type minmax;
@@ -227,15 +230,15 @@ void basic_node_reduce_minmaxsum(
   const double maxGold,
   const double sumGold)
 {
-  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
   using MinMaxSum = sierra::nalu::nalu_ngp::MinMaxSum<double>;
   using value_type = typename MinMaxSum::value_type;
 
   const auto& meta = bulk.mesh_meta_data();
   const auto& coords =  meta.coordinate_field();
   stk::mesh::Selector sel = meta.universal_part();
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpCoords(bulk, *coords);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpCoords(bulk, *coords);
 
   value_type minmaxsum;
   MinMaxSum reducer(minmaxsum);
@@ -258,14 +261,14 @@ void
 basic_node_reduce_array(
   const stk::mesh::BulkData& bulk, ScalarFieldType& pressure, int num_nodes)
 {
-  using MeshIndex = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
   const double presSet = 4.0;
 
   stk::mesh::field_fill(presSet, pressure);
   const auto& meta = bulk.mesh_meta_data();
   stk::mesh::Selector sel = meta.universal_part();
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpPressure(bulk, pressure);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpPressure(bulk, pressure);
 
   using value_type = Kokkos::Sum<sierra::nalu::nalu_ngp::ArrayDbl2>::value_type;
   value_type lsum;
@@ -292,9 +295,9 @@ void basic_elem_loop(
   const double flowRate = 4.0;
   const double presSet = 10.0;
 
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpMassFlowRate(bulk, massFlowRate);
-  ngp::Field<double> ngpPressure(bulk, pressure);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpMassFlowRate(bulk, massFlowRate);
+  stk::mesh::NgpField<double> ngpPressure(bulk, pressure);
 
   const auto& meta = bulk.mesh_meta_data();
   stk::mesh::Selector sel = meta.universal_part();
@@ -302,7 +305,7 @@ void basic_elem_loop(
   sierra::nalu::nalu_ngp::run_elem_algorithm(
     "unittest_basic_elem_loop",
     ngpMesh, stk::topology::ELEMENT_RANK, sel,
-    KOKKOS_LAMBDA(const sierra::nalu::nalu_ngp::EntityInfo<ngp::Mesh>& einfo) {
+    KOKKOS_LAMBDA(const sierra::nalu::nalu_ngp::EntityInfo<stk::mesh::NgpMesh>& einfo) {
       ngpMassFlowRate.get(einfo.meshIdx, 0) = flowRate;
 
       const auto& nodes = einfo.entityNodes;
@@ -347,9 +350,9 @@ void basic_edge_loop(
   const double flowRate = 4.0;
   const double presSet = 10.0;
 
-  ngp::Mesh ngpMesh(bulk);
-  ngp::Field<double> ngpMassFlowRate(bulk, mdotEdge);
-  ngp::Field<double> ngpPressure(bulk, pressure);
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double> ngpMassFlowRate(bulk, mdotEdge);
+  stk::mesh::NgpField<double> ngpPressure(bulk, pressure);
 
   const auto& meta = bulk.mesh_meta_data();
   stk::mesh::Selector sel = meta.universal_part();
@@ -357,7 +360,7 @@ void basic_edge_loop(
   sierra::nalu::nalu_ngp::run_edge_algorithm(
     "unittest_basic_edge_loop",
     ngpMesh, sel,
-    KOKKOS_LAMBDA(const sierra::nalu::nalu_ngp::EntityInfo<ngp::Mesh>& einfo) {
+    KOKKOS_LAMBDA(const sierra::nalu::nalu_ngp::EntityInfo<stk::mesh::NgpMesh>& einfo) {
       ngpMassFlowRate.get(einfo.meshIdx, 0) = flowRate;
 
       const auto& nodes = einfo.entityNodes;
@@ -393,9 +396,9 @@ void elem_loop_scratch_views(
   ScalarFieldType& pressure,
   VectorFieldType& velocity)
 {
-  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
   using Hex8Traits = sierra::nalu::AlgTraitsHex8;
-  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
   typedef Kokkos::DualView<double*, Kokkos::LayoutRight, sierra::nalu::DeviceSpace> DoubleTypeView;
 
   const auto& meta = bulk.mesh_meta_data();
@@ -496,9 +499,9 @@ void calc_mdot_elem_loop(
   VectorFieldType& velocity,
   GenericFieldType& massFlowRate)
 {
-  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>;
+  using Traits = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>;
   using Hex8Traits = sierra::nalu::AlgTraitsHex8;
-  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
 
   const auto& meta = bulk.mesh_meta_data();
   sierra::nalu::ElemDataRequests dataReq(meta);
@@ -522,7 +525,7 @@ void calc_mdot_elem_loop(
   const auto mdotID = massFlowRate.mesh_meta_data_ordinal();
   const auto ngpMesh = meshInfo.ngp_mesh();
   const auto& fieldMgr = meshInfo.ngp_field_manager();
-  ngp::Field<double> ngpMdot = fieldMgr.get_field<double>(mdotID);
+  stk::mesh::NgpField<double> ngpMdot = fieldMgr.get_field<double>(mdotID);
   // SIMD Element field operation handler
   const auto mdotOps = sierra::nalu::nalu_ngp::simd_elem_field_updater(
     ngpMesh, ngpMdot);
@@ -583,9 +586,9 @@ void basic_face_elem_loop(
   ScalarFieldType& wallArea,
   ScalarFieldType& wallNormDist)
 {
-  using MeshIndex = sierra::nalu::nalu_ngp::NGPMeshTraits<ngp::Mesh>::MeshIndex;
+  using MeshIndex = sierra::nalu::nalu_ngp::NGPMeshTraits<stk::mesh::NgpMesh>::MeshIndex;
   using FaceTraits = sierra::nalu::AlgTraitsQuad4Hex8;
-  using FaceSimdData = sierra::nalu::nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+  using FaceSimdData = sierra::nalu::nalu_ngp::FaceElemSimdData<stk::mesh::NgpMesh>;
   const auto& meta = bulk.mesh_meta_data();
   const int ndim = meta.spatial_dimension();
 
@@ -693,7 +696,7 @@ void elem_loop_par_reduce(
   ScalarFieldType& pressure)
 {
   using Hex8Traits = sierra::nalu::AlgTraitsHex8;
-  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<ngp::Mesh>;
+  using ElemSimdData = sierra::nalu::nalu_ngp::ElemSimdData<stk::mesh::NgpMesh>;
   const double presSet = 4.0;
 
   stk::mesh::field_fill(presSet, pressure);
@@ -751,7 +754,7 @@ void basic_face_elem_reduce(
   const GenericFieldType& exposedArea)
 {
   using FaceTraits = sierra::nalu::AlgTraitsQuad4Hex8;
-  using FaceSimdData = sierra::nalu::nalu_ngp::FaceElemSimdData<ngp::Mesh>;
+  using FaceSimdData = sierra::nalu::nalu_ngp::FaceElemSimdData<stk::mesh::NgpMesh>;
   const auto& meta = bulk.mesh_meta_data();
   const int ndim = meta.spatial_dimension();
 

--- a/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
@@ -23,7 +23,12 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_coriolis)
 
   // simplify ICs
   stk::mesh::field_fill(1.0, *velocity_);
+  velocity_->modify_on_host();
+  velocity_->sync_to_device();
+
   stk::mesh::field_fill(1.0, *density_);
+  density_->modify_on_host();
+  density_->sync_to_device();
 
   // Setup solution options for default kernel
   solnOpts_.meshMotion_ = false;
@@ -63,4 +68,5 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_coriolis)
     rhsExact[nnDim + 2] = 0.125 * (-cor.Jxz_  - cor.Jyz_);
   }
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, rhsExact.data());
+
 }


### PR DESCRIPTION

**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

Convert nalu-wind to use new stk::mesh::NgpMesh and stk::mesh::NgpField API

nalu_ngp::FieldManager was added as a lightweight interface for the old ngp::FieldManager workflow.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings (pre-existing Kokkos warnings)
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
