### PR TITLE
Fix parts listing for airfoil regression tests

### DIFF
--- a/reg_tests/test_files/airfoilRANSEdgeNGPHypre.rst/airfoilRANSEdgeNGPHypre.rst.yaml
+++ b/reg_tests/test_files/airfoilRANSEdgeNGPHypre.rst/airfoilRANSEdgeNGPHypre.rst.yaml
@@ -93,7 +93,7 @@ realms:
 
     initial_conditions:
       - constant: ic_1
-        target_name: [Flow-QUAD,Flow-TRIANGLE]
+        target_name: [Flow-QUAD]
         value:
           pressure: 0
           velocity: [14.96346075389736,1.046347106161880]

--- a/reg_tests/test_files/airfoilRANSEdgeNGPTrilinos.rst/airfoilRANSEdgeNGPTrilinos.rst.yaml
+++ b/reg_tests/test_files/airfoilRANSEdgeNGPTrilinos.rst/airfoilRANSEdgeNGPTrilinos.rst.yaml
@@ -78,7 +78,7 @@ realms:
 
     initial_conditions:
       - constant: ic_1
-        target_name: [Flow-QUAD,Flow-TRIANGLE]
+        target_name: [Flow-QUAD]
         value:
           pressure: 0
           velocity: [14.96346075389736,1.046347106161880]

--- a/reg_tests/test_files/airfoilRANSEdgeTrilinos/airfoilRANSEdgeTrilinos.yaml
+++ b/reg_tests/test_files/airfoilRANSEdgeTrilinos/airfoilRANSEdgeTrilinos.yaml
@@ -84,7 +84,7 @@ realms:
 
     initial_conditions:
       - constant: ic_1
-        target_name: [Flow-QUAD,Flow-TRIANGLE]
+        target_name: [Flow-QUAD]
         value:
           pressure: 0
           velocity: [14.96346075389736,1.046347106161880]

--- a/reg_tests/test_files/airfoilRANSElem/airfoilRANSElem.yaml
+++ b/reg_tests/test_files/airfoilRANSElem/airfoilRANSElem.yaml
@@ -82,7 +82,7 @@ realms:
 
     initial_conditions:
       - constant: ic_1
-        target_name: [Flow-QUAD,Flow-TRIANGLE]
+        target_name: [Flow-QUAD]
         value:
           pressure: 0
           velocity: [14.96346075389736,1.046347106161880]


### PR DESCRIPTION
Input files for airfoil tests included a non-existent part. This causes segfaults with latest STK updates.


**Pull-request type:**
- [X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

*All pull requests*
- [X] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [X] Linux
    - [X] MacOS
  - Compilers 
    - [X] GCC
    - [X] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
