### PR TITLE
change to ngp_throw in scratchviews

### DIFF
--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -196,7 +196,7 @@ int create_needed_field_views(const TEAMHANDLETYPE& team,
       }
     }
     else {
-      ThrowRequireMsg(false,"Unknown stk-rank" << fieldEntityRank);
+      NGP_ThrowRequireMsg(false,"Unknown stk-rank");
     }
   }
 


### PR DESCRIPTION
**Pull-request type:**
- [X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Caused an error when compiling on a local cluster.  It's in a `__device__` function, so it definitely would cause problems if throw is ever hit.  This changes it to be the same throw as in `count_needed_field_views`.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [x] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
