### PR TITLE
NGP Test Time Step reduction

### DIFF
--- a/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
@@ -318,7 +318,7 @@ Time_Integrators:
   - StandardTimeIntegrator:
       name: ti_1
       start_time: 0.0
-      termination_step_count: 10
+      termination_step_count: 3
       time_step: 0.5
       time_stepping_type: fixed
       time_step_count: 0

--- a/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
@@ -317,7 +317,7 @@ Time_Integrators:
   - StandardTimeIntegrator:
       name: ti_1
       start_time: 0.0
-      termination_step_count: 10
+      termination_step_count: 3
       time_step: 0.5
       time_stepping_type: fixed
       time_step_count: 0

--- a/reg_tests/test_files/ablNeutralNGPTrilinos/ablNeutralNGPTrilinos.yaml
+++ b/reg_tests/test_files/ablNeutralNGPTrilinos/ablNeutralNGPTrilinos.yaml
@@ -282,7 +282,7 @@ Time_Integrators:
   - StandardTimeIntegrator:
       name: ti_1
       start_time: 0.0
-      termination_step_count: 10
+      termination_step_count: 3
       time_step: 0.5
       time_stepping_type: fixed
       time_step_count: 0

--- a/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.yaml
+++ b/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.yaml
@@ -194,7 +194,7 @@ Time_Integrators:
   - StandardTimeIntegrator:
       name: ti_1
       start_time: 0
-      termination_step_count: 10
+      termination_step_count: 3
       time_step: 0.003
       time_stepping_type: fixed
       time_step_count: 0


### PR DESCRIPTION
The change here is motivated by the amount of time these tests take under the Clang address sanitizer. Right now, each test is running 2-4 hours with asan when doing 10 time steps. This is way too long. I think 3 time steps is sufficient to see that the trajectory is ok.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
