### PR TITLE
Adjust tolerances on ablNeutralStat regression test

### DIFF
--- a/reg_tests/test_files/ablNeutralStat/passfail
+++ b/reg_tests/test_files/ablNeutralStat/passfail
@@ -28,7 +28,6 @@ velocity_tavg
 sfs_stress
 resolved_stress
 sfs_stress_tavg
-resolved_stress_tavg
 temperature
 temperature_tavg
 temperature_sfs_flux_tavg
@@ -49,10 +48,12 @@ for var in $stdtestvars; do
 done
 
 # Now do the temperature variance variables
+# (And any other variables who need looser tolerances)
 TEMPTOL=1.0E-9
 tempvars="
 temperature_variance
 temperature_variance_tavg
+resolved_stress_tavg
 "
 
 # Test each of the temperature variance variables one by one


### PR DESCRIPTION
**Pull-request type:**
- [X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request
Fixed tolerances on `ablNeutralStat` regression test.  Test should pass on Sandia machines with linux and Intel 19.0.3.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [X ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [X ] Compiles without warnings
- [X ] Passes all unit tests
- [X ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
