### PR TITLE
Add NGP flag to actuator unit-tests that need them

### DIFF
--- a/unit_tests/actuator/UnitTestActuatorBulk.C
+++ b/unit_tests/actuator/UnitTestActuatorBulk.C
@@ -19,7 +19,7 @@ namespace nalu {
 
 namespace {
 
-TEST(ActuatorMeta, constructor)
+TEST(ActuatorMeta, NGP_constructor)
 {
   const int numTurbines = 2;
   ActuatorMeta fieldMeta(numTurbines);
@@ -38,7 +38,7 @@ TEST(ActuatorMeta, addTurbine)
   EXPECT_EQ(1024, fieldMeta.numPointsTurbine_.h_view(0));
 }
 
-TEST(ActuatorMeta, copyCtor)
+TEST(ActuatorMeta, NGP_copyCtor)
 {
   const int numTurbines = 2;
   ActuatorMeta fieldMeta(numTurbines);
@@ -58,7 +58,7 @@ TEST(ActuatorMeta, copyCtor)
   EXPECT_EQ(24, fieldMeta.numPointsTurbine_.h_view(1));
 }
 
-TEST(ActuatorBulk, constructor)
+TEST(ActuatorBulk, NGP_constructor)
 {
   const int numTurbines = 2;
   ActuatorMeta fieldMeta(numTurbines);

--- a/unit_tests/actuator/UnitTestActuatorFunctors.C
+++ b/unit_tests/actuator/UnitTestActuatorFunctors.C
@@ -30,7 +30,8 @@ void SetupActPoints(ActuatorBulk& actBulk)
   helper.touch_dual_view(actBulk.pointCentroid_);
   helper.touch_dual_view(actBulk.searchRadius_);
   
-  Kokkos::parallel_for("SetupActPoints",Kokkos::RangePolicy<ActuatorExecutionSpace>(0,point.extent_int(0)),KOKKOS_LAMBDA(int index)
+  Kokkos::parallel_for("SetupActPoints",Kokkos::RangePolicy<ActuatorExecutionSpace>
+    (0,point.extent_int(0)),KOKKOS_LAMBDA(int index)
   {
     point(index, 0) = 1.0 + 1.5 * index;
     point(index, 1) = 2.5;
@@ -51,7 +52,8 @@ void ComputeActuatorForce(ActuatorBulk& actBulk)
   helper.touch_dual_view(actBulk.actuatorForce_);
   helper.touch_dual_view(actBulk.velocity_);
 
-  Kokkos::parallel_for("CompActForce", Kokkos::RangePolicy<ActuatorExecutionSpace>(0,force.extent_int(0)),KOKKOS_LAMBDA(int index)
+  Kokkos::parallel_for("CompActForce", Kokkos::RangePolicy<ActuatorExecutionSpace>
+    (0,force.extent_int(0)),KOKKOS_LAMBDA(int index)
   {
     for (int j = 0; j < 3; j++) {
       force(index, j) = 1.2 * velocity(index, j);
@@ -201,7 +203,7 @@ protected:
   }
 };
 
-TEST_F(ActuatorFunctorTests, testSearchAndInterpolate)
+TEST_F(ActuatorFunctorTests, NGP_testSearchAndInterpolate)
 {
   inputFileSurrogate_ = "actuator:\n"
                         "  type: ActLinePointDrag\n"
@@ -237,7 +239,7 @@ TEST_F(ActuatorFunctorTests, testSearchAndInterpolate)
   }
 }
 
-TEST_F(ActuatorFunctorTests, testSpreadForces)
+TEST_F(ActuatorFunctorTests, NGP_testSpreadForces)
 {
   inputFileSurrogate_ = "actuator:\n"
                         "  type: ActLinePointDrag\n"

--- a/unit_tests/actuator/UnitTestActuatorNGP.C
+++ b/unit_tests/actuator/UnitTestActuatorNGP.C
@@ -15,7 +15,7 @@ namespace sierra {
 namespace nalu {
 
 namespace {
-TEST(ActuatorNGP, testExecuteOnHostOnly)
+TEST(ActuatorNGP, NGP_testExecuteOnHostOnly)
 {
   ActuatorMeta actMeta(1);
   ActuatorInfoNGP infoTurb0;
@@ -41,7 +41,7 @@ TEST(ActuatorNGP, testExecuteOnHostOnly)
   EXPECT_DOUBLE_EQ(9.3, actBulk.actuatorForce_.h_view(1, 2));
 }
 
-TEST(ActuatorNGP, testExecuteOnHostAndDevice)
+TEST(ActuatorNGP, NGP_testExecuteOnHostAndDevice)
 {
   ActuatorMeta actMeta(1);
   ActuatorInfoNGP infoTurb0;

--- a/unit_tests/actuator/UnitTestActuatorParsing.C
+++ b/unit_tests/actuator/UnitTestActuatorParsing.C
@@ -75,7 +75,7 @@ private:
 
 /// Check the minimum parse terms are not violated and
 /// that defaults haven't changed
-TEST_F(ActuatorParsingTest, bareMinimumParse)
+TEST_F(ActuatorParsingTest, NGP_bareMinimumParse)
 {
   try {
     auto y_actuator = create_yaml_node(inputFileLines_);

--- a/unit_tests/actuator/UnitTestActuatorSearch.C
+++ b/unit_tests/actuator/UnitTestActuatorSearch.C
@@ -78,7 +78,7 @@ public:
   const unsigned slabSize;
 };
 
-TEST_F(ActuatorSearchTest, createBoundingSpheres)
+TEST_F(ActuatorSearchTest, NGP_createBoundingSpheres)
 {
   auto spheres = CreateBoundingSpheres(points, radii);
   for (int i = 0; i < nPoints; i++) {
@@ -96,7 +96,7 @@ TEST_F(ActuatorSearchTest, createBoundingSpheres)
   }
 }
 
-TEST_F(ActuatorSearchTest, createElementBoxes)
+TEST_F(ActuatorSearchTest, NGP_createElementBoxes)
 {
   stk::mesh::BulkData& stkBulk = ioBroker.bulk_data();
   typedef stk::mesh::Field<double, stk::mesh::Cartesian> CoordFieldType;
@@ -125,7 +125,7 @@ TEST_F(ActuatorSearchTest, createElementBoxes)
   }
 }
 
-TEST_F(ActuatorSearchTest, executeCoarseSearch)
+TEST_F(ActuatorSearchTest, NGP_executeCoarseSearch)
 {
   stk::mesh::BulkData& stkBulk = ioBroker.bulk_data();
   auto spheres = CreateBoundingSpheres(points, radii);
@@ -149,7 +149,7 @@ TEST_F(ActuatorSearchTest, executeCoarseSearch)
   }
 }
 
-TEST_F(ActuatorSearchTest, executeFineSearch)
+TEST_F(ActuatorSearchTest, NGP_executeFineSearch)
 {
   stk::mesh::BulkData& stkBulk = ioBroker.bulk_data();
   // increase radius to hit multiple elems in coarse search


### PR DESCRIPTION

**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request
These tests should all run fine with a CUDA build and should be included in the nightly unit-tests. Added `NGP_*` to the test name to make sure they are captured by the gtest filter.


## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
