### PR TITLE
instantiate linear interpolation matrix for p=4

### DIFF
--- a/src/matrix_free/Coefficients.C
+++ b/src/matrix_free/Coefficients.C
@@ -40,6 +40,7 @@ constexpr Coeffs<4>::nodal_matrix_type Coeffs<4>::D;
 constexpr Coeffs<4>::scs_matrix_type Coeffs<4>::Nt;
 constexpr Coeffs<4>::scs_matrix_type Coeffs<4>::Dt;
 constexpr Coeffs<4>::linear_nodal_matrix_type Coeffs<4>::Nlin;
+constexpr Coeffs<4>::linear_scs_matrix_type Coeffs<4>::Ntlin;
 
 constexpr LocalArray<double[2]> Coeffs<1>::Wl;
 constexpr LocalArray<double[3]> Coeffs<2>::Wl;


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Missed an instantiation for one of the coefficient matrices for p=4.  The need for these instantiations go away with later versions of C++ but are still required for C++14 and can cause problems with earlier compilers.


## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
