### PR TITLE
Clip TKE only if it becomes negative

### DIFF
--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -359,7 +359,7 @@ ShearStressTransportEquationSystem::update_and_clip()
       const double tkeNew = tkeNp1.get(mi, 0) + kTmp.get(mi, 0);
       const double sdrNew = sdrNp1.get(mi, 0) + wTmp.get(mi, 0);
 
-      tkeNp1.get(mi, 0) = stk::math::max(tkeNew, tkeMinVal);
+      tkeNp1.get(mi, 0) = (tkeNew < 0.0) ? tkeMinVal : tkeNew;
       sdrNp1.get(mi, 0) = stk::math::max(sdrNew, sdrMinVal);
     });
 
@@ -387,7 +387,7 @@ ShearStressTransportEquationSystem::clip_sst(
       const double tkeNew = tke.get(mi, 0);
       const double sdrNew = sdr.get(mi, 0);
 
-      tke.get(mi, 0) = stk::math::max(tkeNew, tkeMinVal);
+      tke.get(mi, 0) = (tkeNew < 0.0) ? tkeMinVal : tkeNew;
       sdr.get(mi, 0) = stk::math::max(sdrNew, sdrMinVal);
     });
   tke.modify_on_device();


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Previous clipping effort was incorrect and overrode the user defined zero BC value of TKE. This ensures TKE is _only_ clipped when it is less than zero

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [X] GCC
    - [ ] LLVM/Clang
    - [X] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all regression tests, except SST/TAMS tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
