### PR TITLE
Move to GPU versions of gradient kernels.

### DIFF
--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -377,7 +377,7 @@ EnthalpyEquationSystem::register_interior_algorithm(
       nodalGradAlgDriver_.register_edge_algorithm<ScalarNodalGradEdgeAlg>(
         algType, part, "enthalpy_nodal_grad", &enthalpyNp1, &dhdxNone);
     else
-      nodalGradAlgDriver_.register_legacy_algorithm<AssembleNodalGradElemAlgorithm>(
+      nodalGradAlgDriver_.register_elem_algorithm<ScalarNodalGradElemAlg>(
         algType, part, "enthalpy_nodal_grad", &enthalpyNp1, &dhdxNone,
         edgeNodalGradient_);
   }

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1176,7 +1176,7 @@ MomentumEquationSystem::register_interior_algorithm(
       nodalGradAlgDriver_.register_edge_algorithm<VectorNodalGradEdgeAlg>(
         algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone);
     else
-      nodalGradAlgDriver_.register_legacy_algorithm<AssembleNodalGradUElemAlgorithm>(
+      nodalGradAlgDriver_.register_elem_algorithm<VectorNodalGradElemAlg>(
         algType, part, "momentum_nodal_grad", &velocityNp1, &dudxNone,
         edgeNodalGradient_);
   }
@@ -2870,7 +2870,7 @@ ContinuityEquationSystem::register_interior_algorithm(
       nodalGradAlgDriver_.register_edge_algorithm<ScalarNodalGradEdgeAlg>(
         algType, part, "continuity_nodal_grad", &pressureNp1, &dpdxNone);
     else
-      nodalGradAlgDriver_.register_legacy_algorithm<AssembleNodalGradElemAlgorithm>(
+      nodalGradAlgDriver_.register_elem_algorithm<ScalarNodalGradElemAlg>(
         algType, part, "continuity_nodal_grad",
         &pressureNp1, &dpdxNone, edgeNodalGradient_);
   }

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -223,7 +223,7 @@ SpecificDissipationRateEquationSystem::register_interior_algorithm(
     nodalGradAlgDriver_.register_edge_algorithm<ScalarNodalGradEdgeAlg>(
       algType, part, "sdr_nodal_grad", &sdrNp1, &dwdxNone);
   else
-    nodalGradAlgDriver_.register_legacy_algorithm<AssembleNodalGradElemAlgorithm>(
+    nodalGradAlgDriver_.register_elem_algorithm<ScalarNodalGradElemAlg>(
       algType, part, "sdr_nodal_grad", &sdrNp1, &dwdxNone,
       edgeNodalGradient_);
 

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -242,7 +242,7 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
       nodalGradAlgDriver_.register_edge_algorithm<ScalarNodalGradEdgeAlg>(
         algType, part, "tke_nodal_grad", &tkeNp1, &dkdxNone);
     else
-      nodalGradAlgDriver_.register_legacy_algorithm<AssembleNodalGradElemAlgorithm>(
+      nodalGradAlgDriver_.register_elem_algorithm<ScalarNodalGradElemAlg>(
         algType, part, "tke_nodal_grad", &tkeNp1, &dkdxNone,
         edgeNodalGradient_);
   }


### PR DESCRIPTION
There was a problem with mixing GPU kernels
and CPU gradient contributions since the
sum into is then in different memory spaces.

This seems to fix much of the difference
between the CPU and GPU results for the
channel flow test we have been using to
debug this.

There are still differences in the results.
A deep dive on the contributions for a single
entry in the right hand side of the momentum
solve shows the order of operations can have
an impact since there are values summed in
of O(10^3) that almost cancel out in the final
result of O(10^-5).


**Pull-request type:**
- [ X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X ] Linux
    - [ ] MacOS
  - Compilers 
    - [X ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ X] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors
There are some diffs in the tests on the Sandia ASCICGPU platforms.  But this seems to
be due to order of operations differences.

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
