### PR TITLE
Fix bug in ActLineSimple introduced by #832

### DIFF
--- a/reg_tests/test_files/ActLineSimple/ActLineSimple.yaml
+++ b/reg_tests/test_files/ActLineSimple/ActLineSimple.yaml
@@ -142,6 +142,10 @@ realms:
         pressure: element
         velocity: element
 
+    - source_terms:
+        momentum:
+          - actuator
+
   actuator:
     type: ActLineSimple
     search_method: stk_kdtree


### PR DESCRIPTION
The change from elem to edge schemes missed adding the node-based lumped actuator source terms to the momentum equation.