### PR TITLE
Rework momentum symmetry element kernel

### DIFF
--- a/include/kernel/MomentumSymmetryElemKernel.h
+++ b/include/kernel/MomentumSymmetryElemKernel.h
@@ -7,7 +7,6 @@
 // for more details.
 //
 
-
 #ifndef MOMENTUMSYMMETRYELEMKERNEL_H
 #define MOMENTUMSYMMETRYELEMKERNEL_H
 
@@ -28,17 +27,22 @@ class MasterElement;
 
 /** Symmetry kernel for momentum equation (velocity DOF)
  */
-template<typename BcAlgTraits>
-class MomentumSymmetryElemKernel: public Kernel
+template <typename BcAlgTraits>
+class MomentumSymmetryElemKernel : public Kernel
 {
 public:
+  // Strengthening this penalty will better approximate the
+  // boundary condition but will also increase the condition number of the
+  // linear system and increase the error in the interior
+  static constexpr double viscous_penalty = 2;
+
   MomentumSymmetryElemKernel(
-    const stk::mesh::MetaData &metaData,
-    const SolutionOptions &solnOpts,
-    VectorFieldType *velocity,
-    ScalarFieldType *viscosity,
-    ElemDataRequests &faceDataPreReqs,
-    ElemDataRequests &elemDataPreReqs);
+    const stk::mesh::MetaData& metaData,
+    const SolutionOptions& solnOpts,
+    VectorFieldType* velocity,
+    ScalarFieldType* viscosity,
+    ElemDataRequests& faceDataPreReqs,
+    ElemDataRequests& elemDataPreReqs);
 
   virtual ~MomentumSymmetryElemKernel();
 
@@ -47,30 +51,30 @@ public:
    */
   using Kernel::execute;
   virtual void execute(
-    SharedMemView<DoubleType**> &lhs,
-    SharedMemView<DoubleType*> &rhs,
-    ScratchViews<DoubleType> &faceScratchViews,
-    ScratchViews<DoubleType> &elemScratchViews,
+    SharedMemView<DoubleType**>& lhs,
+    SharedMemView<DoubleType*>& rhs,
+    ScratchViews<DoubleType>& faceScratchViews,
+    ScratchViews<DoubleType>& elemScratchViews,
     int elemFaceOrdinal);
 
 private:
   MomentumSymmetryElemKernel() = delete;
 
-  unsigned viscosity_      {stk::mesh::InvalidOrdinal};
-  unsigned velocityNp1_    {stk::mesh::InvalidOrdinal};
-  unsigned coordinates_    {stk::mesh::InvalidOrdinal};
-  unsigned exposedAreaVec_ {stk::mesh::InvalidOrdinal};
-
+  const unsigned viscosity_;
+  const unsigned velocityNp1_;
+  const unsigned coordinates_;
+  const unsigned exposedAreaVec_;
   const double includeDivU_;
-  const bool shiftedGradOp_;
 
-  MasterElement *meSCS_{nullptr};
+  MasterElement* meSCS_{nullptr};
 
   /// Shape functions
-  AlignedViewType<DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]> vf_shape_function_ {"view_face_shape_func"};
+  AlignedViewType<
+    DoubleType[BcAlgTraits::numFaceIp_][BcAlgTraits::nodesPerFace_]>
+    vf_shape_function_{"view_face_shape_func"};
 };
 
-}  // nalu
-}  // sierra
+} // namespace nalu
+} // namespace sierra
 
 #endif /* MOMENTUMSYMMETRYELEMKERNEL_H */


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

Applies a new and needed viscous penalty on the normal component of the velocity.  This keeps marc's case (https://github.com/Exawind/nalu-wind/issues/412) stable, with a peak z-velocity on the back face of ~5e-3, decreasing over time, but otherwise gives similar results to the existing symmetry BC.  The approach is valid for general surfaces as well.

Things that I still need to do:
  * Formal verification
  * Adapt for the edge scheme.  I think the penalty term changes to be `viscous_penalty * asq * inv_axdx * un * n[i]`, but I need to work out and check the viscous terms too.

I'm not 100% if I should just finish the items that need to done before issuing the pull request, but I thought I'd put it here for feedback at least.  elemHybridFluids might need to be reblessed but it definitely passes with clang tolerances.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
