### PR TITLE
Finish deprecating boost_rtree search method.

### DIFF
--- a/docs/source/user/nalu_run/turbine_modeling.rst
+++ b/docs/source/user/nalu_run/turbine_modeling.rst
@@ -59,7 +59,7 @@ Actuator Turbine Model
 
 .. inpfile:: actuator.search_method
 
-   String specifying the type of search method used to identify the nodes within the search radius of the actuator points. The recommended option is ``stk_kdtree``. The ``boost_rtree`` option is being deprecated by the STK search library.
+   String specifying the type of search method used to identify the nodes within the search radius of the actuator points. The only valid option is ``stk_kdtree``. The ``boost_rtree`` option has been deprecated by the STK search library.
 
 .. inpfile:: search_target_part
 

--- a/examples/filtered_lifting_line/with_correction/alm_simulation.yaml
+++ b/examples/filtered_lifting_line/with_correction/alm_simulation.yaml
@@ -118,7 +118,7 @@ realms:
 
     actuator:
       type: ActLineFAST
-      search_method: boost_rtree
+      search_method: stk_kdtree
       search_target_part: Unspecified-2-HEX
 
       n_turbines_glob: 1

--- a/examples/filtered_lifting_line/without_correction/alm_simulation.yaml
+++ b/examples/filtered_lifting_line/without_correction/alm_simulation.yaml
@@ -118,7 +118,7 @@ realms:
 
     actuator:
       type: ActLineFAST
-      search_method: boost_rtree
+      search_method: stk_kdtree
       search_target_part: Unspecified-2-HEX
 
       n_turbines_glob: 1

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -98,9 +98,9 @@ NonConformalInfo::NonConformalInfo(
 {
   // determine search method for this pair
   if ( searchMethodName == "boost_rtree" ) {
-    searchMethod_ = stk::search::BOOST_RTREE;
-    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' is being deprecated"
-           <<", please switch to 'stk_kdtree'" << std::endl;
+    searchMethod_ = stk::search::KDTREE;
+    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' has been deprecated"
+           <<", Switching to 'stk_kdtree'" << std::endl;
   }
   else if ( searchMethodName == "stk_kdtree" )
     searchMethod_ = stk::search::KDTREE;

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -99,9 +99,9 @@ PeriodicManager::add_periodic_pair(
   // determine search method for this pair; default is stk_kdtree
   stk::search::SearchMethod searchMethod = stk::search::KDTREE;
   if ( searchMethodName == "boost_rtree" ) {
-    searchMethod = stk::search::BOOST_RTREE;
-    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' is being deprecated"
-        <<", please swithc to 'stk_kdtree'" << std::endl;
+    searchMethod = stk::search::KDTREE;
+    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' has been deprecated"
+        <<", Switching to 'stk_kdtree'" << std::endl;
   }
   else if ( searchMethodName == "stk_kdtree" )
     searchMethod = stk::search::KDTREE;

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -422,9 +422,9 @@ SolutionOptions::load(const YAML::Node & y_node)
         if (fix_pressure["search_method"]) {
           std::string searchMethodName = fix_pressure["search_method"].as<std::string>();
           if (searchMethodName == "boost_rtree") {
-            fixPressureInfo_->searchMethod_ = stk::search::BOOST_RTREE;
-            NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' is being"
-              <<" deprecated. Please switch to 'stk_kdtree'." << std::endl;
+            fixPressureInfo_->searchMethod_ = stk::search::KDTREE;
+            NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' has been"
+              <<" deprecated. Switching to 'stk_kdtree'." << std::endl;
           }
           else if (searchMethodName == "stk_kdtree")
             fixPressureInfo_->searchMethod_ = stk::search::KDTREE;

--- a/src/actuator/Actuator.C
+++ b/src/actuator/Actuator.C
@@ -73,9 +73,9 @@ Actuator::load(const YAML::Node& y_node)
 
     // determine search method for this pair
     if (searchMethodName == "boost_rtree") {
-      searchMethod_ = stk::search::BOOST_RTREE;
+      searchMethod_ = stk::search::KDTREE;
       NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree'"
-                 <<" is being deprecated, please switch to 'stk_kdtree'" << std::endl;
+                 <<" has been deprecated, switching to 'stk_kdtree'" << std::endl;
     }
     else if (searchMethodName == "stk_kdtree")
       searchMethod_ = stk::search::KDTREE;

--- a/src/xfer/Transfer.C
+++ b/src/xfer/Transfer.C
@@ -360,9 +360,9 @@ void Transfer::allocate_stk_transfer() {
   // extract search type
   stk::search::SearchMethod searchMethod = stk::search::KDTREE;
   if ( searchMethodName_ == "boost_rtree" ) {
-    searchMethod = stk::search::BOOST_RTREE;
-    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' is being deprecated"
-          <<", please switch to 'stk_kdtree'" << std::endl;
+    searchMethod = stk::search::KDTREE;
+    NaluEnv::self().naluOutputP0() << "Warning: search method 'boost_rtree' has been deprecated"
+          <<", switching to 'stk_kdtree'" << std::endl;
   }
   else if ( searchMethodName_ == "stk_kdtree" )
     searchMethod = stk::search::KDTREE;


### PR DESCRIPTION
boost will soon be removed from stk_search, leaving
stk_kdtree as the only search method.
The ArborX search library will possibly be integrated
into stk-search in the future, but the time-frame
for that is unknown.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ x] Compiles without warnings
- [ ] Passes all unit tests
- [x ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
