### PR TITLE
Two ngp fixes:

### DIFF
--- a/include/ElemDataRequestsGPU.h
+++ b/include/ElemDataRequestsGPU.h
@@ -103,7 +103,7 @@ public:
     const nalu_ngp::FieldManager& fieldMgr,
     const ElemDataRequests& dataReq, unsigned totalFields);
 
-  ~ElemDataRequestsGPU() {}
+  KOKKOS_FUNCTION ~ElemDataRequestsGPU() {}
 
   void add_cvfem_face_me(MasterElement *meFC)
   { meFC_ = meFC; }

--- a/src/MatrixFreeHeatCondEquationSystem.C
+++ b/src/MatrixFreeHeatCondEquationSystem.C
@@ -202,10 +202,12 @@ MatrixFreeHeatCondEquationSystem::predict_state()
 {
   stk::mesh::ProfilingBlock("MatrixFreeHeatCondEquationSystem::predict_state");
 
-  const auto& current_state =
+  auto& current_state =
     get_node_field(meta_, names::temperature, stk::mesh::StateN);
   auto& predicted_state =
     get_node_field(meta_, names::temperature, stk::mesh::StateNP1);
+  current_state.sync_to_device();
+  predicted_state.sync_to_device();
   stk::mesh::for_each_entity_run(
     realm_.ngp_mesh(), stk::topology::NODE_RANK, interior_selector_,
     KOKKOS_LAMBDA(stk::mesh::FastMeshIndex mi) {


### PR DESCRIPTION
ElemDataRequestsGPU destructor needs to be KOKKOS_FUNCTION to
stop a compiler warning on gpu.

The matrix-free file needs the sync_to_device calls to fix
a diff that appears for a coming stk update (conduction_p4 on gpu).
(Stk is gradually changing, during sierra milestone optimizations, to do less
implicit syncs so that requires that apps have to be more
careful to do syncs when they need them.)


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
