### PR TITLE
CUDA enhancements and fixes for warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(nalu PUBLIC $<$<BOOL:${MPI_CXX_FOUND}>:MPI::MPI_CXX>)
 target_link_libraries(nalu PUBLIC $<$<BOOL:${MPI_Fortran_FOUND}>:MPI::MPI_Fortran>)
 
 if(ENABLE_CUDA)
-  find_package(CUDA REQUIRED)
+  enable_language(CUDA)
   target_link_libraries(nalu PUBLIC
     ${CUDA_cusparse_LIBRARY}
     ${CUDA_curand_LIBRARY}
@@ -91,6 +91,9 @@ if(ENABLE_CUDA)
   separate_arguments(Trilinos_CXX_COMPILER_FLAGS)
   target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:CXX>:${Trilinos_CXX_COMPILER_FLAGS}>)
   target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:CXX>:--expt-relaxed-constexpr>)
+  if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.194")
+    target_compile_options(nalu PUBLIC $<$<COMPILE_LANGUAGE:CXX>:-Wext-lambda-captures-this>)
+  endif()
 endif()
 
 ############################ FFTW ######################################

--- a/include/utils/LinearInterpolation.h
+++ b/include/utils/LinearInterpolation.h
@@ -6,12 +6,6 @@
 #include <stdexcept>
 #include <utility>
 
-#if defined(__GNUC__) && (6 < __GNUC__)
-#define NALU_CASE_FALLTHROUGH __attribute__ ((fallthrough));
-#else
-#define NALU_CASE_FALLTHROUGH
-#endif
-
 namespace sierra {
 namespace nalu {
 namespace utils {
@@ -124,8 +118,10 @@ linear_interp(
         << std::endl
         << "WARNING: Out of bound values encountered during interpolation"
         << std::endl;
-    // no break here... allow fallthrough
-        NALU_CASE_FALLTHROUGH   
+      // Repeated code to avoid fallthrough warnings
+      yout = yinp[idx.second];
+      break;
+
     case OutOfBounds::CLAMP:
       yout = yinp[idx.second];
       break;


### PR DESCRIPTION
- Use `enable_language` instead of `find_package` for CUDA

- For CUDA versions 11.0.2 and above enable `-Wext-lambda-captures-this` flag which will warn users when a local copy of class instance variables are not created

- Fix long standing warnings with fallthrough in linear interpolation switch statement


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [X] Feature enhancement

## Checklist

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [X] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [X] NVIDIA CUDA
- [X] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
