### PR TITLE
Address issue 595: fix compilation warnings in DataProbePostProcessing.C

### DIFF
--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -98,9 +98,9 @@ DataProbePostProcessing::DataProbePostProcessing(
     searchExpansionFactor_(1.5),
     probeType_(DataProbeSampleType::STEPCOUNT),
     previousTime_(0.0),
-    exoName_("data_probes.exo"),
-    gzLevel_(0), 
     writeCoords_(true),
+    gzLevel_(0), 
+    exoName_("data_probes.exo"),
     precisionvar_(8)
 {
   // load the data
@@ -1185,7 +1185,7 @@ DataProbePostProcessing::provide_output_txt(
 
 		  if ((probeInfo->onlyOutputField_[inp] == "") || (probeInfo->onlyOutputField_[inp] == allFieldNames[ifi])) {
 		    double * theF = (double*)stk::mesh::field_data(*(allFields[ifi]), node );
-		    for ( int jj = 0; jj < fieldSize[ifi]; ++jj ) {
+		    for ( size_t jj = 0; jj < fieldSize[ifi]; ++jj ) {
 		      sprintf(buffer, " %12.6e",theF[jj]);
 		      filestring.append(buffer);
 		    }


### PR DESCRIPTION
**Pull-request type:**
- [X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Fixed compilation warnings in `DataProbePostProcessing.C`.  
- Changed order of `gzLevel_`, `exoName_` in struct
- Fixed type comparisons in for loop

See warning details in issue [595](https://github.com/Exawind/nalu-wind/issues/595).

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [X] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
