### PR TITLE
Hypre Preconditioner Recomputation Logic

### DIFF
--- a/include/HypreDirectSolver.h
+++ b/include/HypreDirectSolver.h
@@ -62,6 +62,9 @@ public:
   //! Return the type of solver instance
   virtual PetraType getType() override { return PT_HYPRE; }
 
+  //! public API for resetting the flag for how often the preconditioner is recomputed
+  virtual void set_initialize_solver_flag();
+  
   //! Instance of the Hypre parallel matrix
   mutable HYPRE_ParCSRMatrix parMat_;
 
@@ -133,7 +136,10 @@ protected:
   bool isPrecondSetup_{false};
 
   //! Flag indicating whether this class instance has been initialized fully
-  bool isInitialized_{false};
+  bool initializeSolver_{true};
+
+  //! Used with recomputePrecondFrequency to determine when to reinitialize the solver/preconditioner
+  unsigned internalIterCounter_{0};
 
 private:
   HypreDirectSolver() = delete;

--- a/include/LinearSolverConfig.h
+++ b/include/LinearSolverConfig.h
@@ -56,6 +56,9 @@ public:
   inline bool recomputePreconditioner() const
   { return recomputePreconditioner_; }
 
+  inline unsigned recomputePrecondFrequency() const
+  { return recomputePrecondFrequency_; }
+
   inline bool reusePreconditioner() const
   { return reusePreconditioner_; }
 
@@ -91,6 +94,7 @@ protected:
   Teuchos::RCP<Teuchos::ParameterList> paramsPrecond_;
 
   bool recomputePreconditioner_{true};
+  unsigned recomputePrecondFrequency_{1}; /* positive integer. Recompute precond before all solves */
   bool reusePreconditioner_{false};
   bool useSegregatedSolver_{false};
   bool writeMatrixFiles_{false};

--- a/src/HypreLinearSolverConfig.C
+++ b/src/HypreLinearSolverConfig.C
@@ -53,6 +53,8 @@ HypreLinearSolverConfig::load(const YAML::Node& node)
 
   get_if_present(node, "recompute_preconditioner",
                  recomputePreconditioner_, recomputePreconditioner_);
+  get_if_present(node, "recompute_preconditioner_frequency",
+                 recomputePrecondFrequency_, recomputePrecondFrequency_);
   get_if_present(node, "reuse_preconditioner",
                  reusePreconditioner_, reusePreconditioner_);
   get_if_present(node, "segregated_solver", useSegregatedSolver_, useSegregatedSolver_);

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -2325,6 +2325,9 @@ HypreLinearSystem::solve(stk::mesh::FieldBase* linearSolutionField)
 
   status = solver->solve(iters, finalResidNorm, realm_.isFinalOuterIter_);
 
+  /* set this after the solve calls */
+  solver->set_initialize_solver_flag();
+
   if (solver->getConfig()->getWriteMatrixFiles()) {
     std::string writeCounter = std::to_string(eqSys_->linsysWriteCounter_);
     const std::string slnFile = eqSysName_ + ".IJV." + writeCounter + ".sln";

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -257,6 +257,9 @@ HypreUVWLinearSystem::solve(stk::mesh::FieldBase* slnField)
   copy_hypre_to_stk(slnField, rhsNorm);
   sync_field(slnField);
 
+  /* set this after the solve calls */
+  solver->set_initialize_solver_flag();
+
   if (solver->getConfig()->getWriteMatrixFiles()) {
     for (unsigned d=0; d < nDim_; ++d) {
       std::string writeCounter = std::to_string(eqSys_->linsysWriteCounter_);

--- a/src/HypreUVWSolver.C
+++ b/src/HypreUVWSolver.C
@@ -36,8 +36,7 @@ HypreUVWSolver::solve(
 {
   // Initialize the solver on first entry
   double time = -NaluEnv::self().nalu_time();
-  if (!isInitialized_ || config_->recomputePreconditioner())
-    initSolver();
+  if (initializeSolver_) initSolver();
   time += NaluEnv::self().nalu_time();
   timerPrecond_ = time;
 


### PR DESCRIPTION
… defined frequency measured by every picard iteration. If one does 4 picard iterations per time step and one selects precond_recompute_frequency=2, then the preconditioner will be recomputed before the first and third picard iterations. Other related parameters, reuse_preconditioner and and recompute_preconditioner, continue to work and they take precedence over this new parameter. Hypre CPU tests were run on rhodes and are unaffected by this change.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
