### PR TITLE
Fix CDash warnings with Clang v10.0

### DIFF
--- a/include/ElemDataRequestsGPU.h
+++ b/include/ElemDataRequestsGPU.h
@@ -49,6 +49,9 @@ struct FieldInfoNGP {
   : field(), scalarsDim1(0), scalarsDim2(0)
   {}
 
+  KOKKOS_DEFAULTED_FUNCTION
+  FieldInfoNGP& operator=(const FieldInfoNGP&) = default;
+
   NGPDoubleFieldType field;
   unsigned scalarsDim1;
   unsigned scalarsDim2;

--- a/include/ngp_algorithms/CourantReReduceHelper.h
+++ b/include/ngp_algorithms/CourantReReduceHelper.h
@@ -26,6 +26,9 @@ struct CflRe
     max_re = -1.0e6;
   }
 
+  KOKKOS_DEFAULTED_FUNCTION
+  CflRe(const CflRe&) = default;
+
   KOKKOS_INLINE_FUNCTION
   void operator=(const CflRe& rhs)
   {

--- a/include/ngp_utils/NgpReducers.h
+++ b/include/ngp_utils/NgpReducers.h
@@ -21,6 +21,9 @@ struct MinMaxSumScalar {
   Scalar min_val,max_val, total_sum;
 
   KOKKOS_DEFAULTED_FUNCTION
+  MinMaxSumScalar() = default;
+
+  KOKKOS_DEFAULTED_FUNCTION
   MinMaxSumScalar(const MinMaxSumScalar&) = default;
 
   KOKKOS_INLINE_FUNCTION

--- a/include/ngp_utils/NgpReducers.h
+++ b/include/ngp_utils/NgpReducers.h
@@ -20,6 +20,9 @@ template<class Scalar>
 struct MinMaxSumScalar {
   Scalar min_val,max_val, total_sum;
 
+  KOKKOS_DEFAULTED_FUNCTION
+  MinMaxSumScalar(const MinMaxSumScalar&) = default;
+
   KOKKOS_INLINE_FUNCTION
   void operator = (const MinMaxSumScalar& rhs) {
     min_val = rhs.min_val;


### PR DESCRIPTION
```
In file included from /projects/ecp/exawind/nalu-wind-testing/nalu-wind/src/ElemDataRequestsGPU.C:11:
/projects/ecp/exawind/nalu-wind-testing/nalu-wind/include/ElemDataRequestsGPU.h:44:3: warning: definition of implicit copy assignment operator for 'FieldInfoNGP' is deprecated because it has a user-declared copy constructor [-Wdeprecated-copy]
  FieldInfoNGP(const FieldInfoNGP& rhs)
  ^
/projects/ecp/exawind/nalu-wind-testing/nalu-wind/src/ElemDataRequestsGPU.C:76:21: note: in implicit copy assignment operator for 'sierra::nalu::FieldInfoNGP' first required here
    hostFields(i++) = FieldInfoType(
                    ^
```

[CDash link](https://my.cdash.org/build/1973496/notes)