### PR TITLE
Fix stk modify-flags errors.

### DIFF
--- a/include/ngp_utils/NgpFieldBLAS.h
+++ b/include/ngp_utils/NgpFieldBLAS.h
@@ -46,6 +46,8 @@ inline void field_axpby(
   using Traits = NGPMeshTraits<Mesh>;
   using MeshIndex = typename Traits::MeshIndex;
 
+  yField.sync_to_device();
+
   nalu_ngp::run_entity_algorithm(
     "ngp_field_axpby",
     ngpMesh, rank, sel,

--- a/src/gcl/MeshVelocityAlg.C
+++ b/src/gcl/MeshVelocityAlg.C
@@ -135,7 +135,12 @@ MeshVelocityAlg<AlgTraits>::execute()
         }
       }
 
-      for (int ip = 0; ip < AlgTraits::numScsIp_; ++ip) {
+      int nip = std::min(12,AlgTraits::numScsIp_);
+      if (AlgTraits::numScsIp_ > nip) {
+        std::cerr << "Error: MeshVelocityAlg can't support more than 12 integration points." << std::endl;
+      }
+
+      for (int ip = 0; ip < nip; ++ip) {
 
         DoubleType scs_vol_coords[8][3];
 

--- a/src/ngp_algorithms/GeometryAlgDriver.C
+++ b/src/ngp_algorithms/GeometryAlgDriver.C
@@ -150,6 +150,7 @@ GeometryAlgDriver::mesh_motion_prework()
   ngpSweptVol.set_all(ngpMesh, 0.0);
   auto* sweptVol = meta.get_field<GenericFieldType>(entityRank, svFieldName);
   stk::mesh::field_fill(0.0, *sweptVol);
+  ngpSweptVol.sync_to_device();
 
   if (realm_.realmUsesEdges_) {
     const double dt = realm_.get_time_step();

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -78,6 +78,8 @@ void GeometryInteriorAlg<AlgTraits>::impl_compute_dual_nodal_volume()
   const auto dnvOps = nalu_ngp::simd_elem_nodal_field_updater(ngpMesh, dualVol);
   const auto elemVolOps = nalu_ngp::simd_elem_field_updater(ngpMesh, elemVol);
   MasterElement *meSCV = meSCV_;
+  dualVol.sync_to_device();
+  elemVol.sync_to_device();
 
   const stk::mesh::Selector sel = meta.locally_owned_part()
     & stk::mesh::selectUnion(partVec_)


### PR DESCRIPTION
It appears as though there were some missing sync_to_device calls,
which were previously ignored due to stk's less-than-rigorous
checking, which has now been strengthened somewhat.

Also added an error-print in MeshVelocityAlg because some template
instantiations were using Hex27 elements with an algorithm that is
set up to only support 12 integration points. Hex27 has 216. This is
apparently not being hit in current testing, but some builds were
noticing the problem since AlgTraits::numScsIp_ is a compile-time
number.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
