### PR TITLE
Hybrid-solver overset: add fine-grained methods to API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,11 +308,17 @@ export(
 install(
   EXPORT ${PROJECT_NAME}Targets
   NAMESPACE ${PROJECT_NAME}::
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  DESTINATION lib/cmake/${PROJECT_NAME})
 configure_package_config_file(
   cmake/${PROJECT_NAME}Config.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-  INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+  DESTINATION lib/cmake/${PROJECT_NAME})
+
+# Provide CMake files for downstream projects
+install(FILES
+  ${PROJECT_SOURCE_DIR}/cmake/FindHYPRE.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/FindFFTW.cmake
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/Modules)

--- a/cmake/Nalu-WindConfig.cmake.in
+++ b/cmake/Nalu-WindConfig.cmake.in
@@ -1,12 +1,54 @@
 @PACKAGE_INIT@
 
-set(NALU_WIND_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_INCLUDEDIR@")
-set(NALU_WIND_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_LIBDIR@")
+list(APPEND CMAKE_MODULE_PATH "${PACKAGE_PREFIX_DIR}/@CMAKE_INSTALL_DATADIR@/cmake/Modules")
+
+# Set informational variables for all dependencies that were enabled
+set(NALU_USES_HYPRE @ENABLE_HYPRE@)
+set(NALU_USES_TIOGA @ENABLE_TIOGA@)
+set(NALU_USES_OPENFAST @ENABLE_OPENFAST@)
+set(NALU_USES_FFTW @ENABLE_FFTW@)
+
+# Load dependency libraries so that the targets are available
+
+if (NOT ${Trilinos_FOUND})
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "@Trilinos_DIR@")
+  find_package(Trilinos QUIET REQUIRED)
+endif()
+
+if (NOT ${YAML-CPP_FOUND})
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "@YAML-CPP_DIR@")
+  find_package(YAML-CPP QUIET REQUIRED)
+endif()
+
+if (NOT ${Boost_FOUND})
+  find_package(Boost QUIET REQUIRED COMPONENTS filesystem iostreams)
+endif()
+
+if (${NALU_USES_TIOGA} AND NOT ${TIOGA_FOUND})
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "@TIOGA_DIR@")
+  find_package(TIOGA QUIET REQUIRED)
+endif()
+
+if (${NALU_USES_OPENFAST} AND NOT ${OpenFAST_FOUND})
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "@OpenFAST_DIR@")
+  find_package(OpenFAST QUIET REQUIRED)
+endif()
+
+if (${NALU_USES_HYPRE} AND NOT ${HYPRE_FOUND})
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "@HYPRE_DIR@")
+  find_package(HYPRE QUIET REQUIRED)
+endif()
+
+if (${NALU_USES_FFTW} AND NOT ${FFTW_FOUND})
+  set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} "@FFTW_DIR@")
+  find_package(FFTW QUIET REQUIRED)
+endif()
+
+set_and_check(NALU_WIND_INCLUDE_DIRS "${PACKAGE_PREFIX_DIR}/include")
+set_and_check(NALU_WIND_LIBRARY_DIRS "${PACKAGE_PREFIX_DIR}/lib")
 
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
-
 set(NALU_WIND_LIBRARIES "@PROJECT_NAME@::nalu")
-
 set(NALU_WIND_FOUND TRUE)
 
 check_required_components(NALU_WIND)

--- a/include/Simulation.h
+++ b/include/Simulation.h
@@ -38,6 +38,8 @@ public:
   void load(const YAML::Node & node);
   void breadboard();
   void initialize();
+  void init_prolog();
+  void init_epilog();
   void run();
   void high_level_banner();
   Simulation *root() { return this; }

--- a/include/overset/ExtOverset.h
+++ b/include/overset/ExtOverset.h
@@ -29,15 +29,34 @@ public:
 
   ~ExtOverset();
 
+  //! Initialize MPI comm for TIOGA instance
   void set_communicator();
 
+  //! Set up mesh metadata structures within overset instances
   void breadboard();
 
+  /** Perform initial connectivity between participating meshes
+   */
   void initialize();
 
+  /** Update overset connectivity for moving meshes
+   */
   void update_connectivity();
 
+  //! Update solution fields using TIOGA
   void exchange_solution();
+
+  //! Register meshes to TIOGA to perform overset connectivity with external meshes
+  void pre_overset_conn_work();
+
+  //! Perform IBLANK updates (and ghosting if necessary) after connectivity
+  void post_overset_conn_work();
+
+  //! Register solution fields to TIOGA before interpolation step
+  int register_solution();
+
+  //! Update solution fields after TIOGA has performed interpolations
+  void update_solution();
 
   bool multi_solver_mode() const { return multiSolverMode_; }
 

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -20,6 +20,7 @@
 #include <TimeIntegrator.h>
 #include <LinearSolvers.h>
 #include <NaluVersionInfo.h>
+#include "overset/ExtOverset.h"
 
 #include <Ioss_SerializeIO.h>
 
@@ -148,6 +149,18 @@ void Simulation::initialize()
   timeIntegrator_->initialize();
   transfers_->initialize();
   realms_->initialize_epilog();
+}
+
+void Simulation::init_prolog()
+{
+  realms_->initialize_prolog();
+  timeIntegrator_->overset_->initialize();
+}
+
+void Simulation::init_epilog()
+{
+  realms_->initialize_epilog();
+  transfers_->initialize();
 }
 
 void Simulation::run()

--- a/src/overset/ExtOverset.C
+++ b/src/overset/ExtOverset.C
@@ -108,6 +108,28 @@ void ExtOverset::update_connectivity()
 #endif
 }
 
+void ExtOverset::pre_overset_conn_work()
+{
+  if (!hasOverset_) return;
+
+#ifdef NALU_USES_TIOGA
+  for (auto* tgiface: tgIfaceVec_) {
+    tgiface->register_mesh();
+  }
+#endif
+}
+
+void ExtOverset::post_overset_conn_work()
+{
+  if (!hasOverset_) return;
+
+#ifdef NALU_USES_TIOGA
+  for (auto* tgiface: tgIfaceVec_) {
+    tgiface->post_connectivity_work(isDecoupled_);
+  }
+#endif
+}
+
 void ExtOverset::exchange_solution()
 {
   if (!hasOverset_) return;
@@ -134,6 +156,37 @@ void ExtOverset::exchange_solution()
   }
 #endif
 }
+
+int ExtOverset::register_solution()
+{
+  int ncomp = 0;
+  if (!hasOverset_) return ncomp;
+
+#ifdef NALU_USES_TIOGA
+  for (auto* realm: time_.realmVec_) {
+    if (!realm->hasOverset_) continue;
+
+    auto& mgr = dynamic_cast<OversetManagerTIOGA*>(realm->oversetManager_)->tiogaIface_;
+    ncomp = mgr.register_solution(realm->equationSystems_.oversetUpdater_->fields_);
+  }
+#endif
+  return ncomp;
+}
+
+void ExtOverset::update_solution()
+{
+  if (!hasOverset_) return;
+
+#ifdef NALU_USES_TIOGA
+  for (auto* realm: time_.realmVec_) {
+    if (!realm->hasOverset_) continue;
+
+    auto& mgr = dynamic_cast<OversetManagerTIOGA*>(realm->oversetManager_)->tiogaIface_;
+    mgr.update_solution(realm->equationSystems_.oversetUpdater_->fields_);
+  }
+#endif
+}
+
 
 }  // nalu
 }  // sierra


### PR DESCRIPTION
This PR adds two changes 

- Adds fine-grained methods in overset interface to control information exchange with an external solver
- Updates CMake install logic to do the following:
  - Install cmake files for finding FFTW and HYPRE packages that can be used by downstream users
  - Update Nalu-Wind config file to automatically load its dependencies to simply import of Nalu-Wind for downstream packages

## Checklist

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [X] MacOS
  - Compilers 
    - [ ] GCC
    - [X] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all regression tests
- [X] Documentation builds without errors

