### PR TITLE
NaluWind: fix another uncleared modified_on_host error

### DIFF
--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -890,6 +890,7 @@ TurbulenceAveragingPostProcessing::compute_reynolds_stress(
   const double oldWeight = oldTimeFilter * zeroCurrent;
   const double currentTimeFilter = currentTimeFilter_;
 
+  stress.sync_to_device();
   nalu_ngp::run_entity_algorithm(
     "TurbPP::compute_restress",
     ngpMesh, stk::topology::NODE_RANK, s_all_nodes,


### PR DESCRIPTION
This should fix the nightly SSTWallHumpEdge dashboard failure:

`Error: Modify on device called for Field: reynolds_stress but it has an uncleared modified_on_host`

I reproduced the test failure locally and verified that this commit fixes it.