### PR TITLE
add an option to use Trilinos' s-step GMRES

### DIFF
--- a/src/LinearSolver.C
+++ b/src/LinearSolver.C
@@ -26,7 +26,6 @@
 #include <BelosConfigDefs.hpp>
 #include <BelosLinearProblem.hpp>
 #include <BelosTpetraAdapter.hpp>
-#include <Belos_Tpetra_GmresSstep.hpp>
 
 #include <Ifpack2_Factory.hpp>
 #include <Kokkos_DefaultNode.hpp>
@@ -113,10 +112,6 @@ void TpetraLinearSolver::setupLinearSolver(
 
     // create the solver, e.g., gmres, cg, tfqmr, bicgstab
     LinSys::SolverFactory sFactory;
-    if (config_->get_method() == "TPETRA GMRES S-STEP") {
-      bool verbose = (params_->get<int>("Output Frequency", 0) > 0);
-      BelosTpetra::Impl::register_GmresSstep (verbose);
-    }
     solver_ = sFactory.create(config_->get_method(), params_);
     solver_->setProblem(problem_);
   }

--- a/src/LinearSolver.C
+++ b/src/LinearSolver.C
@@ -26,6 +26,7 @@
 #include <BelosConfigDefs.hpp>
 #include <BelosLinearProblem.hpp>
 #include <BelosTpetraAdapter.hpp>
+#include <Belos_Tpetra_GmresSstep.hpp>
 
 #include <Ifpack2_Factory.hpp>
 #include <Kokkos_DefaultNode.hpp>
@@ -112,6 +113,10 @@ void TpetraLinearSolver::setupLinearSolver(
 
     // create the solver, e.g., gmres, cg, tfqmr, bicgstab
     LinSys::SolverFactory sFactory;
+    if (config_->get_method() == "TPETRA GMRES S-STEP") {
+      bool verbose = (params_->get<int>("Output Frequency", 0) > 0);
+      BelosTpetra::Impl::register_GmresSstep (verbose);
+    }
     solver_ = sFactory.create(config_->get_method(), params_);
     solver_->setProblem(problem_);
   }

--- a/src/LinearSolverConfig.C
+++ b/src/LinearSolverConfig.C
@@ -55,6 +55,19 @@ TpetraLinearSolverConfig::load(const YAML::Node & node)
 
   //Teuchos::RCP<Teuchos::ParameterList> params = Teuchos::params();
   params_->set("Solver Name", method_);
+  if (method_ == "sstep_gmres") {
+    method_ = "TPETRA GMRES S-STEP";
+
+    int step_size;
+    get_if_present(node, "krylov_step_size", step_size, step_size);
+    params_->set("Step Size", step_size);
+
+    bool ritz_on_fly = true;
+    params_->set("Compute Ritz Values on Fly", ritz_on_fly);
+
+    bool useCholQR2 = true;
+    params_->set("CholeskyQR2", useCholQR2);
+  }
   params_->set("Convergence Tolerance", tol);
   params_->set("Maximum Iterations", max_iterations);
   if (output_level > 0)


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

This PR adds an option to use s-step GMRES from Trilinos. 
- In the input file, we can specify to use s-step GMRES by "method: sstep_gmres" in the input file (with an optional step size "krylov_step_size: 5")   
- Currently, there is no unit-test for this option, but I have tested the option with a couple of inputs on Summit.

## Checklist

*All pull requests*
- [x] Builds successfully on Summit
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
