### PR TITLE
hypre: Fix hypre initialization for GPUs

### DIFF
--- a/include/HypreNGP.h
+++ b/include/HypreNGP.h
@@ -10,6 +10,10 @@
 #ifndef HYPRENGP_H
 #define HYPRENGP_H
 
+#ifdef NALU_USES_HYPRE
+#include "HYPRE_config.h"
+#endif
+
 #ifdef HYPRE_USING_CUDA
 #include "HYPRE_utilities.h"
 #include "krylov.h"

--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -12,7 +12,6 @@
 #ifndef NaluParsing_h
 #define NaluParsing_h
 
-#include "edge_kernels/MomentumOpenEdgeKernel.h"
 #include <BoundaryConditions.h>
 #include <Enums.h>
 #include <InitialConditions.h>


### PR DESCRIPTION
Fix HypreNGP.h header to properly include the necessary hypre headers. Current
behavior depended on nalu.C including NaluParsing.h which in turn pulled hypre
configuration headers through the inclusion of a momentum kernel.

This explains the weird behavior that was discussed in PR #786
