### PR TITLE
default to using 1/T0 for the thermal expansion coefficient in boussinesq

### DIFF
--- a/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.template.yaml
+++ b/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.template.yaml
@@ -216,7 +216,6 @@ realms:
             reference_density: 1.178037722969475
             reference_temperature: 300.0
             gravity: [0.0,0.0,-9.81]
-            thermal_expansion_coefficient: 3.33333333e-3           
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 45.0

--- a/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.yaml
+++ b/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.yaml
@@ -216,7 +216,6 @@ realms:
             reference_density: 1.178037722969475
             reference_temperature: 300.0
             gravity: [0.0,0.0,-9.81]
-            thermal_expansion_coefficient: 3.33333333e-3           
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 45.0

--- a/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
@@ -217,7 +217,6 @@ realms:
             reference_density: 1.178037722969475
             reference_temperature: 300.0
             gravity: [0.0,0.0,-9.81]
-            thermal_expansion_coefficient: 3.33333333e-3           
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 45.0

--- a/reg_tests/test_files/ablNeutralEdgeSegregated/ablNeutralEdgeSegregated.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeSegregated/ablNeutralEdgeSegregated.yaml
@@ -227,7 +227,6 @@ realms:
             reference_density: 1.178037722969475
             reference_temperature: 300.0
             gravity: [0.0,0.0,-9.81]
-            thermal_expansion_coefficient: 3.33333333e-3
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 45.0

--- a/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
@@ -231,7 +231,6 @@ realms:
             reference_density: 1.178037722969475
             reference_temperature: 300.0
             gravity: [0.0,0.0,-9.81]
-            thermal_expansion_coefficient: 3.33333333e-3           
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 45.0

--- a/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
@@ -230,7 +230,6 @@ realms:
             reference_density: 1.178037722969475
             reference_temperature: 300.0
             gravity: [0.0,0.0,-9.81]
-            thermal_expansion_coefficient: 3.33333333e-3           
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 45.0

--- a/reg_tests/test_files/ablNeutralNGPTrilinos/ablNeutralNGPTrilinos.yaml
+++ b/reg_tests/test_files/ablNeutralNGPTrilinos/ablNeutralNGPTrilinos.yaml
@@ -201,7 +201,6 @@ realms:
             reference_density: 1.178037722969475
             reference_temperature: 300.0
             gravity: [0.0,0.0,-9.81]
-            thermal_expansion_coefficient: 3.33333333e-3           
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 45.0

--- a/reg_tests/test_files/ablNeutralStat/ablNeutralStat.yaml
+++ b/reg_tests/test_files/ablNeutralStat/ablNeutralStat.yaml
@@ -216,7 +216,6 @@ realms:
             reference_density: 1.178037722969475
             reference_temperature: 300.0
             gravity: [0.0,0.0,-9.81]
-            thermal_expansion_coefficient: 3.33333333e-3           
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 45.0

--- a/reg_tests/test_files/ablStableEdge/ablStableEdge.yaml
+++ b/reg_tests/test_files/ablStableEdge/ablStableEdge.yaml
@@ -211,7 +211,6 @@ realms:
         reference_density: 1.3223
         reference_temperature: 263.5
         gravity: [0.0, 0.0, -9.81]
-        thermal_expansion_coefficient: 3.33333333e-3
         east_vector: [1.0, 0.0, 0.0]
         north_vector: [0.0, 1.0, 0.0]
         latitude: 73.0

--- a/reg_tests/test_files/ablUnstableEdge/ablUnstableEdge.yaml
+++ b/reg_tests/test_files/ablUnstableEdge/ablUnstableEdge.yaml
@@ -177,7 +177,6 @@ realms:
             reference_density: 1.00
             reference_temperature: 290.0
             gravity: [0.0, 0.0, -9.81]
-            thermal_expansion_coefficient: 3.33333333e-3
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 90.0

--- a/reg_tests/test_files/ablUnstableEdge_ra/ablUnstableEdge_ra.yaml
+++ b/reg_tests/test_files/ablUnstableEdge_ra/ablUnstableEdge_ra.yaml
@@ -177,7 +177,6 @@ realms:
             reference_density: 1.00
             reference_temperature: 290.0
             gravity: [0.0, 0.0, -9.81]
-            thermal_expansion_coefficient: 3.33333333e-3
             east_vector: [1.0, 0.0, 0.0]
             north_vector: [0.0, 1.0, 0.0]
             latitude: 90.0

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -315,8 +315,24 @@ SolutionOptions::load(const YAML::Node & y_node)
           const YAML::Node y_user_constants = y_option["user_constants"];
           get_if_present(y_user_constants, "reference_density",  referenceDensity_, referenceDensity_);
           get_if_present(y_user_constants, "reference_temperature",  referenceTemperature_, referenceTemperature_);
-          get_if_present(y_user_constants, "thermal_expansion_coefficient",  thermalExpansionCoeff_, thermalExpansionCoeff_);
-          get_if_present(y_user_constants, "stefan_boltzmann",  stefanBoltzmann_, stefanBoltzmann_);
+
+          const auto thermal_expansion_option = "thermal_expansion_coefficient";
+          if (
+            y_user_constants["reference_temperature"] &&
+            !y_user_constants[thermal_expansion_option]) {
+            thermalExpansionCoeff_ = 1 / referenceTemperature_;
+            NaluEnv::self().naluOutputP0()
+              << "Using ideal gas relationship for thermal expansion "
+                 "coefficient of "
+              << thermalExpansionCoeff_ << "\n  -- specify "
+              << thermal_expansion_option
+              << " in user constants to set a different value"
+              << std::endl;
+          }
+          get_if_present(
+            y_user_constants, thermal_expansion_option, thermalExpansionCoeff_,
+            thermalExpansionCoeff_);
+          
           get_if_present(y_user_constants, "earth_angular_velocity", earthAngularVelocity_, earthAngularVelocity_);
           get_if_present(y_user_constants, "latitude", latitude_, latitude_);
           get_if_present(y_user_constants, "boussinesq_time_scale", raBoussinesqTimeScale_, raBoussinesqTimeScale_);


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

Sets the default value of the thermal expansion to `1/reference_temperature` if `reference_temperature` is specified but `thermal_expansion_coefficient` is not.

Neglecting to update the thermal expansion coefficient when updating the reference temperature (for air) is a pretty common mistake. This won't fix any cases since I left the ability to specify the thermal expansion coefficient independently of the reference temperature (for water etc).  Not sure on whether that's the best approach.

Will need a rebless of the unstable/stable cases.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
