### PR TITLE
Update OpenFAST files to work with OpenFAST v2.6.0

### DIFF
--- a/reg_tests/test_files/nrel5MWactuatorLine/5MW_Baseline/NRELOffshrBsline5MW_Onshore_AeroDyn15.dat
+++ b/reg_tests/test_files/nrel5MWactuatorLine/5MW_Baseline/NRELOffshrBsline5MW_Onshore_AeroDyn15.dat
@@ -6,7 +6,7 @@ False         Echo               - Echo the input to "<rootname>.AD.ech"?  (flag
           0   WakeMod            - Type of wake/induction model (switch) {0=none, 1=BEMT, 2=DBEMT} [WakeMod cannot be 2 when linearizing]
           2   AFAeroMod          - Type of blade airfoil aerodynamics model (switch) {1=steady model, 2=Beddoes-Leishman unsteady model} [AFAeroMod must be 1 when linearizing]
           1   TwrPotent          - Type tower influence on wind based on potential flow around the tower (switch) {0=none, 1=baseline potential flow, 2=potential flow with Bak correction}
-False         TwrShadow          - Calculate tower influence on wind based on downstream tower shadow? (flag)
+          0   TwrShadow          - Calculate tower influence on wind based on downstream tower shadow? (flag)
 True          TwrAero            - Calculate tower aerodynamic loads? (flag)
 False         FrozenWake         - Assume frozen wake during linearization? (flag) [used only when WakeMod=1 and when linearizing]
 False         CavitCheck         - Perform cavitation check? (flag) [AFAeroMod must be 1 when CavitCheck=true]
@@ -60,20 +60,20 @@ True          UseBlCm            - Include aerodynamic pitching moment in calcul
 "NRELOffshrBsline5MW_AeroDyn_blade.dat"    ADBlFile(3)        - Name of file containing distributed aerodynamic properties for Blade #3 (-) [unused if NumBl < 3]
 ======  Tower Influence and Aerodynamics ============================================================= [used only when TwrPotent/=0, TwrShadow=True, or TwrAero=True]
          12   NumTwrNds         - Number of tower nodes used in the analysis  (-) [used only when TwrPotent/=0, TwrShadow=True, or TwrAero=True]
-TwrElev        TwrDiam        TwrCd
-(m)              (m)           (-)
-0.0000000E+00  6.0000000E+00  1.0000000E+00  
-8.5261000E+00  5.7870000E+00  1.0000000E+00  
-1.7053000E+01  5.5740000E+00  1.0000000E+00  
-2.5579000E+01  5.3610000E+00  1.0000000E+00  
-3.4105000E+01  5.1480000E+00  1.0000000E+00  
-4.2633000E+01  4.9350000E+00  1.0000000E+00  
-5.1158000E+01  4.7220000E+00  1.0000000E+00  
-5.9685000E+01  4.5090000E+00  1.0000000E+00  
-6.8211000E+01  4.2960000E+00  1.0000000E+00  
-7.6738000E+01  4.0830000E+00  1.0000000E+00  
-8.5268000E+01  3.8700000E+00  1.0000000E+00  
-8.7600000E+01  3.8700000E+00  1.0000000E+00  
+TwrElev        TwrDiam        TwrCd          TwrTI (used only with TwrShadow=2)
+(m)              (m)           (-)            (-)
+0.0000000E+00  6.0000000E+00  1.0000000E+00  1.0000000E-01
+8.5261000E+00  5.7870000E+00  1.0000000E+00  1.0000000E-01
+1.7053000E+01  5.5740000E+00  1.0000000E+00  1.0000000E-01
+2.5579000E+01  5.3610000E+00  1.0000000E+00  1.0000000E-01
+3.4105000E+01  5.1480000E+00  1.0000000E+00  1.0000000E-01
+4.2633000E+01  4.9350000E+00  1.0000000E+00  1.0000000E-01
+5.1158000E+01  4.7220000E+00  1.0000000E+00  1.0000000E-01
+5.9685000E+01  4.5090000E+00  1.0000000E+00  1.0000000E-01
+6.8211000E+01  4.2960000E+00  1.0000000E+00  1.0000000E-01
+7.6738000E+01  4.0830000E+00  1.0000000E+00  1.0000000E-01
+8.5268000E+01  3.8700000E+00  1.0000000E+00  1.0000000E-01
+8.7600000E+01  3.8700000E+00  1.0000000E+00  1.0000000E-01         
 ======  Outputs  ====================================================================================
 True          SumPrint            - Generate a summary file listing input options and interpolated properties to "<rootname>.AD.sum"?  (flag)
           7   NBlOuts             - Number of blade node outputs [0 - 9] (-)
@@ -217,4 +217,21 @@ B3N5Fy
 B3N6Fy 
 B3N7Fy
 END of input file (the word "END" must appear in the first 3 columns of this last OutList line)
----------------------------------------------------------------------------------------
+====== Outputs for all blade stations (same ending as above for B1N1.... =========================== [optional section]
+1              BldNd_BladesOut     - Number of blades to output all node information at.  Up to number of blades on turbine. (-)
+"All"          BldNd_BlOutNd       - Future feature will allow selecting a portion of the nodes to output.  Not implemented yet. (-)
+                  OutList             - The next line(s) contains a list of output parameters.  See OutListParameters.xlsx for a listing of available output channels, (-)
+"Fx, Fy"
+"Vx, Vy"
+Vrel
+TnInd
+AxInd
+Theta
+Phi
+Vindx
+Vindy
+Alpha
+Fl
+Fd
+END (the word "END" must appear in the first 3 columns of this last OutList line in the optional nodal output section)
+


### PR DESCRIPTION
I have not tested this with nalu-wind yet, but I did test it with AMR-Wind yesterday using the OpenFAST develop branch.  I'm hoping we can use this as a patch to get the nightly tests passing (we'll have to update OpenFAST builds) since these changes won't work with the main branch.  

In general we need to come up with a more robust strategy for testing against openfast.  I was thinking a common repo that can be shared by amr-wind and nalu-wind that will also work with openfast master and develop.  It would be good to test against both like we do with Trilinos since this is a more volatile library like Trilinos.  Shreyas suggested using OpenFAST's regression test suite which could work well provided we get the paths and controller build to work.