### PR TITLE
Add 'sync_host' call to avoid kokkos error-check.

### DIFF
--- a/src/actuator/ActuatorSearch.C
+++ b/src/actuator/ActuatorSearch.C
@@ -137,6 +137,8 @@ ExecuteCoarseSearch(
   coarsePointIds.resize(numLocalMatches);
   coarseElemIds.resize(numLocalMatches);
 
+  coarsePointIds.sync_host();
+  coarseElemIds.sync_host();
   coarsePointIds.modify_host();
   coarseElemIds.modify_host();
 


### PR DESCRIPTION
This fixes a GPU error which happens in debug builds. It doesn't
seem to get hit in a release-mode build. But in a debug build kokkos
is complaining that the host-modify flag is being raised when the
device-modify flag is already raised. Calling sync_host before
modify_host makes it work.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
