### PR TITLE
Fix 2x discrepancy between CPU and GPU for TKE periodic BC node rhs

### DIFF
--- a/src/ngp_algorithms/TKEWallFuncAlgDriver.C
+++ b/src/ngp_algorithms/TKEWallFuncAlgDriver.C
@@ -68,6 +68,9 @@ void TKEWallFuncAlgDriver::post_work()
     realm_.periodic_field_update(bcNodalTkeField, nComp, bypassFieldCheck);
   }
 
+  ngpBcNodalTke.modify_on_host();
+  ngpBcNodalTke.sync_to_device();
+
   // Normalize the computed BC TKE at integration points with assembled wall
   // area and assign it to TKE and TKE BC fields on this sideset for use in the
   // next solve.


### PR DESCRIPTION
coeffs.

Now, comparing log files for CPU vs GPU runs (for just 1 MPI rank
in each case, to remove that as a variable), the TKE residuals
match very well, and the 'Mean system norm' matches in 9 decimal
places after 10 time steps.

For follow-on work, we do need to convert to using the ngp version
of periodic_field_update which should help performance.


**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
