### PR TITLE
Add clipping when transferring tke/sdr

### DIFF
--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -167,6 +167,7 @@ public:
   virtual double provide_norm() const;
   virtual double provide_norm_increment() const;
   virtual bool system_is_converged() const;
+  virtual void post_external_data_transfer_work() {};
   
   virtual void register_wall_bc(
     stk::mesh::Part * /* part */,

--- a/include/EquationSystems.h
+++ b/include/EquationSystems.h
@@ -190,6 +190,8 @@ class EquationSystems
    */
   void post_iter_work();
 
+  void post_external_data_transfer_work();
+
 
   void register_overset_field_update(stk::mesh::FieldBase*, int, int);
 

--- a/include/ShearStressTransportEquationSystem.h
+++ b/include/ShearStressTransportEquationSystem.h
@@ -57,6 +57,7 @@ public:
   virtual void solve_and_update();
 
   void initial_work();
+  virtual void post_external_data_transfer_work();
 
   void clip_min_distance_to_wall();
   void compute_f_one_blending();

--- a/include/TurbKineticEnergyEquationSystem.h
+++ b/include/TurbKineticEnergyEquationSystem.h
@@ -87,6 +87,8 @@ public:
   void manage_projected_nodal_gradient(
     EquationSystems& eqSystems);
   void compute_projected_nodal_gradient();
+
+  void post_external_data_transfer_work();
   
   const bool managePNG_;
 

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -881,6 +881,20 @@ EquationSystems::populate_boundary_data()
 }
 
 //--------------------------------------------------------------------------
+//-------- post_external_data_transfer_work --------------------------------
+//--------------------------------------------------------------------------
+void
+EquationSystems::post_external_data_transfer_work()
+{
+  EquationSystemVector::iterator ii;
+  for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii ) {
+    for ( size_t k = 0; k < (*ii)->bcDataAlg_.size(); ++k ) {
+      (*ii)->post_external_data_transfer_work();
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
 //-------- boundary_data_to_state_data -------------------------------------
 //--------------------------------------------------------------------------
 void

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -4227,6 +4227,8 @@ Realm::process_external_data_transfer()
   std::vector<Transfer *>::iterator ii;
   for( ii=externalDataTransferVec_.begin(); ii!=externalDataTransferVec_.end(); ++ii )
     (*ii)->execute();
+
+  equationSystems_.post_external_data_transfer_work();
   timeXfer += NaluEnv::self().nalu_time();
   timerTransferExecute_ += timeXfer;
 }


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Currently, when we transfer in tke/sdr during the simulation, e.g. for inflow BC, we don't check that these quantities have remained positive.  Slight floating point changes in the interpolative transfer can result in slightly out-of-bounds values for TKE, which will cause the simulation to halt when we take the square root.  This provides a `post_external_data_transfer_work()` function where we can do a straight-forward clipping of the transferred data in the case of Ksgs or a more complicated clipping in the case of SST.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
