### PR TITLE
Fix momentum-body-force build warning and test failure.

### DIFF
--- a/include/node_kernels/MomentumBodyForceBoxNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceBoxNodeKernel.h
@@ -60,7 +60,6 @@ private:
   NALU_ALIGNED NodeKernelTraits::DblType lo_[NodeKernelTraits::NDimMax];
   NALU_ALIGNED NodeKernelTraits::DblType hi_[NodeKernelTraits::NDimMax];
   stk::mesh::Part* mdotPart_;
-  stk::mesh::PartVector dragPartVec_;
   GeometryAlgDriver* geometryAlgDriver_;
   MdotAlgDriver* mdotAlgDriver_;
 


### PR DESCRIPTION
It's not legal to have a std::vector in a device kernel.
A std::vector was added as a class member of a class that gets copied to device for kernel execution.
I've now removed it, it didn't need to be a class member anyway.

**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
