### PR TITLE
Sideset writer that doesn't require transfers

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -78,6 +78,7 @@ class MeshMotionAlg;
 class MeshTransformationAlg;
 
 class SolutionNormPostProcessing;
+class SideWriterContainer;
 class TurbulenceAveragingPostProcessing;
 class DataProbePostProcessing;
 struct ActuatorModel;
@@ -417,6 +418,7 @@ class Realm {
   stk::mesh::MetaData *metaData_;
   stk::mesh::BulkData *bulkData_;
   stk::io::StkMeshIoBroker *ioBroker_;
+  std::unique_ptr<SideWriterContainer> sideWriters_;
 
   size_t resultsFileIndex_;
   size_t restartFileIndex_;

--- a/include/SideWriter.h
+++ b/include/SideWriter.h
@@ -7,11 +7,17 @@
 // for more details.
 //
 #include <set>
+#include <vector>
+#include <string>
+#include <memory>
 
 namespace Ioss {
 class Region;
 } // namespace Ioss
 
+namespace YAML {
+class Node;
+}
 namespace stk {
 namespace mesh {
 class BulkData;
@@ -40,6 +46,24 @@ private:
   const stk::mesh::BulkData& bulk_;
   std::unique_ptr<Ioss::Region> output_;
   std::set<const stk::mesh::FieldBase*> fields_;
+};
+
+class SideWriterContainer
+{
+public:
+  void load(const YAML::Node& node);
+  void construct_writers(const stk::mesh::BulkData& bulk);
+  void write_sides(const int stepCount, const double time);
+  // use outputFileNames since writers have to be constructed
+  // so this can be used before the construction
+  inline int number_of_writers() { return outputFileNames_.size(); };
+
+private:
+  std::vector<SideWriter> sideWriters_;
+  std::vector<std::string> outputFileNames_;
+  std::vector<int> outputFrequency_;
+  std::vector<std::vector<std::string>> sideNames_;
+  std::vector<std::vector<std::string>> fieldNames_;
 };
 } // namespace nalu
 } // namespace sierra

--- a/include/SideWriter.h
+++ b/include/SideWriter.h
@@ -1,0 +1,45 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+#include <set>
+
+namespace Ioss {
+class Region;
+} // namespace Ioss
+
+namespace stk {
+namespace mesh {
+class BulkData;
+class Selector;
+class FieldBase;
+class Part;
+} // namespace mesh
+} // namespace stk
+
+namespace sierra {
+namespace nalu {
+
+class SideWriter
+{
+public:
+  SideWriter(
+    const stk::mesh::BulkData& bulk,
+    std::vector<const stk::mesh::Part*> sides,
+    std::vector<const stk::mesh::FieldBase*> fields,
+    std::string fname);
+
+  void write_database_data(double time);
+
+private:
+  void add_fields(std::vector<const stk::mesh::FieldBase*> fields);
+  const stk::mesh::BulkData& bulk_;
+  std::unique_ptr<Ioss::Region> output_;
+  std::set<const stk::mesh::FieldBase*> fields_;
+};
+} // namespace nalu
+} // namespace sierra

--- a/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.yaml
+++ b/reg_tests/test_files/ablNeutralEdge/ablNeutralEdge.yaml
@@ -258,6 +258,18 @@ realms:
        - temperature
        - turbulent_ke
 
+    sideset_writers:
+      - name: boundary_output
+        output_data_base_name: side.exo
+        output_frequency: 5
+        target_name: north
+        output_variables: 
+        - velocity
+        - pressure
+        - enthalpy
+        - temperature
+        - turbulent_ke
+
     # Compute spatial averages of velocity and temperature at all height levels
     # available on the ABL mesh. This is used for post-processing as well as
     # determining the ABL forcing necessary to drive the wind to a certain

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/ABLProfileFunction.C
    ${CMAKE_CURRENT_SOURCE_DIR}/Algorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AlgorithmDriver.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/AMSAlgDriver.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleContinuityNonConformalSolverAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleElemSolverAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleFaceElemSolverAlgorithm.C
@@ -17,6 +18,7 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/AssemblePNGNonConformalSolverAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleScalarEigenEdgeSolverAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleScalarNonConformalSolverAlgorithm.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/AssembleWallDistNonConformalAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleWallHeatTransferAlgorithmDriver.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AuxFunctionAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AveragingInfo.C
@@ -71,6 +73,7 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/Realms.C
    ${CMAKE_CURRENT_SOURCE_DIR}/ScratchViews.C
    ${CMAKE_CURRENT_SOURCE_DIR}/ShearStressTransportEquationSystem.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/SideWriter.C
    ${CMAKE_CURRENT_SOURCE_DIR}/Simulation.C
    ${CMAKE_CURRENT_SOURCE_DIR}/SolutionNormPostProcessing.C
    ${CMAKE_CURRENT_SOURCE_DIR}/SolutionOptions.C
@@ -81,7 +84,6 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/SurfaceForceAndMomentAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/SurfaceForceAndMomentAlgorithmDriver.C
    ${CMAKE_CURRENT_SOURCE_DIR}/SurfaceForceAndMomentWallFunctionAlgorithm.C
-   ${CMAKE_CURRENT_SOURCE_DIR}/AMSAlgDriver.C
    ${CMAKE_CURRENT_SOURCE_DIR}/TimeIntegrator.C
    ${CMAKE_CURRENT_SOURCE_DIR}/TpetraLinearSystem.C
    ${CMAKE_CURRENT_SOURCE_DIR}/TpetraLinearSystemHelpers.C
@@ -90,7 +92,6 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/TurbViscSmagorinskyAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/TurbViscWaleAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/TurbulenceAveragingPostProcessing.C
-   ${CMAKE_CURRENT_SOURCE_DIR}/AssembleWallDistNonConformalAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/WallDistEquationSystem.C
 )
 

--- a/src/SideWriter.C
+++ b/src/SideWriter.C
@@ -302,10 +302,32 @@ SideWriter::add_fields(std::vector<const stk::mesh::FieldBase*> fields)
     for (const auto* field : fields_) {
       const int nb_size = block->get_property("entity_count").get_int();
       ThrowRequireMsg(field->type_is<double>(), "only double fields supported");
-      Ioss::Field ioss_field(
-        field->name(), Ioss::Field::DOUBLE, "scalar", Ioss::Field::TRANSIENT,
-        nb_size);
-      block->field_add(ioss_field);
+      switch (field->max_size(stk::topology::NODE_RANK)) {
+      case 1: {
+        Ioss::Field ioss_field(
+          field->name(), Ioss::Field::DOUBLE, "scalar", Ioss::Field::TRANSIENT,
+          nb_size);
+        block->field_add(ioss_field);
+        break;
+      }
+      case 2: {
+        Ioss::Field ioss_field(
+          field->name(), Ioss::Field::DOUBLE, "vector_2d",
+          Ioss::Field::TRANSIENT, nb_size);
+        block->field_add(ioss_field);
+        break;
+      }
+      case 3: {
+        Ioss::Field ioss_field(
+          field->name(), Ioss::Field::DOUBLE, "vector_3d",
+          Ioss::Field::TRANSIENT, nb_size);
+        block->field_add(ioss_field);
+        break;
+      }
+      default:
+        throw std::runtime_error(
+          "Field type not supported for sideset_writers: " + field->name());
+      }
     }
   }
 }

--- a/src/SideWriter.C
+++ b/src/SideWriter.C
@@ -324,6 +324,27 @@ SideWriter::add_fields(std::vector<const stk::mesh::FieldBase*> fields)
         block->field_add(ioss_field);
         break;
       }
+      case 4: {
+        Ioss::Field ioss_field(
+          field->name(), Ioss::Field::DOUBLE, "full_tensor_22",
+          Ioss::Field::TRANSIENT, nb_size);
+        block->field_add(ioss_field);
+        break;
+      }
+      case 6: {
+        Ioss::Field ioss_field(
+          field->name(), Ioss::Field::DOUBLE, "sym_tensor_33",
+          Ioss::Field::TRANSIENT, nb_size);
+        block->field_add(ioss_field);
+        break;
+      }
+      case 9: {
+        Ioss::Field ioss_field(
+          field->name(), Ioss::Field::DOUBLE, "full_tensor_36",
+          Ioss::Field::TRANSIENT, nb_size);
+        block->field_add(ioss_field);
+        break;
+      }
       default:
         throw std::runtime_error(
           "Field type not supported for sideset_writers: " + field->name());

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSideIsInElement.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSideNodeOrdinals.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSidePCoords.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSideWriter.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSimdBasic.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSingleHexPromotion.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSpinnerLidarPattern.C

--- a/unit_tests/UnitTestSideWriter.C
+++ b/unit_tests/UnitTestSideWriter.C
@@ -4,6 +4,7 @@
 #include "stk_io/StkMeshIoBroker.hpp"
 #include "stk_mesh/base/BulkData.hpp"
 #include "stk_mesh/base/Field.hpp"
+#include <yaml-cpp/yaml.h>
 
 namespace sierra {
 namespace nalu {
@@ -58,6 +59,26 @@ TEST_F(SideWriterFixture, side)
     }
   }
   side_io.write_database_data(1.);
+}
+
+TEST(SideWriterContainerTest, load)
+{
+  const char* input = R"test(sideset_writers:
+    - name: w1
+      output_data_base_name: w1.exo
+      output_frequency: 1
+      target_name: side_1
+      output_variables: [velocity]
+    - name: w2
+      output_data_base_name: w2.exo
+      output_frequency: 2
+      target_name: [side_2]
+      output_variables: [pressure])test";
+
+  const YAML::Node y_node = YAML::Load(input);
+  SideWriterContainer container;
+  ASSERT_NO_THROW(container.load(y_node));
+  EXPECT_EQ(container.number_of_writers(), 2);
 }
 
 } // namespace nalu

--- a/unit_tests/UnitTestSideWriter.C
+++ b/unit_tests/UnitTestSideWriter.C
@@ -1,0 +1,64 @@
+#include "gtest/gtest.h"
+#include "SideWriter.h"
+
+#include "stk_io/StkMeshIoBroker.hpp"
+#include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/Field.hpp"
+
+namespace sierra {
+namespace nalu {
+class SideWriterFixture : public ::testing::Test
+{
+public:
+  SideWriterFixture()
+    : meta(3u),
+      bulk(meta, MPI_COMM_WORLD, stk::mesh::BulkData::NO_AUTO_AURA),
+      io(bulk.parallel()),
+      test_field(meta.declare_field<stk::mesh::Field<double>>(
+        stk::topology::NODE_RANK, "test"))
+
+  {
+    double minus_one = -1;
+    stk::mesh::put_field_on_mesh(
+      test_field, meta.universal_part(), 1, &minus_one);
+  }
+  stk::mesh::MetaData meta;
+  stk::mesh::BulkData bulk;
+  stk::io::StkMeshIoBroker io;
+  stk::mesh::Field<double>& test_field;
+};
+
+TEST_F(SideWriterFixture, side)
+{
+  const std::string name = "generated:3x3x3|sideset:xXyYzZ";
+  io.set_bulk_data(bulk);
+  io.add_mesh_database(name, stk::io::READ_MESH);
+  io.create_input_mesh();
+  io.populate_bulk_data();
+  stk::io::put_io_part_attribute(meta.universal_part());
+  std::vector<const stk::mesh::Part*> sides{
+    meta.get_part("surface_1"), meta.get_part("surface_2")};
+  auto& coord_field =
+    *static_cast<const stk::mesh::Field<double, stk::mesh::Cartesian3d>*>(
+      meta.coordinate_field());
+  const auto& all_node_buckets =
+    bulk.get_buckets(stk::topology::NODE_RANK, meta.universal_part());
+  for (const auto* ib : all_node_buckets) {
+    for (const auto node : *ib) {
+      *stk::mesh::field_data(test_field, node) =
+        stk::mesh::field_data(coord_field, node)[0];
+    }
+  }
+  SideWriter side_io(bulk, sides, {&test_field}, "file.e");
+  side_io.write_database_data(0.);
+
+  for (const auto* ib : all_node_buckets) {
+    for (const auto node : *ib) {
+      *stk::mesh::field_data(test_field, node) = stk::mesh::field_data(coord_field, node)[1];
+    }
+  }
+  side_io.write_database_data(1.);
+}
+
+} // namespace nalu
+} // namespace sierra


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

Add a sideset writer option to nalu-wind that doesn't require transfers.  Thanks to @rcknaus for putting the utility together.  I've tested this on the ellipse problem and it works well. Resolves #859.  Removes need for #874 and also #870.  However it would still be best to have the stk team put this functionality into stk for an optimized long term solution as noted in the comments of #870.


## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [x] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
