### PR TITLE
filter out nullptrs from the promoted part vector before setting coords

### DIFF
--- a/src/element_promotion/PromoteElementImpl.C
+++ b/src/element_promotion/PromoteElementImpl.C
@@ -104,6 +104,10 @@ promote_elements_hex(
 
   stk::mesh::PartVector promotedSideParts = create_boundary_elements(poly, bulk, partsToBePromoted);
 
+  promotedElemParts.erase(
+    std::remove(promotedElemParts.begin(), promotedElemParts.end(), nullptr),
+    promotedElemParts.end());
+
   set_coordinates_hex(nodeLocs1D, bulk, desc, promotedElemParts, coordField);
   return std::make_pair(promotedElemParts, promotedSideParts);
 }


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

The promoted element part vector gets some nullptr entries in the part manipulations I do.  This just filters them out before passing the vector to`stk::mesh::selectUnion`.  Part of https://github.com/Exawind/nalu-wind/issues/802

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
