### PR TITLE
Fix unittest issue referencing nrel5mw.fst

### DIFF
--- a/unit_tests/actuator/CMakeLists.txt
+++ b/unit_tests/actuator/CMakeLists.txt
@@ -14,4 +14,9 @@ if(ENABLE_OPENFAST)
    	  ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestActuatorFunctorsFAST.C
    	  ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestActuatorBulkDiskFAST.C
    )
+   # create symlink to nrelmw.fst 
+   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
+     ${CMAKE_BINARY_DIR}/reg_tests/test_files/nrel5MWactuatorLine/nrel5mw.fst
+     ${CMAKE_BINARY_DIR}/nrel5mw.fst
+   )
 endif()

--- a/unit_tests/actuator/UnitTestActuatorBulkFAST.C
+++ b/unit_tests/actuator/UnitTestActuatorBulkFAST.C
@@ -61,8 +61,7 @@ TEST_F(ActuatorBulkFastTests, initializeActuatorBulk)
   ASSERT_EQ(fi.tMax, 0.0625);
 
   ASSERT_EQ(
-    fi.globTurbineData[0].FASTInputFileName,
-    "reg_tests/test_files/nrel5MWactuatorLine/nrel5mw.fst");
+    fi.globTurbineData[0].FASTInputFileName, "nrel5mw.fst");
   ASSERT_EQ(fi.globTurbineData[0].FASTRestartFileName, "blah");
   ASSERT_EQ(fi.globTurbineData[0].TurbID, 0);
   ASSERT_EQ(fi.globTurbineData[0].numForcePtsBlade, 10);

--- a/unit_tests/actuator/UnitTestActuatorUtil.h
+++ b/unit_tests/actuator/UnitTestActuatorUtil.h
@@ -30,8 +30,7 @@ static std::vector<std::string> nrel5MWinputs = {
   "    turbine_name: turbinator\n",
   "    epsilon: [5.0, 5.0, 5.00]\n",
   "    turb_id: 0\n",
-  "    fast_input_filename: "
-  "reg_tests/test_files/nrel5MWactuatorLine/nrel5mw.fst\n",
+  "    fast_input_filename: nrel5mw.fst\n",
   "    restart_filename: blah\n",
   "    num_force_pts_blade: 10\n",
   "    num_force_pts_tower: 10\n",


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Make actuator unittests run with executables in any location by symlinking to the `nrel5mw.fst` input deck at the executable location.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
