### PR TITLE
Prepare overset interface for NGP 

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -257,6 +257,12 @@ class Realm {
     const unsigned sizeRow,
     const unsigned sizeCol);
 
+  void overset_field_update(
+    stk::mesh::FieldBase* field,
+    const unsigned nRows,
+    const unsigned nCols,
+    const bool doFinalSyncToDevice = true);
+
   virtual void populate_initial_condition();
   virtual void populate_boundary_data();
   virtual void boundary_data_to_state_data();

--- a/include/overset/OversetManager.h
+++ b/include/overset/OversetManager.h
@@ -79,7 +79,8 @@ public:
   virtual void overset_update_fields(const std::vector<OversetFieldData>&) = 0;
 
   virtual void overset_update_field(
-    stk::mesh::FieldBase* field, int nrows = 1, int ncols = 1) = 0;
+    stk::mesh::FieldBase* field, const int nrows = 1, const int ncols = 1,
+    const bool doFinalSyncToDevice = true) = 0;
 
   Realm& realm_;
 

--- a/include/overset/OversetManager.h
+++ b/include/overset/OversetManager.h
@@ -99,6 +99,12 @@ public:
 
   std::vector<int> ghostCommProcs_;
 
+  //! Timer for overset connectivity
+  double timerConnectivity_{0.0};
+
+  //! Timer for overset field interpolations
+  double timerFieldUpdate_{0.0};
+
 private:
   OversetManager() = delete;
   OversetManager(const OversetManager&) = delete;

--- a/include/overset/OversetManager.h
+++ b/include/overset/OversetManager.h
@@ -11,6 +11,7 @@
 #ifndef OVERSETMANAGER_H
 #define OVERSETMANAGER_H
 
+#include "KokkosInterface.h"
 #include "overset/OversetFieldData.h"
 
 #include <stk_mesh/base/Selector.hpp>
@@ -45,6 +46,8 @@ class OversetInfo;
 class OversetManager
 {
 public:
+  using EntityList = Kokkos::View<stk::mesh::Entity*, Kokkos::LayoutRight, MemSpace>;
+
   OversetManager(Realm& realm);
 
   virtual ~OversetManager();
@@ -90,6 +93,9 @@ public:
 
   std::vector<stk::mesh::Entity> holeNodes_;
   std::vector<stk::mesh::Entity> fringeNodes_;
+
+  EntityList ngpHoleNodes_;
+  EntityList ngpFringeNodes_;
 
   std::vector<int> ghostCommProcs_;
 

--- a/include/overset/OversetManagerTIOGA.h
+++ b/include/overset/OversetManagerTIOGA.h
@@ -44,7 +44,8 @@ public:
   virtual void overset_update_fields(const std::vector<OversetFieldData>&) override;
 
   virtual void overset_update_field(
-    stk::mesh::FieldBase* field, int nrows = 1, int ncols = 1) override;
+    stk::mesh::FieldBase* field, const int nrows = 1, const int ncols = 1,
+    const bool doFinalSyncToDevice = true) override;
 
   /// Instance holding all the data from input files
   const OversetUserData& oversetUserData_;

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -103,6 +103,12 @@ private:
    */
   void populate_overset_info();
 
+  //! Synchronize fields before performing overset connectivity
+  void pre_connectivity_sync();
+
+  //! Synchronize modified fields after performing overset connectivity
+  void post_connectivity_sync();
+
   //! Reference to Nalu OversetManager object
   sierra::nalu::OversetManagerTIOGA& oversetManager_;
 

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -70,7 +70,8 @@ public:
     const std::vector<sierra::nalu::OversetFieldData>&);
 
   virtual void overset_update_field(
-    stk::mesh::FieldBase* field, int nrows = 1, int ncols = 1);
+    stk::mesh::FieldBase* field, const int nrows = 1, const int ncols = 1,
+    const bool doFinalSyncToDevice = true);
 
 private:
   TiogaSTKIface() = delete;

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -1185,7 +1185,7 @@ EnthalpyEquationSystem::solve_and_update()
         1.0, enthalpy_->field_of_state(stk::mesh::StateNP1));
 
       if (decoupledOverset_ && realm_.hasOverset_)
-        realm_.overset_orphan_node_field_update(enthalpy_, 1, 1);
+        realm_.overset_field_update(enthalpy_, 1, 1);
       double timeB = NaluEnv::self().nalu_time();
       timerAssemble_ += (timeB-timeA);
     }

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -1183,11 +1183,11 @@ EnthalpyEquationSystem::solve_and_update()
       solution_update(
         1.0, *hTmp_,
         1.0, enthalpy_->field_of_state(stk::mesh::StateNP1));
+      double timeB = NaluEnv::self().nalu_time();
+      timerAssemble_ += (timeB-timeA);
 
       if (decoupledOverset_ && realm_.hasOverset_)
         realm_.overset_field_update(enthalpy_, 1, 1);
-      double timeB = NaluEnv::self().nalu_time();
-      timerAssemble_ += (timeB-timeA);
     }
 
     // projected nodal gradient

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -724,6 +724,8 @@ EquationSystems::initialize()
     NaluEnv::self().naluOutputP0()
       << "EquationSystems: overset solution strategy" << std::endl;
     for (auto* eqsys: equationSystemVector_) {
+      // Skip wrapper equations LowMach, SST etc.
+      if (eqsys->linsys_ == nullptr) continue;
       NaluEnv::self().naluOutputP0()
         << " - " << eqsys->eqnTypeName_ << ": "
         << (eqsys->decoupledOverset_ ? "decoupled" : "coupled") << std::endl;

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -706,13 +706,13 @@ LowMachEquationSystem::solve_and_update()
         1.0, *momentumEqSys_->uTmp_,
         1.0, momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1),
         realm_.meta_data().spatial_dimension());
+      timeB = NaluEnv::self().nalu_time();
+      momentumEqSys_->timerAssemble_ += (timeB-timeA);
 
       if (momentumEqSys_->decoupledOverset_ && realm_.hasOverset_)
         realm_.overset_field_update(
           &momentumEqSys_->velocity_->field_of_state(stk::mesh::StateNP1),
           1, realm_.meta_data().spatial_dimension());
-      timeB = NaluEnv::self().nalu_time();
-      momentumEqSys_->timerAssemble_ += (timeB-timeA);
     }
 
     // compute velocity relative to mesh with new velocity
@@ -733,12 +733,12 @@ LowMachEquationSystem::solve_and_update()
       solution_update(
         1.0, *continuityEqSys_->pTmp_,
         1.0, *continuityEqSys_->pressure_);
+      timeB = NaluEnv::self().nalu_time();
+      continuityEqSys_->timerAssemble_ += (timeB-timeA);
 
       if (continuityEqSys_->decoupledOverset_ && realm_.hasOverset_)
         realm_.overset_field_update(
           &continuityEqSys_->pressure_->field_of_state(stk::mesh::StateNP1), 1, 1);
-      timeB = NaluEnv::self().nalu_time();
-      continuityEqSys_->timerAssemble_ += (timeB-timeA);
     }
 
     // compute mdot
@@ -753,8 +753,8 @@ LowMachEquationSystem::solve_and_update()
     // update pressure
     const std::string dofName="pressure";
     const double relaxFP = realm_.solutionOptions_->get_relaxation_factor(dofName);
+    timeA = NaluEnv::self().nalu_time();
     if (std::fabs(1.0 - relaxFP) > 1.0e-3) {
-      timeA = NaluEnv::self().nalu_time();
       // Take care of the possibility that we have multiple overset correctors
       // and we need to do a pressure update that is the sum of all the deltaP
       // that were accumulated over the multiple correctors.

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -3606,7 +3606,7 @@ Realm::dump_simulation_time()
   }
 
   // nonconformal or overset
-  if ( has_non_matching_boundary_face_alg() ) {
+  if ( hasNonConformal_ ) {
     double g_totalNonconformal = 0.0, g_minNonconformal= 0.0, g_maxNonconformal = 0.0;
     stk::all_reduce_min(NaluEnv::self().parallel_comm(), &timerNonconformal_, &g_minNonconformal, 1);
     stk::all_reduce_max(NaluEnv::self().parallel_comm(), &timerNonconformal_, &g_maxNonconformal, 1);
@@ -3615,6 +3615,20 @@ Realm::dump_simulation_time()
     NaluEnv::self().naluOutputP0() << "Timing for Nonconformal: " << std::endl;
     NaluEnv::self().naluOutputP0() << "  nonconformal bc --  " << " \tavg: " << g_totalNonconformal/double(nprocs)
                                    << " \tmin: " << g_minNonconformal << " \tmax: " << g_maxNonconformal << std::endl;
+  }
+
+  if (hasOverset_) {
+    double connTime[2] = {oversetManager_->timerConnectivity_, oversetManager_->timerFieldUpdate_};
+    double totTime[2], minTime[2], maxTime[2];
+    stk::all_reduce_sum(NaluEnv::self().parallel_comm(), connTime, totTime, 2);
+    stk::all_reduce_min(NaluEnv::self().parallel_comm(), connTime, minTime, 2);
+    stk::all_reduce_max(NaluEnv::self().parallel_comm(), connTime, maxTime, 2);
+    NaluEnv::self().naluOutputP0()
+      << "Timing for Overset:" << std::endl
+      << "     connectivity --  \tavg: " << totTime[0] / double(nprocs)
+      << " \tmin: " << minTime[0] << " \tmax: " << maxTime[0] << std::endl
+      << "     field update --  \tavg: " << totTime[1] / double(nprocs)
+      << " \tmin: " << minTime[1] << " \tmax: " << maxTime[1] << std::endl;
   }
 
   // transfer

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2969,6 +2969,9 @@ Realm::overset_field_update(
   const unsigned nCols,
   const bool doFinalSyncToDevice)
 {
+  if (!hasOverset_) return;
+
+  const double timeA = NaluEnv::self().nalu_time();
   const auto& fieldMgr = ngp_field_manager();
   auto& ngpField =
     fieldMgr.get_field<double>(field->mesh_meta_data_ordinal());
@@ -2978,6 +2981,9 @@ Realm::overset_field_update(
 
   if (doFinalSyncToDevice)
     ngpField.sync_to_device();
+
+  const double timeB = NaluEnv::self().nalu_time();
+  oversetManager_->timerFieldUpdate_ += (timeB - timeA);
 }
 
 //--------------------------------------------------------------------------

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2972,16 +2972,8 @@ Realm::overset_field_update(
   if (!hasOverset_) return;
 
   const double timeA = NaluEnv::self().nalu_time();
-  const auto& fieldMgr = ngp_field_manager();
-  auto& ngpField =
-    fieldMgr.get_field<double>(field->mesh_meta_data_ordinal());
-  ngpField.sync_to_host();
-  oversetManager_->overset_update_field(field, nRows, nCols);
-  ngpField.modify_on_host();
-
-  if (doFinalSyncToDevice)
-    ngpField.sync_to_device();
-
+  oversetManager_->overset_update_field(
+    field, nRows, nCols, doFinalSyncToDevice);
   const double timeB = NaluEnv::self().nalu_time();
   oversetManager_->timerFieldUpdate_ += (timeB - timeA);
 }

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -262,8 +262,8 @@ ShearStressTransportEquationSystem::solve_and_update()
       update_and_clip();
 
       if (decoupledOverset_ && realm_.hasOverset_) {
-        realm_.overset_orphan_node_field_update(tkeEqSys_->tke_, 1, 1);
-        realm_.overset_orphan_node_field_update(sdrEqSys_->sdr_, 1, 1);
+        realm_.overset_field_update(tkeEqSys_->tke_, 1, 1);
+        realm_.overset_field_update(sdrEqSys_->sdr_, 1, 1);
       }
     }
     // compute projected nodal gradients

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -905,7 +905,7 @@ TurbKineticEnergyEquationSystem::solve_and_update()
       update_and_clip();
 
       if (decoupledOverset_ && realm_.hasOverset_)
-        realm_.overset_orphan_node_field_update(tke_, 1, 1);
+        realm_.overset_field_update(tke_, 1, 1);
       double timeB = NaluEnv::self().nalu_time();
       timerAssemble_ += (timeB-timeA);
     }

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -903,11 +903,11 @@ TurbKineticEnergyEquationSystem::solve_and_update()
       // update
       double timeA = NaluEnv::self().nalu_time();
       update_and_clip();
+      double timeB = NaluEnv::self().nalu_time();
+      timerAssemble_ += (timeB-timeA);
 
       if (decoupledOverset_ && realm_.hasOverset_)
         realm_.overset_field_update(tke_, 1, 1);
-      double timeB = NaluEnv::self().nalu_time();
-      timerAssemble_ += (timeB-timeA);
     }
 
     // projected nodal gradient

--- a/src/WallDistEquationSystem.C
+++ b/src/WallDistEquationSystem.C
@@ -418,7 +418,7 @@ WallDistEquationSystem::solve_and_update()
     assemble_and_solve(wallDistPhi_);
 
     if (decoupledOverset_)
-      realm_.overset_orphan_node_field_update(wallDistPhi_, 1, 1);
+      realm_.overset_field_update(wallDistPhi_, 1, 1);
   }
 
   // projected nodal gradient
@@ -477,7 +477,7 @@ WallDistEquationSystem::compute_wall_distance()
     stk::mesh::communicate_field_data(
       *realm_.nonConformalManager_->nonConformalGhosting_, fVec);
   if (realm_.hasOverset_)
-    realm_.overset_orphan_node_field_update(wallDistance_, 1, 1);
+    realm_.overset_field_update(wallDistance_, 1, 1);
 }
 
 void

--- a/src/ngp_algorithms/FieldUpdateAlgDriver.C
+++ b/src/ngp_algorithms/FieldUpdateAlgDriver.C
@@ -67,7 +67,8 @@ FieldUpdateAlgDriver::post_work()
   }
 
   if (realm_.hasOverset_) {
-    realm_.overset_orphan_node_field_update(field, nDim, nDim);
+    const bool doFinalSyncToDevice = false;
+    realm_.overset_field_update(field, nDim, nDim, doFinalSyncToDevice);
   }
 
   ngpField.modify_on_host();

--- a/src/ngp_algorithms/NodalGradAlgDriver.C
+++ b/src/ngp_algorithms/NodalGradAlgDriver.C
@@ -76,7 +76,7 @@ void NodalGradAlgDriver<GradPhiType>::post_work()
   }
 
   if (realm_.hasOverset_) {
-    realm_.overset_orphan_node_field_update(gradPhi, dim1, dim2);
+    realm_.overset_field_update(gradPhi, dim1, dim2, doFinalSyncToDevice);
   }
 
   ngpGradPhi.modify_on_host();

--- a/src/overset/OversetConstraintBase.C
+++ b/src/overset/OversetConstraintBase.C
@@ -40,11 +40,14 @@ OversetConstraintBase::initialize_connectivity()
 void
 OversetConstraintBase::prepare_constraints()
 {
-  const auto& holeRows = realm_.oversetManager_->holeNodes_;
   const int& numDof = eqSystem_->linsys_->numDof();
+  const auto& holeRows = realm_.oversetManager_->ngpHoleNodes_;
 
-  // Reset existing entries and zero out the entire row
-  eqSystem_->linsys_->resetRows(holeRows, 0, numDof, 1.0, 0.0);
+  auto* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
+  Kokkos::parallel_for(
+    holeRows.size(), KOKKOS_LAMBDA(const size_t& i) {
+      coeffApplier->resetRows(1, &holeRows(i), 0, numDof, 1.0, 0.0);
+    });
 }
 
 }  // nalu

--- a/src/overset/OversetManagerTIOGA.C
+++ b/src/overset/OversetManagerTIOGA.C
@@ -80,19 +80,13 @@ OversetManagerTIOGA::initialize(const bool isDecoupled)
 
 void OversetManagerTIOGA::overset_update_fields(const std::vector<OversetFieldData>& fields)
 {
-  const double timeA = NaluEnv::self().nalu_time();
   tiogaIface_.overset_update_fields(fields);
-  const double timeB = NaluEnv::self().nalu_time();
-  timerFieldUpdate_ += (timeB - timeA);
 }
 
 void OversetManagerTIOGA::overset_update_field(
   stk::mesh::FieldBase *field, int nrows, int ncols)
 {
-  const double timeA = NaluEnv::self().nalu_time();
   tiogaIface_.overset_update_field(field, nrows, ncols);
-  const double timeB = NaluEnv::self().nalu_time();
-  timerFieldUpdate_ += (timeB - timeA);
 }
 
 

--- a/src/overset/OversetManagerTIOGA.C
+++ b/src/overset/OversetManagerTIOGA.C
@@ -70,7 +70,7 @@ OversetManagerTIOGA::initialize(const bool isDecoupled)
   tiogaIface_.execute(isDecoupled);
 
   const double timeB = NaluEnv::self().nalu_time();
-  realm_.timerNonconformal_ += (timeB - timeA);
+  timerConnectivity_ += (timeB - timeA);
 
 #if 0
   NaluEnv::self().naluOutputP0() 
@@ -80,13 +80,19 @@ OversetManagerTIOGA::initialize(const bool isDecoupled)
 
 void OversetManagerTIOGA::overset_update_fields(const std::vector<OversetFieldData>& fields)
 {
+  const double timeA = NaluEnv::self().nalu_time();
   tiogaIface_.overset_update_fields(fields);
+  const double timeB = NaluEnv::self().nalu_time();
+  timerFieldUpdate_ += (timeB - timeA);
 }
 
 void OversetManagerTIOGA::overset_update_field(
   stk::mesh::FieldBase *field, int nrows, int ncols)
 {
+  const double timeA = NaluEnv::self().nalu_time();
   tiogaIface_.overset_update_field(field, nrows, ncols);
+  const double timeB = NaluEnv::self().nalu_time();
+  timerFieldUpdate_ += (timeB - timeA);
 }
 
 

--- a/src/overset/OversetManagerTIOGA.C
+++ b/src/overset/OversetManagerTIOGA.C
@@ -84,9 +84,10 @@ void OversetManagerTIOGA::overset_update_fields(const std::vector<OversetFieldDa
 }
 
 void OversetManagerTIOGA::overset_update_field(
-  stk::mesh::FieldBase *field, int nrows, int ncols)
+  stk::mesh::FieldBase *field, const int nrows, const int ncols,
+  const bool doFinalSyncToDevice)
 {
-  tiogaIface_.overset_update_field(field, nrows, ncols);
+  tiogaIface_.overset_update_field(field, nrows, ncols, doFinalSyncToDevice);
 }
 
 

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -15,7 +15,8 @@
 
 #include "overset/OversetManagerTIOGA.h"
 #include "overset/OversetInfo.h"
-#include <utils/StkHelpers.h>
+#include "utils/StkHelpers.h"
+#include "ngp_utils/NgpFieldUtils.h"
 
 #include "NaluEnv.h"
 #include "Realm.h"
@@ -104,6 +105,9 @@ void TiogaSTKIface::execute(const bool isDecoupled)
 {
   reset_data_structures();
 
+  // Synchronize fields to host during transition period
+  pre_connectivity_sync();
+
   // Update the coordinates for TIOGA and register updates to the TIOGA mesh block.
   for (auto& tb: blocks_) {
     tb->update_coords();
@@ -132,6 +136,8 @@ void TiogaSTKIface::execute(const bool isDecoupled)
   std::vector<const stk::mesh::FieldBase*> pvec{ibf};
   stk::mesh::copy_owned_to_shared(bulk_, pvec);
 
+  post_connectivity_sync();
+
   if (!isDecoupled) {
     get_receptor_info();
 
@@ -143,6 +149,11 @@ void TiogaSTKIface::execute(const bool isDecoupled)
     // Update overset fringe connectivity information for Constraint based algorithm
     populate_overset_info();
   }
+#ifdef KOKKOS_ENABLE_CUDA
+  else {
+    throw std::runtime_error("Non-decoupled overset connectivity not available in NGP build");
+  }
+#endif
 }
 
 void TiogaSTKIface::reset_data_structures()
@@ -451,6 +462,58 @@ void TiogaSTKIface::overset_update_field(
 
   for (auto& tb: blocks_)
     tb->update_solution(fdata);
+}
+
+void TiogaSTKIface::pre_connectivity_sync()
+{
+  auto& meshInfo = oversetManager_.realm_.mesh_info();
+  auto& ngpCoords = sierra::nalu::nalu_ngp::get_ngp_field(meshInfo, coordsName_);
+  auto& ngpDualVol = sierra::nalu::nalu_ngp::get_ngp_field(meshInfo, "dual_nodal_volume");
+  auto& ngpElemVol = sierra::nalu::nalu_ngp::get_ngp_field(
+    meshInfo, "element_volume", stk::topology::ELEM_RANK);
+
+  ngpCoords.sync_to_host();
+  ngpDualVol.sync_to_host();
+  ngpElemVol.sync_to_host();
+}
+
+void TiogaSTKIface::post_connectivity_sync()
+{
+  // Push iblank fields to device
+  auto& meshInfo = oversetManager_.realm_.mesh_info();
+  auto& ngpIblank = sierra::nalu::nalu_ngp::get_ngp_field<int>(
+    meshInfo, "iblank");
+  auto& ngpIblankCell = sierra::nalu::nalu_ngp::get_ngp_field<int>(
+    meshInfo, "iblank_cell", stk::topology::ELEM_RANK);
+
+  ngpIblank.modify_on_host();
+  ngpIblank.sync_to_device();
+  ngpIblankCell.modify_on_host();
+  ngpIblankCell.sync_to_device();
+
+  // Create device version of the fringe/hole lists for reset rows
+
+  const auto& fringes = oversetManager_.fringeNodes_;
+  const auto& holes = oversetManager_.holeNodes_;
+  auto& ngpFringes = oversetManager_.ngpFringeNodes_;
+  auto& ngpHoles = oversetManager_.ngpHoleNodes_;
+
+  ngpFringes = sierra::nalu::OversetManager::EntityList(
+    "ngp_fringe_list", fringes.size());
+  ngpHoles = sierra::nalu::OversetManager::EntityList(
+    "ngp_hole_list", holes.size());
+
+  auto h_fringes = Kokkos::create_mirror_view(ngpFringes);
+  auto h_holes = Kokkos::create_mirror_view(ngpHoles);
+
+  for (size_t i=0; i < fringes.size(); ++i) {
+    h_fringes[i] = fringes[i];
+  }
+  for (size_t i=0; i < holes.size(); ++i) {
+    h_holes[i] = holes[i];
+  }
+  Kokkos::deep_copy(ngpFringes, h_fringes);
+  Kokkos::deep_copy(ngpHoles, h_holes);
 }
 
 } // tioga

--- a/src/overset/UpdateOversetFringeAlgorithmDriver.C
+++ b/src/overset/UpdateOversetFringeAlgorithmDriver.C
@@ -50,18 +50,7 @@ void UpdateOversetFringeAlgorithmDriver::execute()
 #endif
   }
 
-  const auto& fieldMgr = realm_.mesh_info().ngp_field_manager();
-  for (auto& finfo: fields_) {
-    auto& ngpField = fieldMgr.get_field<double>(finfo.field_->mesh_meta_data_ordinal());
-    ngpField.sync_to_host();
-  }
   oversetManager->overset_update_fields(fields_);
-  for (auto& finfo: fields_) {
-    auto& ngpField = fieldMgr.get_field<double>(finfo.field_->mesh_meta_data_ordinal());
-    ngpField.modify_on_host();
-    ngpField.sync_to_device();
-  }
-
   const double timeB = NaluEnv::self().nalu_time();
   oversetManager->timerFieldUpdate_ += (timeB - timeA);
 }

--- a/src/overset/UpdateOversetFringeAlgorithmDriver.C
+++ b/src/overset/UpdateOversetFringeAlgorithmDriver.C
@@ -10,6 +10,7 @@
 
 #include "overset/UpdateOversetFringeAlgorithmDriver.h"
 #include "Realm.h"
+#include "NaluEnv.h"
 #include "overset/OversetManager.h"
 #include "ngp_utils/NgpFieldUtils.h"
 
@@ -35,6 +36,7 @@ UpdateOversetFringeAlgorithmDriver::register_overset_field_update(
 
 void UpdateOversetFringeAlgorithmDriver::execute()
 {
+  const double timeA = NaluEnv::self().nalu_time();
   auto* oversetManager = realm_.oversetManager_;
   if (oversetManager->oversetGhosting_ != nullptr) {
 #ifndef KOKKOS_ENABLE_CUDA
@@ -59,6 +61,9 @@ void UpdateOversetFringeAlgorithmDriver::execute()
     ngpField.modify_on_host();
     ngpField.sync_to_device();
   }
+
+  const double timeB = NaluEnv::self().nalu_time();
+  oversetManager->timerFieldUpdate_ += (timeB - timeA);
 }
 
 }  // nalu


### PR DESCRIPTION
This pull-request prepares the overset interface for NGP transition. Overset connectivity is still performed via TIOGA, but on the nalu-wind side it now performs necessary field sync (that will go away as more pieces are moved to GPU), and has the ability to perform linear system updates for overset rows on the device. Due to lack of ghosting on device, this capability is restricted to only _decoupled overset solves_ for NGP builds. 

- Introduce NGP versions of overset field interpolation/updates. Perform a sync to host and then back again to device. This will in future be removed as we gradually transition parts of overset search onto device.
- Introduce Kokkos Views for storing entities where linear system rows must be reset for decoupled overset algorithm. 
- Use device coeff applier to populate linear system for the overset rows.
- Add necessary throw statements to prevent non-decoupled overset algorithms being run on GPU builds.
- Add new timers to track overset connectivity and field updates separately. This will be used to keep track of the field interpolation overhead due to sync between host and device.

## Checklist

- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [x] MacOS
  - Compilers 
    - [x] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
