### PR TITLE
add option to use two-stage SGS for Trilinos solver

### DIFF
--- a/src/LinearSolverConfig.C
+++ b/src/LinearSolverConfig.C
@@ -82,6 +82,15 @@ TpetraLinearSolverConfig::load(const YAML::Node & node)
     paramsPrecond_->set("relaxation: type","MT Symmetric Gauss-Seidel");
     paramsPrecond_->set("relaxation: sweeps",1);
   }
+  else if (precond_ == "sgs2") {
+    preconditionerType_ = "RELAXATION";
+    paramsPrecond_->set("relaxation: type","Two-stage Symmetric Gauss-Seidel");
+    paramsPrecond_->set("relaxation: sweeps",1);
+
+    int inner_iterations;
+    get_if_present(node, "inner_iterations", inner_iterations, 1);
+    paramsPrecond_->set ("relaxation: inner sweeps", inner_iterations);
+  }
   else if (precond_ == "jacobi" || precond_ == "default") {
     preconditionerType_ = "RELAXATION";
     paramsPrecond_->set("relaxation: type","Jacobi");


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request
- This PR adds the option to use two-stage SGS for Trilinos 
- In the input file, we can specify to use two-stage SGS by
   preconditioner: sgs2
- Optionally, the number of inner iterations (default is 1) can be specified by
    inner_iterations: 1

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist
*All pull requests*
- [x] Builds successfully on Summit
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
