### PR TITLE
Improve check for isotropic Gaussian

### DIFF
--- a/src/actuator/ActuatorParsing.C
+++ b/src/actuator/ActuatorParsing.C
@@ -209,6 +209,10 @@ epsilon_parsing(int iTurb, const YAML::Node& turbNode, ActuatorMeta& actMeta)
   } else if (epsilon_chord) {
     // require epsilon chord and epsilon min
     get_required(turbNode, "epsilon_chord", epsilonTemp);
+      if (
+        epsilonTemp[0] == epsilonTemp[1] && epsilonTemp[1] == epsilonTemp[2]) {
+        actMeta.isotropicGaussian_ = true;
+      }
     for (int j = 0; j < 3; j++) {
       if (epsilonTemp[j] <= 0.0) {
         throw std::runtime_error(
@@ -221,6 +225,10 @@ epsilon_parsing(int iTurb, const YAML::Node& turbNode, ActuatorMeta& actMeta)
     // Minimum epsilon allowed in simulation. This is required when
     //   specifying epsilon/chord
     get_required(turbNode, "epsilon_min", epsilonTemp);
+      if (
+        !(actMeta.isotropicGaussian_ && epsilonTemp[0] == epsilonTemp[1] && epsilonTemp[1] == epsilonTemp[2])) {
+        actMeta.isotropicGaussian_ = false;
+      }
     for (int j = 0; j < 3; j++) {
       actMeta.epsilon_.h_view(iTurb, j) = epsilonTemp[j];
     }


### PR DESCRIPTION
**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Allow isotropic Gaussian flag to be set correctly when using `epsilonChord`/`epsilonMin`

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [x] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
