### PR TITLE
Transition overset interface to NGP

### DIFF
--- a/include/overset/OversetNGP.h
+++ b/include/overset/OversetNGP.h
@@ -1,0 +1,46 @@
+#ifndef OVERSETNGP_H
+#define OVERSETNGP_H
+
+#include "KokkosInterface.h"
+
+namespace tioga_nalu {
+
+template<typename T,
+         typename Layout = Kokkos::LayoutRight,
+         typename Space = sierra::nalu::MemSpace>
+using OversetArrayViewType = Kokkos::View<T, Layout, Space>;
+
+template<typename T,
+         typename Layout = Kokkos::LayoutRight,
+         typename Space = sierra::nalu::MemSpace>
+struct OversetArrayType
+{
+  using ArrayType = OversetArrayViewType<T, Layout, Space>;
+  using HostArrayType = typename ArrayType::HostMirror;
+
+  ArrayType d_view;
+  HostArrayType h_view;
+
+  OversetArrayType() : d_view(), h_view() {}
+
+  OversetArrayType(const std::string& label, const size_t len)
+    : d_view(label, len), h_view(Kokkos::create_mirror_view(d_view))
+  {
+  }
+
+  size_t size() const { return d_view.size(); }
+
+  void init(const std::string& label, const size_t len)
+  {
+    d_view = ArrayType(label, len);
+    h_view = Kokkos::create_mirror_view(d_view);
+  }
+
+  void sync_device() { Kokkos::deep_copy(d_view, h_view); }
+
+  void sync_host() { Kokkos::deep_copy(h_view, d_view); }
+};
+
+}
+
+#endif /* OVERSETNGP_H */

--- a/include/overset/TiogaOptions.h
+++ b/include/overset/TiogaOptions.h
@@ -47,7 +47,13 @@ public:
 
   bool reduce_fringes() const { return reduceFringes_; }
 
+  double cell_res_mult() const { return cellResMult_; }
+  double node_res_mult() const { return nodeResMult_; }
+
 private:
+  double cellResMult_{1.0};
+  double nodeResMult_{1.0};
+
   //! Symmetry plane direction [1 = x; 2 = y; 3 = z]; default = 3
   int symmetryDir_{3};
 

--- a/src/TimeIntegrator.C
+++ b/src/TimeIntegrator.C
@@ -309,6 +309,14 @@ TimeIntegrator::integrate_realm()
 
   prepare_for_time_integration();
 
+  bool update_overset = false;
+  for (auto* realm: realmVec_) {
+    if (realm->has_mesh_motion()) {
+      update_overset = true;
+      break;
+    }
+  }
+
   //=====================================
   // time integration
   //=====================================
@@ -317,7 +325,7 @@ TimeIntegrator::integrate_realm()
     const double startTime = NaluEnv::self().nalu_time();
 
     pre_realm_advance_stage1();
-    overset_->update_connectivity();
+    if (update_overset) overset_->update_connectivity();
     pre_realm_advance_stage2();
 
     const double endPreProc = NaluEnv::self().nalu_time();

--- a/src/overset/TiogaOptions.C
+++ b/src/overset/TiogaOptions.C
@@ -34,6 +34,13 @@ void TiogaOptions::load(const YAML::Node& node)
     hasMexclude_ = true;
     mExclude_= node["num_exclude"].as<int>();
   }
+
+  if (node["cell_resolution_multiplier"]) {
+    cellResMult_ = node["cell_resolution_multiplier"].as<double>();
+  }
+  if (node["node_resolution_multiplier"]) {
+    nodeResMult_ = node["node_resolution_multiplier"].as<double>();
+  }
 }
 
 void TiogaOptions::set_options(TIOGA::tioga& tg)


### PR DESCRIPTION
This PR is a first in the series of updates to overset interface so that we can access the NGP API of TIOGA when running on GPUs. Changes

- Update data structures that were using `std::vector` and `std::map` in Tioga interface classes to Kokkos::Views
- Update the code to consistently manage host/device views of the data
- Register the host views using the current interface
- Fix code in TimeIntegrator so that tioga instance is no longer created for non-overset runs

I decided to keep the code simple by explicitly handling View+HostMirror instead of using `Kokkos::DualView`, but it should be fairly easy to switch these out in future if the need arises. 

## Checklist

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [X] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [X] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all regression tests
- [ ] Documentation builds without errors