### PR TITLE
issue 602: fix compilation warnings in DataProbePostProcessing.C

### DIFF
--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -92,14 +92,14 @@ DataProbePostProcessing::DataProbePostProcessing(
   const YAML::Node &node)
   : realm_(realm),
     outputFreq_(10),
+    writeCoords_(true),
+    gzLevel_(0), 
     w_(26),
     searchMethodName_("none"),
     searchTolerance_(1.0e-4),
     searchExpansionFactor_(1.5),
     probeType_(DataProbeSampleType::STEPCOUNT),
     previousTime_(0.0),
-    writeCoords_(true),
-    gzLevel_(0), 
     exoName_("data_probes.exo"),
     precisionvar_(8)
 {


### PR DESCRIPTION
**Pull-request type:**
- [X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Addresses issue [602](https://github.com/Exawind/nalu-wind/issues/602).  Able to replicate warnings using `-Wall -Wreorder` during intel compilation, and reordered initialization to fix problem.

No further warnings using `-Wall` with intel, hopefully no warnings for gcc as well.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [X] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
