### PR TITLE
Remove redundant data sync to device

### DIFF
--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -790,28 +790,28 @@ PeriodicManager::ngp_parallel_communicate_field(
 
     if (theField->type_is<double>()) {
       std::vector<NGPDoubleFieldType *> fieldVec(1, &fieldMgr.get_field<double>(fieldOrd));
-      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec, false);
       stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
     else if (theField->type_is<stk::mesh::EntityId>()) {
       std::vector<NGPGlobalIdFieldType *> fieldVec(1, &fieldMgr.get_field<stk::mesh::EntityId>(fieldOrd));
-      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec, false);
       stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
     else if (theField->type_is<int>()) {
       std::vector<NGPScalarIntFieldType *> fieldVec(1, &fieldMgr.get_field<int>(fieldOrd));
-      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec, false);
       stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
     else if (theField->type_is<LinSys::GlobalOrdinal>()) {
       std::vector<stk::mesh::NgpField<LinSys::GlobalOrdinal>*> fieldVec(1, &fieldMgr.get_field<LinSys::GlobalOrdinal>(fieldOrd));
-      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec, false);
       stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
 #ifdef NALU_USES_HYPRE
     else if (theField->type_is<HypreIntType>()) {
       std::vector<stk::mesh::NgpField<HypreIntType>*> fieldVec(1, &fieldMgr.get_field<HypreIntType>(fieldOrd));
-      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec);
+      stk::mesh::copy_owned_to_shared( bulk_data, fieldVec, false);
       stk::mesh::communicate_field_data(bulk_data.aura_ghosting(), fieldVec);
     }
 #endif


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

There were calls to Ngp version of copy_owned_to_shared() immediately followed by communicate_field_data(). Since both copy_owned_to_shared() and communicate_field_data() call sync_to_device() at the end, syncs were unnecessarily invoked twice. This change will stop copy_owned_to_shared() from calling sync_to_device().

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
