### PR TITLE
Hypre linear system assembly fixes for dirichlet rows

### DIFF
--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -1506,6 +1506,8 @@ HypreLinearSystem::HypreLinSysCoeffApplier::sum_into(
 	const double* cur_lhs = &lhs(ir, 0);
 	hid = localIds[ir];
 	
+	if (!map_shared_.exists(hid)) continue;
+
 	/* Find the index of the row */
 	unsigned index = map_shared_.value_at(map_shared_.find(hid));
 	unsigned lower = mat_row_start_shared_(index);
@@ -1574,6 +1576,7 @@ HypreLinearSystem::HypreLinSysCoeffApplier::sum_into_1DoF(
       rhsIndex = Kokkos::atomic_fetch_add(&rhs_counter_owned_(rhsIndex), (unsigned)1);
       rhs_vals_owned_(rhsIndex,0) = rhs[i];
     } else {
+      if (!map_shared_.exists(hid)) continue;
       /* Find the index of the row */
       unsigned index = map_shared_.value_at(map_shared_.find(hid));
       unsigned lower = mat_row_start_shared_(index);
@@ -1583,7 +1586,7 @@ HypreLinearSystem::HypreLinSysCoeffApplier::sum_into_1DoF(
       for (unsigned k=0; k<numEntities; ++k) {
 	/* binary search subrange rather than a map.find */
 	HypreIntType col = localIds[k];
-	unsigned matIndex=globalNumRows_+1;
+	unsigned matIndex;
 	binarySearchShared(lower,upper,col,matIndex);	  
 	/* Find the matrix element memory location */
 	matIndex = Kokkos::atomic_fetch_add(&mat_counter_shared_(matIndex), (unsigned)1);

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -453,6 +453,7 @@ HypreUVWLinearSystem::HypreUVWLinSysCoeffApplier::sum_into(
 	rhs_vals_owned_(rhsIndex,d) = rhs[ir];
       }
     } else {
+      if (!map_shared_.exists(hid)) continue;
       int offset = 0;
       unsigned index = map_shared_.value_at(map_shared_.find(hid));
       unsigned lower = mat_row_start_shared_(index);


### PR DESCRIPTION
This branch fixes bugs observed in many core Hypre runs. Dirichlet nodes were in the ghost cells were being accumulated multiple times to the matrix and rhs and the skipped rows logic was not catching this. The fix is to ensure that in the shared rows of the matrix, that row actually exists and is a dirichlet row i.e. not accumulated through the normal Assemble*Algorithm mechanism.


**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
