### PR TITLE
Introduce logic to solve WallDistance differently with hybrid solvers

### DIFF
--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -356,6 +356,7 @@ public:
   bool decoupledOverset_{false};
 
   bool extractDiagonal_{false};
+  bool resetOversetRows_{true};
 
 
   virtual ScalarFieldType* get_diagonal_field() { return nullptr; }

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -233,6 +233,8 @@ class Realm {
     stk::mesh::Part *part,
     const stk::topology &theTopo);
 
+  void register_overset_bc();
+
   void setup_overset_bc(
     const OversetBoundaryConditionData &oversetBCData);
 
@@ -566,6 +568,7 @@ class Realm {
    *
    */
   stk::mesh::PartVector bcPartVec_;
+  stk::mesh::PartVector oversetBCPartVec_;
 
   // empty part vector should it be required
   stk::mesh::PartVector emptyPartVector_;

--- a/include/SolverAlgorithm.h
+++ b/include/SolverAlgorithm.h
@@ -70,6 +70,7 @@ struct NGPApplyCoeff
   const unsigned nDim_{3};
   const bool hasOverset_{false};
   const bool extractDiagonal_{false};
+  const bool resetOversetRows_{true};
 };
 
 class SolverAlgorithm : public Algorithm

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -623,12 +623,8 @@ EquationSystems::register_non_conformal_bc(
 //-------- register_overset_bc ---------------------------------------------
 //--------------------------------------------------------------------------
 void
-EquationSystems::register_overset_bc(
-  const OversetBoundaryConditionData &oversetBCData)
+EquationSystems::register_overset_bc(const OversetBoundaryConditionData&)
 {
-  // set up the overset bc, e.g., manager, parts, etc.
-  realm_.setup_overset_bc(oversetBCData);
-
   // register algs on the equation system
   EquationSystemVector::iterator ii;
   for( ii=equationSystemVector_.begin(); ii!=equationSystemVector_.end(); ++ii )

--- a/src/SolverAlgorithm.C
+++ b/src/SolverAlgorithm.C
@@ -62,7 +62,8 @@ NGPApplyCoeff::NGPApplyCoeff(EquationSystem* eqSystem)
     deviceSumInto_(eqSystem->linsys_->get_coeff_applier()),
     nDim_(eqSystem->linsys_->numDof()),
     hasOverset_(eqSystem->realm_.hasOverset_),
-    extractDiagonal_(eqSystem->extractDiagonal_)
+    extractDiagonal_(eqSystem->extractDiagonal_),
+    resetOversetRows_(eqSystem->resetOversetRows_)
 {
   if (extractDiagonal_) {
     diagField_ = nalu_ngp::get_ngp_field(
@@ -127,7 +128,7 @@ void NGPApplyCoeff::operator()(
   if (extractDiagonal_)
     extract_diagonal(numMeshobjs, symMeshobjs, lhs);
 
-  if (hasOverset_)
+  if (hasOverset_ && resetOversetRows_)
     reset_overset_rows(numMeshobjs, symMeshobjs, rhs, lhs);
 
   (*deviceSumInto_)(

--- a/src/overset/OversetManagerTIOGA.C
+++ b/src/overset/OversetManagerTIOGA.C
@@ -49,7 +49,10 @@ OversetManagerTIOGA::~OversetManagerTIOGA()
 void
 OversetManagerTIOGA::setup()
 {
-  tiogaIface_.setup(realm_.bcPartVec_);
+  tiogaIface_.setup(realm_.oversetBCPartVec_);
+
+  for (auto* part: realm_.oversetBCPartVec_)
+    realm_.bcPartVec_.push_back(part);
 }
 
 void OversetManagerTIOGA::initialize()


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [X] Feature enhancement

This PR introduces the necessary logic to handle wall distance computations when using nalu-wind in hybrid solver mode with AMR-Wind. 

## Checklist

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [X] MacOS
  - Compilers 
    - [X] GCC
    - [ ] LLVM/Clang
    - [X] Intel compilers
    - [ ] NVIDIA CUDA
- [X] Compiles without warnings
- [X] Passes all unit tests
- [X] Passes all regression tests
- [ ] Documentation builds without errors