### PR TITLE
Add user option to reuse linear systems for decoupled overset runs

### DIFF
--- a/include/LinearSolverConfig.h
+++ b/include/LinearSolverConfig.h
@@ -65,6 +65,16 @@ public:
   inline bool useSegregatedSolver() const
   { return useSegregatedSolver_; }
 
+  /** User flag indicating whether equation systems must attempt to reuse linear
+   *  system data structures even for cases with mesh motion.
+   *
+   *  This option only affects decoupled overset system solves where the matrix
+   *  graph doesn't change, only the entries within the graph. This can be
+   *  controlled on a per-solver basis.
+   */
+  inline bool reuseLinSysIfPossible() const
+  { return reuseLinSysIfPossible_; }
+
   std::string get_method() const
   {return method_;}
 
@@ -100,6 +110,7 @@ protected:
   bool writeMatrixFiles_{false};
   bool ensureReproducible_{false};
   bool useNativeCudaSort_{false};
+  bool reuseLinSysIfPossible_{false};
 };
 
 class TpetraLinearSolverConfig : public LinearSolverConfig

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -37,6 +37,7 @@ namespace nalu{
 class EquationSystem;
 class Realm;
 class LinearSolver;
+class LinearSolverConfig;
 
 class CoeffApplier
 {
@@ -87,6 +88,8 @@ public:
   }
 
   static LinearSystem *create(Realm& realm, const unsigned numDof, EquationSystem *eqSys, LinearSolver *linearSolver);
+
+  const LinearSolverConfig& config() const;
 
   // Graph/Matrix Construction
   virtual void buildNodeGraph(const stk::mesh::PartVector & parts)=0; // for nodal assembly (e.g., lumped mass and source)
@@ -204,7 +207,7 @@ protected:
 
   const unsigned numDof_;
   const std::string eqSysName_;
-  LinearSolver * linearSolver_;
+  LinearSolver * linearSolver_{nullptr};
   int linearSolveIterations_;
   double nonLinearResidual_;
   double linearResidual_;

--- a/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.i
+++ b/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.i
@@ -23,6 +23,7 @@ linear_solvers:
     ensure_reproducible: no
     use_native_cuda_sort: no
     write_matrix_files: no
+    reuse_linear_system: yes
 
   # solver for the pressure
   - name: solve_scalar
@@ -39,6 +40,7 @@ linear_solvers:
     ensure_reproducible: no
     use_native_cuda_sort: no
     write_matrix_files:  no
+    reuse_linear_system: yes
 
 realms:
 

--- a/reg_tests/test_files/oversetRotCylNGPTrilinos/oversetRotCylNGPTrilinos.i
+++ b/reg_tests/test_files/oversetRotCylNGPTrilinos/oversetRotCylNGPTrilinos.i
@@ -15,6 +15,7 @@ linear_solvers:
     max_iterations: 200
     kspace: 50
     output_level: 0
+    reuse_linear_system: yes
 
   - name: solve_cont
     type: tpetra
@@ -25,6 +26,7 @@ linear_solvers:
     kspace: 50
     muelu_xml_file_name: ../../xml/milestone.xml
     output_level: 0
+    reuse_linear_system: yes
 
 realms:
 

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -1108,6 +1108,10 @@ EnthalpyEquationSystem::initialize()
 void
 EnthalpyEquationSystem::reinitialize_linear_system()
 {
+  // If this is decoupled overset simulation and the user has requested that the
+  // linear system be reused, then do nothing
+  if (decoupledOverset_ && linsys_->config().reuseLinSysIfPossible()) return;
+
   // delete linsys
   delete linsys_;
 

--- a/src/HypreLinearSolverConfig.C
+++ b/src/HypreLinearSolverConfig.C
@@ -58,6 +58,7 @@ HypreLinearSolverConfig::load(const YAML::Node& node)
   get_if_present(node, "reuse_preconditioner",
                  reusePreconditioner_, reusePreconditioner_);
   get_if_present(node, "segregated_solver", useSegregatedSolver_, useSegregatedSolver_);
+  get_if_present(node, "reuse_linsys", reuseLinSysIfPossible_, reuseLinSysIfPossible_);
 
   if (node["absolute_tolerance"]) {
     hasAbsTol_ = true;

--- a/src/LinearSolverConfig.C
+++ b/src/LinearSolverConfig.C
@@ -133,7 +133,7 @@ TpetraLinearSolverConfig::load(const YAML::Node & node)
   get_if_present(node, "recompute_preconditioner", recomputePreconditioner_, recomputePreconditioner_);
   get_if_present(node, "reuse_preconditioner",     reusePreconditioner_,     reusePreconditioner_);
   get_if_present(node, "segregated_solver",        useSegregatedSolver_,     useSegregatedSolver_);
-
+  get_if_present(node, "reuse_linear_system", reuseLinSysIfPossible_, reuseLinSysIfPossible_);
 }
 
 } // namespace nalu

--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -97,6 +97,12 @@ bool LinearSystem::useSegregatedSolver() const {
   return linearSolver_ ? linearSolver_->getConfig()->useSegregatedSolver() : false;
 }
 
+const LinearSolverConfig& LinearSystem::config() const
+{
+  ThrowAssert(linearSolver_ != nullptr);
+  return *(linearSolver_->getConfig());
+}
+
 // static method
 LinearSystem *LinearSystem::create(Realm& realm, const unsigned numDof, EquationSystem *eqSys, LinearSolver *solver)
 {

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -2437,6 +2437,9 @@ MomentumEquationSystem::initialize()
 void
 MomentumEquationSystem::reinitialize_linear_system()
 {
+  // If this is decoupled overset simulation and the user has requested that the
+  // linear system be reused, then do nothing
+  if (decoupledOverset_ && linsys_->config().reuseLinSysIfPossible()) return;
 
   // delete linsys
   delete linsys_;
@@ -3637,6 +3640,9 @@ ContinuityEquationSystem::initialize()
 void
 ContinuityEquationSystem::reinitialize_linear_system()
 {
+  // If this is decoupled overset simulation and the user has requested that the
+  // linear system be reused, then do nothing
+  if (decoupledOverset_ && linsys_->config().reuseLinSysIfPossible()) return;
 
   // delete linsys
   delete linsys_;

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -719,6 +719,9 @@ SpecificDissipationRateEquationSystem::initialize()
 void
 SpecificDissipationRateEquationSystem::reinitialize_linear_system()
 {
+  // If this is decoupled overset simulation and the user has requested that the
+  // linear system be reused, then do nothing
+  if (decoupledOverset_ && linsys_->config().reuseLinSysIfPossible()) return;
 
   // delete linsys
   delete linsys_;

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -844,6 +844,9 @@ TurbKineticEnergyEquationSystem::initialize()
 void
 TurbKineticEnergyEquationSystem::reinitialize_linear_system()
 {
+  // If this is decoupled overset simulation and the user has requested that the
+  // linear system be reused, then do nothing
+  if (decoupledOverset_ && linsys_->config().reuseLinSysIfPossible()) return;
 
   // delete linsys
   delete linsys_;

--- a/src/WallDistEquationSystem.C
+++ b/src/WallDistEquationSystem.C
@@ -374,6 +374,10 @@ WallDistEquationSystem::initialize()
 void
 WallDistEquationSystem::reinitialize_linear_system()
 {
+  // If this is decoupled overset simulation and the user has requested that the
+  // linear system be reused, then do nothing
+  if (decoupledOverset_ && linsys_->config().reuseLinSysIfPossible()) return;
+
   delete linsys_;
   const EquationType eqID = EQ_WALL_DISTANCE;
   auto solverName = realm_.equationSystems_.get_solver_block_name("ndtw");


### PR DESCRIPTION
Introduces an option in linear systems section to control whether the equation
systems should attempt to reuse linear system graph structures (avoid init costs)
when performing decoupled overset solves with mesh motion.

For the `oversetRotCylinderNGPTrilinos` unit test

With linsys reinit:    74.9 s
Without linsys reinit: 42.3 s

## Checklist

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [X] MacOS
  - Compilers 
    - [X] GCC
    - [X] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all **overset** regression tests
- [ ] Documentation builds without errors
