### PR TITLE
Simpler HYPRE IJMatrix Assemble:

### DIFF
--- a/include/HypreLinearSystem.h
+++ b/include/HypreLinearSystem.h
@@ -20,9 +20,6 @@
 #endif // HYPRE_LINEAR_SYSTEM_DEBUG
 #undef HYPRE_LINEAR_SYSTEM_DEBUG
 
-#include <iostream>
-#include <fstream>
-
 #include "LinearSystem.h"
 #include "HypreDirectSolver.h"
 
@@ -215,7 +212,7 @@ public:
    */
   virtual void loadComplete();
 
-  virtual void dumpRowsNNZStats();
+  virtual void dumpMatrixStats();
 
   /** Reset the matrix and rhs data structures for the next iteration/timestep
    *

--- a/include/HypreUVWLinearSystem.h
+++ b/include/HypreUVWLinearSystem.h
@@ -101,7 +101,8 @@ public:
       const double rhs_residual,
       const HypreIntType iLower,
       const HypreIntType iUpper,
-      const unsigned nDim);
+      const unsigned nDim,
+      HypreIntType memShift);
 
     KOKKOS_FUNCTION
     virtual void resetRows(
@@ -117,11 +118,13 @@ public:
       unsigned numEntities,
       const stk::mesh::NgpMesh::ConnectedNodes& entities,
       const SharedMemView<int*, DeviceShmem>& localIds,
+      const SharedMemView<int*, DeviceShmem>& sortPermutation,
       const SharedMemView<const double*, DeviceShmem>& rhs,
       const SharedMemView<const double**, DeviceShmem>& lhs,
       const HypreIntType& iLower,
       const HypreIntType& iUpper,
-      unsigned nDim);
+      unsigned nDim,
+      HypreIntType memShift);
 
     KOKKOS_FUNCTION
     virtual void operator()(

--- a/include/LinearSolverConfig.h
+++ b/include/LinearSolverConfig.h
@@ -59,12 +59,6 @@ public:
   inline bool useSegregatedSolver() const
   { return useSegregatedSolver_; }
 
-  inline bool simpleHypreMatrixAssemble() const
-  { return simpleHypreMatrixAssemble_; }
-
-  inline bool dumpHypreMatrixStats() const
-  { return dumpHypreMatrixStats_; }
-
   /** User flag indicating whether equation systems must attempt to reuse linear
    *  system data structures even for cases with mesh motion.
    *
@@ -109,8 +103,6 @@ protected:
   bool useSegregatedSolver_{false};
   bool writeMatrixFiles_{false};
   bool reuseLinSysIfPossible_{false};
-  bool simpleHypreMatrixAssemble_{false};
-  bool dumpHypreMatrixStats_{false};
 };
 
 class TpetraLinearSolverConfig : public LinearSolverConfig
@@ -144,6 +136,12 @@ public:
   virtual void load(const YAML::Node&);
 
   bool useSegregatedSolver() const { return useSegregatedSolver_; }
+
+  inline bool simpleHypreMatrixAssemble() const
+  { return simpleHypreMatrixAssemble_; }
+
+  inline bool dumpHypreMatrixStats() const
+  { return dumpHypreMatrixStats_; }
 
 protected:
   //! List of HYPRE API calls and corresponding arugments to configure solver
@@ -184,6 +182,8 @@ protected:
   bool isHypreSolver_{true};
   bool hasAbsTol_{false};
   bool useSegregatedSolver_{false};
+  bool simpleHypreMatrixAssemble_{false};
+  bool dumpHypreMatrixStats_{false};
 
 private:
   void boomerAMG_solver_config(const YAML::Node&);

--- a/include/LinearSolverConfig.h
+++ b/include/LinearSolverConfig.h
@@ -59,6 +59,12 @@ public:
   inline bool useSegregatedSolver() const
   { return useSegregatedSolver_; }
 
+  inline bool simpleHypreMatrixAssemble() const
+  { return simpleHypreMatrixAssemble_; }
+
+  inline bool dumpHypreMatrixStats() const
+  { return dumpHypreMatrixStats_; }
+
   /** User flag indicating whether equation systems must attempt to reuse linear
    *  system data structures even for cases with mesh motion.
    *
@@ -103,6 +109,8 @@ protected:
   bool useSegregatedSolver_{false};
   bool writeMatrixFiles_{false};
   bool reuseLinSysIfPossible_{false};
+  bool simpleHypreMatrixAssemble_{false};
+  bool dumpHypreMatrixStats_{false};
 };
 
 class TpetraLinearSolverConfig : public LinearSolverConfig
@@ -166,6 +174,9 @@ protected:
   int bamgRelaxType_{6};
   int bamgRelaxOrder_{1};
   int bamgNumSweeps_{2};
+  int bamgNumDownSweeps_{1};
+  int bamgNumUpSweeps_{2};
+  int bamgNumCoarseSweeps_{2};
   int bamgMaxLevels_{20};
   int bamgInterpType_{0};
   std::string bamgEuclidFile_{""};

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -643,6 +643,8 @@ class Realm {
 
   bool isFinalOuterIter_{false};
 
+  std::vector<stk::mesh::EntityId> hypreOffsets_;
+
   /** The starting index (global) of the HYPRE linear system in this MPI rank
    *
    *  Note that this is actually the offset into the linear system. This index

--- a/reg_tests/hypre_settings/hypre_blade_resolved.yaml
+++ b/reg_tests/hypre_settings/hypre_blade_resolved.yaml
@@ -1,6 +1,6 @@
 hypre_simple_precon:
   bamg_max_levels: 1
-  bamg_relax_type: 11 # Use 11 for Hypre master or v2.21 and later, 8 for earlier
+  bamg_relax_type: 12 # Use 11 for Hypre master or v2.21 and later, 8 for earlier
   bamg_num_sweeps: 2
   bamg_relax_order: 0
 
@@ -9,12 +9,15 @@ hypre_elliptic:
   bamg_coarsen_type: 8 # 10 for CPUs (HMIS). For GPUs, use 8 (PMIS)
   bamg_interp_type: 6
   bamg_relax_type: 11 # Use 11 for Hypre master or v2.21 and later, 8 for earlier
-  bamg_num_sweeps: 2
+  #bamg_num_sweeps: 2
+  bamg_num_up_sweeps: 1
+  bamg_num_down_sweeps: 2
+  bamg_num_coarse_sweeps: 1
   bamg_cycle_type: 1
   bamg_relax_order: 0
   bamg_trunc_factor: 0.1
   bamg_agg_num_levels: 2
-  bamg_agg_interp_type: 5 # for 4 CPUs. For GPUs, use 5 (less communication) or 7 (better convergence)
+  bamg_agg_interp_type: 7 # use 4 for CPUs. For GPUs, use 5 (less communication) or 7 (better convergence)
   bamg_agg_pmax_elmts: 3
   bamg_pmax_elmts: 3
   bamg_strong_threshold: 0.25

--- a/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
@@ -19,6 +19,8 @@ linear_solvers:
     write_matrix_files: no
     reuse_linear_system: yes
     recompute_preconditioner_frequency: 100
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -36,6 +38,8 @@ linear_solvers:
     write_matrix_files: no
     reuse_linear_system: yes
     recompute_preconditioner_frequency: 100
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -53,6 +57,8 @@ linear_solvers:
     write_matrix_files: no
     reuse_linear_system: yes
     recompute_preconditioner_frequency: 100
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml

--- a/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
@@ -19,6 +19,8 @@ linear_solvers:
     write_matrix_files: no
     reuse_linear_system: yes
     recompute_preconditioner_frequency: 100
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -36,6 +38,8 @@ linear_solvers:
     write_matrix_files: no
     reuse_linear_system: yes
     recompute_preconditioner_frequency: 100
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -53,6 +57,8 @@ linear_solvers:
     write_matrix_files: no
     reuse_linear_system: yes
     recompute_preconditioner_frequency: 100
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml

--- a/reg_tests/test_files/airfoilRANSEdgeNGPHypre.rst/airfoilRANSEdgeNGPHypre.rst.yaml
+++ b/reg_tests/test_files/airfoilRANSEdgeNGPHypre.rst/airfoilRANSEdgeNGPHypre.rst.yaml
@@ -22,6 +22,8 @@ linear_solvers:
     output_level: 0
     segregated_solver: yes
     write_matrix_files: no
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -37,6 +39,8 @@ linear_solvers:
     kspace: 75
     output_level: 0
     write_matrix_files: no
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -52,6 +56,8 @@ linear_solvers:
     kspace: 75
     output_level: 0
     write_matrix_files: no
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml

--- a/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.yaml
+++ b/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.yaml
@@ -17,6 +17,8 @@ linear_solvers:
     output_level: 0
     segregated_solver: yes
     write_matrix_files: no
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -32,6 +34,8 @@ linear_solvers:
     kspace: 75
     output_level: 0
     write_matrix_files: no
+    simple_hypre_matrix_assemble: no
+    dump_hypre_matrix_stats: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -9,6 +9,9 @@
 
 #include "HypreLinearSystem.h"
 
+#include <iostream>
+#include <fstream>
+
 namespace sierra {
 namespace nalu {
 
@@ -916,7 +919,8 @@ HypreLinearSystem::computeRowSizes()
   HypreIntType totalRhsElmts = hcApplier->num_rows_owned_;
 
   HypreDirectSolver* solver = reinterpret_cast<HypreDirectSolver*>(linearSolver_);
-  if (solver->getConfig()->simpleHypreMatrixAssemble()) {
+  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
+  if (config->simpleHypreMatrixAssemble()) {
     /* set the key hypre parameters */
     offProcNNZToSend_ = hcApplier->num_nonzeros_shared_;
     offProcRhsToSend_ = hcApplier->num_rows_shared_;
@@ -1516,7 +1520,8 @@ HypreLinearSystem::hypreIJMatrixSetAddToValues()
   auto num_nonzeros_shared = hcApplier->num_nonzeros_shared_;
 
   HypreDirectSolver* solver = reinterpret_cast<HypreDirectSolver*>(linearSolver_);
-  if (solver->getConfig()->simpleHypreMatrixAssemble()) {
+  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
+  if (config->simpleHypreMatrixAssemble()) {
 #if 0
     /* set the key hypre parameters */
     HYPRE_IJMatrixSetMaxOnProcElmts(mat_, hcApplier->num_nonzeros_owned_);
@@ -1549,7 +1554,8 @@ HypreLinearSystem::hypreIJVectorSetAddToValues()
   auto num_rows_shared = hcApplier->num_rows_shared_;
 
   HypreDirectSolver* solver = reinterpret_cast<HypreDirectSolver*>(linearSolver_);
-  if (solver->getConfig()->simpleHypreMatrixAssemble()) {
+  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
+  if (config->simpleHypreMatrixAssemble()) {
 #if 0
     /* set the key hypre parameters */
     HYPRE_IJVectorSetMaxOnProcElmts(rhs_, num_rows_owned);
@@ -1574,7 +1580,7 @@ HypreLinearSystem::hypreIJVectorSetAddToValues()
 }
 
 void
-HypreLinearSystem::dumpRowsNNZStats()
+HypreLinearSystem::dumpMatrixStats()
 {
   HypreLinSysCoeffApplier* hcApplier =
     dynamic_cast<HypreLinSysCoeffApplier*>(hostCoeffApplier.get());
@@ -1708,8 +1714,9 @@ HypreLinearSystem::loadCompleteSolver()
 
   solver->comm_ = realm_.bulk_data().parallel();
 
-  if (solver->getConfig()->dumpHypreMatrixStats() && !matrixStatsDumped_) {
-    dumpRowsNNZStats();
+  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
+  if (config->dumpHypreMatrixStats() && !matrixStatsDumped_) {
+    dumpMatrixStats();
     matrixStatsDumped_ = true;
   }
 

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -143,8 +143,9 @@ HypreUVWLinearSystem::hypreIJVectorSetAddToValues()
   auto num_rows_shared = hcApplier->num_rows_shared_;
 
   HypreDirectSolver* solver = reinterpret_cast<HypreDirectSolver*>(linearSolver_);
+  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
   for (unsigned i = 0; i < nDim_; ++i) {
-    if (solver->getConfig()->simpleHypreMatrixAssemble()) {
+    if (config->simpleHypreMatrixAssemble()) {
 #if 0
       /* set the key hypre parameters */
       HYPRE_IJVectorSetMaxOnProcElmts(rhs_[i], num_rows_owned);
@@ -254,8 +255,9 @@ HypreUVWLinearSystem::loadCompleteSolver()
 
   solver->comm_ = realm_.bulk_data().parallel();
 
-  if (solver->getConfig()->dumpHypreMatrixStats() && !matrixStatsDumped_) {
-    dumpRowsNNZStats();
+  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
+  if (config->dumpHypreMatrixStats() && !matrixStatsDumped_) {
+    dumpMatrixStats();
     matrixStatsDumped_ = true;
   }
 

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -3251,7 +3251,8 @@ Realm::set_hypre_global_id()
   int nprocs = bulkData_->parallel_size();
   int iproc = bulkData_->parallel_rank();
   std::vector<int> nodesPerProc(nprocs);
-  std::vector<stk::mesh::EntityId> hypreOffsets(nprocs+1);
+  //std::vector<stk::mesh::EntityId> hypreOffsets(nprocs+1);
+  hypreOffsets_.resize(nprocs+1);
 
   // 1. Determine the number of nodes per partition and determine appropriate
   // offsets on each MPI rank.
@@ -3260,15 +3261,15 @@ Realm::set_hypre_global_id()
   MPI_Allgather(&num_nodes, 1, MPI_INT, nodesPerProc.data(), 1, MPI_INT,
                 bulkData_->parallel());
 
-  hypreOffsets[0] = 0;
+  hypreOffsets_[0] = 0;
   for (int i=1; i <= nprocs; i++)
-    hypreOffsets[i] = hypreOffsets[i-1] + nodesPerProc[i-1];
+    hypreOffsets_[i] = hypreOffsets_[i-1] + nodesPerProc[i-1];
 
   // These are set up for NDOF=1, the actual lower/upper extents will be
   // finalized in HypreLinearSystem class based on the equation being solved.
-  hypreILower_ = hypreOffsets[iproc];
-  hypreIUpper_ = hypreOffsets[iproc+1];
-  hypreNumNodes_ = hypreOffsets[nprocs];
+  hypreILower_ = hypreOffsets_[iproc];
+  hypreIUpper_ = hypreOffsets_[iproc+1];
+  hypreNumNodes_ = hypreOffsets_[nprocs];
 
   // 2. Sort the local STK IDs so that we retain a 1-1 mapping as much as possible
   size_t ii=0;


### PR DESCRIPTION
Regressions test would pass on Rhodes except for the changes in reg_tests/hypre_settings/hypre_blade_resolved.yaml. I've changed these to reflect new smoothers/preconditioners and better parameters to use for BoomerAMG in the ABL tests. 

Now to the actual changes.

In this branch, the data structures for the assembled matrix (i,j,values) are combined into one large
monolithic buffer for owned and shared. The owned part comes first, then the shared. In addition,
the number of contributions (nnz, including repeats) on rank i from all other ranks is computed. This
allows us to resize the monolithic buffers to be nnz_owned + max(nnz_shared, nnz_shared_recv). Then,
this buffer can be reused inside IJMatrixAssemble thus saving a substantial amount of memory. Since this
optimized hypre assembly algorithnm is not yet in Hypre master, the API methods that indicate to
Hypre to use this new algorithm are disabled (though the code is left in for future use). The current
version of this new Nalu data structure works with Hypre master (without the disabled code!). As a part of this
development, the row_indices/counts has been replaced by rows which is the same size of as cols/values.
This allows us to use simpler IJMatrixSet/AddToValues2 APIs which use less memory and have fewer kernel
calls. We have added the option "simple_hypre_matrix_assemble", which will us to toggle between the
optimized and more general assembly algorithms, and will be useful once the optimized version is in
Hypre master.

Next, for all calls to sumInto* (HypreLinearSystem and HypreUVWLinearSystem), we have replaced the
binarySearch method for finding matrix write location with a sort and a constrained linear search. Because
the matrix locations defined by the column are sorted, one can use the old linear search as the starting
point for the next matrix write location, defined by the next column, which is sorted in ascending order.
These optimizations are facilitated by moving all read-only data structures in the numeric assembly to
RandomAccess Kokkos views. That is, we attempt to use fast Texture memory where possible.

We have added the ability to dump matrix statistics (rows, nnz per rank). This is useful for measuring
the effect of load balancing strategies and partitioning algorithms like parmetis. This is turned off
by default. Moreover, if toggled, we only dump matrix stats once per equation system construction after
the global matrix assembly. The option is "dump_hypre_matrix_stats".


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
