### PR TITLE
Performance optimization of sample plane output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ endif()
 
 ############################ BOOST #####################################
 set(CMAKE_PREFIX_PATH ${Boost_DIR} ${CMAKE_PREFIX_PATH})
-find_package(Boost REQUIRED QUIET COMPONENTS filesystem)
+find_package(Boost REQUIRED QUIET COMPONENTS filesystem iostreams)
 if(Boost_FOUND)
   message(STATUS "Found Boost = ${Boost_LIBRARY_DIRS}")
   target_link_libraries(nalu PUBLIC ${Boost_LIBRARIES})

--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -1345,6 +1345,11 @@ Data probes
    coordinate file will be written at the beginning of the output
    sequence if it does not already exist.
 
+.. inpfile:: data_probes.time_performance
+	     
+   Optional input, applies to sample planes only.  Boolean specifying
+   whether to display timing information when writing sample planes.
+
 .. inpfile:: data_probes.specifications
 
    A list of data probe properties with the following parameters

--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -1240,19 +1240,20 @@ Data probes
    .. code-block:: yaml
 
         data_probes:
-
           output_frequency: 100
-	  output_format: text
+          output_format: text
+          search_method: stk_octree
+          search_tolerance: 1.0e-3
+          search_expansion_factor: 2.0
 
-	  search_method: stk_octree
-	  search_tolerance: 1.0e-3
-	  search_expansion_factor: 2.0
+          gzip_level: 0            
+          write_coords: true       
 
-	  specifications:
+          specifications:
             - name: probe_bottomwall
-	      from_target_part: bottomwall
+              from_target_part: bottomwall
 
-	      line_of_site_specifications:
+              line_of_site_specifications:
 	        - name: probe_bottomwall
 	          number_of_points: 100
 		  tip_coordinates: [-6.39, 0.0, 0.0]
@@ -1263,7 +1264,7 @@ Data probes
 		  field_size: 1
 		- field_name: pressure
 
-	  specifications:
+          specifications:
             - name: probe_profile
 	      from_target_part: interior
 
@@ -1282,6 +1283,7 @@ Data probes
 		  edge2_numPoints: 21
 		  offset_vector:   [0, 0, 1]
 		  offset_spacings: [0, 2]
+		  only_output_field: velocity  
 
 	      output_variables:
 	        - field_name: velocity
@@ -1305,10 +1307,12 @@ Data probes
    available options are ``text`` or ``exodus``.  If not specified, the
    default is text.  Multiple output formats can be specified like the
    following:
+
    .. code-block:: yaml
-	  output_format:
-	  - text
-	  - exodus
+
+          output_format:
+          - text
+          - exodus
 
 .. inpfile:: data_probes.search_method
 
@@ -1322,6 +1326,24 @@ Data probes
 .. inpfile:: data_probes.search_expansion_factor
 
    Number specifying the factor to use when expanding the node search.
+
+.. inpfile:: data_probes.gzip_level
+
+   Optional input, applies to sample planes only.  Integer specifying
+   amount of compression to apply to sample plane output.  The default
+   ``gzip_level=0``, means no compression.  To apply compression, use
+   ``gzip_level`` from 1 to 9, with 9 indicating maximum compression
+   (and slowest speed).  Generally ``gzip_level=1`` or
+   ``gzip_level=2`` is sufficient.
+
+.. inpfile:: data_probes.write_coords
+
+   Optional input, applies to sample planes only.  Boolean specifying
+   whether the sample plane x,y,z coordinates and indices are to be
+   included with every sample plane output.  The default is
+   ``write_coords=true``.  For ``write_coords=false``, a separate
+   coordinate file will be written at the beginning of the output
+   sequence if it does not already exist.
 
 .. inpfile:: data_probes.specifications
 
@@ -1363,6 +1385,7 @@ Data probes
    edge2_numPoints    Number of points along edge 2
    offset_vector      [Optional] List containing the vector defining the offset direction for additional planes
    offset_spacings    [Optional] List containing how far each plane is to be offset in the offset_vector direction
+   only_output_field  [Optional] Only include the output of this variable in the sample plane output.
    ================== =============================================================
 
 .. inpfile:: data_probes.specifications.output_variables

--- a/include/DataProbePostProcessing.h
+++ b/include/DataProbePostProcessing.h
@@ -75,7 +75,7 @@ public:
   std::vector<stk::mesh::Part *> part_;
 
   // variables for sample planes
-  bool isSamplePlane_;   
+  bool isSamplePlane_;  
   std::vector<DataProbeGeomType> geomType_;
   std::vector<Coordinates> cornerCoordinates_;
   std::vector<Coordinates> edge1Vector_;
@@ -84,7 +84,7 @@ public:
   std::vector<int>         edge2NumPoints_;
   std::vector<Coordinates> offsetDir_;
   std::vector<std::vector<double>>  offsetSpacings_;
-
+  std::vector<std::string> onlyOutputField_;
 
 };
 
@@ -159,6 +159,9 @@ public:
 
   // frequency of output
   double outputFreq_;
+
+  bool writeCoords_;
+  int  gzLevel_; 
 
   // width for output
   int w_;

--- a/include/DataProbePostProcessing.h
+++ b/include/DataProbePostProcessing.h
@@ -190,6 +190,7 @@ private:
   double previousTime_;
   bool useExo_{false};
   bool useText_{false};
+  bool enablePerfTiming_{false};
   std::string exoName_;
   size_t fileIndex_;
   size_t precisionvar_;

--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -882,22 +882,23 @@ DataProbePostProcessing::execute()
   }
 
   if ( isOutput ) {
-    const double t1 = NaluEnv::self().nalu_time();  //LCCTIME
+    const double t1 = NaluEnv::self().nalu_time();  
     // execute and provide results...
     transfers_->execute();
-    const double t2 = NaluEnv::self().nalu_time();  //LCCTIME
+    const double t2 = NaluEnv::self().nalu_time();  
     if (useExo_) {
       provide_output_exodus(currentTime);
     }
     if (useText_) {
       provide_output_txt(currentTime);
     }
-    const double t3 = NaluEnv::self().nalu_time();  //LCCTIME
-    NaluEnv::self().naluOutputP0() << "DataProbePostProcessing::execute " 
-				   << " transfer_time: "<<t2-t1
-				   << " output_time: "<<t3-t2      
-				   << " total_time: "<<t3-t1
-				   << std::endl;
+    const double t3 = NaluEnv::self().nalu_time();  
+    // Uncomment below to provide timing statistics
+    // NaluEnv::self().naluOutputP0() << "DataProbePostProcessing::execute " 
+    // 				   << " transfer_time: "<<t2-t1
+    // 				   << " output_time: "<<t3-t2      
+    // 				   << " total_time: "<<t3-t1
+    // 				   << std::endl;
   
   }
 }
@@ -1025,7 +1026,6 @@ DataProbePostProcessing::provide_output_txt(
 	    ss << std::setw(7)<<std::setfill('0')<<timeStepCount;
 	    ss <<"_"<<processorId;
 	          std::string fileName = probeInfo->partName_[inp] + "_" + ss.str() + ".dat";
-	    //std::ofstream myfile;
 	    if ( processorId == NaluEnv::self().parallel_rank()) {    
 
 	      const int N1 = probeInfo->edge1NumPoints_[inp];
@@ -1111,11 +1111,8 @@ DataProbePostProcessing::provide_output_txt(
 		}
 	      }
 
-	      //myfile.open(fileName.c_str(), std::ios_base::out); // std::ios_base::app
 	      std::ofstream file(fileName.c_str(), std::ios_base::out);
 	      outbuf.push(file);
-	      //std::ostream myfile(&outbuf);
-	      //std::ostringstream myfile;
 	      std::string filestring;
 	      std::string coordfilestring("");
 	      char buffer[1000];
@@ -1123,17 +1120,11 @@ DataProbePostProcessing::provide_output_txt(
 
 	      if (!printcoords) coordfilestring="CoordinateFile: "+coordFileName;
 	      
-	      //myfile << "#Time: "<< std::setprecision(precisionvar_) << currentTime << std::endl;
-	      //myfile << "# ";
 	      sprintf(buffer, "#Time: %18.12e %s\n#",currentTime, coordfilestring.c_str());
 	      filestring.append(buffer);
 	      if (printcoords)  {
-		// myfile << std::setw(w_-1) << std::right << "Plane_Number"
-		//        << std::setw(w_) << std::right << "Index_j"
-		//        << std::setw(w_) << std::right << "Index_i"; 
 		filestring += "Plane_Number Index_j Index_i";
 		for ( int jj = 0; jj < nDim; ++jj ) {
-		  //myfile << std::setw(w_-2) << std::right << "coordinates[" << jj << "]" ;         
 		  sprintf(buffer, " coordinates[%i]", jj);
 		  filestring.append(buffer);
 		}
@@ -1144,13 +1135,11 @@ DataProbePostProcessing::provide_output_txt(
 		if ((probeInfo->onlyOutputField_[inp] == "") || (probeInfo->onlyOutputField_[inp] == fieldName)) {
 		  const int fieldSize = probeSpec->fieldInfo_[ifi].second;
 		  for ( int jj = 0; jj < fieldSize; ++jj ) {
-		    //myfile << std::setw(w_-3) << std::right << fieldName << "[" << jj << "]" ;
 		    sprintf(buffer, " %s[%i]", fieldName.c_str(), jj);
 		    filestring.append(buffer);
 		  } 
 		}
 	      }
-	      //myfile << '\n'; //std::endl;	      
 	      filestring += '\n';
 
 
@@ -1179,44 +1168,32 @@ DataProbePostProcessing::provide_output_txt(
 		  const int localn = inv - planei*pointsPerPlane;
 		  const int indexj = localn/N1;
 		  const int indexi = localn - indexj*N1;
-		  //myfile <<std::right<< std::setw(w_) << planei << std::setw(w_) << indexj << std::setw(w_) << indexi << std::setw(w_);
+
 		  sprintf(buffer, "%18i %18i %18i",planei, indexj, indexi);
 		  filestring.append(buffer);
 		  
 		  // Output coordinates
 		  for ( int jj = 0; jj < nDim; ++jj ) {
-		    //myfile << std::setprecision(precisionvar_) << theCoord[jj] << std::setw(w_);
 		    sprintf(buffer, " %12.5e",theCoord[jj]);
 		    filestring.append(buffer);
 		  }
-		} else {
-		  //myfile <<std::right<<std::setw(w_)<< std::setprecision(precisionvar_);
-		}
+		} 
 		// now all of the other fields required
 		for ( size_t ifi = 0; ifi < probeSpec->fieldInfo_.size(); ++ifi ) {
-		  //const std::string fieldName = probeSpec->fieldInfo_[ifi].first;
-		  //const stk::mesh::FieldBase *theField = metaData.get_field(stk::topology::NODE_RANK, fieldName);
-		  //double * theF = (double*)stk::mesh::field_data(*theField, node );
-		  //const int fieldSize = probeSpec->fieldInfo_[ifi].second;
 
 		  if ((probeInfo->onlyOutputField_[inp] == "") || (probeInfo->onlyOutputField_[inp] == allFieldNames[ifi])) {
 		    double * theF = (double*)stk::mesh::field_data(*(allFields[ifi]), node );
-		    //std::vector<double> theF(fieldSize[ifi], 0.0);
 		    for ( int jj = 0; jj < fieldSize[ifi]; ++jj ) {
-		      //myfile << theF[jj] << std::setw(w_);
 		      sprintf(buffer, " %12.6e",theF[jj]);
 		      filestring.append(buffer);
 		    }
 		  }
 		}
 		// row complete
-		//myfile << '\n'; //std::endl;
 		filestring += '\n';
 	      }
 	      // done with file output
-	      //myfile.close();
 	      std::ostream fileout(&outbuf);
-	      //fileout<<myfile.str();
 	      fileout<<filestring;
 	      boost::iostreams::close(outbuf); // Don't forget this!
 	      file.close();


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [X] Documentation update
- [X] Feature enhancement

## Description of the pull-request

Based on discussions with @psakievich, @alhs6577, and @rcknaus, it was found that the current sample plane output incurs a significant performance penalty when writing out very large planes at very high frequency.  I've made some changes which should increase the performance of the plane outputs and reduce the size of the output files.

Here is a quick summary of the feature updates:
-	The plane outputs can now be written out in a compressed gzip format, which shrinks the files and decreases the amount of data that needs to be written.
-	The coordinates and indices of the plane point can be written out in a separate file, so they don’t need to be included with every write.
-	You can have a separate plane file for each variable.  This allows the work to be spread out over more processors.

Based on speed tests from @alhs6577, sample plane output time dropped from 1.23 sec to 0.092 sec per iteration due to these changes.

Code changes are mostly contained within `DataProbePostProcessing.C`, with a minor addition to `CMakeLists.txt` for adding `boost::iostreams` libraries.  The corresponding documentation has also been updated.  Some changes to people's postprocessing scripts may also be required.

Lawrence

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [X] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [X] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
