### PR TITLE
Refactor overset implementation in preparation for multi-Realm/multi-solver overset coupling

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -255,11 +255,6 @@ class Realm {
 
   const stk::mesh::PartVector &get_slave_part_vector();
 
-  void overset_orphan_node_field_update(
-    stk::mesh::FieldBase *theField,
-    const unsigned sizeRow,
-    const unsigned sizeCol);
-
   void overset_field_update(
     stk::mesh::FieldBase* field,
     const unsigned nRows,

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -485,6 +485,7 @@ class Realm {
   OversetManager *oversetManager_;
   bool hasNonConformal_;
   bool hasOverset_;
+  bool isExternalOverset_{false};
 
   // three type of transfer operations
   bool hasMultiPhysicsTransfer_;

--- a/include/TimeIntegrator.h
+++ b/include/TimeIntegrator.h
@@ -15,6 +15,7 @@
 #include <Enums.h>
 #include <vector>
 #include <string>
+#include <memory>
 
 namespace YAML { class Node; }
 
@@ -23,12 +24,13 @@ namespace nalu{
 
 class Realm;
 class Simulation;
+class ExtOverset;
 
 class TimeIntegrator
 {
 public:
 
-  TimeIntegrator() {}
+  TimeIntegrator();
   TimeIntegrator(Simulation* sim);
   ~TimeIntegrator();
 
@@ -79,7 +81,8 @@ public:
   double get_total_sim_time();
   int get_max_time_step_count();
   void compute_gamma();
- 
+
+  std::unique_ptr<ExtOverset> overset_;
 };
 
 } // namespace nalu

--- a/include/overset/ExtOverset.h
+++ b/include/overset/ExtOverset.h
@@ -1,0 +1,63 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef EXTOVERSET_H
+#define EXTOVERSET_H
+
+#include "TimeIntegrator.h"
+#include "stk_util/parallel/Parallel.hpp"
+
+namespace tioga_nalu {
+class TiogaSTKIface;
+}
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+class ExtOverset
+{
+public:
+  ExtOverset(TimeIntegrator& timeIntegrator_);
+
+  ~ExtOverset();
+
+  void set_communicator();
+
+  void breadboard();
+
+  void initialize();
+
+  void update_connectivity();
+
+  void exchange_solution();
+
+  bool multi_solver_mode() const { return multiSolverMode_; }
+
+  void set_multi_solver_mode(const bool flag)
+  { multiSolverMode_ = flag; }
+
+private:
+  TimeIntegrator& time_;
+
+#ifdef NALU_USES_TIOGA
+  std::vector<tioga_nalu::TiogaSTKIface*> tgIfaceVec_;
+#endif
+
+  bool multiSolverMode_{false};
+  bool isDecoupled_{true};
+  bool hasOverset_{false};
+};
+
+}  // nalu
+}  // sierra
+
+
+#endif /* EXTOVERSET_H */

--- a/include/overset/OversetManager.h
+++ b/include/overset/OversetManager.h
@@ -61,11 +61,13 @@ public:
    */
   virtual void setup();
 
-  /** Setup all data structures and perform connectivity
-   *
-   * This method must be implemented by concrete OGA implementations.
+  /** Setup all the initial data structures (one time setup)
    */
-  virtual void initialize(const bool isDecoupled = false) = 0;
+  virtual void initialize() = 0;
+
+  /** Perform overset connectivity
+   */
+  virtual void execute(const bool isDecoupled) = 0;
 
   virtual void overset_orphan_node_field_update(
     stk::mesh::FieldBase*,
@@ -81,6 +83,8 @@ public:
   virtual void overset_update_field(
     stk::mesh::FieldBase* field, const int nrows = 1, const int ncols = 1,
     const bool doFinalSyncToDevice = true) = 0;
+
+  virtual void reset_data_structures();
 
   Realm& realm_;
 

--- a/include/overset/OversetManagerTIOGA.h
+++ b/include/overset/OversetManagerTIOGA.h
@@ -39,7 +39,9 @@ public:
 
   virtual void setup() override;
 
-  virtual void initialize(const bool isDecoupled = false) override;
+  virtual void initialize() override;
+
+  virtual void execute(const bool isDecoupled) override;
 
   virtual void overset_update_fields(const std::vector<OversetFieldData>&) override;
 

--- a/include/overset/TiogaRef.h
+++ b/include/overset/TiogaRef.h
@@ -1,0 +1,72 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef TIOGAREF_H
+#define TIOGAREF_H
+
+#include <memory>
+
+namespace TIOGA {
+class tioga;
+}
+
+namespace tioga_nalu {
+
+/** Manager for the TIOGA handle
+ *
+ *  This class manages access to the global TIOGA instance across multiple
+ *  realms as well as across multi-solver interfaces (e.g., amr-wind/nalu-wind
+ *  coupling). This class allows both use-cases: 1. nalu-wind only run where
+ *  overset might be coupling within just one realm or multiple realms but owns
+ *  the TIOGA reference, 2. hybrid solver run where an external code interface
+ *  owns the TIOGA reference.
+ *
+ */
+class TiogaRef
+{
+public:
+  /** Access the reference object
+   *
+   *  The first invocation can pass a pointer to a valid TIOGA instance which
+   *  makes this a non-owning reference holder. Otherwise it will create a new
+   *  instance and take ownership of that reference.
+   *
+   *  \param tg Pointer to an existing TIOGA instance
+   */
+  static TiogaRef& self(TIOGA::tioga* tg = nullptr);
+
+  ~TiogaRef();
+
+  TiogaRef(const TiogaRef&) = delete;
+  TiogaRef& operator=(const TiogaRef&) = delete;
+
+  inline operator TIOGA::tioga&()
+  {
+    return *tg_;
+  }
+
+  //! Access the underlying TIOGA reference
+  inline TIOGA::tioga& get()
+  {
+    return *tg_;
+  }
+
+private:
+  TiogaRef();
+
+  TiogaRef(TIOGA::tioga* tg);
+
+  TIOGA::tioga* tg_{nullptr};
+
+  bool owned_{false};
+};
+
+}
+
+#endif /* TIOGAREF_H */

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -130,7 +130,7 @@ private:
   std::vector<std::unique_ptr<TiogaBlock>> blocks_;
 
   //! Reference to the TIOGA API interface
-  std::unique_ptr<TIOGA::tioga> tg_;
+  TIOGA::tioga* tg_;
 
   //! Work array used to hold donor elements that require ghosting to receptor
   //! MPI ranks

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -74,6 +74,10 @@ public:
 
   void post_connectivity_work(const bool isDecoupled = true);
 
+  int register_solution(const std::vector<sierra::nalu::OversetFieldData>&);
+
+  void update_solution(const std::vector<sierra::nalu::OversetFieldData>&);
+
   virtual void overset_update_fields(
     const std::vector<sierra::nalu::OversetFieldData>&);
 

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -70,6 +70,10 @@ public:
    */
   void execute(const bool isDecoupled);
 
+  void register_mesh();
+
+  void post_connectivity_work(const bool isDecoupled = true);
+
   virtual void overset_update_fields(
     const std::vector<sierra::nalu::OversetFieldData>&);
 

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -10,11 +10,14 @@
 
 #include "overset/TiogaOptions.h"
 #include "overset/OversetFieldData.h"
-#include "yaml-cpp/yaml.h"
 
 #include <vector>
 #include <memory>
 #include <array>
+
+namespace YAML {
+class Node;
+}
 
 namespace TIOGA {
 class tioga;
@@ -44,7 +47,8 @@ public:
    *  @param node YAML node containing overset inputs
    */
   TiogaSTKIface(sierra::nalu::OversetManagerTIOGA&,
-                const YAML::Node&);
+                const YAML::Node&,
+                const std::string&);
 
   ~TiogaSTKIface();
 

--- a/include/overset/TiogaSTKIface.h
+++ b/include/overset/TiogaSTKIface.h
@@ -130,7 +130,7 @@ private:
   std::vector<std::unique_ptr<TiogaBlock>> blocks_;
 
   //! Reference to the TIOGA API interface
-  TIOGA::tioga* tg_;
+  TIOGA::tioga& tg_;
 
   //! Work array used to hold donor elements that require ghosting to receptor
   //! MPI ranks

--- a/src/AssembleNodalGradAlgorithmDriver.C
+++ b/src/AssembleNodalGradAlgorithmDriver.C
@@ -120,7 +120,7 @@ AssembleNodalGradAlgorithmDriver::post_work()
   if ( realm_.hasOverset_ ) {
     // this is a vector
     const unsigned nDim = meta_data.spatial_dimension();
-    realm_.overset_orphan_node_field_update(dqdx, 1, nDim);
+    realm_.overset_field_update(dqdx, 1, nDim);
   }
 }
 

--- a/src/AssembleNodalGradUAlgorithmDriver.C
+++ b/src/AssembleNodalGradUAlgorithmDriver.C
@@ -110,7 +110,7 @@ AssembleNodalGradUAlgorithmDriver::post_work()
   if ( realm_.hasOverset_ ) {
     // this is a tensor
     const unsigned nDim = meta_data.spatial_dimension();
-    realm_.overset_orphan_node_field_update(dudx, nDim, nDim);
+    realm_.overset_field_update(dudx, nDim, nDim);
   }
 }
 

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -546,10 +546,10 @@ Realm::initialize()
   if ( hasNonConformal_ )
     initialize_non_conformal();
 
-  if ( hasOverset_ ) {
-    oversetManager_->initialize();
-    initialize_overset();
-  }
+  // if ( hasOverset_ ) {
+  //   oversetManager_->initialize();
+  //   initialize_overset();
+  // }
 
   initialize_post_processing_algorithms();
 
@@ -2350,7 +2350,7 @@ Realm::initialize_non_conformal()
 void
 Realm::initialize_overset()
 {
-  if (!isExternalOverset_)
+  if (hasOverset_ && !isExternalOverset_)
     oversetManager_->execute(equationSystems_.all_systems_decoupled());
 }
 
@@ -3003,7 +3003,7 @@ Realm::overset_field_update(
   const unsigned nCols,
   const bool doFinalSyncToDevice)
 {
-  if (!hasOverset_) return;
+  if (!hasOverset_ || isExternalOverset_) return;
 
   const double timeA = NaluEnv::self().nalu_time();
   oversetManager_->overset_update_field(

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -546,8 +546,10 @@ Realm::initialize()
   if ( hasNonConformal_ )
     initialize_non_conformal();
 
-  if ( hasOverset_ )
+  if ( hasOverset_ ) {
+    oversetManager_->initialize();
     initialize_overset();
+  }
 
   initialize_post_processing_algorithms();
 
@@ -2348,7 +2350,8 @@ Realm::initialize_non_conformal()
 void
 Realm::initialize_overset()
 {
-  oversetManager_->initialize(equationSystems_.all_systems_decoupled());
+  if (!isExternalOverset_)
+    oversetManager_->execute(equationSystems_.all_systems_decoupled());
 }
 
 //--------------------------------------------------------------------------

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1774,8 +1774,8 @@ Realm::pre_timestep_work()
       initialize_non_conformal();
 
     // and overset algorithm
-    if ( hasOverset_ )
-      initialize_overset();
+    // if ( hasOverset_ )
+    //   initialize_overset();
 
     // Reset the stk::mesh::NgpMesh instance
     meshInfo_.reset(new typename Realm::NgpMeshInfo(*bulkData_));

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2993,25 +2993,6 @@ Realm::get_slave_part_vector()
     return emptyPartVector_;
 }
 
-#ifdef KOKKOS_ENABLE_CUDA
-void
-Realm::overset_orphan_node_field_update(
-  stk::mesh::FieldBase*, const unsigned, const unsigned)
-{
-  throw std::runtime_error(
-    "Non-NGP version of overset algorithm called in NGP build");
-}
-#else
-void
-Realm::overset_orphan_node_field_update(
-  stk::mesh::FieldBase *theField,
-  const unsigned sizeRow,
-  const unsigned sizeCol)
-{
-  oversetManager_->overset_update_field(theField, sizeRow, sizeCol);
-}
-#endif
-
 void
 Realm::overset_field_update(
   stk::mesh::FieldBase* field,

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -546,10 +546,10 @@ Realm::initialize()
   if ( hasNonConformal_ )
     initialize_non_conformal();
 
-  // if ( hasOverset_ ) {
-  //   oversetManager_->initialize();
-  //   initialize_overset();
-  // }
+  if ( hasOverset_ && !isExternalOverset_ ) {
+    oversetManager_->initialize();
+    initialize_overset();
+  }
 
   initialize_post_processing_algorithms();
 
@@ -1774,8 +1774,8 @@ Realm::pre_timestep_work()
       initialize_non_conformal();
 
     // and overset algorithm
-    // if ( hasOverset_ )
-    //   initialize_overset();
+    if ( hasOverset_ )
+      initialize_overset();
 
     // Reset the stk::mesh::NgpMesh instance
     meshInfo_.reset(new typename Realm::NgpMeshInfo(*bulkData_));

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2520,8 +2520,11 @@ Realm::compute_vrtm(const std::string& velName)
   auto vrtm = fieldMgr.get_field<double>(
     get_field_ordinal(*metaData_, velName + "_rtm"));
 
+  auto* vrtm_field = metaData_->get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, velName + "_rtm");
   const stk::mesh::Selector sel = (
-    metaData_->locally_owned_part() | metaData_->globally_shared_part());
+    metaData_->locally_owned_part() | metaData_->globally_shared_part()) &
+    stk::mesh::selectField(*vrtm_field);
   nalu_ngp::run_entity_algorithm(
     "compute_vrtm",
     ngpMesh, stk::topology::NODE_RANK, sel,
@@ -2547,7 +2550,8 @@ Realm::init_current_coordinates()
   VectorFieldType *displacement = metaData_->get_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_displacement");
 
   stk::mesh::Selector s_all_nodes
-    = (metaData_->locally_owned_part() | metaData_->globally_shared_part());
+    = (metaData_->locally_owned_part() | metaData_->globally_shared_part()) &
+    stk::mesh::selectField(*currentCoords);
 
   stk::mesh::BucketVector const& node_buckets = bulkData_->get_buckets( stk::topology::NODE_RANK, s_all_nodes );
   for ( stk::mesh::BucketVector::const_iterator ib = node_buckets.begin() ;

--- a/src/TimeIntegrator.C
+++ b/src/TimeIntegrator.C
@@ -19,6 +19,8 @@
 #include <SolutionOptions.h>
 #include <NaluEnv.h>
 #include <NaluParsing.h>
+#include <mesh_motion/MeshMotionAlg.h>
+#include "overset/ExtOverset.h"
 
 #include <limits>
 #include <iomanip>
@@ -26,14 +28,50 @@
 namespace sierra{
 namespace nalu{
 
-//==========================================================================
-// Class Definition
-//==========================================================================
-// TimeIntegrator - base class for algorithm
-//==========================================================================
-//--------------------------------------------------------------------------
-//-------- constructor -----------------------------------------------------
-//--------------------------------------------------------------------------
+namespace {
+void pre_timestep_prolog(Realm& realm)
+{
+  if (!realm.solutionOptions_->meshMotion_)
+    return;
+
+  realm.meshMotionAlg_->execute(realm.get_current_time());
+
+  realm.compute_geometry();
+
+  realm.meshMotionAlg_->post_compute_geometry();
+
+  // and non-conformal algorithm
+  if (realm.hasNonConformal_)
+    realm.initialize_non_conformal();
+}
+
+void pre_timestep_epilog(Realm& realm) {
+  if (realm.solutionOptions_->meshMotion_) {
+    // now re-initialize linear system
+    realm.equationSystems_.reinitialize_linear_system();
+  }
+  // deal with non-topology changes, however, moving mesh
+  if ( realm.has_mesh_deformation() ) {
+    // extract target parts for this physics
+    if ( realm.solutionOptions_->externalMeshDeformation_ ) {
+      std::vector<std::string> targetNames = realm.get_physics_target_names();
+      for ( size_t itarget = 0; itarget < targetNames.size(); ++itarget ) {
+        stk::mesh::Part *targetPart = realm.metaData_->get_part(targetNames[itarget]);
+        realm.set_current_coordinates(targetPart);
+      }
+    }
+    realm.compute_geometry();
+  }
+
+  // ask the equation system to do some work
+  realm.equationSystems_.pre_timestep_work();
+}
+
+} // namespace
+
+TimeIntegrator::TimeIntegrator()
+{}
+
 TimeIntegrator::TimeIntegrator(Simulation* sim)
   : sim_(sim),
     totalSimTime_(1.0),
@@ -49,7 +87,8 @@ TimeIntegrator::TimeIntegrator(Simulation* sim)
     secondOrderTimeAccurate_(false),
     adaptiveTimeStep_(false),
     terminateBasedOnTime_(false),
-    nonlinearIterations_(1)
+    nonlinearIterations_(1),
+    overset_(new ExtOverset(*this))
 {
   // does nothing  
 }
@@ -137,11 +176,14 @@ void TimeIntegrator::breadboard()
     realm->timeIntegrator_ = this;
     realmVec_.push_back(realm);
   }
+
+  overset_->breadboard();
 }
 
 void TimeIntegrator::initialize()
 {
-  // nothing to do now for the integrator
+  // overset_->initialize();
+  // overset_->update_connectivity();
 }
 
 Simulation *TimeIntegrator::root() { return parent()->root(); }
@@ -156,7 +198,7 @@ TimeIntegrator::integrate_realm()
   //=====================================
   // start-up procedure
   //=====================================
-  
+
   // initial conditions
   for ( ii = realmVec_.begin(); ii!=realmVec_.end(); ++ii) {
     (*ii)->populate_initial_condition();
@@ -277,8 +319,14 @@ TimeIntegrator::integrate_realm()
     }
     
     // pre-step work; mesh motion, search, etc
-    for ( ii = realmVec_.begin(); ii!=realmVec_.end(); ++ii) {
-      (*ii)->pre_timestep_work();
+    // for ( ii = realmVec_.begin(); ii!=realmVec_.end(); ++ii) {
+    //   (*ii)->pre_timestep_work();
+    // }
+    for (auto realm: realmVec_) {
+      pre_timestep_prolog(*realm);
+      // realm->initialize_overset();
+      overset_->update_connectivity();
+      pre_timestep_epilog(*realm);
     }
 
     // populate boundary data

--- a/src/overset/CMakeLists.txt
+++ b/src/overset/CMakeLists.txt
@@ -15,5 +15,6 @@ if(ENABLE_TIOGA)
       ${CMAKE_CURRENT_SOURCE_DIR}/TiogaOptions.C
       ${CMAKE_CURRENT_SOURCE_DIR}/TiogaBlock.C
       ${CMAKE_CURRENT_SOURCE_DIR}/TiogaSTKIface.C
+      ${CMAKE_CURRENT_SOURCE_DIR}/TiogaRef.C
    )
 endif()

--- a/src/overset/CMakeLists.txt
+++ b/src/overset/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/OversetInfo.C
    ${CMAKE_CURRENT_SOURCE_DIR}/OversetManager.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UpdateOversetFringeAlgorithmDriver.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/ExtOverset.C
 )
 
 if(ENABLE_TIOGA)

--- a/src/overset/ExtOverset.C
+++ b/src/overset/ExtOverset.C
@@ -1,0 +1,105 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include "overset/ExtOverset.h"
+#include "overset/TiogaRef.h"
+#include "overset/OversetManagerTIOGA.h"
+#include "NaluEnv.h"
+#include "Realm.h""
+
+#include "tioga.h"
+
+namespace sierra {
+namespace nalu {
+
+ExtOverset::ExtOverset(TimeIntegrator& time)
+  : time_(time)
+{}
+
+ExtOverset::~ExtOverset() = default;
+
+void ExtOverset::set_communicator()
+{
+#ifdef NALU_USES_TIOGA
+  auto& tg = tioga_nalu::TiogaRef::self().get();
+
+  auto& env = NaluEnv::self();
+  tg.setCommunicator(
+    env.parallel_comm(), env.parallel_rank(), env.parallel_size());
+#endif
+}
+
+void ExtOverset::breadboard()
+{
+  int noverset = 0;
+  for (auto* realm : time_.realmVec_) {
+    if (realm->query_for_overset()) {
+      ++noverset;
+
+      isDecoupled_ = isDecoupled_ &&
+        realm->equationSystems_.all_systems_decoupled();
+    }
+  }
+
+  if (multiSolverMode_ && (noverset == 0)) {
+    throw std::runtime_error(
+      "Multi-solver mode is active but no realm has overset");
+  }
+
+  if (!isDecoupled_ && (noverset > 1)) {
+    throw std::runtime_error("External overset requires decoupled solves");
+  }
+
+  if (noverset > 0)
+    hasOverset_ = true;
+  if (noverset > 1 || multiSolverMode_) {
+    for (auto* realm : time_.realmVec_)
+      realm->isExternalOverset_ = true;
+  }
+
+  if (!multiSolverMode_)
+    set_communicator();
+}
+
+void ExtOverset::initialize()
+{
+  if (!hasOverset_) return;
+
+#ifdef NALU_USES_TIOGA
+  for (auto* realm: time_.realmVec_) {
+    auto* mgr = dynamic_cast<OversetManagerTIOGA*>(realm->oversetManager_);
+    tgIfaceVec_.push_back(&mgr->tiogaIface_);
+
+    mgr->initialize();
+  }
+#endif
+}
+
+void ExtOverset::update_connectivity()
+{
+  if (!hasOverset_) return;
+
+#ifdef NALU_USES_TIOGA
+  auto& tg = tioga_nalu::TiogaRef::self().get();
+
+  for (auto* tgiface: tgIfaceVec_) {
+    tgiface->register_mesh();
+  }
+
+  tg.profile();
+  tg.performConnectivity();
+
+  for (auto* tgiface: tgIfaceVec_) {
+    tgiface->post_connectivity_work(isDecoupled_);
+  }
+#endif
+}
+
+}  // nalu
+}  // sierra

--- a/src/overset/ExtOverset.C
+++ b/src/overset/ExtOverset.C
@@ -118,7 +118,6 @@ void ExtOverset::exchange_solution()
 
     auto& mgr = dynamic_cast<OversetManagerTIOGA*>(realm->oversetManager_)->tiogaIface_;
     ncomp = mgr.register_solution(realm->equationSystems_.oversetUpdater_->fields_);
-    std::cerr << realm->name() << " " << ncomp << std::endl;
   }
 
   tg.dataUpdate(ncomp, row_major);

--- a/src/overset/OversetManager.C
+++ b/src/overset/OversetManager.C
@@ -58,6 +58,15 @@ OversetManager::get_inactive_selector()
 }
 
 void
+OversetManager::reset_data_structures()
+{
+  delete_info_vec();
+  oversetInfoVec_.clear();
+  holeNodes_.clear();
+  fringeNodes_.clear();
+}
+
+void
 OversetManager::overset_orphan_node_field_update(
   stk::mesh::FieldBase *theField,
   const int sizeRow,

--- a/src/overset/OversetManagerTIOGA.C
+++ b/src/overset/OversetManagerTIOGA.C
@@ -11,13 +11,11 @@
 #ifdef NALU_USES_TIOGA
 
 #include "overset/OversetManagerTIOGA.h"
-
 #include "overset/OversetInfo.h"
-
-#include <NaluEnv.h>
-#include <NaluParsing.h>
-#include <Realm.h>
-#include <master_element/MasterElement.h>
+#include "overset/OversetFieldData.h"
+#include "NaluEnv.h"
+#include "NaluParsing.h"
+#include "Realm.h"
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
@@ -37,7 +35,8 @@ OversetManagerTIOGA::OversetManagerTIOGA(
   const OversetUserData& oversetUserData)
   : OversetManager(realm),
     oversetUserData_(oversetUserData),
-    tiogaIface_(*this, oversetUserData.oversetBlocks_)
+    tiogaIface_(*this, oversetUserData.oversetBlocks_,
+                realm.get_coordinates_name())
 {
   ThrowRequireMsg(
     metaData_->spatial_dimension() == 3u,

--- a/src/overset/OversetManagerTIOGA.C
+++ b/src/overset/OversetManagerTIOGA.C
@@ -52,19 +52,25 @@ OversetManagerTIOGA::setup()
   tiogaIface_.setup(realm_.bcPartVec_);
 }
 
-void
-OversetManagerTIOGA::initialize(const bool isDecoupled)
+void OversetManagerTIOGA::initialize()
 {
   const double timeA = NaluEnv::self().nalu_time();
   if (isInit_) {
     tiogaIface_.initialize();
     isInit_ = false;
   }
+  const double timeB = NaluEnv::self().nalu_time();
+  timerConnectivity_ += (timeB - timeA);
+}
 
-  delete_info_vec();
-  oversetInfoVec_.clear();
-  holeNodes_.clear();
-  fringeNodes_.clear();
+void
+OversetManagerTIOGA::execute(const bool isDecoupled)
+{
+  const double timeA = NaluEnv::self().nalu_time();
+  if (isInit_) {
+    tiogaIface_.initialize();
+    isInit_ = false;
+  }
 
   tiogaIface_.execute(isDecoupled);
 

--- a/src/overset/TiogaRef.C
+++ b/src/overset/TiogaRef.C
@@ -1,0 +1,60 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifdef NALU_USES_TIOGA
+
+#include "overset/TiogaRef.h"
+
+#include "tioga.h"
+
+#include <iostream>
+
+namespace tioga_nalu {
+
+TiogaRef& TiogaRef::self(TIOGA::tioga* tg)
+{
+  static bool initialized{false};
+  static std::unique_ptr<TiogaRef> tgref;
+
+  if (initialized) {
+    if (tg != nullptr)
+      throw std::runtime_error("Multiple registration of TIOGA object encountered");
+  } else {
+    if (tg == nullptr) {
+      tgref.reset(new TiogaRef());
+    } else {
+      tgref.reset(new TiogaRef(tg));
+    }
+    initialized = true;
+  }
+
+  return *tgref;
+}
+
+TiogaRef::TiogaRef()
+  : tg_(new TIOGA::tioga())
+  , owned_(true)
+{}
+
+TiogaRef::TiogaRef(TIOGA::tioga* tg)
+  : tg_(tg)
+  , owned_(false)
+{}
+
+TiogaRef::~TiogaRef()
+{
+  if (owned_ && (tg_ != nullptr)) {
+    delete tg_;
+    tg_ = nullptr;
+  }
+}
+
+}
+
+#endif

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -471,6 +471,32 @@ TiogaSTKIface::overset_update_fields(
   }
 }
 
+int TiogaSTKIface::register_solution(const std::vector<sierra::nalu::OversetFieldData>& fields)
+{
+  int nComp = 0;
+  for (auto& f: fields) {
+    f.field_->sync_to_host();
+    nComp += f.sizeRow_ * f.sizeCol_;
+  }
+
+  for (auto& tb: blocks_)
+    tb->register_solution(tg_, fields, nComp);
+
+  return nComp;
+}
+
+void TiogaSTKIface::update_solution(const std::vector<sierra::nalu::OversetFieldData>& fields)
+{
+  for (auto& tb: blocks_)
+    tb->update_solution(fields);
+
+  for (auto& finfo: fields) {
+    auto* fld = finfo.field_;
+    fld->modify_on_host();
+    fld->sync_to_device();
+  }
+}
+
 void TiogaSTKIface::overset_update_field(
   stk::mesh::FieldBase* field, const int nrows, const int ncols, const bool doFinalSyncToDevice)
 {

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -20,6 +20,7 @@
 #include "ngp_utils/NgpFieldUtils.h"
 
 #include "NaluEnv.h"
+#include "Realm.h"
 #include "master_element/MasterElement.h"
 #include "master_element/MasterElementFactory.h"
 #include "stk_util/parallel/ParallelReduce.hpp"
@@ -64,9 +65,13 @@ TiogaSTKIface::load(const YAML::Node& node)
   int num_meshes = oset_groups.size();
   blocks_.resize(num_meshes);
 
+  int offset = 0;
+  if (node["mesh_tag_offset"]) {
+    offset = node["mesh_tag_offset"].as<int>();
+  }
   for (int i = 0; i < num_meshes; i++) {
     blocks_[i].reset(new TiogaBlock(
-      meta_, bulk_, tiogaOpts_, oset_groups[i], coordsName_, i + 1));
+      meta_, bulk_, tiogaOpts_, oset_groups[i], coordsName_, offset + i + 1));
   }
 
   sierra::nalu::NaluEnv::self().naluOutputP0()

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -162,6 +162,7 @@ void TiogaSTKIface::execute(const bool isDecoupled)
 
 void TiogaSTKIface::reset_data_structures()
 {
+  oversetManager_.reset_data_structures();
   elemsToGhost_.clear();
   donorIDs_.clear();
   receptorIDs_.clear();

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -12,6 +12,7 @@
 
 #include "overset/TiogaSTKIface.h"
 #include "overset/TiogaBlock.h"
+#include "overset/TiogaRef.h"
 
 #include "overset/OversetManagerTIOGA.h"
 #include "overset/OversetInfo.h"
@@ -43,7 +44,7 @@ TiogaSTKIface::TiogaSTKIface(
 ) : oversetManager_(oversetManager),
     meta_(*oversetManager.metaData_),
     bulk_(*oversetManager.bulkData_),
-    tg_(new TIOGA::tioga()),
+    tg_(&TiogaRef::self().get()),
     coordsName_(coordsName)
 {
   load(node);

--- a/src/overset/UpdateOversetFringeAlgorithmDriver.C
+++ b/src/overset/UpdateOversetFringeAlgorithmDriver.C
@@ -36,6 +36,8 @@ UpdateOversetFringeAlgorithmDriver::register_overset_field_update(
 
 void UpdateOversetFringeAlgorithmDriver::execute()
 {
+  if (realm_.isExternalOverset_) return;
+
   const double timeA = NaluEnv::self().nalu_time();
   auto* oversetManager = realm_.oversetManager_;
   if (oversetManager->oversetGhosting_ != nullptr) {


### PR DESCRIPTION
This pull-request is the first stage of refactor of the overset connectivity algorithm implementation within Nalu-Wind to extract the overset connectivity logic from inside Realm to a higher-level so that we can do multi-Realm overset and AMR-Wind/Nalu-Wind overset simulations. 

## Checklist

- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [x] MacOS
  - Compilers 
    - [x] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors
