### PR TITLE
Add a sinusoidal rotation mesh motion kernel

### DIFF
--- a/include/mesh_motion/MotionRotationKernel.h
+++ b/include/mesh_motion/MotionRotationKernel.h
@@ -44,8 +44,12 @@ public:
     const mm::ThreeDVecType& mxyz,
     const mm::ThreeDVecType& cxyz);
 
-private:
+protected:
   void load(const YAML::Node&);
+
+  virtual double get_cur_angle(const double time);
+
+  virtual double get_cur_ang_vel(const double /* time */);
 
   mm::ThreeDVecType axis_{0.0,0.0,1.0};
 

--- a/include/mesh_motion/MotionSinRotationKernel.h
+++ b/include/mesh_motion/MotionSinRotationKernel.h
@@ -1,0 +1,37 @@
+#ifndef MOTIONSINROTATIONKERNEL_H
+#define MOTIONSINROTATIONKERNEL_H
+
+#include "NgpMotion.h"
+#include "MotionRotationKernel.h"
+
+namespace sierra{
+namespace nalu{
+
+class MotionSinRotationKernel : public MotionRotationKernel
+{
+public:
+  MotionSinRotationKernel(const YAML::Node&);
+
+  KOKKOS_FUNCTION
+  MotionSinRotationKernel() = default;
+
+  KOKKOS_FUNCTION
+  virtual ~MotionSinRotationKernel() = default;
+
+private:
+  void load(const YAML::Node&);
+
+  double get_cur_angle(const double time);
+
+  double get_cur_ang_vel(const double time);
+
+  double amplt_{0.0};
+  double ang_vel_{0.0};
+  double phase_{0.0};
+
+};
+
+} // nalu
+} //sierra
+
+#endif /* MOTIONSINROTATIONKERNEL_H */

--- a/src/mesh_motion/CMakeLists.txt
+++ b/src/mesh_motion/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/MeshTransformationAlg.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionPulsatingSphereKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionRotationKernel.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/MotionSinRotationKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionScalingKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionTranslationKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionWavesKernel.C

--- a/src/mesh_motion/MotionSinRotationKernel.C
+++ b/src/mesh_motion/MotionSinRotationKernel.C
@@ -1,0 +1,49 @@
+#include "mesh_motion/MotionSinRotationKernel.h"
+
+#include <NaluEnv.h>
+#include <NaluParsing.h>
+
+namespace sierra{
+namespace nalu{
+
+MotionSinRotationKernel::MotionSinRotationKernel(const YAML::Node& node)
+    : MotionRotationKernel(node)
+{
+  load(node);
+}
+
+void MotionSinRotationKernel::load(const YAML::Node& node)
+{
+
+  get_if_present(node, "amplitude", amplt_, amplt_);
+  amplt_ = amplt_*M_PI/180;
+
+  get_if_present(node, "phase", phase_, phase_);
+  phase_ = phase_*M_PI/180.0;
+
+}
+
+double MotionSinRotationKernel::get_cur_angle(const double time)
+{
+  double motionTime = (time < endTime_)? time : endTime_;
+
+  // determine current angle
+  angle_ = amplt_ * stk::math::sin(omega_ * (motionTime-startTime_) + phase_ );
+
+  return angle_;
+}
+
+double MotionSinRotationKernel::get_cur_ang_vel(const double time)
+{
+    double motionTime = (time < endTime_)? time : endTime_;
+
+    // determine current angular velocity
+    ang_vel_ = amplt_ * omega_ *
+        stk::math::cos(omega_ * (motionTime-startTime_) + phase_ );
+    
+    return ang_vel_;
+}
+
+
+} // nalu
+} // sierra


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

Adds a mesh motion kernel corresponding to a sinusoidal mesh motion of the type

theta = ampl * sin (omega * t)

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [x] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [x] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
