### PR TITLE
Allow users to fix hub epsilon

### DIFF
--- a/include/actuator/ActuatorBulkFAST.h
+++ b/include/actuator/ActuatorBulkFAST.h
@@ -38,6 +38,7 @@ struct ActuatorMetaFAST : public ActuatorMeta
   ActVectorDblDv epsilon_;
   ActVectorDblDv epsilonChord_;
   ActVectorDblDv epsilonTower_;
+  ActVectorDblDv epsilonHub_;
   ActFixScalarBool useUniformAziSampling_;
   ActFixScalarInt nPointsSwept_;
   ActFixScalarInt nBlades_;

--- a/src/actuator/ActuatorBulkFAST.C
+++ b/src/actuator/ActuatorBulkFAST.C
@@ -7,7 +7,6 @@
 // for more details.
 //
 
-#include <Kokkos_DualView.hpp>
 #include <actuator/ActuatorBulkFAST.h>
 #include <actuator/UtilitiesActuator.h>
 #include <actuator/ActuatorFunctorsFAST.h>

--- a/src/actuator/ActuatorParsingFAST.C
+++ b/src/actuator/ActuatorParsingFAST.C
@@ -11,8 +11,6 @@
 #include <NaluParsing.h>
 #include <actuator/ActuatorParsingFAST.h>
 #include <NaluEnv.h>
-#include <yaml-cpp/node/node.h>
-#include <yaml-cpp/node/type.h>
 
 namespace sierra {
 namespace nalu {

--- a/src/actuator/ActuatorParsingFAST.C
+++ b/src/actuator/ActuatorParsingFAST.C
@@ -11,6 +11,8 @@
 #include <NaluParsing.h>
 #include <actuator/ActuatorParsingFAST.h>
 #include <NaluEnv.h>
+#include <yaml-cpp/node/node.h>
+#include <yaml-cpp/node/type.h>
 
 namespace sierra {
 namespace nalu {
@@ -135,6 +137,21 @@ readTurbineData(int iTurb, ActuatorMetaFAST& actMetaFAST, YAML::Node turbNode)
      for (int j = 0; j < 3; j++) {
        actMetaFAST.epsilonTower_.h_view(iTurb, j) =
          actMetaFAST.epsilon_.h_view(iTurb, j);
+     }
+   }
+   const YAML::Node epsilon_hub = turbNode["epsilon_hub"];
+   if(epsilon_hub){
+     if(epsilon_hub.Type() == YAML::NodeType::Scalar){
+       const double epsilonHub = epsilon_hub.as<double>();
+       for(int j=0; j<3; j++){
+         actMetaFAST.epsilonHub_.h_view(iTurb, j) = epsilonHub;
+       }
+     }
+     else{
+       epsilonTemp = epsilon_hub.as<std::vector<double>>();
+       for(int j=0; j<3; j++){
+         actMetaFAST.epsilonHub_.h_view(iTurb, j) = epsilonTemp[j];
+       }
      }
    }
   get_required(turbNode, "turb_id", fi.globTurbineData[iTurb].TurbID);


### PR DESCRIPTION
The current nacelle model determines epsilon automatically
based on the paramaters that are supplied.
One side affect of this model is as cD and area are increased so is
epsilon, making the nacellel forcing more diffuse.
This change allows users to fix the hub epsilon to concentrate the
actuator force from the hub instead of having it be calculated
automatically for them.

An intermediate step to give analysts a little more freedom while we work on #673 


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
