### PR TITLE
Fix Summit Power9 build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,17 @@ if(ENABLE_CUDA)
     CUDA::nvToolsExt)
 endif()
 
+# Handle issues for Power9 builds
+if ((${CMAKE_SYSTEM_PROCESSOR} MATCHES "ppc") AND (NOT ENABLE_CUDA))
+  # Fix warnings regarding NALU_ALIGNED in CPU builds
+  target_compile_definitions(nalu PUBLIC NALU_USE_POWER9_ALIGNMENT)
+  if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND
+      (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 9.0))
+    # Skip SIMD when building with GCC versions less than 9.0
+    target_compile_definitions(nalu PUBLIC USE_STK_SIMD_NONE)
+  endif()
+endif()
+
 ########################## TRILINOS ####################################
 set(CMAKE_PREFIX_PATH ${Trilinos_DIR} ${CMAKE_PREFIX_PATH})
 find_package(Trilinos QUIET REQUIRED)

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -19,6 +19,8 @@
 
 #ifdef KOKKOS_ENABLE_CUDA
 #define NALU_ALIGNED alignas(sizeof(double))
+#elif defined(NALU_USE_POWER9_ALIGNMENT)
+#define NALU_ALIGNED alignas(16)
 #else
 #define NALU_ALIGNED alignas(KOKKOS_MEMORY_ALIGNMENT)
 #endif


### PR DESCRIPTION
This PR adds two changes that address issues observed in Summit CPU-only builds:

- Disable STK SIMD when building for CPUs on Summit with GCC v7.5.0. This is a temporary workaround to address #817 
- Change default value for `NALU_ALIGNED` on Summit to remove warnings generated during CPU-only builds.