### PR TITLE
Allow user to suppress tower in openfast

### DIFF
--- a/src/actuator/ActuatorBulkFAST.C
+++ b/src/actuator/ActuatorBulkFAST.C
@@ -143,7 +143,7 @@ ActuatorBulkFAST::init_epsilon(const ActuatorMetaFAST& actMeta)
   for (int iTurb = 0; iTurb < nTurb; iTurb++) {
     if (openFast_.get_procNo(iTurb) == NaluEnv::self().parallel_rank()) {
       ThrowAssert(actMeta.numPointsTotal_ >= openFast_.get_numForcePts(iTurb));
-      const int numForcePts = openFast_.get_numForcePts(iTurb);
+      const int numForcePts = actMeta.numPointsTurbine_.h_view(iTurb);
       const int offset = turbIdOffset_.h_view(iTurb);
       auto epsilonChord =
         Kokkos::subview(actMeta.epsilonChord_.view_host(), iTurb, Kokkos::ALL);


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Previously if the tower was surpressed it would
create a bug leading to zero epsilon and nan's
due to inconsistencies in the interface between
nalu-wind and openfast

This fixes that issues

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
