### PR TITLE
Address remaining diffs noted #821

### DIFF
--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1186,8 +1186,6 @@ MomentumEquationSystem::register_nodal_fields(
       stk::topology::NODE_RANK, "abl_wall_no_slip_wall_func_node_mask");
   double one = 1;
   stk::mesh::put_field_on_mesh(node_mask, *part, 1, &one);
-  node_mask.modify_on_host();
-  node_mask.sync_to_device();
 }
 
 //--------------------------------------------------------------------------

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1186,6 +1186,8 @@ MomentumEquationSystem::register_nodal_fields(
       stk::topology::NODE_RANK, "abl_wall_no_slip_wall_func_node_mask");
   double one = 1;
   stk::mesh::put_field_on_mesh(node_mask, *part, 1, &one);
+  node_mask.modify_on_host();
+  node_mask.sync_to_device();
 }
 
 //--------------------------------------------------------------------------

--- a/src/edge_kernels/MomentumABLWallShearStressEdgeKernel.C
+++ b/src/edge_kernels/MomentumABLWallShearStressEdgeKernel.C
@@ -58,15 +58,13 @@ MomentumABLWallShearStressEdgeKernel<BcAlgTraits>::execute(
   const auto& v_areavec = scratchViews.get_scratch_view_2D(exposedAreaVec_);
   const auto& v_wallshearstress = scratchViews.get_scratch_view_2D(wallShearStress_);
 
-  const int* ipNodeMap = meFC_->ipNodeMap();
-
   for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
 
     // Decide which node the shear stress will be applied to
     // rowBase is the first row in the matrix associated with the velocity for this node
-    const int rowBase = slip_ 
-      ? (ipNodeMap[ip] * BcAlgTraits::nDim_) 
-      : (meSCS_->opposingNodes(elemFaceOrdinal, ip) * BcAlgTraits::nDim_);
+    const int rowBase =
+      slip_ ? (meSCS_->ipNodeMap(elemFaceOrdinal)[ip] * BcAlgTraits::nDim_)
+            : (meSCS_->opposingNodes(elemFaceOrdinal, ip) * BcAlgTraits::nDim_);
 
     DoubleType amag = 0.0;
     for (int d=0; d < BcAlgTraits::nDim_; ++d) {

--- a/src/ngp_algorithms/MomentumABLWallFuncMaskUtil.C
+++ b/src/ngp_algorithms/MomentumABLWallFuncMaskUtil.C
@@ -33,7 +33,7 @@ MomentumABLWallFuncMaskUtil::execute()
   const auto& meta     = realm_.meta_data();
   const auto ngpMesh   = realm_.ngp_mesh();
   const auto& fieldMgr = realm_.ngp_field_manager();
-  const auto myNodeMask    = fieldMgr.get_field<double>(maskNodeIndex_);
+  auto myNodeMask = fieldMgr.get_field<double>(maskNodeIndex_);
 
   const stk::mesh::Selector sel = (meta.locally_owned_part() | meta.globally_shared_part()) &
                                   stk::mesh::selectUnion(partVec_) &
@@ -45,6 +45,7 @@ MomentumABLWallFuncMaskUtil::execute()
      KOKKOS_LAMBDA(const Traits::MeshIndex& meshIdx) {
        myNodeMask.get(meshIdx, 0) = 0;
      });
+  myNodeMask.modify_on_device();
 }
 
 }


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Addressing remaining diffs from #810 as noted in #821.  There was a bug in the implementation from changing from a face lag to face elem alg.  Only ordinal 0 was being used in the ipMap for the `slip` branch of the stress model causing diffs at the wall.

It's interesting that this wasn't caught in `ablNeutralEdge` on the CPU runs.

However, we've tested this with `ablNeutralNGPTrilinos` and `ablNeturalStat` and the diffs were resolved for these two cases.  My GPU build of hypre failed so I didn't test the hypre variants but the mechanism of failure should be the same. This should close #821.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
