### PR TITLE
Fix memory leak reported in CDash

### DIFF
--- a/include/master_element/Edge22DCVFEM.h
+++ b/include/master_element/Edge22DCVFEM.h
@@ -35,8 +35,7 @@ class Edge2DSCS : public MasterElement
 public:
   KOKKOS_FUNCTION
   Edge2DSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Edge2DSCS() = default;
+  KOKKOS_FUNCTION virtual ~Edge2DSCS() {}
   using AlgTraits = AlgTraitsEdge_2D;
   using MasterElement::shape_fcn;
   using MasterElement::determinant;

--- a/include/master_element/Edge32DCVFEM.h
+++ b/include/master_element/Edge32DCVFEM.h
@@ -41,8 +41,7 @@ public:
 
   KOKKOS_FUNCTION
   Edge32DSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Edge32DSCS() = default;
+  KOKKOS_FUNCTION virtual ~Edge32DSCS() {}
   using MasterElement::determinant;
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;

--- a/include/master_element/Hex27CVFEM.h
+++ b/include/master_element/Hex27CVFEM.h
@@ -40,8 +40,7 @@ public:
 
   KOKKOS_FUNCTION
   HexahedralP2Element();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~HexahedralP2Element() = default;
+  KOKKOS_FUNCTION virtual ~HexahedralP2Element() {}
 
   void shape_fcn(double *shpfc);
   void shifted_shape_fcn(double *shpfc);
@@ -243,8 +242,7 @@ class Hex27SCV : public HexahedralP2Element
 public:
   KOKKOS_FUNCTION
   Hex27SCV();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Hex27SCV() = default;
+  KOKKOS_FUNCTION virtual ~Hex27SCV() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
@@ -329,8 +327,7 @@ class Hex27SCS : public HexahedralP2Element
 public:
   KOKKOS_FUNCTION
   Hex27SCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Hex27SCS() = default;
+  KOKKOS_FUNCTION virtual ~Hex27SCS() {}
 
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -56,8 +56,7 @@ public:
   KOKKOS_FUNCTION
   HexSCV();
 
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~HexSCV() = default;
+  KOKKOS_FUNCTION virtual ~HexSCV() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
@@ -171,8 +170,7 @@ public:
   KOKKOS_FUNCTION
   HexSCS();
 
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~HexSCS() = default;
+  KOKKOS_FUNCTION virtual ~HexSCS() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 

--- a/include/master_element/Hex8FEM.h
+++ b/include/master_element/Hex8FEM.h
@@ -24,8 +24,7 @@ public:
 
   KOKKOS_FUNCTION
   Hex8FEM();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Hex8FEM() = default;
+  KOKKOS_FUNCTION virtual ~Hex8FEM() {}
 
   using AlgTraits = AlgTraitsHex8;
   using MasterElement::grad_op;

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -47,8 +47,7 @@ class MasterElement
 public:
   KOKKOS_FUNCTION
   MasterElement(const double scaleToStandardIsoFac=1.0);
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~MasterElement() = default;
+  KOKKOS_FUNCTION virtual ~MasterElement() {}
 
   // NGP-ready methods first
   KOKKOS_FUNCTION virtual void shape_fcn(

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -46,8 +46,7 @@ public:
 
   KOKKOS_FUNCTION
   PyrSCV();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~PyrSCV() = default;
+  KOKKOS_FUNCTION virtual ~PyrSCV() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
@@ -149,8 +148,7 @@ public:
 
   KOKKOS_FUNCTION
   PyrSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~PyrSCS() = default;
+  KOKKOS_FUNCTION virtual ~PyrSCS() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 

--- a/include/master_element/Quad42DCVFEM.h
+++ b/include/master_element/Quad42DCVFEM.h
@@ -39,8 +39,7 @@ public:
 
   KOKKOS_FUNCTION
   Quad42DSCV();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Quad42DSCV() = default;
+  KOKKOS_FUNCTION virtual ~Quad42DSCV() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
@@ -135,8 +134,7 @@ public:
 
   KOKKOS_FUNCTION
   Quad42DSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Quad42DSCS() = default;
+  KOKKOS_FUNCTION virtual ~Quad42DSCS() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 

--- a/include/master_element/Quad43DCVFEM.h
+++ b/include/master_element/Quad43DCVFEM.h
@@ -28,8 +28,7 @@ public:
 
   KOKKOS_FUNCTION
   Quad3DSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Quad3DSCS() = default;
+  KOKKOS_FUNCTION virtual ~Quad3DSCS() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
  

--- a/include/master_element/Quad92DCVFEM.h
+++ b/include/master_element/Quad92DCVFEM.h
@@ -38,8 +38,7 @@ public:
 
   KOKKOS_FUNCTION
   QuadrilateralP2Element();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~QuadrilateralP2Element() = default;
+  KOKKOS_FUNCTION virtual ~QuadrilateralP2Element() {}
 
 protected:
   struct ContourData {
@@ -148,8 +147,7 @@ public:
 
   KOKKOS_FUNCTION
   Quad92DSCV();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Quad92DSCV() = default;
+  KOKKOS_FUNCTION virtual ~Quad92DSCV() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final ;
 
@@ -233,8 +231,7 @@ public:
 
   KOKKOS_FUNCTION
   Quad92DSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Quad92DSCS() = default;
+  KOKKOS_FUNCTION virtual ~Quad92DSCS() {}
 
   KOKKOS_FUNCTION virtual void shape_fcn(
      SharedMemView<DoubleType**, DeviceShmem> &shpfc) override;

--- a/include/master_element/Quad93DCVFEM.h
+++ b/include/master_element/Quad93DCVFEM.h
@@ -38,8 +38,7 @@ public:
   using AlgTraits = AlgTraitsQuad9;
   KOKKOS_FUNCTION
   Quad93DSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Quad93DSCS() = default;
+  KOKKOS_FUNCTION virtual ~Quad93DSCS() {}
 
   using MasterElement::determinant;
 

--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -28,8 +28,7 @@ public:
 
   KOKKOS_FUNCTION
   TetSCV();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~TetSCV() = default;
+  KOKKOS_FUNCTION virtual ~TetSCV() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
@@ -127,8 +126,7 @@ public:
 
   KOKKOS_FUNCTION
   TetSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~TetSCS() = default;
+  KOKKOS_FUNCTION virtual ~TetSCS() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -41,8 +41,7 @@ public:
 
   KOKKOS_FUNCTION
   Tri32DSCV();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Tri32DSCV() = default;
+  KOKKOS_FUNCTION virtual ~Tri32DSCV() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 
@@ -140,8 +139,7 @@ public:
 
   KOKKOS_FUNCTION
   Tri32DSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Tri32DSCS() = default;
+  KOKKOS_FUNCTION virtual ~Tri32DSCS() {}
 
   KOKKOS_FUNCTION virtual const int *  ipNodeMap(int ordinal = 0) const final;
 

--- a/include/master_element/Tri33DCVFEM.h
+++ b/include/master_element/Tri33DCVFEM.h
@@ -37,8 +37,7 @@ public:
 
   KOKKOS_FUNCTION
   Tri3DSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~Tri3DSCS() = default;
+  KOKKOS_FUNCTION virtual ~Tri3DSCS() {}
 
   using AlgTraits = AlgTraitsTri3;
   using MasterElement::determinant;

--- a/include/master_element/Wed6CVFEM.h
+++ b/include/master_element/Wed6CVFEM.h
@@ -24,8 +24,7 @@ class WedSCV : public MasterElement
 public:
   KOKKOS_FUNCTION
   WedSCV();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~WedSCV() = default;
+  KOKKOS_FUNCTION virtual ~WedSCV() {}
 
   using AlgTraits = AlgTraitsWed6;
   using MasterElement::determinant;
@@ -122,8 +121,7 @@ class WedSCS : public MasterElement
 public:
   KOKKOS_FUNCTION
   WedSCS();
-  KOKKOS_DEFAULTED_FUNCTION
-  virtual ~WedSCS() = default;
+  KOKKOS_FUNCTION virtual ~WedSCS() {}
 
   using AlgTraits = AlgTraitsWed6;
   using MasterElement::determinant;

--- a/src/master_element/MasterElementFactory.C
+++ b/src/master_element/MasterElementFactory.C
@@ -168,13 +168,17 @@ namespace nalu{
     return theElem;
   }
 
-  std::map<stk::topology, MasterElement*> &MasterElementRepo::volumeMeMapDev() {
-     static std::map<stk::topology, MasterElement*> M;
-     return M;
+  std::map<stk::topology, MasterElement*>&
+  MasterElementRepo::volumeMeMapDev()
+  {
+    static std::map<stk::topology, MasterElement*> M;
+    return M;
   }
-  std::map<stk::topology, MasterElement*> &MasterElementRepo::surfaceMeMapDev() {
-     static std::map<stk::topology, MasterElement*> M;
-     return M;
+  std::map<stk::topology, MasterElement*>&
+  MasterElementRepo::surfaceMeMapDev()
+  {
+    static std::map<stk::topology, MasterElement*> M;
+    return M;
   }
 
   void MasterElementRepo::clear()
@@ -182,10 +186,18 @@ namespace nalu{
     surfaceMeMap_.clear();
     volumeMeMap_.clear();
     for (std::pair<stk::topology, MasterElement*> a : volumeMeMapDev()) {
+      const std::string debuggingName("MEDestroy: " + a.first.name());
+      auto* meobj = a.second;
+      Kokkos::parallel_for(
+        debuggingName, 1, KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
       sierra::nalu::kokkos_free_on_device(a.second);
     }
     volumeMeMapDev().clear();
     for (std::pair<stk::topology, MasterElement*> a : surfaceMeMapDev()) {
+      const std::string debuggingName("MEDestroy: " + a.first.name());
+      auto* meobj = a.second;
+      Kokkos::parallel_for(
+        debuggingName, 1, KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
       sierra::nalu::kokkos_free_on_device(a.second);
     }
     surfaceMeMapDev().clear();


### PR DESCRIPTION
This commit fixes the memory leak reported in CDash while simultaneously ensuring that the MasterElement creation on device works in both CUDA 9.2.x and 10.2.x

See [CDash](https://my.cdash.org/test/16023552) for details of the memory leak. See #743 for discussion regarding issues with CUDA builds