### PR TITLE
Update nightly test script

### DIFF
--- a/reg_tests/CTestNightlyScript.cmake
+++ b/reg_tests/CTestNightlyScript.cmake
@@ -16,6 +16,10 @@ else()
   message(FATAL_ERROR "You need to set the NALU_DIR variable. CMake will exit." )
 endif()
 
+if("${BUILD_DIR}" STREQUAL "" )
+  set(BUILD_DIR "${NALU_DIR}/build")
+endif()
+
 # -----------------------------------------------------------
 # -- Configure CTest
 # -----------------------------------------------------------
@@ -24,14 +28,16 @@ endif()
 set(CTEST_SITE "${HOST_NAME}")
 set(CTEST_BUILD_NAME "${CMAKE_SYSTEM_NAME}${EXTRA_BUILD_NAME}")
 set(CTEST_SOURCE_DIRECTORY "${NALU_DIR}")
-set(CTEST_BINARY_DIRECTORY "${NALU_DIR}/build")
+set(CTEST_BINARY_DIRECTORY "${BUILD_DIR}")
 set(CTEST_START_WITH_EMPTY_BINARY_DIRECTORY TRUE)
 find_program(CTEST_GIT_COMMAND NAMES git)
 find_program(MAKE NAMES make)
 
 # Add parallelism capability to testing
-include(ProcessorCount)
-ProcessorCount(NP)
+if("${NP}" STREQUAL "")
+  include(ProcessorCount)
+  ProcessorCount(NP)
+endif()
 message(STATUS "\nNumber of processors detected: ${NP}")
 set(CTEST_BUILD_FLAGS "-j${NP}")
 if(CTEST_DISABLE_OVERLAPPING_TESTS)


### PR DESCRIPTION
These updates will enable calling this script via spack but should preserve backwards compatibility of the current testing infrastructure.

