### PR TITLE
test: Add relative tolerance for regression tests

### DIFF
--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -17,7 +17,8 @@ set(NALU_GOLD_NORMS_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE PATH
 
 if (NOT ${NALU_GOLD_NORMS_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   message(STATUS "Setting custom gold norms path: ${NALU_GOLD_NORMS_DIR}")
-  set(TEST_TOLERANCE 0.000000000000001)
+  set(TEST_TOLERANCE "1.0e-15")
+  set(TEST_REL_TOL "1.0e-12")
 endif()
 
 # Set TOLERANCE for testing
@@ -29,12 +30,26 @@ else(NOT ${TEST_TOLERANCE} STREQUAL "")
      AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
      AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 7.0
      AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 8.0)
-    set(TOLERANCE 0.000000000000001)
+    set(TOLERANCE "1.0e-15")
   else()
     set(TOLERANCE 0.05) # Otherwise set some useless default
   endif()
 endif()
-message(STATUS "Using test tolerance of ${TOLERANCE}")
+
+if(NOT ${TEST_REL_TOL} STREQUAL "")
+  set(REL_TOLERANCE ${TEST_REL_TOL}) # User defined
+else(NOT ${TEST_REL_TOL} STREQUAL "")
+  # Golds are generated with Linux GCC 7.4.0
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Linux"
+      AND "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU"
+      AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL 7.0
+      AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 8.0)
+    set(REL_TOLERANCE "1.0e-13")
+  else()
+    set(REL_TOLERANCE "1.0e-7")
+  endif()
+endif()
+message(STATUS "Using test tolerance: abs = ${TOLERANCE}; rel = ${REL_TOLERANCE}")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_BINARY_DIR}/CTestCustom.cmake)
 

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -4,21 +4,21 @@
 
 # Standard regression test
 function(add_test_r testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} --rel-tol ${REL_TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_r)
 
 # Standard performance test
 function(add_test_p testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} --rel-tol ${REL_TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "performance")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_p)
 
 # Regression test with single restart
 function(add_test_r_rst testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold; ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}_rst.yaml -o ${testname}_rst.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname}_rst ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}_rst.norm.gold")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} --rel-tol ${REL_TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold; ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}_rst.yaml -o ${testname}_rst.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} --rel-tol ${REL_TOLERANCE} ${testname}_rst ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}_rst.norm.gold")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_r_rst)
@@ -32,7 +32,7 @@ endfunction(add_test_r_post)
 
 # Regression test with input
 function(add_test_r_inp testname np)
-    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold; ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}_Input.yaml -o ${testname}_Input.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname}_Input ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}_Input.norm.gold")
+    add_test(${testname} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} --rel-tol ${REL_TOLERANCE} ${testname} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}.norm.gold; ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}_Input.yaml -o ${testname}_Input.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} --rel-tol ${REL_TOLERANCE} ${testname}_Input ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}_Input.norm.gold")
     set_tests_properties(${testname} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_r_inp)
@@ -53,7 +53,7 @@ endfunction(add_test_v2)
 
 # Regression test that runs with different numbers of processes
 function(add_test_r_np testname np)
-    add_test(${testname}Np${np} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}Np${np}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} ${testname}Np${np} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}Np${np}.norm.gold")
+    add_test(${testname}Np${np} sh -c "${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} ${np} ${MPIEXEC_PREFLAGS} ${CMAKE_BINARY_DIR}/${nalu_ex_name} ${MPIEXEC_POSTFLAGS} -i ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${testname}/${testname}.yaml -o ${testname}Np${np}.log && ${CMAKE_CURRENT_SOURCE_DIR}/pass_fail.py --abs-tol ${TOLERANCE} --rel-tol ${REL_TOLERANCE} ${testname}Np${np} ${NALU_GOLD_NORMS_DIR}/test_files/${testname}/${testname}Np${np}.norm.gold")
     set_tests_properties(${testname}Np${np} PROPERTIES TIMEOUT 18000 PROCESSORS ${np} WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}" LABELS "regression")
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname})
 endfunction(add_test_r_np)

--- a/reg_tests/pass_fail.py
+++ b/reg_tests/pass_fail.py
@@ -26,7 +26,7 @@ def parse_arguments():
     parser = argparse.ArgumentParser(
         description="Nalu-Wind regression test check utility")
     parser.add_argument(
-        '--abs-tol', type=float, default=1.0e-16,
+        '--abs-tol', type=float, default=1.0e-15,
         help="Tolerance for absolute error")
     parser.add_argument(
         '--rel-tol', type=float, default=1.0e-7,
@@ -51,7 +51,7 @@ def generate_test_norms(testname):
     """Parse the log file and generate test norms"""
     logname = testname + ".log"
     norm_name = testname + ".norm"
-    cmdline = """grep "Mean System Norm:" "%s" | awk '{ print $4, $5, $6; }' > %s """%(
+    cmdline = """awk '/Mean System Norm:/ { print $4, $5, $6; }' %s > %s """%(
         logname, norm_name)
     os.system(cmdline)
     return load_norm_file(norm_name)
@@ -59,7 +59,7 @@ def generate_test_norms(testname):
 def get_run_time(testname):
     """Return STKPERF total time"""
     logname = testname + ".log"
-    cmdline = """ grep "STKPERF: Total Time" "%s" | awk '{ print $4; }' """%(
+    cmdline = """awk '/STKPERF: Total Time/ { print $4; }' %s """%(
         logname)
     try:
         pp = subprocess.run(cmdline, shell=True, check=True, capture_output=True)


### PR DESCRIPTION
## Changes

- Introduce `TEST_REL_TOL` variable to control relative test tolerance for regression tests via CMake.

- Set default relative tolerance to 1.0e-13 for the GOLD system (Linux/GCC v.7.4.0) instead of the relaxed 1.0e-7 tolerance in the pass/fail python script.

- Fix unnecessary piping in pass/fail python script.

## Additional background 

With the new `pass-fail.py` script, the default relative tolerance is set to `1.0e-7`, this is too lax for the Linux/GCC v7.4.0 build and lets tests pass even if the norms do not match as show below [CDash link](https://my.cdash.org/test/15151477)

```
PASS: airfoilRANSEdgeNGPHypre.................   119.1670s 6.2707e-04 9.7410e-10
```

In the past, this would have indicated that the gold files should be updated after looking at the commit that caused this change. The changes in this PR is an attempt to catch such issues. 

## Checklist

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [X] MacOS
  - Compilers 
    - [X] GCC
    - [X] LLVM/Clang
    - [X] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all regression tests
- [ ] Documentation builds without errors
