### PR TITLE
Overset: update hybrid solver solution exchange interface

### DIFF
--- a/include/overset/ExtOverset.h
+++ b/include/overset/ExtOverset.h
@@ -53,7 +53,7 @@ public:
   void post_overset_conn_work();
 
   //! Register solution fields to TIOGA before interpolation step
-  int register_solution();
+  int register_solution(const std::vector<std::string>& fnames);
 
   //! Update solution fields after TIOGA has performed interpolations
   void update_solution();
@@ -71,6 +71,8 @@ private:
 #ifdef NALU_USES_TIOGA
   std::vector<tioga_nalu::TiogaSTKIface*> tgIfaceVec_;
 #endif
+
+  std::vector<std::string> slnFieldNames_;
 
   //! Flag indicating whether we are interfacing external solver
   bool multiSolverMode_{false};

--- a/include/overset/overset_utils.h
+++ b/include/overset/overset_utils.h
@@ -1,0 +1,30 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef OVERSET_UTILS_H
+#define OVERSET_UTILS_H
+
+#include "overset/OversetFieldData.h"
+#include <vector>
+#include <string>
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+namespace overset_utils {
+
+std::vector<OversetFieldData> get_overset_field_data(Realm&, std::vector<std::string> fnames);
+
+}
+} // namespace nalu
+} // namespace sierra
+
+#endif /* OVERSET_UTILS_H */

--- a/src/overset/CMakeLists.txt
+++ b/src/overset/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/OversetManager.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UpdateOversetFringeAlgorithmDriver.C
    ${CMAKE_CURRENT_SOURCE_DIR}/ExtOverset.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/overset_utils.C
 )
 
 if(ENABLE_TIOGA)

--- a/src/overset/overset_utils.C
+++ b/src/overset/overset_utils.C
@@ -1,0 +1,36 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include "overset/overset_utils.h"
+#include "Realm.h"
+
+namespace sierra {
+namespace nalu {
+namespace overset_utils {
+
+std::vector<OversetFieldData> get_overset_field_data(Realm& realm, std::vector<std::string> fnames)
+{
+  std::vector<OversetFieldData> fields;
+  const auto& meta = realm.meta_data();
+  const int row = 1;
+
+  for (const auto& ff: fnames) {
+    auto* fld = meta.get_field(stk::topology::NODE_RANK, ff);
+    ThrowAssert(fld != nullptr);
+
+    const int col = fld->max_size(fld->entity_rank());
+    fields.emplace_back(fld, row, col);
+  }
+
+  return fields;
+}
+
+}
+}  // nalu
+}  // sierra


### PR DESCRIPTION
This PR updates the hybrid overset interface in Nalu-Wind to explicitly take a list of fields to exchange to allow more flexibility when coupling with AMR-Wind. 

Currently, the field exchange is only performed for fields registered by the equation systems and their order is determined by the order in which these equations have been specified in the input file. This would lead to inconsistencies if AMR-Wind has equations in a different order. Another reason is that AMR-Wind has cell-centered fields and one node-centered field (pressure). So the exchange of solutions has to be treated specially to deal with the differences between the solver. 

This modification doesn't affect any of the regression tests in nalu-wind as they do not use the external interface. 

## Checklist

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [X] MacOS
  - Compilers 
    - [ ] GCC
    - [X] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all regression tests
- [ ] Documentation builds without errors
