### PR TITLE
Fix memory leak in ADM

### DIFF
--- a/src/actuator/ActuatorBulkDiskFAST.C
+++ b/src/actuator/ActuatorBulkDiskFAST.C
@@ -132,6 +132,7 @@ ActuatorBulkDiskFAST::resize_arrays(const ActuatorMetaFAST& actMeta)
   Kokkos::resize(pointIsLocal_, newSize);
   Kokkos::resize(localParallelRedundancy_, newSize);
   Kokkos::resize(elemContainingPoint_, newSize);
+  Kokkos::resize(relativeVelocity_, newSize);
 }
 
 void


### PR DESCRIPTION
Fix memory leak in ADM due to array not being resized for ADM. Closes #876 .  