### PR TITLE
Remove usage of Boost search and stk NgpConstField

### DIFF
--- a/include/matrix_free/ConductionSolutionUpdate.h
+++ b/include/matrix_free/ConductionSolutionUpdate.h
@@ -46,7 +46,7 @@ public:
   ConductionSolutionUpdate(
     Teuchos::ParameterList,
     const stk::mesh::NgpMesh& mesh,
-    stk::mesh::NgpConstField<typename Tpetra::Map<>::global_ordinal_type> gids,
+    stk::mesh::NgpField<typename Tpetra::Map<>::global_ordinal_type> gids,
     stk::mesh::Selector active_mesh,
     stk::mesh::Selector dirichlet = {},
     stk::mesh::Selector flux = {},

--- a/include/matrix_free/StkSimdGatheredElementData.h
+++ b/include/matrix_free/StkSimdGatheredElementData.h
@@ -37,7 +37,7 @@ struct stk_simd_scalar_field_gather_t
 {
   static void invoke(
     const_elem_mesh_index_view<p> connectivity,
-    const stk::mesh::NgpConstField<double>& field,
+    const stk::mesh::NgpField<double>& field,
     scalar_view<p> simd_element_field);
 };
 } // namespace impl
@@ -49,7 +49,7 @@ struct stk_simd_vector_field_gather_t
 {
   static void invoke(
     const_elem_mesh_index_view<p> connectivity,
-    const stk::mesh::NgpConstField<double>& field,
+    const stk::mesh::NgpField<double>& field,
     vector_view<p> simd_element_field);
 };
 } // namespace impl
@@ -61,7 +61,7 @@ struct stk_simd_face_scalar_field_gather_t
 {
   static void invoke(
     const_face_mesh_index_view<p> connectivity,
-    const stk::mesh::NgpConstField<double>& field,
+    const stk::mesh::NgpField<double>& field,
     face_scalar_view<p> simd_element_field);
 };
 } // namespace impl
@@ -73,7 +73,7 @@ struct stk_simd_face_vector_field_gather_t
 {
   static void invoke(
     const_face_mesh_index_view<p> connectivity,
-    const stk::mesh::NgpConstField<double>& field,
+    const stk::mesh::NgpField<double>& field,
     face_vector_view<p> simd_element_field);
 };
 } // namespace impl
@@ -81,7 +81,7 @@ P_INVOKEABLE(stk_simd_face_vector_field_gather)
 
 void stk_simd_scalar_node_gather(
   const_node_mesh_index_view,
-  const stk::mesh::NgpConstField<double>&,
+  const stk::mesh::NgpField<double>&,
   node_scalar_view);
 
 } // namespace matrix_free

--- a/include/matrix_free/StkToTpetraLocalIndices.h
+++ b/include/matrix_free/StkToTpetraLocalIndices.h
@@ -25,7 +25,7 @@ Kokkos::View<const typename Tpetra::Map<>::local_ordinal_type*>
 make_stk_lid_to_tpetra_lid_map(
   const stk::mesh::NgpMesh& mesh,
   const stk::mesh::Selector& active_in_mesh,
-  stk::mesh::NgpConstField<typename Tpetra::Map<>::global_ordinal_type> gids,
+  stk::mesh::NgpField<typename Tpetra::Map<>::global_ordinal_type> gids,
   const Tpetra::Map<>::local_map_type& local_oas_map);
 
 Kokkos::View<const stk::mesh::FastMeshIndex*> make_tpetra_lid_to_stk_lid(

--- a/include/matrix_free/StkToTpetraMap.h
+++ b/include/matrix_free/StkToTpetraMap.h
@@ -41,7 +41,7 @@ public:
   StkToTpetraMaps(
     const stk::mesh::NgpMesh& mesh,
     const stk::mesh::Selector& active,
-    stk::mesh::NgpConstField<gid_t> gid,
+    stk::mesh::NgpField<gid_t> gid,
     stk::mesh::Selector replicas = {});
 
   const Tpetra::Map<> owned;
@@ -66,12 +66,12 @@ Tpetra::Map<> make_owned_row_map(
 Tpetra::Map<> shared_row_map(
   const stk::mesh::NgpMesh& mesh,
   const stk::mesh::Selector& active_linsys,
-  stk::mesh::NgpConstField<typename Tpetra::Map<>::global_ordinal_type> gids);
+  stk::mesh::NgpField<typename Tpetra::Map<>::global_ordinal_type> gids);
 
 Tpetra::Map<> make_owned_and_shared_row_map(
   const stk::mesh::NgpMesh& mesh,
   const stk::mesh::Selector& active_linsys,
-  stk::mesh::NgpConstField<typename Tpetra::Map<>::global_ordinal_type> gids);
+  stk::mesh::NgpField<typename Tpetra::Map<>::global_ordinal_type> gids);
 
 } // namespace matrix_free
 } // namespace nalu

--- a/src/MatrixFreeHeatCondEquationSystem.C
+++ b/src/MatrixFreeHeatCondEquationSystem.C
@@ -184,8 +184,8 @@ field_hadamard(
   const stk::mesh::NgpMesh& mesh,
   const stk::mesh::Selector& selector,
   stk::mesh::NgpField<double>& xy,
-  const stk::mesh::NgpConstField<double>& x,
-  const stk::mesh::NgpConstField<double>& y)
+  const stk::mesh::NgpField<double>& x,
+  const stk::mesh::NgpField<double>& y)
 {
   stk::mesh::for_each_entity_run(
     mesh, stk::topology::NODE_RANK, selector,

--- a/src/actuator/ActuatorParsing.C
+++ b/src/actuator/ActuatorParsing.C
@@ -46,10 +46,10 @@ actuator_parse(const YAML::Node& y_node)
     y_actuator, "search_method", searchMethodName, searchMethodName);
   // determine search method for this pair
   if (searchMethodName == "boost_rtree") {
-    actMeta.searchMethod_ = stk::search::BOOST_RTREE;
+    actMeta.searchMethod_ = stk::search::KDTREE;
     NaluEnv::self().naluOutputP0()
       << "Warning: search method 'boost_rtree'"
-      << " is being deprecated, please switch to 'stk_kdtree'" << std::endl;
+      << " is being deprecated, switching to 'stk_kdtree'" << std::endl;
   } else if (searchMethodName == "stk_kdtree")
     actMeta.searchMethod_ = stk::search::KDTREE;
   else

--- a/src/matrix_free/ConductionSolutionUpdate.C
+++ b/src/matrix_free/ConductionSolutionUpdate.C
@@ -59,7 +59,7 @@ template <int p>
 ConductionSolutionUpdate<p>::ConductionSolutionUpdate(
   Teuchos::ParameterList params,
   const stk::mesh::NgpMesh& mesh_in,
-  stk::mesh::NgpConstField<typename Tpetra::Map<>::global_ordinal_type> gid,
+  stk::mesh::NgpField<typename Tpetra::Map<>::global_ordinal_type> gid,
   stk::mesh::Selector active_in,
   stk::mesh::Selector dirichlet_in,
   stk::mesh::Selector flux_in,

--- a/src/matrix_free/ConductionUpdate.C
+++ b/src/matrix_free/ConductionUpdate.C
@@ -82,7 +82,7 @@ copy_state(
   const stk::mesh::NgpMesh& mesh,
   const stk::mesh::Selector& active_,
   stk::mesh::NgpField<double> dst,
-  stk::mesh::NgpConstField<double> src)
+  stk::mesh::NgpField<double> src)
 {
   stk::mesh::ProfilingBlock pf("BDF2TimeStepper<p>::copy_state");
   stk::mesh::for_each_entity_run(

--- a/src/matrix_free/StkSimdGatheredElementData.C
+++ b/src/matrix_free/StkSimdGatheredElementData.C
@@ -30,7 +30,7 @@ template <int p>
 void
 stk_simd_scalar_field_gather_t<p>::invoke(
   const_elem_mesh_index_view<p> conn,
-  const stk::mesh::NgpConstField<double>& field,
+  const stk::mesh::NgpField<double>& field,
   scalar_view<p> simd_element_field)
 {
   Kokkos::parallel_for(
@@ -58,7 +58,7 @@ template <int p>
 void
 stk_simd_vector_field_gather_t<p>::invoke(
   const_elem_mesh_index_view<p> conn,
-  const stk::mesh::NgpConstField<double>& field,
+  const stk::mesh::NgpField<double>& field,
   vector_view<p> simd_element_field)
 {
   Kokkos::parallel_for(
@@ -92,7 +92,7 @@ template <int p>
 void
 stk_simd_face_scalar_field_gather_t<p>::invoke(
   const_face_mesh_index_view<p> conn,
-  const stk::mesh::NgpConstField<double>& field,
+  const stk::mesh::NgpField<double>& field,
   face_scalar_view<p> simd_element_field)
 {
   Kokkos::parallel_for(
@@ -117,7 +117,7 @@ template <int p>
 void
 stk_simd_face_vector_field_gather_t<p>::invoke(
   const_face_mesh_index_view<p> conn,
-  const stk::mesh::NgpConstField<double>& field,
+  const stk::mesh::NgpField<double>& field,
   face_vector_view<p> simd_element_field)
 {
   Kokkos::parallel_for(
@@ -152,7 +152,7 @@ namespace matrix_free {
 void
 stk_simd_scalar_node_gather(
   const_node_mesh_index_view conn,
-  const stk::mesh::NgpConstField<double>& field,
+  const stk::mesh::NgpField<double>& field,
   node_scalar_view simd_node_field)
 {
   Kokkos::parallel_for(

--- a/src/matrix_free/StkToTpetraLocalIndices.C
+++ b/src/matrix_free/StkToTpetraLocalIndices.C
@@ -21,7 +21,7 @@ Kokkos::View<const typename Tpetra::Map<>::local_ordinal_type*>
 make_stk_lid_to_tpetra_lid_map(
   const stk::mesh::NgpMesh& mesh,
   const stk::mesh::Selector& active_in_mesh,
-  stk::mesh::NgpConstField<typename Tpetra::Map<>::global_ordinal_type> gids,
+  stk::mesh::NgpField<typename Tpetra::Map<>::global_ordinal_type> gids,
   const Tpetra::Map<>::local_map_type& local_oas_map)
 {
   Kokkos::View<typename Tpetra::Map<>::local_ordinal_type*> elid(

--- a/src/matrix_free/StkToTpetraMap.C
+++ b/src/matrix_free/StkToTpetraMap.C
@@ -25,7 +25,7 @@ namespace matrix_free {
 StkToTpetraMaps::StkToTpetraMaps(
   const stk::mesh::NgpMesh& mesh,
   const stk::mesh::Selector& active,
-  stk::mesh::NgpConstField<typename Tpetra::Map<>::global_ordinal_type> tgid,
+  stk::mesh::NgpField<typename Tpetra::Map<>::global_ordinal_type> tgid,
   stk::mesh::Selector replicas)
   : owned(make_owned_row_map(mesh, active - replicas)),
     owned_and_shared(
@@ -150,7 +150,7 @@ Tpetra::Map<>
 make_owned_and_shared_row_map(
   const stk::mesh::NgpMesh& mesh,
   const stk::mesh::Selector& active_linsys,
-  stk::mesh::NgpConstField<typename Tpetra::Map<>::global_ordinal_type> gids)
+  stk::mesh::NgpField<typename Tpetra::Map<>::global_ordinal_type> gids)
 {
   const auto& bulk = mesh.get_bulk_on_host();
   const auto& meta = bulk.mesh_meta_data();


### PR DESCRIPTION
The next stk update will remove boost search and
will also remove NgpConstField. NgpField will be the
only stk gpu-friendly field.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
