### PR TITLE
Resolve warnings in Apple-clang

### DIFF
--- a/include/edge_kernels/MomentumSSTTAMSDiffEdgeKernel.h
+++ b/include/edge_kernels/MomentumSSTTAMSDiffEdgeKernel.h
@@ -31,7 +31,7 @@ public:
     const stk::mesh::BulkData&, const SolutionOptions&);
 
   KOKKOS_FUNCTION
-  MomentumSSTTAMSDiffEdgeKernel() = default;
+  MomentumSSTTAMSDiffEdgeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~MomentumSSTTAMSDiffEdgeKernel() = default;

--- a/include/edge_kernels/MomentumSSTTAMSDiffEdgeKernel.h
+++ b/include/edge_kernels/MomentumSSTTAMSDiffEdgeKernel.h
@@ -30,7 +30,6 @@ public:
   MomentumSSTTAMSDiffEdgeKernel(
     const stk::mesh::BulkData&, const SolutionOptions&);
 
-  KOKKOS_FUNCTION
   MomentumSSTTAMSDiffEdgeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/EnthalpyABLForceNodeKernel.h
+++ b/include/node_kernels/EnthalpyABLForceNodeKernel.h
@@ -32,7 +32,7 @@ public:
     const SolutionOptions&);
 
   KOKKOS_FUNCTION
-  EnthalpyABLForceNodeKernel() = default;
+  EnthalpyABLForceNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~EnthalpyABLForceNodeKernel() = default;

--- a/include/node_kernels/EnthalpyABLForceNodeKernel.h
+++ b/include/node_kernels/EnthalpyABLForceNodeKernel.h
@@ -31,7 +31,6 @@ public:
     const stk::mesh::BulkData&,
     const SolutionOptions&);
 
-  KOKKOS_FUNCTION
   EnthalpyABLForceNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/MomentumABLForceNodeKernel.h
+++ b/include/node_kernels/MomentumABLForceNodeKernel.h
@@ -32,7 +32,7 @@ public:
     const SolutionOptions&);
 
   KOKKOS_FUNCTION
-  MomentumABLForceNodeKernel() = default;
+  MomentumABLForceNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~MomentumABLForceNodeKernel() = default;

--- a/include/node_kernels/MomentumABLForceNodeKernel.h
+++ b/include/node_kernels/MomentumABLForceNodeKernel.h
@@ -31,7 +31,6 @@ public:
     const stk::mesh::BulkData&,
     const SolutionOptions&);
 
-  KOKKOS_FUNCTION
   MomentumABLForceNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/MomentumActuatorNodeKernel.h
+++ b/include/node_kernels/MomentumActuatorNodeKernel.h
@@ -27,7 +27,7 @@ public:
   MomentumActuatorNodeKernel(const stk::mesh::MetaData&);
 
   KOKKOS_FUNCTION
-  MomentumActuatorNodeKernel() = default;
+  MomentumActuatorNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~MomentumActuatorNodeKernel() = default;

--- a/include/node_kernels/MomentumActuatorNodeKernel.h
+++ b/include/node_kernels/MomentumActuatorNodeKernel.h
@@ -26,7 +26,6 @@ class MomentumActuatorNodeKernel : public NGPNodeKernel<MomentumActuatorNodeKern
 public:
   MomentumActuatorNodeKernel(const stk::mesh::MetaData&);
 
-  KOKKOS_FUNCTION
   MomentumActuatorNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/MomentumBodyForceBoxNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceBoxNodeKernel.h
@@ -32,7 +32,7 @@ public:
     const std::vector<double>& = std::vector<double>());
 
   KOKKOS_FUNCTION
-  MomentumBodyForceBoxNodeKernel() = default;
+  MomentumBodyForceBoxNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~MomentumBodyForceBoxNodeKernel() = default;

--- a/include/node_kernels/MomentumBodyForceNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceNodeKernel.h
@@ -29,7 +29,7 @@ public:
     const std::vector<double>&);
 
   KOKKOS_FUNCTION
-  MomentumBodyForceNodeKernel() = default;
+  MomentumBodyForceNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~MomentumBodyForceNodeKernel() = default;

--- a/include/node_kernels/MomentumBodyForceNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceNodeKernel.h
@@ -28,7 +28,6 @@ public:
     const stk::mesh::BulkData&,
     const std::vector<double>&);
 
-  KOKKOS_FUNCTION
   MomentumBodyForceNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/MomentumBoussinesqNodeKernel.h
+++ b/include/node_kernels/MomentumBoussinesqNodeKernel.h
@@ -31,7 +31,7 @@ public:
     const SolutionOptions&);
 
   KOKKOS_FUNCTION
-  MomentumBoussinesqNodeKernel() = default;
+  MomentumBoussinesqNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~MomentumBoussinesqNodeKernel() = default;

--- a/include/node_kernels/MomentumBoussinesqNodeKernel.h
+++ b/include/node_kernels/MomentumBoussinesqNodeKernel.h
@@ -30,7 +30,6 @@ public:
     const stk::mesh::BulkData&,
     const SolutionOptions&);
 
-  KOKKOS_FUNCTION
   MomentumBoussinesqNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/MomentumCoriolisNodeKernel.h
+++ b/include/node_kernels/MomentumCoriolisNodeKernel.h
@@ -31,7 +31,6 @@ public:
     const stk::mesh::BulkData&,
     const SolutionOptions&);
 
-  KOKKOS_FUNCTION
   MomentumCoriolisNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/MomentumCoriolisNodeKernel.h
+++ b/include/node_kernels/MomentumCoriolisNodeKernel.h
@@ -32,7 +32,7 @@ public:
     const SolutionOptions&);
 
   KOKKOS_FUNCTION
-  MomentumCoriolisNodeKernel() = default;
+  MomentumCoriolisNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~MomentumCoriolisNodeKernel() = default;

--- a/include/node_kernels/MomentumSSTTAMSForcingNodeKernel.h
+++ b/include/node_kernels/MomentumSSTTAMSForcingNodeKernel.h
@@ -31,7 +31,7 @@ public:
     const stk::mesh::BulkData&, const SolutionOptions&);
 
   KOKKOS_FUNCTION
-  MomentumSSTTAMSForcingNodeKernel() = default;
+  MomentumSSTTAMSForcingNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~MomentumSSTTAMSForcingNodeKernel() = default;

--- a/include/node_kernels/MomentumSSTTAMSForcingNodeKernel.h
+++ b/include/node_kernels/MomentumSSTTAMSForcingNodeKernel.h
@@ -30,7 +30,6 @@ public:
   MomentumSSTTAMSForcingNodeKernel(
     const stk::mesh::BulkData&, const SolutionOptions&);
 
-  KOKKOS_FUNCTION
   MomentumSSTTAMSForcingNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/SDRSSTDESNodeKernel.h
+++ b/include/node_kernels/SDRSSTDESNodeKernel.h
@@ -30,7 +30,7 @@ public:
   SDRSSTDESNodeKernel(const stk::mesh::MetaData&);
 
   KOKKOS_FORCEINLINE_FUNCTION
-  SDRSSTDESNodeKernel() = default;
+  SDRSSTDESNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~SDRSSTDESNodeKernel() = default;

--- a/include/node_kernels/SDRSSTNodeKernel.h
+++ b/include/node_kernels/SDRSSTNodeKernel.h
@@ -29,7 +29,6 @@ class SDRSSTNodeKernel : public NGPNodeKernel<SDRSSTNodeKernel>
 public:
   SDRSSTNodeKernel(const stk::mesh::MetaData&);
 
-  KOKKOS_FORCEINLINE_FUNCTION
   SDRSSTNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/SDRSSTNodeKernel.h
+++ b/include/node_kernels/SDRSSTNodeKernel.h
@@ -30,7 +30,7 @@ public:
   SDRSSTNodeKernel(const stk::mesh::MetaData&);
 
   KOKKOS_FORCEINLINE_FUNCTION
-  SDRSSTNodeKernel() = default;
+  SDRSSTNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~SDRSSTNodeKernel() = default;

--- a/include/node_kernels/SDRSSTTAMSNodeKernel.h
+++ b/include/node_kernels/SDRSSTTAMSNodeKernel.h
@@ -28,7 +28,6 @@ class SDRSSTTAMSNodeKernel : public NGPNodeKernel<SDRSSTTAMSNodeKernel>
 public:
   SDRSSTTAMSNodeKernel(const stk::mesh::MetaData&, const std::string);
 
-  KOKKOS_FUNCTION
   SDRSSTTAMSNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/SDRSSTTAMSNodeKernel.h
+++ b/include/node_kernels/SDRSSTTAMSNodeKernel.h
@@ -29,7 +29,7 @@ public:
   SDRSSTTAMSNodeKernel(const stk::mesh::MetaData&, const std::string);
 
   KOKKOS_FUNCTION
-  SDRSSTTAMSNodeKernel() = default;
+  SDRSSTTAMSNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~SDRSSTTAMSNodeKernel() = default;

--- a/include/node_kernels/TKEKsgsNodeKernel.h
+++ b/include/node_kernels/TKEKsgsNodeKernel.h
@@ -30,7 +30,7 @@ public:
   TKEKsgsNodeKernel(const stk::mesh::MetaData&);
 
   KOKKOS_FORCEINLINE_FUNCTION
-  TKEKsgsNodeKernel() = default;
+  TKEKsgsNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~TKEKsgsNodeKernel() = default;

--- a/include/node_kernels/TKEKsgsNodeKernel.h
+++ b/include/node_kernels/TKEKsgsNodeKernel.h
@@ -29,7 +29,6 @@ class TKEKsgsNodeKernel : public NGPNodeKernel<TKEKsgsNodeKernel>
 public:
   TKEKsgsNodeKernel(const stk::mesh::MetaData&);
 
-  KOKKOS_FORCEINLINE_FUNCTION
   TKEKsgsNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/TKERodiNodeKernel.h
+++ b/include/node_kernels/TKERodiNodeKernel.h
@@ -34,7 +34,6 @@ class TKERodiNodeKernel : public NGPNodeKernel<TKERodiNodeKernel>
 public:
   TKERodiNodeKernel(const stk::mesh::MetaData&, const SolutionOptions&);
 
-  KOKKOS_FUNCTION
   TKERodiNodeKernel() = delete;
   
   KOKKOS_FUNCTION

--- a/include/node_kernels/TKERodiNodeKernel.h
+++ b/include/node_kernels/TKERodiNodeKernel.h
@@ -35,7 +35,7 @@ public:
   TKERodiNodeKernel(const stk::mesh::MetaData&, const SolutionOptions&);
 
   KOKKOS_FUNCTION
-  TKERodiNodeKernel() = default;
+  TKERodiNodeKernel() = delete;
   
   KOKKOS_FUNCTION
   virtual ~TKERodiNodeKernel() = default;

--- a/include/node_kernels/TKESSTDESNodeKernel.h
+++ b/include/node_kernels/TKESSTDESNodeKernel.h
@@ -29,7 +29,6 @@ class TKESSTDESNodeKernel : public NGPNodeKernel<TKESSTDESNodeKernel>
 public:
   TKESSTDESNodeKernel(const stk::mesh::MetaData&);
 
-  KOKKOS_FORCEINLINE_FUNCTION
   TKESSTDESNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/TKESSTDESNodeKernel.h
+++ b/include/node_kernels/TKESSTDESNodeKernel.h
@@ -30,7 +30,7 @@ public:
   TKESSTDESNodeKernel(const stk::mesh::MetaData&);
 
   KOKKOS_FORCEINLINE_FUNCTION
-  TKESSTDESNodeKernel() = default;
+  TKESSTDESNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~TKESSTDESNodeKernel() = default;

--- a/include/node_kernels/TKESSTIDDESNodeKernel.h
+++ b/include/node_kernels/TKESSTIDDESNodeKernel.h
@@ -25,7 +25,7 @@ public:
   TKESSTIDDESNodeKernel(const stk::mesh::MetaData&);
 
   KOKKOS_FORCEINLINE_FUNCTION
-  TKESSTIDDESNodeKernel() = default;
+  TKESSTIDDESNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~TKESSTIDDESNodeKernel() = default;

--- a/include/node_kernels/TKESSTIDDESNodeKernel.h
+++ b/include/node_kernels/TKESSTIDDESNodeKernel.h
@@ -24,7 +24,6 @@ class TKESSTIDDESNodeKernel : public NGPNodeKernel<TKESSTIDDESNodeKernel>
 public:
   TKESSTIDDESNodeKernel(const stk::mesh::MetaData&);
 
-  KOKKOS_FORCEINLINE_FUNCTION
   TKESSTIDDESNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/TKESSTNodeKernel.h
+++ b/include/node_kernels/TKESSTNodeKernel.h
@@ -30,7 +30,7 @@ public:
   TKESSTNodeKernel(const stk::mesh::MetaData&);
 
   KOKKOS_FORCEINLINE_FUNCTION
-  TKESSTNodeKernel() = default;
+  TKESSTNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~TKESSTNodeKernel() = default;

--- a/include/node_kernels/TKESSTNodeKernel.h
+++ b/include/node_kernels/TKESSTNodeKernel.h
@@ -29,7 +29,6 @@ class TKESSTNodeKernel : public NGPNodeKernel<TKESSTNodeKernel>
 public:
   TKESSTNodeKernel(const stk::mesh::MetaData&);
 
-  KOKKOS_FORCEINLINE_FUNCTION
   TKESSTNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/include/node_kernels/TKESSTTAMSNodeKernel.h
+++ b/include/node_kernels/TKESSTTAMSNodeKernel.h
@@ -29,7 +29,7 @@ public:
   TKESSTTAMSNodeKernel(const stk::mesh::MetaData&, const std::string);
 
   KOKKOS_FUNCTION
-  TKESSTTAMSNodeKernel() = default;
+  TKESSTTAMSNodeKernel() = delete;
 
   KOKKOS_FUNCTION
   virtual ~TKESSTTAMSNodeKernel() = default;

--- a/include/node_kernels/TKESSTTAMSNodeKernel.h
+++ b/include/node_kernels/TKESSTTAMSNodeKernel.h
@@ -28,7 +28,6 @@ class TKESSTTAMSNodeKernel : public NGPNodeKernel<TKESSTTAMSNodeKernel>
 public:
   TKESSTTAMSNodeKernel(const stk::mesh::MetaData&, const std::string);
 
-  KOKKOS_FUNCTION
   TKESSTTAMSNodeKernel() = delete;
 
   KOKKOS_FUNCTION

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -171,7 +171,7 @@ namespace sierra
       {
         case OversetBoundaryConditionData::TPL_TIOGA:
 #ifdef NALU_USES_TIOGA
-          oversetBC.userData_.oversetBlocks_ = oversetUserData;
+          oversetBC.userData_.oversetBlocks_ = node["overset_user_data"];
           break;
 #else
           throw std::runtime_error(

--- a/src/NaluParsing.C
+++ b/src/NaluParsing.C
@@ -167,8 +167,6 @@ namespace sierra
         }
       }
 
-      const YAML::Node& oversetUserData = node["overset_user_data"];
-
       switch (oversetBC.oversetConnectivityType_)
       {
         case OversetBoundaryConditionData::TPL_TIOGA:


### PR DESCRIPTION
## Description of the pull-request

I got tired of the seeing all the warnings in about deleted constructors. This compiles with `-Werror` on my Mac at least for the base code and OpenFAST turned on.  I'll do a follow up PR with other TPL's turned on.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
