### PR TITLE
Fix bug in NGP loops unit tests for edges

### DIFF
--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -372,6 +372,11 @@ void basic_edge_loop(
         ngpPressure.get(ngpMesh, nodes[i], 0) = presSet;
     });
 
+  ngpMassFlowRate.modify_on_device();
+  ngpMassFlowRate.sync_to_host();
+  ngpPressure.modify_on_device();
+  ngpPressure.sync_to_host();
+
   {
     const auto& edgeBuckets = bulk.get_buckets(stk::topology::EDGE_RANK,  sel);
     const double tol = 1.0e-16;


### PR DESCRIPTION
Updates in PR #832 exposed a long-standing bug within the unit-test for the
basic edge loop. This test was not really executing the loops because
`create_edges` was never called. Updates in PR #832 changed the behavior of
creating hex8 meshes where edges are always created. Now the edge loops were
executing in the NGPLoops tests, and it exposed the fact that the device fields
were never synced to the host before the checks were performed.
