### PR TITLE
Add check for periodic and fix-pressure-at-node combination

### DIFF
--- a/include/PeriodicManager.h
+++ b/include/PeriodicManager.h
@@ -88,9 +88,12 @@ class PeriodicManager {
 
   const stk::mesh::PartVector &get_slave_part_vector();
 
-  double get_search_time();
+  const stk::mesh::PartVector& periodic_parts_vector()
+  {
+    return periodicPartVec_;
+  }
 
-// private:
+  double get_search_time();
 
   void augment_periodic_selector_pairs();
 
@@ -174,6 +177,8 @@ class PeriodicManager {
 
   // vector of master:slave selector pairs
   std::vector<SelectorPair> periodicSelectorPairs_;
+
+  stk::mesh::PartVector periodicPartVec_;
 
   // vector of slave parts
   stk::mesh::PartVector slavePartVector_;

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -86,6 +86,8 @@ PeriodicManager::add_periodic_pair(
   // use most stringent tolerance (min) for all of user specifications
   searchTolerance_ = std::min(searchTolerance_, userSearchTolerance);
 
+  periodicPartVec_.push_back(masterMeshPart);
+  periodicPartVec_.push_back(slaveMeshPart);
   // form the slave part vector
   slavePartVector_.push_back(slaveMeshPart);
 


### PR DESCRIPTION
Raise an error if the node where pressure fixing is applied happens to lie on a
periodic sideset. Periodic nodes could be ghosted, and then participate in
linear system, but this was not properly checked.


**Pull-request type:**
- [X] Bug fix 

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [X] GCC
    - [ ] LLVM/Clang
    - [X] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
