### PR TITLE
Fix issues with PecletAlg and TAMS source terms

### DIFF
--- a/include/edge_kernels/MomentumEdgeSolverAlg.h
+++ b/include/edge_kernels/MomentumEdgeSolverAlg.h
@@ -33,13 +33,11 @@ private:
   unsigned coordinates_ {stk::mesh::InvalidOrdinal};
   unsigned velocityRTM_ {stk::mesh::InvalidOrdinal};
   unsigned velocity_ {stk::mesh::InvalidOrdinal};
-  unsigned density_ {stk::mesh::InvalidOrdinal};
   unsigned dudx_ {stk::mesh::InvalidOrdinal};
   unsigned edgeAreaVec_ {stk::mesh::InvalidOrdinal};
   unsigned massFlowRate_ {stk::mesh::InvalidOrdinal};
   unsigned viscosity_ {stk::mesh::InvalidOrdinal};
-
-  PecletFunction<AssembleEdgeSolverAlgorithm::DblType>* pecletFunction_{nullptr};
+  unsigned pecletFactor_ {stk::mesh::InvalidOrdinal};
 };
 
 }  // nalu

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1289,12 +1289,24 @@ MomentumEquationSystem::register_interior_algorithm(
           theSolverAlg->supplementalAlg_.push_back(suppAlg);
         }
       }
-    }
-    else {
+    } else {
       itsi->second->partVec_.push_back(part);
+
+      const bool hasAMS = realm_.realmUsesEdges_ && (theTurbModel == SST_TAMS);
+      if (hasAMS) {
+        auto* tamsAlg = solverAlgDriver_->solverAlgMap_.at(SRC);
+        tamsAlg->partVec_.push_back(part);
+      }
+
+      const bool useStrelets =
+        realm_.realmUsesEdges_ && (theTurbModel == SST_IDDES);
+      if (useStrelets) {
+        // Should have been instantiated previously with another part
+        ThrowAssert(pecletAlg_);
+        pecletAlg_->partVec_.push_back(part);
+      }
     }
-  }
-  else {
+  } else {
     // Homogeneous implementation
     if ( realm_.realmUsesEdges_ )
       throw std::runtime_error("MomentumElemSrcTerms::Error can not use element source terms for an edge-based scheme");
@@ -1393,7 +1405,6 @@ MomentumEquationSystem::register_interior_algorithm(
       dataPreReqs);
 
     kb.report();
-
   }
 
   // Check if the user has requested CMM or LMM algorithms; if so, do not

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -713,7 +713,7 @@ LowMachEquationSystem::solve_and_update()
 
     for (int oi=0; oi < momentumEqSys_->numOversetIters_; ++oi) {
       momentumEqSys_->dynPressAlgDriver_.execute();
-      // if (momentumEqSys_->pecletAlg_) momentumEqSys_->pecletAlg_->execute();
+      if (momentumEqSys_->pecletAlg_) momentumEqSys_->pecletAlg_->execute();
       momentumEqSys_->assemble_and_solve(momentumEqSys_->uTmp_);
 
       timeA = NaluEnv::self().nalu_time();
@@ -1042,7 +1042,7 @@ MomentumEquationSystem::initial_work()
     const double timeA = NaluEnv::self().nalu_time();
     compute_wall_function_params();
     compute_turbulence_parameters();
-    // if (pecletAlg_) pecletAlg_->execute();
+    if (pecletAlg_) pecletAlg_->execute();
     cflReAlgDriver_.execute();
 
     const double timeB = NaluEnv::self().nalu_time();

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1298,13 +1298,7 @@ MomentumEquationSystem::register_interior_algorithm(
         tamsAlg->partVec_.push_back(part);
       }
 
-      const bool useStrelets =
-        realm_.realmUsesEdges_ && (theTurbModel == SST_IDDES);
-      if (useStrelets) {
-        // Should have been instantiated previously with another part
-        ThrowAssert(pecletAlg_);
-        pecletAlg_->partVec_.push_back(part);
-      }
+      if (pecletAlg_) pecletAlg_->partVec_.push_back(part);
     }
   } else {
     // Homogeneous implementation

--- a/src/edge_kernels/MomentumEdgeSolverAlg.C
+++ b/src/edge_kernels/MomentumEdgeSolverAlg.C
@@ -14,6 +14,8 @@
 #include "SolutionOptions.h"
 #include "utils/StkHelpers.h"
 #include "edge_kernels/EdgeKernelUtils.h"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/Types.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -33,15 +35,18 @@ MomentumEdgeSolverAlg::MomentumEdgeSolverAlg(
   const std::string velName = "velocity";
   velocity_ = get_field_ordinal(meta, velName, stk::mesh::StateNP1);
 
-  const std::string viscName =
-    realm.is_turbulent() ? "effective_viscosity_u" : "viscosity";
+  std::string viscName;
+  if ((realm.is_turbulent()) && (realm.solutionOptions_->turbulenceModel_ != SST_TAMS))
+       viscName = "effective_viscosity_u";
+  else 
+       viscName = "viscosity";
+
   viscosity_ = get_field_ordinal(meta, viscName);
-  density_ = get_field_ordinal(meta, "density", stk::mesh::StateNP1);
   dudx_ = get_field_ordinal(meta, "dudx");
   edgeAreaVec_ = get_field_ordinal(meta, "edge_area_vector", stk::topology::EDGE_RANK);
   massFlowRate_ = get_field_ordinal(meta, "mass_flow_rate", stk::topology::EDGE_RANK);
-
-  pecletFunction_ = eqSystem->ngp_create_peclet_function<double>(velName);
+  pecletFactor_ =
+    get_field_ordinal(meta, "peclet_factor", stk::topology::EDGE_RANK);
 }
 
 void
@@ -61,19 +66,16 @@ MomentumEdgeSolverAlg::execute()
   const DblType om_alpha = 1.0 - alpha;
   const DblType om_alphaUpw = 1.0 - alphaUpw;
 
-  // STK ngp::Field instances for capture by lambda
+  // STK stk::mesh::NgpField instances for capture by lambda
   const auto& fieldMgr = realm_.ngp_field_manager();
   const auto coordinates = fieldMgr.get_field<double>(coordinates_);
   const auto vrtm = fieldMgr.get_field<double>(velocityRTM_);
   const auto vel = fieldMgr.get_field<double>(velocity_);
   const auto dudx = fieldMgr.get_field<double>(dudx_);
-  const auto density = fieldMgr.get_field<double>(density_);
   const auto viscosity = fieldMgr.get_field<double>(viscosity_);
   const auto edgeAreaVec = fieldMgr.get_field<double>(edgeAreaVec_);
   const auto massFlowRate = fieldMgr.get_field<double>(massFlowRate_);
-
-  // Local pointer for device capture
-  auto* pecFunc = pecletFunction_;
+  const auto pecletFactor = fieldMgr.get_field<double>(pecletFactor_);
 
   run_algorithm(
     realm_.bulk_data(),
@@ -91,24 +93,18 @@ MomentumEdgeSolverAlg::execute()
 
       const DblType mdot = massFlowRate.get(edge, 0);
 
-      const DblType densityL = density.get(nodeL, 0);
-      const DblType densityR = density.get(nodeR, 0);
-
       const DblType viscosityL = viscosity.get(nodeL, 0);
       const DblType viscosityR = viscosity.get(nodeR, 0);
 
       const DblType viscIp = 0.5 * (viscosityL + viscosityR);
-      const DblType diffIp = 0.5 * (viscosityL / densityL + viscosityR / densityR);
 
       // Compute area vector related quantities and (U dot areaVec)
       DblType axdx = 0.0;
       DblType asq = 0.0;
-      DblType udotx = 0.0;
       for (int d=0; d < ndim; ++d) {
         const DblType dxj = coordinates.get(nodeR, d) - coordinates.get(nodeL, d);
         asq += av[d] * av[d];
         axdx += av[d] * dxj;
-        udotx += 0.5 * dxj * (vrtm.get(nodeR, d) + vrtm.get(nodeL, d));
       }
       const DblType inv_axdx = 1.0 / axdx;
 
@@ -128,12 +124,11 @@ MomentumEdgeSolverAlg::execute()
         }
       }
 
-      const DblType pecnum = stk::math::abs(udotx) / (diffIp + eps);
-      const DblType pecfac = pecFunc->execute(pecnum);
+      const DblType pecfac = pecletFactor.get(edge, 0);
       const DblType om_pecfac = 1.0 - pecfac;
 
-      NALU_ALIGNED DblType limitL[NDimMax_] = {1.0, 1.0, 1.0};
-      NALU_ALIGNED DblType limitR[NDimMax_] = {1.0, 1.0, 1.0};
+      NALU_ALIGNED DblType limitL[NDimMax_] = { 1.0, 1.0, 1.0};
+      NALU_ALIGNED DblType limitR[NDimMax_] = { 1.0, 1.0, 1.0};
 
       if (useLimiter) {
         for (int d=0; d < ndim; ++d) {
@@ -153,6 +148,7 @@ MomentumEdgeSolverAlg::execute()
         uIpR[d] = vel.get(nodeR, d) - duR[d] * hoUpwind * limitR[d];
       }
 
+      // TODO(psakiev) extract this a funciton into EdgeKernelUtils.h
       // Computation of duidxj term, reproduce original comment by S. P. Domino
       /*
         form duidxj with over-relaxed procedure of Jasak:


### PR DESCRIPTION
This commit fixes two bugs in Nalu-Wind related to #346 and #725. The underlying issue is the same in both cases: the necessary algorithms are only registered on the first part when the mesh interior is composed of multiple interior parts.