### PR TITLE
Change tolerance from 0 to -machEps.

### DIFF
--- a/include/EigenDecomposition.h
+++ b/include/EigenDecomposition.h
@@ -323,6 +323,7 @@ KOKKOS_FUNCTION void
 {
 
   const T pi = stk::math::acos(-1.0);
+  const T machEps = std::numeric_limits<T>::min();
 
   // Characteristic equation for A is ax^3 + bx^2 + cx + d = 0 where x are the
   // eigenvalues and a = 1, b = -trA, c = coFacA, d = -detA
@@ -340,7 +341,7 @@ KOKKOS_FUNCTION void
                  4.0 * trA * trA * trA * detA - 27.0 * detA * detA +
                  18.0 * trA * coFacA * detA;
 
-  const auto check_one = disc < 0.0;
+  const auto check_one = disc < -machEps;
   const bool exit_now = stk::simd::are_all(check_one);
   if (exit_now) {
 #ifndef KOKKOS_ENABLE_CUDA


### PR DESCRIPTION
**Pull-request type:**
- [✓] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Fix error in CDASH SSTAMSOversetRotCylinder tests introduced from #774, due to the tolerance on the non-negative discriminant in EigenDecomposition.h 

I can't seem to replicate this issue on Eagle, so I'm hoping this will resolve it.  Is there another way I can test it before we merge?

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [✓] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [✓] Linux
    - [✓] MacOS
  - Compilers 
    - [✓] GCC
    - [ ] LLVM/Clang
    - [✓] Intel compilers
    - [ ] NVIDIA CUDA
- [✓] Compiles without warnings
- [✓] Passes all unit tests
- [✓] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
