### PR TITLE
Overset: Adjust resolutions for mandatory fringes

### DIFF
--- a/include/overset/TiogaBlock.h
+++ b/include/overset/TiogaBlock.h
@@ -30,24 +30,78 @@ typedef stk::mesh::Field<int> ScalarIntFieldType;
  */
 struct NgpTiogaBlock
 {
+  /** Number of cell types supported by TIOGA
+   *
+   *  Currently it supports hex, tet, wedge, and pyramids
+   */
   static constexpr int max_vertex_types = 4;
 
+  //! Coordinates of the nodes for this mesh (size = 3 * num_nodes)
   OversetArrayType<double*> xyz_;
+
+  //! Nodal resolutions used for resolution check (size = num_nodes)
   OversetArrayType<double*> node_res_;
+
+  //! Cell resolutions used for resolution checks (size = num_elements)
   OversetArrayType<double*> cell_res_;
-  OversetArrayType<double*> qnode_;
+
+  //! IBLANK array populated after overset connectivity (size = num_nodes)
   OversetArrayType<int*> iblank_;
+
+  //! IBLANK array populated after overset connectivity (size = num_nodes)
   OversetArrayType<int*> iblank_cell_;
+
+  /** Indices of the nodes that define the wall boundaries
+   *
+   *  The indices are 1-based (Fortran style)
+   */
   OversetArrayType<int*> wallIDs_;
+
+  /** Indices of the nodes that define the overset boundaries
+   *
+   *  The indices are 1-based (Fortran style)
+   */
   OversetArrayType<int*> ovsetIDs_;
+
+  /** Array indicating the number of vertices in the element topologies
+   *
+   *  The number of vertices indicate the element type, i.e., `8 = hex, 6 =
+   *  wedge, 5 = pyramid, 4 = tet`. No other values are allowed.
+   *
+   *  For a mesh containing solely hex elements, this array just contains one
+   *  entry: `{8}`.
+   */
   OversetArrayType<int*> num_verts_;
+
+  /** Array indicating the number of elements for each element topology.
+   *
+   *  This array is the same size as `num_verts_`.
+   */
   OversetArrayType<int*> num_cells_;
+
+  /** Element connectivity information
+   *
+   *  Pointers to arrays containing connectivity information for the elements.
+   *  Ony num_vertex_types entries are filled. Each array has (num_vertices *
+   *  num_cells) entries for individual topologies.
+   */
   OversetArrayType<int*> connect_[max_vertex_types];
 
+  //! TIOGA index lookup using local entity index. TIOGA uses 1-based indexing,
+  //! so the first entry (node/element) has the index set to 1. This must be
+  //! taken into account when dereferencing entries in TIOGA data arrays.
   OversetArrayType<int*> eid_map_;
+
+  //! The global STK identifier for this node. Used to identify shared nodes
+  //! across domain partitions.
   OversetArrayType<stk::mesh::EntityId*> node_gid_;
+
+  //! The global STK identifier for an element. Used to identify donors on a
+  //! different MPI partition at the receptor MPI ranks. Not necessary if STK
+  //! ghosting is not used.
   OversetArrayType<stk::mesh::EntityId*> cell_gid_;
 
+  //! Solution array used to exchange data between meshes through TIOGA
   OversetArrayType<double*> qsol_;
 };
 

--- a/include/overset/TiogaBlock.h
+++ b/include/overset/TiogaBlock.h
@@ -106,6 +106,10 @@ public:
    */
   void update_element_volumes();
 
+  /** Adjust resolutions of mandatory fringe entities
+   */
+  void adjust_resolutions();
+
   /** Register this block with TIOGA
    *
    *  Wrapper method to handle mesh block registration using TIOGA API. In

--- a/include/overset/TiogaOptions.h
+++ b/include/overset/TiogaOptions.h
@@ -47,6 +47,15 @@ public:
 
   bool reduce_fringes() const { return reduceFringes_; }
 
+  /** Adjust resolutions for mandatory fringe nodes
+   *
+   *  If true, then the entities connected to overset sidesets have their
+   *  nodal/cell resolutions adjusted so that TIOGA will never consider these
+   *  cells as donors. This adjustment is necessary to avoid fringe/field
+   *  mismatch across domain partition boundaries.
+   */
+  bool adjust_resolutions() const { return adjustResolutionsForFringes_; }
+
   double cell_res_mult() const { return cellResMult_; }
   double node_res_mult() const { return nodeResMult_; }
 
@@ -86,6 +95,10 @@ private:
 
   //! Flag indicating whether user has set the mexclude variable
   bool hasMexclude_{false};
+
+  //! Flag indicating whether the node/cell resolutions should be adjusted for
+  //! mandatory fringes
+  bool adjustResolutionsForFringes_{true};
 };
 
 }

--- a/src/overset/TiogaBlock.C
+++ b/src/overset/TiogaBlock.C
@@ -287,7 +287,7 @@ void TiogaBlock::adjust_resolutions()
 
       for (unsigned ie=0; ie < num_elems; ++ie) {
         const auto elem = elems[ie];
-        const int eidx = eidmap(elem.local_offset() - 1);
+        const int eidx = eidmap(elem.local_offset()) - 1;
         cellres[eidx] = large_volume;
 
         const auto* nodes = bulk_.begin_nodes(elem);
@@ -295,7 +295,7 @@ void TiogaBlock::adjust_resolutions()
 
         for (unsigned in=0; in < num_nodes; ++in) {
           const auto node = nodes[in];
-          const int nidx = eidmap(node.local_offset() - 1);
+          const int nidx = eidmap(node.local_offset()) - 1;
           noderes[nidx] = large_volume;
         }
       }

--- a/src/overset/TiogaBlock.C
+++ b/src/overset/TiogaBlock.C
@@ -265,6 +265,47 @@ void TiogaBlock::update_iblank_cell()
   }
 }
 
+void TiogaBlock::adjust_resolutions()
+{
+  // For every face on the sideset, grab the connected element and set its
+  // cell resolution to a large value. Also for each node of that element, set
+  // the nodal resolution to a large value.
+
+  constexpr double large_volume = std::numeric_limits<double>::max();
+  stk::mesh::Selector mesh_selector = get_node_selector(ovsetParts_);
+  const stk::mesh::BucketVector& mbkts = bulk_.get_buckets(
+    meta_.side_rank(), mesh_selector);
+
+  auto& eidmap = bdata_.eid_map_.h_view;
+  auto& cellres = bdata_.cell_res_.h_view;
+  auto& noderes = bdata_.node_res_.h_view;
+  for (auto b: mbkts) {
+    for (size_t fi=0; fi < b->size(); ++fi) {
+      const auto face = (*b)[fi];
+      const auto* elems = bulk_.begin_elements(face);
+      const auto num_elems = bulk_.num_elements(face);
+
+      for (unsigned ie=0; ie < num_elems; ++ie) {
+        const auto elem = elems[ie];
+        const int eidx = eidmap(elem.local_offset() - 1);
+        cellres[eidx] = large_volume;
+
+        const auto* nodes = bulk_.begin_nodes(elem);
+        const auto num_nodes = bulk_.num_nodes(elem);
+
+        for (unsigned in=0; in < num_nodes; ++in) {
+          const auto node = nodes[in];
+          const int nidx = eidmap(node.local_offset() - 1);
+          noderes[nidx] = large_volume;
+        }
+      }
+    }
+  }
+
+  bdata_.cell_res_.sync_device();
+  bdata_.node_res_.sync_device();
+}
+
 void TiogaBlock::get_donor_info(TIOGA::tioga& tg, stk::mesh::EntityProcVec& egvec)
 {
   // Do nothing if this mesh block isn't present in this MPI Rank

--- a/src/overset/TiogaOptions.C
+++ b/src/overset/TiogaOptions.C
@@ -41,6 +41,11 @@ void TiogaOptions::load(const YAML::Node& node)
   if (node["node_resolution_multiplier"]) {
     nodeResMult_ = node["node_resolution_multiplier"].as<double>();
   }
+
+  if (node["adjust_mandatory_fringe_resolutions"]) {
+    adjustResolutionsForFringes_ =
+      node["adjust_mandatory_fringe_resolutions"].as<bool>();
+  }
 }
 
 void TiogaOptions::set_options(TIOGA::tioga& tg)

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -149,7 +149,7 @@ void TiogaSTKIface::post_connectivity_work(const bool isDecoupled)
 
     // For each block determine donor elements that needs to be ghosted to other
     // MPI ranks
-    tb->get_donor_info(tg_, elemsToGhost_);
+    if (!isDecoupled) tb->get_donor_info(tg_, elemsToGhost_);
   }
 
   // Synchronize IBLANK data for shared nodes

--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -134,6 +134,8 @@ void TiogaSTKIface::register_mesh()
   for (auto& tb: blocks_) {
     tb->update_coords();
     tb->update_element_volumes();
+    if (tiogaOpts_.adjust_resolutions())
+      tb->adjust_resolutions();
     tb->register_block(tg_);
   }
 }


### PR DESCRIPTION
Adds an option to TIOGA overset connectivity logic that is used to provide 
hints to TIOGA regarding nodes/cells that are adjacent to the overset boundaries
and must be ignored when considering potential donors. This is done by setting
a high value of nodal/cell resolutions, the criteria that TIOGA uses to determine
potential donors.

## Checklist

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [X] MacOS
  - Compilers 
    - [X] GCC
    - [X] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all **overset** regression tests

