### PR TITLE
Change default restart_start to 0

### DIFF
--- a/src/OutputInfo.C
+++ b/src/OutputInfo.C
@@ -47,7 +47,7 @@ OutputInfo::OutputInfo()
     restartTime_(0.0),
     restartDBName_("restart.rst"),
     restartFreq_(500),
-    restartStart_(500),
+    restartStart_(0),
     restartMaxDataBaseStepSize_(100000),
     restartNodeSet_(true),
     outputCompressionLevel_(0),


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

Change the default value of `restart_start` to 0 instead of 500. 

I didn't run any regression/unit tests because I don't expect this to change anything related to any of them.

*For new code updates*
- [x] Documentation updates - additions to user, theory, and verification manuals

 The user manual does not contain the default value for `restart_start` right now - https://nalu-wind.readthedocs.io/en/latest/source/user/nalu_run/nalu_inp.html#inpfile-restart.restart_start So there should be no change required here.

- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
