### PR TITLE
Added ENABLE_BOOST/NALU_USES_BOOST flags to optionally remove boost dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(ENABLE_TIOGA "Use TIOGA TPL to perform overset connectivity" OFF)
 option(ENABLE_ALL_WARNINGS "Show most warnings for most compilers" ON)
 option(ENABLE_WERROR "Warnings are errors" OFF)
 option(ENABLE_OPENMP "Enable OpenMP flags" OFF)
-option(ENABLE_BOOST  "Enable Boost libraries" ON)
+option(ENABLE_BOOST  "Enable Boost libraries" OFF)
 
 set(CMAKE_CXX_STANDARD 14)       # Set nalu-wind C++14 standard
 set(CMAKE_CXX_EXTENSIONS OFF)    # Do not enable GNU extensions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(ENABLE_TIOGA "Use TIOGA TPL to perform overset connectivity" OFF)
 option(ENABLE_ALL_WARNINGS "Show most warnings for most compilers" ON)
 option(ENABLE_WERROR "Warnings are errors" OFF)
 option(ENABLE_OPENMP "Enable OpenMP flags" OFF)
+option(ENABLE_BOOST  "Enable Boost libraries" ON)
 
 set(CMAKE_CXX_STANDARD 14)       # Set nalu-wind C++14 standard
 set(CMAKE_CXX_EXTENSIONS OFF)    # Do not enable GNU extensions
@@ -59,12 +60,15 @@ if(Trilinos_BUILD_SHARED_LIBS)
 endif()
 
 ############################ BOOST #####################################
-set(CMAKE_PREFIX_PATH ${Boost_DIR} ${CMAKE_PREFIX_PATH})
-find_package(Boost REQUIRED COMPONENTS filesystem iostreams)
-if(Boost_VERSION VERSION_GREATER_EQUAL "1.70.0")
-  target_link_libraries(nalu PUBLIC Boost::filesystem Boost::iostreams)
-else()
-  target_link_libraries(nalu PUBLIC ${Boost_LIBRARIES})
+if(ENABLE_BOOST)
+  set(CMAKE_PREFIX_PATH ${Boost_DIR} ${CMAKE_PREFIX_PATH})
+  find_package(Boost REQUIRED COMPONENTS filesystem iostreams)
+  if(Boost_VERSION VERSION_GREATER_EQUAL "1.70.0")
+    target_link_libraries(nalu PUBLIC Boost::filesystem Boost::iostreams)
+  else()
+    target_link_libraries(nalu PUBLIC ${Boost_LIBRARIES})
+  endif()
+  target_compile_definitions(nalu PUBLIC NALU_USES_BOOST)
 endif()
 
 ############################ YAML ######################################

--- a/cmake/Nalu-WindConfig.cmake.in
+++ b/cmake/Nalu-WindConfig.cmake.in
@@ -7,6 +7,7 @@ set(NALU_USES_HYPRE @ENABLE_HYPRE@)
 set(NALU_USES_TIOGA @ENABLE_TIOGA@)
 set(NALU_USES_OPENFAST @ENABLE_OPENFAST@)
 set(NALU_USES_FFTW @ENABLE_FFTW@)
+set(NALU_USES_BOOST @ENABLE_BOOST@)
 
 # Load dependency libraries so that the targets are available
 
@@ -20,7 +21,7 @@ if (NOT ${YAML-CPP_FOUND})
   find_package(YAML-CPP QUIET REQUIRED)
 endif()
 
-if (NOT ${Boost_FOUND})
+if (${NALU_USES_BOOST} AND NOT ${Boost_FOUND})
   find_package(Boost QUIET REQUIRED COMPONENTS filesystem iostreams)
 endif()
 

--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -47,10 +47,12 @@
 #include <iostream>
 
 // boost
+#ifdef NALU_USES_BOOST
 #include <boost/filesystem.hpp>
 #include <boost/iostreams/filtering_streambuf.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/filter/gzip.hpp>
+#endif
 
 namespace sierra{
 namespace nalu{

--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -943,6 +943,7 @@ DataProbePostProcessing::provide_output_txt(
         if ( processorId == NaluEnv::self().parallel_rank()) {    
 
 	  // Get the path to the file name, and create any directories necessary
+          #ifdef NALU_USES_BOOST
 	  boost::filesystem::path pathdir{fileName};
 	  if (pathdir.has_parent_path()) { 
 	    if (!boost::filesystem::exists(pathdir.parent_path().string())) 
@@ -958,6 +959,7 @@ DataProbePostProcessing::provide_output_txt(
 		}
 	      }
 	  }
+	  #endif
           
           // one banner per file 
           const bool addBanner = std::ifstream(fileName.c_str()) ? false : true;
@@ -1037,14 +1039,17 @@ DataProbePostProcessing::provide_output_txt(
 	      const int pointsPerPlane = N1*N2;
 
 	      // Use gzip compression when writing
+	      #ifdef NALU_USES_BOOST
 	      boost::iostreams::filtering_streambuf<boost::iostreams::output> outbuf;
 	      if ((0<gzlevel)&&(gzlevel<10)) {
 		fileName = fileName+".gz";
 		outbuf.push(boost::iostreams::gzip_compressor(
 		boost::iostreams::gzip_params(gzlevel, boost::iostreams::zlib::deflated, 15, 9, boost::iostreams::zlib::huffman_only)));
 	      }
+	      #endif
 
 	      // Get the path to the file name, and create any directories necessary
+              #ifdef NALU_USES_BOOST
 	      boost::filesystem::path pathdir{fileName};
 	      if (pathdir.has_parent_path()) { 
 		if (!boost::filesystem::exists(pathdir.parent_path().string())) 
@@ -1060,6 +1065,7 @@ DataProbePostProcessing::provide_output_txt(
 		    }
 		  }
 	      }
+	      #endif
 
 	      // ** Check to see if we need to add a coordinate file
 	      std::string coordFileName = 
@@ -1070,6 +1076,7 @@ DataProbePostProcessing::provide_output_txt(
 		  = std::ifstream(coordFileName.c_str()) ? false : true;
 		if (addCoordFile) { 
 		  // -- Add the coordinate file
+	          #ifdef NALU_USES_BOOST
 		  boost::iostreams::filtering_streambuf<boost::iostreams::output> outstream;
 		  if ((0<gzlevel)&&(gzlevel<10)) {
 		    outstream.push(boost::iostreams::gzip_compressor(
@@ -1110,12 +1117,15 @@ DataProbePostProcessing::provide_output_txt(
 
 		  boost::iostreams::close(outstream); 
 		  coordfile.close();
+		  #endif
 		  // -- Done with the coordinate file
 		}
 	      }
 
 	      std::ofstream file(fileName.c_str(), std::ios_base::out);
+              #ifdef NALU_USES_BOOST
 	      outbuf.push(file);
+	      #endif
 	      std::string filestring;
 	      std::string coordfilestring("");
 	      char buffer[1000];
@@ -1195,10 +1205,12 @@ DataProbePostProcessing::provide_output_txt(
 		// row complete
 		filestring += '\n';
 	      }
+              #ifdef NALU_USES_BOOST
 	      // done with file output
 	      std::ostream fileout(&outbuf);
 	      fileout<<filestring;
 	      boost::iostreams::close(outbuf); // Don't forget this!
+	      #endif
 	      file.close();
 
 	    } // END if ( processorId == NaluEnv::self().parallel_rank())

--- a/src/wind_energy/ABLForcingAlgorithm.C
+++ b/src/wind_energy/ABLForcingAlgorithm.C
@@ -20,7 +20,9 @@
 
 #include <stk_util/parallel/ParallelReduce.hpp>
 
+#ifdef NALU_USES_BOOST
 #include <boost/format.hpp>
+#endif
 #include <fstream>
 #include <iostream>
 #include <iomanip>
@@ -199,6 +201,7 @@ ABLForcingAlgorithm::initialize()
   }
 
   // Prepare output files to dump sources when computed during precursor phase
+  #ifdef NALU_USES_BOOST
   if (( NaluEnv::self().parallel_rank() == 0 ) &&
       ( momSrcType_ == COMPUTED )) {
     std::string uxname((boost::format(outFileFmt_)%"Ux").str());
@@ -224,6 +227,7 @@ ABLForcingAlgorithm::initialize()
     uyFile.close();
     uzFile.close();
   }
+  #endif
 }
 
 void
@@ -276,6 +280,7 @@ ABLForcingAlgorithm::compute_momentum_sources()
     }
   }
 
+  #ifdef NALU_USES_BOOST
   const int tcount = realm_.get_time_step_count();
   if (( NaluEnv::self().parallel_rank() == 0 ) &&
       ( momSrcType_ == COMPUTED ) &&
@@ -309,6 +314,7 @@ ABLForcingAlgorithm::compute_momentum_sources()
     uyFile.close();
     uzFile.close();
   }
+  #endif
 }
 
 void
@@ -333,6 +339,7 @@ ABLForcingAlgorithm::compute_temperature_sources()
     }
   }
 
+  #ifdef NALU_USES_BOOST
   const int tcount = realm_.get_time_step_count();
   if (( NaluEnv::self().parallel_rank() == 0 ) &&
       ( tempSrcType_ == COMPUTED ) &&
@@ -350,6 +357,8 @@ ABLForcingAlgorithm::compute_temperature_sources()
     tFile << std::endl;
     tFile.close();
   }
+  #endif
+
 }
 
 void


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request
@neilmatula and I worked to remove boost dependencies from Nalu-Wind.  The following is an initial step towards removal.
- Added `ENABLE_BOOST` compile flag and `NALU_USES_BOOST` preprocessor flags
- If `ENABLE_BOOST` is `OFF`, boost calls will not be included at compile time. 

Removal of boost dependencies affects the following functionality:
- `DataProbePostprocessing` output files
- `ABLForcingAlgorithm` computed forcing output files

The boost calls will be replaced shortly with equivalent calls to recover this functionality.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [X ] Intel compilers
    - [ ] NVIDIA CUDA
- [X ] Compiles without warnings
- [X ] Passes all unit tests
- [X ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
