### PR TITLE
Update regression test tolerance check

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -4,21 +4,21 @@
 
 # Standard regression test
 function(add_test_r testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold ${TOLERANCE}")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_r)
 
 # Standard performance test
 function(add_test_p testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold ${TOLERANCE}")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "performance")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_p)
 
 # Regression test with single restart
 function(add_test_r_rst testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold ${TOLERANCE}; ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}_rst.yaml -o ${testname}_rst.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname}_rst ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}_rst.norm.gold ${TOLERANCE}")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold; ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}_rst.yaml -o ${testname}_rst.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname}_rst ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}_rst.norm.gold")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_r_rst)
@@ -32,7 +32,7 @@ endfunction(add_test_r_post)
 
 # Regression test with input
 function(add_test_r_inp testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold ${TOLERANCE}; ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}_Input.yaml -o ${testname}_Input.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname}_Input ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}_Input.norm.gold ${TOLERANCE}")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold; ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}_Input.yaml -o ${testname}_Input.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname}_Input ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}_Input.norm.gold")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_r_inp)
@@ -53,7 +53,7 @@ endfunction(add_test_v2)
 
 # Regression test that runs with different numbers of processes
 function(add_test_r_np testname np)
-    add_test(${testname}Np${np} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}Np${np}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.sh ${testname}Np${np} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}Np${np}.norm.gold ${TOLERANCE}")
+    add_test(${testname}Np${np} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}Np${np}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname}Np${np} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}Np${np}.norm.gold")
     set_tests_properties(${testname}Np${np} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_r_np)

--- a/reg_tests/pass_fail.py
+++ b/reg_tests/pass_fail.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Check mean system norm errors in regression tests
+
+This script determines the pass/fail status of a regression test by comparing
+the "Mean System Norm" values output at each timestep against "gold values"
+from the reference file provided by the user.
+
+Success is determined by the following criteria: the number of timesteps in the
+log file matches the number of timesteps in the gold file, and for each
+timestep the system norms meet the absolute and relative tolerances (default
+1.0e-16 and 1.0e-7 respectively). The tolerances can be adjusted using command
+line arguments, pass `-h` to get a brief usage message.
+"""
+
+import sys
+import os
+import math
+import subprocess
+import argparse
+
+def parse_arguments():
+    """Parse command line arguments"""
+    parser = argparse.ArgumentParser(
+        description="Nalu-Wind regression test check utility")
+    parser.add_argument(
+        '--abs-tol', type=float, default=1.0e-16,
+        help="Tolerance for absolute error")
+    parser.add_argument(
+        '--rel-tol', type=float, default=1.0e-7,
+        help="Tolerance for relative error")
+    parser.add_argument(
+        "test_name", help="Regression test name")
+    parser.add_argument(
+        "gold_norms", help="Absolute path to the gold norms file")
+    return parser.parse_args()
+
+def load_norm_file(fname):
+    """Parse the norm file and return the mean system norms"""
+    try:
+        with open(fname, 'r') as fh:
+            lines = fh.readlines()
+            norms = [float(ll.strip().split()[0]) for ll in lines]
+            return norms
+    except:
+        return []
+
+def generate_test_norms(testname):
+    """Parse the log file and generate test norms"""
+    logname = testname + ".log"
+    norm_name = testname + ".norm"
+    cmdline = """grep "Mean System Norm:" "%s" | awk '{ print $4, $5, $6; }' > %s """%(
+        logname, norm_name)
+    os.system(cmdline)
+    return load_norm_file(norm_name)
+
+def get_run_time(testname):
+    """Return STKPERF total time"""
+    logname = testname + ".log"
+    cmdline = """ grep "STKPERF: Total Time" "%s" | awk '{ print $4; }' """%(
+        logname)
+    try:
+        pp = subprocess.run(cmdline, shell=True, check=True, capture_output=True)
+        return pp.stdout.decode('UTF-8').strip()
+    except:
+        return ""
+
+def check_norms(test_norms, gold_norms, atol, rtol):
+    """Check the regression test norms"""
+    if len(test_norms) != len(gold_norms):
+        print("Number of timesteps do not match", flush=True)
+        return (False, 1.0e16, 1.0e16)
+
+    test_pass = True
+    abs_diff = 0.0
+    rel_diff = 0.0
+
+    for t1, t2 in zip(test_norms, gold_norms):
+        adiff = abs(t1 - t2)
+        rdiff = abs(t1 / t2 - 1.0)
+
+        abs_diff = max(abs_diff, adiff)
+        rel_diff = max(rel_diff, rdiff)
+
+        if (adiff > atol) and (rdiff > rtol):
+            test_pass = False
+
+    return (test_pass, abs_diff, rel_diff)
+
+def main():
+    """Driver function"""
+    args = parse_arguments()
+    test_norms = generate_test_norms(args.test_name)
+    gold_norms = load_norm_file(args.gold_norms)
+    run_time = get_run_time(args.test_name)
+    run_time = float(run_time) if run_time else 0.0
+    status, adiff, rdiff = check_norms(
+        test_norms, gold_norms, args.abs_tol, args.rel_tol)
+
+    name = args.test_name.ljust(40, ".")
+    status_str = "PASS:" if status else "FAIL:"
+    print("%s %-40s %10.4fs %.4e %.4e"%(
+        status_str, name, run_time, adiff, rdiff), flush=True)
+    sys.exit(0 if status else 1)
+
+if __name__ == "__main__":
+    main()

--- a/reg_tests/test_files/BoussinesqNonIso/norms.py
+++ b/reg_tests/test_files/BoussinesqNonIso/norms.py
@@ -1,11 +1,18 @@
+#!/usr/bin/env python3
+
+"""
+Check L2 norms
+"""
+
 import os
 import math
 import os.path
+import subprocess
 
 
 def exit_if_file_does_not_exist(fname):
     if not os.path.exists(fname):
-        print 'No file: ' + fname
+        print ('No file: ' + fname)
         exit(1)
 
 
@@ -25,10 +32,9 @@ def num_lines_output(fname):
 
 def tail(fname, n):
     exit_if_file_does_not_exist(fname)
-    stdin, stdout = os.popen2("tail -n " + str(n) + " " + fname)
-    stdin.close()
-    lines = stdout.readlines()
-    stdout.close()
+    cmdline = "tail -n " + str(n) + " " + fname
+    pp = subprocess.run(cmdline, shell=True, capture_output=True)
+    lines = pp.stdout.decode("UTF-8").strip().split("\n")
     return lines
 
 
@@ -48,11 +54,11 @@ def compute_and_check_ooas(basep_name, numResolutions, dim, min_ooas):
     linesToRead = num_lines_output(first_name)
     nodes0, norm0 = extract_norm(tail(first_name, linesToRead))
 
-    for j in xrange(numResolutions - 1):
+    for j in range(numResolutions - 1):
         name = basep_name + "_R" + str(j + 1) + ".dat"
         nodes1, norm1 = extract_norm(tail(name, linesToRead))
         order = {}
-        for varname, norm in norm1.iteritems():
+        for varname, norm in norm1.items():
             num_ratio = math.log(float(norm1[varname]) / float(norm0[varname]))
             order[varname] = num_ratio / math.log(2.0)
 
@@ -61,11 +67,11 @@ def compute_and_check_ooas(basep_name, numResolutions, dim, min_ooas):
 
         output_string = "R" + str(j + 1) + "-" + str(j)
 
-        for varname, ooa in order.iteritems():
+        for varname, ooa in order.items():
             output_string += " " + varname + ": " + str(ooa)
             if ooa > min_ooas[varname]:
-                print 'Bad convergence'
-                print output_string
+                print ('Bad convergence')
+                print (output_string)
                 exit(1)
 
 


### PR DESCRIPTION
This PR updates the regression test pass/fail status checks to use both absolute and relative tolerance checks. Currently, the pass/fail checks on non-GCC-7.4.0 build lines are set to really lax tolerances because the current script only checks absolute tolerances. This is an issue for certain regression tests (e.g., `airfoilRANSEdge`) that have a really high `Mean System Norm` due to the SDR equation system. Checking relative tolerance (in addition to absolute tolerance) will account for these problematic tests. 

- Replace `pass_fail.sh` with `pass_fail.py`. It is easier to add command line arguments, help message, and perform checks in a python script than a bash script.
- Update `norms.py` to python3. `python2` has been deprecated since Jan 1, 2020. 
- Update CTest rules to use the new python script

**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [X] Feature enhancement

## Checklist


*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [ ] MacOS
  - Compilers 
    - [X] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
