### PR TITLE
Move all actuator tests to IOSS generated meshes

### DIFF
--- a/reg_tests/test_files/ActLineSimpleNGP/ActLineSimpleNGP.yaml
+++ b/reg_tests/test_files/ActLineSimpleNGP/ActLineSimpleNGP.yaml
@@ -59,7 +59,7 @@ linear_solvers:
 realms:
 
 - name: realm_1
-  mesh: ../../mesh/mesh_actlinesimple.exo
+  mesh: "generated:100x32x32|bbox:-50.0,-16.0,-16.0,50.0,16.0,16.0|sideset:xXyYzZ|show"
   use_edges: yes
   automatic_decomposition_type: rcb
 
@@ -81,13 +81,13 @@ realms:
   initial_conditions:
 
   - constant: ic_1
-    target_name: Unspecified-2-HEX
+    target_name: block_1
     value:
       pressure: 0.0
       velocity: [2.0, 0.0, 0.0]
 
   material_properties:
-    target_name: Unspecified-2-HEX
+    target_name: block_1
     specifications:
     - name: density
       type: constant
@@ -100,30 +100,30 @@ realms:
   boundary_conditions:
 
   - inflow_boundary_condition: bc_1
-    target_name: west
+    target_name: surface_1
     inflow_user_data:
       velocity: [2.0, 0.0, 0.0]
 
   - open_boundary_condition: bc_2
-    target_name: east
+    target_name: surface_2
     open_user_data:
       pressure: 0.0
       velocity: [2.0, 0.0, 0.0]
 
   - symmetry_boundary_condition: bc_3
-    target_name: north
+    target_name: surface_3
     symmetry_user_data:
 
   - symmetry_boundary_condition: bc_4
-    target_name: south
+    target_name: surface_4
     symmetry_user_data:
 
   - symmetry_boundary_condition: bc_5
-    target_name: lower
+    target_name: surface_5
     symmetry_user_data:
 
   - symmetry_boundary_condition: bc_6
-    target_name: upper
+    target_name: surface_6
     symmetry_user_data:
 
   solution_options:
@@ -149,7 +149,7 @@ realms:
   actuator:
     type: ActLineSimpleNGP
     search_method: stk_kdtree
-    search_target_part: Unspecified-2-HEX
+    search_target_part: block_1
 
     n_simpleblades: 1
     debug_output: no
@@ -183,7 +183,7 @@ realms:
 
     specifications:
     - name: probe_surface
-      from_target_part: Unspecified-2-HEX
+      from_target_part: block_1
       plane_specifications:        
         - name: slicedir/zslice1_SimpleNGP
           corner_coordinates:  [-50.0, -16.0, 0.0]  

--- a/reg_tests/test_files/nrel5MWactuatorDisk/nrel5MWactuatorDisk.yaml
+++ b/reg_tests/test_files/nrel5MWactuatorDisk/nrel5MWactuatorDisk.yaml
@@ -28,7 +28,7 @@ linear_solvers:
 realms:
 
   - name: realm_1
-    mesh: ../../mesh/nrel5MWactuatorLine.g
+    mesh: "generated:30x80x160|bbox:-30.0,-80.0,-90.0,30.0,80.0,240.0|sideset:xXyYzZ|show"
     use_edges: yes
     automatic_decomposition_type: rcb
 
@@ -50,13 +50,13 @@ realms:
     initial_conditions:
 
       - constant: ic_1
-        target_name: Unspecified-2-HEX
+        target_name: block_1
         value:
           pressure: 0.0
           velocity: [8.0,0.0,0.0]
 
     material_properties:
-      target_name: Unspecified-2-HEX
+      target_name: block_1
       specifications:
         - name: density
           type: constant
@@ -69,30 +69,30 @@ realms:
     boundary_conditions:
 
     - inflow_boundary_condition: bc_1
-      target_name: inflow
+      target_name: surface_1
       inflow_user_data:
         velocity: [8.0,0.0,0.0]
 
     - open_boundary_condition: bc_2
-      target_name: outflow
+      target_name: surface_2
       open_user_data:
         pressure: 0.0
         velocity: [8.0,0.0,0.0]
 
     - symmetry_boundary_condition: bc_3
-      target_name: left
+      target_name: surface_3
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_4
-      target_name: right
+      target_name: surface_4
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_5
-      target_name: bottom
+      target_name: surface_5
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_6
-      target_name: top
+      target_name: surface_6
       symmetry_user_data:
 
     solution_options:
@@ -117,7 +117,7 @@ realms:
     actuator:
       type: ActDiskFASTNGP
       search_method: stk_kdtree
-      search_target_part: Unspecified-2-HEX
+      search_target_part: block_1
 
       n_turbines_glob: 1
       debug:    False

--- a/reg_tests/test_files/nrel5MWactuatorLineAnisoGauss/nrel5MWactuatorLineAnisoGauss.yaml
+++ b/reg_tests/test_files/nrel5MWactuatorLineAnisoGauss/nrel5MWactuatorLineAnisoGauss.yaml
@@ -28,7 +28,7 @@ linear_solvers:
 realms:
 
   - name: realm_1
-    mesh: ../../mesh/nrel5MWactuatorLine.g
+    mesh: "generated:30x80x160|bbox:-30.0,-80.0,-90.0,30.0,80.0,240.0|sideset:xXyYzZ|show"
     use_edges: yes
     automatic_decomposition_type: rcb
 
@@ -50,13 +50,13 @@ realms:
     initial_conditions:
 
       - constant: ic_1
-        target_name: Unspecified-2-HEX
+        target_name: block_1
         value:
           pressure: 0.0
           velocity: [8.0,0.0,0.0]
 
     material_properties:
-      target_name: Unspecified-2-HEX
+      target_name: block_1
       specifications:
         - name: density
           type: constant
@@ -69,30 +69,30 @@ realms:
     boundary_conditions:
 
     - inflow_boundary_condition: bc_1
-      target_name: inflow
+      target_name: surface_1
       inflow_user_data:
         velocity: [8.0,0.0,0.0]
 
     - open_boundary_condition: bc_2
-      target_name: outflow
+      target_name: surface_2
       open_user_data:
         pressure: 0.0
         velocity: [8.0,0.0,0.0]
 
     - symmetry_boundary_condition: bc_3
-      target_name: left
+      target_name: surface_3
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_4
-      target_name: right
+      target_name: surface_4
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_5
-      target_name: bottom
+      target_name: surface_5
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_6
-      target_name: top
+      target_name: surface_6
       symmetry_user_data:
 
     solution_options:
@@ -117,7 +117,7 @@ realms:
     actuator:
       type: ActLineFASTNGP
       search_method: stk_kdtree
-      search_target_part: Unspecified-2-HEX
+      search_target_part: block_1
 
       n_turbines_glob: 1
       debug:    False

--- a/reg_tests/test_files/nrel5MWactuatorLineFllc/nrel5MWactuatorLineFllc.yaml
+++ b/reg_tests/test_files/nrel5MWactuatorLineFllc/nrel5MWactuatorLineFllc.yaml
@@ -28,7 +28,7 @@ linear_solvers:
 realms:
 
   - name: realm_1
-    mesh: ../../mesh/nrel5MWactuatorLine.g
+    mesh: "generated:30x80x160|bbox:-30.0,-80.0,-90.0,30.0,80.0,240.0|sideset:xXyYzZ|show"
     use_edges: yes
     automatic_decomposition_type: rcb
 
@@ -50,13 +50,13 @@ realms:
     initial_conditions:
 
       - constant: ic_1
-        target_name: Unspecified-2-HEX
+        target_name: block_1
         value:
           pressure: 0.0
           velocity: [8.0,0.0,0.0]
 
     material_properties:
-      target_name: Unspecified-2-HEX
+      target_name: block_1
       specifications:
         - name: density
           type: constant
@@ -69,30 +69,30 @@ realms:
     boundary_conditions:
 
     - inflow_boundary_condition: bc_1
-      target_name: inflow
+      target_name: surface_1
       inflow_user_data:
         velocity: [8.0,0.0,0.0]
 
     - open_boundary_condition: bc_2
-      target_name: outflow
+      target_name: surface_2
       open_user_data:
         pressure: 0.0
         velocity: [8.0,0.0,0.0]
 
     - symmetry_boundary_condition: bc_3
-      target_name: left
+      target_name: surface_3
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_4
-      target_name: right
+      target_name: surface_4
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_5
-      target_name: bottom
+      target_name: surface_5
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_6
-      target_name: top
+      target_name: surface_6
       symmetry_user_data:
 
     solution_options:
@@ -117,7 +117,7 @@ realms:
     actuator:
       type: ActLineFASTNGP
       search_method: stk_kdtree
-      search_target_part: Unspecified-2-HEX
+      search_target_part: block_1
 
       n_turbines_glob: 1
       dry_run:  False

--- a/reg_tests/test_files/nrel5MWadvActLine/nrel5MWadvActLine.yaml
+++ b/reg_tests/test_files/nrel5MWadvActLine/nrel5MWadvActLine.yaml
@@ -28,7 +28,7 @@ linear_solvers:
 realms:
 
   - name: realm_1
-    mesh: ../../mesh/nrel5MWactuatorLine.g
+    mesh: "generated:30x80x160|bbox:-30.0,-80.0,-90.0,30.0,80.0,240.0|sideset:xXyYzZ|show"
     use_edges: yes
     automatic_decomposition_type: rcb
 
@@ -50,13 +50,13 @@ realms:
     initial_conditions:
 
       - constant: ic_1
-        target_name: Unspecified-2-HEX
+        target_name: block_1
         value:
           pressure: 0.0
           velocity: [8.0,0.0,0.0]
 
     material_properties:
-      target_name: Unspecified-2-HEX
+      target_name: block_1
       specifications:
         - name: density
           type: constant
@@ -69,30 +69,30 @@ realms:
     boundary_conditions:
 
     - inflow_boundary_condition: bc_1
-      target_name: inflow
+      target_name: surface_1
       inflow_user_data:
         velocity: [8.0,0.0,0.0]
 
     - open_boundary_condition: bc_2
-      target_name: outflow
+      target_name: surface_2
       open_user_data:
         pressure: 0.0
         velocity: [8.0,0.0,0.0]
 
     - symmetry_boundary_condition: bc_3
-      target_name: left
+      target_name: surface_3
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_4
-      target_name: right
+      target_name: surface_4
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_5
-      target_name: bottom
+      target_name: surface_5
       symmetry_user_data:
 
     - symmetry_boundary_condition: bc_6
-      target_name: top
+      target_name: surface_6
       symmetry_user_data:
 
     solution_options:
@@ -117,7 +117,7 @@ realms:
     actuator:
       type: ActLineFAST
       search_method: stk_kdtree
-      search_target_part: Unspecified-2-HEX
+      search_target_part: block_1
 
       n_turbines_glob: 1
       dry_run:  False


### PR DESCRIPTION
Use IOSS mesh generation for actuator regression tests that just use box meshes

Regression tests pass locally