### PR TITLE
Fix seg fault from moving actuatorModel init location

### DIFF
--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1125,7 +1125,7 @@ MomentumEquationSystem::register_nodal_fields(
   }
 
   // speciality source
-  if (realm_.actuatorModel_->is_active()) {
+  if (realm_.actuatorModel_) {
     VectorFieldType *actuatorSource
       =  &(meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source"));
     VectorFieldType* actuatorSourceLHS =

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -939,7 +939,8 @@ Realm::setup_post_processing_algorithms()
     dataProbePostProcessing_->setup();
   }
 
-  actuatorModel_->setup(get_time_step_from_file(), bulk_data());
+  if (actuatorModel_)
+    actuatorModel_->setup(get_time_step_from_file(), bulk_data());
 
   // check for norm nodal fields
   if ( NULL != solutionNormPostProcessing_ )
@@ -1719,7 +1720,7 @@ Realm::advance_time_step()
   compute_vrtm();
 
   // check for  actuator; assemble the source terms for this step
-  if (actuatorModel_->is_active()) {
+  if (actuatorModel_) {
     const double start_time = NaluEnv::self().nalu_time();
     actuatorModel_->execute(timerActuator_);
     const double end_time = NaluEnv::self().nalu_time();
@@ -2205,7 +2206,8 @@ Realm::initialize_post_processing_algorithms()
     ablForcingAlg_->initialize();
   }
 
-  actuatorModel_->init(bulk_data());
+  if (actuatorModel_)
+    actuatorModel_->init(bulk_data());
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

When I changed the init of actuator models from Realm's constructor to inside the body, I forgot to add checks for the pointer validity. 99.999% certain this is why almost every test seg-faulted on CDash today.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
