### PR TITLE
Update NaluEnv for multi-solver simulations

### DIFF
--- a/include/NaluEnv.h
+++ b/include/NaluEnv.h
@@ -51,7 +51,20 @@ class NaluEnv
   MPI_Comm parallel_comm();
   int parallel_size();
   int parallel_rank();
-  void set_log_file_stream(std::string naluLogName, bool pprint = false);
+
+  /** Redirect output to a log file
+   *
+   *  \param naluLogName Name of the file where outputs are redirected
+   *
+   *  \param pprint (Parallel print) If true, all MPI ranks output to their own file
+   *
+   *  \param capture_cout If true, `std::cout` is redirected to log file
+   *
+   */
+  void set_log_file_stream(
+    std::string naluLogName,
+    bool pprint = false,
+    const bool capture_cout = false);
   void close_log_file_stream();
   double nalu_time();
 };

--- a/nalu.C
+++ b/nalu.C
@@ -146,7 +146,8 @@ int main( int argc, char ** argv )
     pprint = true;
   }
   // deal with log file stream
-  naluEnv.set_log_file_stream(logFileName, pprint);
+  const bool capture_stdout = true;
+  naluEnv.set_log_file_stream(logFileName, pprint, capture_stdout);
 
   // proceed with reading input file "document" from YAML
   YAML::Node doc = YAML::LoadFile(inputFileName.c_str());
@@ -244,6 +245,9 @@ int main( int argc, char ** argv )
     naluEnv.naluOutputP0(), false, true, false, Teuchos::Union);
   }
   Kokkos::finalize_all();
+
+  MPI_Finalize();
+
   // all done  
   return 0;
 }

--- a/src/NaluEnv.C
+++ b/src/NaluEnv.C
@@ -36,7 +36,7 @@ NaluEnv::NaluEnv()
     pSize_(-1),
     pRank_(-1),
     stdoutStream_(std::cout.rdbuf()),
-    naluLogStream_(&std::cout), // std::cout redirects to log file
+    naluLogStream_(new std::ostream(std::cout.rdbuf())),
     naluParallelStream_(new std::ostream(&naluParallelStreamBuffer_)),
     parallelLog_(false)
 {
@@ -103,7 +103,8 @@ NaluEnv::parallel_comm()
 //-------- set_log_file_stream ---------------------------------------------
 //--------------------------------------------------------------------------
 void
-NaluEnv::set_log_file_stream(std::string naluLogName, bool pprint)
+NaluEnv::set_log_file_stream(
+  std::string naluLogName, bool pprint, const bool capture_cout)
 {
   if ( pRank_ == 0 ) {
     naluStreamBuffer_.open(naluLogName.c_str(), std::ios::out);
@@ -112,6 +113,9 @@ NaluEnv::set_log_file_stream(std::string naluLogName, bool pprint)
   else {
     naluLogStream_->rdbuf(&naluEmptyStreamBuffer_);
   }
+
+  if (capture_cout)
+    std::cout.rdbuf(naluLogStream_->rdbuf());
 
   // default to an empty stream buffer for parallel unless pprint is set
   parallelLog_ = pprint;
@@ -153,10 +157,11 @@ NaluEnv::close_log_file_stream()
 NaluEnv::~NaluEnv()
 {
   close_log_file_stream();
+  delete naluLogStream_;
   delete naluParallelStream_;
 
   // shut down MPI
-  MPI_Finalize();
+  // MPI_Finalize();
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
- Move MPI_Finalize out of NaluEnv destructor to avoid errors with multiple
  calls to MPI_Finalize, when using an external driver with Nalu-Wind

- Do not hijack std::cout's buffer to allow different codes to direct I/O to
  their own files or to standard out.

- Default behavior (hijacking `std::cout`) is restored when running through
  `naluX`


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement


*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
