### PR TITLE
Make sure that integers with leading zeros are parsed in decimal

### DIFF
--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -312,13 +312,35 @@ struct UserFunctionInitialConditionData : public InitialCondition {
   std::map<std::string, std::vector<double> > functionParams_;
 };
 
+inline bool string_represents_positive_integer(std::string v) {
+  return !v.empty () && v.find_first_not_of("0123456789") == std::string::npos;
+} 
+
+template <typename T>
+typename std::enable_if<std::is_integral<T>::value, T>::type get_yaml_value(const YAML::Node& v) {
+  // yaml will parse inputs with leading zeros as octals if
+  // the number is an octal, e.g. max_itertions: 0010 is
+  // equivalent to max_iterations: 8.
+  // this works around that to have 0010 equivalent to 10
+  if (string_represents_positive_integer(v.template as<std::string>())) {
+    return std::stoi(v.template as<std::string>());
+  }
+  else {
+    return v.template as<T>();
+  }
+}
+
+template <typename T>
+typename std::enable_if<!std::is_integral<T>::value, T>::type get_yaml_value(const YAML::Node& v) {
+  return v.template as<T>();
+}
+
 /// Set @param result if the @param key is present in the @param node, else set it to the given default value
 template<typename T>
 void get_if_present(const YAML::Node & node, const std::string& key, T& result, const T& default_if_not_present = T())
 {
   if (node[key]) {
-    const YAML::Node value = node[key];
-    result = value.as<T>();
+    result = get_yaml_value<T>(node[key]);
   }
   else {
     result = default_if_not_present;
@@ -330,8 +352,7 @@ template<typename T>
 void get_if_present_no_default(const YAML::Node & node, const std::string& key, T& result)
 {
   if (node[key]) {
-    const YAML::Node value = node[key];
-    result = value.as<T>();
+    result = get_yaml_value<T>(node[key]);
   }
 }
 
@@ -340,8 +361,7 @@ template<typename T>
 void get_required(const YAML::Node & node, const std::string& key, T& result)
 {
   if (node[key]) {
-    const YAML::Node value = node[key];
-    result = value.as<T>();
+    result = get_yaml_value<T>(node[key]);
   }
   else    {
     if (!NaluEnv::self().parallel_rank()) {


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

For `yaml-cpp`, specifying `max_iterations: 0010` will currently set the max iterations to 8, since numbers with leading zeros like that will be parsed as octal numbers.  This changes it so that `max_iterations: 0010` sets max iterations to 10.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
