### PR TITLE
Improve FAST timestep ratio tolerance

### DIFF
--- a/include/actuator/ActuatorBulkFAST.h
+++ b/include/actuator/ActuatorBulkFAST.h
@@ -50,8 +50,11 @@ struct ActuatorBulkFAST : public ActuatorBulk
   void step_fast();
   bool fast_is_time_zero();
   void output_torque_info(stk::mesh::BulkData& stkBulk);
-  void init_openfast(const ActuatorMetaFAST& actMeta, double naluTimeStep);
+  void
+  init_openfast(const ActuatorMetaFAST& actMeta, const double naluTimeStep);
   void init_epsilon(const ActuatorMetaFAST& actMeta);
+  bool is_tstep_ratio_admissable(
+    const ActuatorMetaFAST& actMeta, const double naluTimeStep);
 
   virtual ~ActuatorBulkFAST();
 

--- a/include/actuator/ActuatorBulkFAST.h
+++ b/include/actuator/ActuatorBulkFAST.h
@@ -54,7 +54,7 @@ struct ActuatorBulkFAST : public ActuatorBulk
   init_openfast(const ActuatorMetaFAST& actMeta, const double naluTimeStep);
   void init_epsilon(const ActuatorMetaFAST& actMeta);
   bool is_tstep_ratio_admissable(
-    const ActuatorMetaFAST& actMeta, const double naluTimeStep);
+    const double fastTimeStep, const double naluTimeStep);
 
   virtual ~ActuatorBulkFAST();
 

--- a/src/actuator/ActuatorBulkFAST.C
+++ b/src/actuator/ActuatorBulkFAST.C
@@ -64,10 +64,9 @@ ActuatorBulkFAST::~ActuatorBulkFAST() { openFast_.end(); }
 
 bool
 ActuatorBulkFAST::is_tstep_ratio_admissable(
-  const ActuatorMetaFAST& actMeta, const double naluTimeStep)
+  const double fastTimeStep, const double naluTimeStep)
 {
-  const double stepCheck =
-    std::abs(naluTimeStep / actMeta.fastInputs_.dtFAST - tStepRatio_);
+  const double stepCheck = std::abs(naluTimeStep / fastTimeStep - tStepRatio_);
   return stepCheck < 1e-12;
 }
 
@@ -76,7 +75,7 @@ ActuatorBulkFAST::init_openfast(
   const ActuatorMetaFAST& actMeta, const double naluTimeStep)
 {
   openFast_.setInputs(actMeta.fastInputs_);
-  if (!is_tstep_ratio_admissable(actMeta, naluTimeStep)) {
+  if (!is_tstep_ratio_admissable(actMeta.fastInputs_.dtFAST, naluTimeStep)) {
     throw std::runtime_error("ActuatorFAST: Ratio of Nalu's time step is not "
                              "an integral multiple of FAST time step.");
   } else {
@@ -109,12 +108,15 @@ ActuatorBulkFAST::init_openfast(
   } else {
     squash_fast_output(std::bind(&fast::OpenFAST::init, &openFast_));
   }
-  if (!is_tstep_ratio_admissable(actMeta, naluTimeStep)) {
+  /* TODO update/uncomment this check once openfast adds in a way 
+  to get the actual time step from fast::OpenFAST
+  if (!is_tstep_ratio_admissable(openFast_.dtFAST, naluTimeStep)) {
     throw std::runtime_error("OpenFAST is using a different time step than "
                              "what was specified in the input deck. "
                              "Please check that your workflow is consistent "
                              "(restarts, FAST files, etc.");
   }
+  */
 
   for (int i = 0; i < nTurb; ++i) {
     if (localTurbineId_ == openFast_.get_procNo(i)) {

--- a/unit_tests/actuator/UnitTestActuatorBulkFAST.C
+++ b/unit_tests/actuator/UnitTestActuatorBulkFAST.C
@@ -45,7 +45,10 @@ protected:
 
 TEST_F(ActuatorBulkFastTests, NGP_initializeActuatorBulk)
 {
-  const YAML::Node y_node = actuator_unit::create_yaml_node(fastParseParams_);
+  std::vector<std::string> modInputs(fastParseParams_);
+  modInputs[4] = "  dt_fast: 0.005\n";
+  modInputs[5] = "  t_max: 0.29\n";
+  const YAML::Node y_node = actuator_unit::create_yaml_node(modInputs);
   auto actMetaFast = actuator_FAST_parse(y_node, actMeta_);
 
   const fast::fastInputs& fi = actMetaFast.fastInputs_;
@@ -57,8 +60,8 @@ TEST_F(ActuatorBulkFastTests, NGP_initializeActuatorBulk)
   ASSERT_EQ(fi.tStart, 0.0);
   ASSERT_EQ(fi.simStart, fast::init);
   ASSERT_EQ(fi.nEveryCheckPoint, 1);
-  ASSERT_EQ(fi.dtFAST, 0.00625);
-  ASSERT_EQ(fi.tMax, 0.0625);
+  ASSERT_EQ(fi.dtFAST, 0.005);
+  ASSERT_EQ(fi.tMax, 0.29);
 
   ASSERT_EQ(
     fi.globTurbineData[0].FASTInputFileName, "nrel5mw.fst");
@@ -71,7 +74,8 @@ TEST_F(ActuatorBulkFastTests, NGP_initializeActuatorBulk)
   ASSERT_EQ(fi.globTurbineData[0].nacelle_cd, 1.0);
 
   try {
-    ActuatorBulkFAST actBulk(actMetaFast, 0.0625);
+    ActuatorBulkFAST actBulk(actMetaFast, 0.29);
+    EXPECT_EQ(actBulk.tStepRatio_, 58);
     EXPECT_FALSE(actBulk.openFast_.isDebug());
   } catch (std::exception const& err) {
     FAIL() << err.what();


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Analyst have reported an issue with the computation of the timestep ratio for FAST and nalu-wind.  I've updated the unit test to use their case and tightened the checking tolerance.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
