### PR TITLE
Use correct periodic update for sst_length_scale

### DIFF
--- a/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
+++ b/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
@@ -153,7 +153,7 @@ ComputeSSTMaxLengthScaleElemAlgorithm::execute()
   
   // deal with periodicity
   if ( realm_.hasPeriodic_) {
-    realm_.periodic_field_update(maxLengthScale_, 1);
+    realm_.periodic_field_max(maxLengthScale_, 1);
   }
  
 }


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

While reviewing the IDDES channel fields @ndevelder and I noticed the `sst_max_length_scale` was being summed on the boundaries leading to the wrong values (4x at corners and 2x at faces).  This corrects that bug. 

I wouldn't be surprised if some SST tests have small diffs. I wasn't able to detect them on my mac with the default relative tolerances.  I ran most the SST tests and the IDDES reg test.

I also noticed that we have a second set of files `SSTMaxLengthScaleAlg.C/h` and `SSTMaxLengthScaleDriver.C/h` for this computation that don't seem to be currently in action outside of unit tests.  

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x ] Compiles without warnings
- [x ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
