### PR TITLE
Allow STK Balance to check for ParMETIS support

### DIFF
--- a/src/Realm.C
+++ b/src/Realm.C
@@ -142,6 +142,7 @@
 #include <stk_util/parallel/ParallelReduce.hpp>
 
 // stk_balance
+#include <Zoltan2_config.h>
 #include <stk_balance/balance.hpp>
 #include <stk_balance/balanceUtils.hpp>
 


### PR DESCRIPTION
Using mesh rebalance options with ParMETIS graph decompositions requires Zoltan2 defines

https://github.com/Exawind/nalu-wind/blob/2dc5b7ede2c7cb00937fda52058d6f09feaf3f82/src/Realm.C#L4686-L4696