### PR TITLE
IDDES updates:

### DIFF
--- a/include/ShearStressTransportEquationSystem.h
+++ b/include/ShearStressTransportEquationSystem.h
@@ -53,7 +53,8 @@ public:
 
   void initial_work();
   virtual void post_external_data_transfer_work();
-  virtual void post_iter_work();
+  void post_iter_work() final;
+  void pre_iter_work() final;
 
   void clip_min_distance_to_wall();
   void compute_f_one_blending();

--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -150,6 +150,7 @@ public:
   double latitude_;
   double raBoussinesqTimeScale_;
   double symmetryBcPenaltyFactor_;
+  bool useStreletsUpwinding_;
 
   // global mdot correction alg
   bool activateOpenMdotCorrection_;

--- a/reg_tests/test_files/IDDESPeriodicHillEdge/IDDESPeriodicHillEdge.yaml
+++ b/reg_tests/test_files/IDDESPeriodicHillEdge/IDDESPeriodicHillEdge.yaml
@@ -110,6 +110,7 @@ realms:
     solution_options:
       name: myOptions
       turbulence_model: sst_iddes
+      strelets_upwinding: yes
       projected_timescale_type: momentum_diag_inv
 
       fix_pressure_at_node:

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -666,8 +666,9 @@ LowMachEquationSystem::solve_and_update()
     timeB = NaluEnv::self().nalu_time();
     continuityEqSys_->timerMisc_ += (timeB-timeA);
 
-    if (realm_.solutionOptions_->turbulenceModel_ == SST_AMS)
+    if (realm_.solutionOptions_->turbulenceModel_ == SST_AMS) {
       momentumEqSys_->AMSAlgDriver_->initial_mdot();
+    }
 
     isInit_ = false;
   } else if (
@@ -704,7 +705,6 @@ LowMachEquationSystem::solve_and_update()
       timeB = NaluEnv::self().nalu_time();
       continuityEqSys_->timerAssemble_ += (timeB - timeA);
     }
-
   }
 
   // compute tvisc and effective viscosity
@@ -1272,7 +1272,9 @@ MomentumEquationSystem::register_interior_algorithm(
           theSolverSrcAlg = new AssembleAMSEdgeKernelAlg(realm_, part, this);
           solverAlgDriver_->solverAlgMap_[SRC] = theSolverSrcAlg;
         }
-        if (realm_.is_turbulent() && theTurbModel == SST_IDDES) {
+        if (
+          realm_.is_turbulent() &&
+          realm_.solutionOptions_->useStreletsUpwinding_) {
           pecletAlg_.reset(new StreletsUpwindEdgeAlg(realm_, part));
         } else if (realm_.is_turbulent() && theTurbModel == SST_AMS) {
           pecletAlg_.reset(new AMSMomentumEdgePecletAlg(realm_, part, this));

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -514,6 +514,21 @@ ShearStressTransportEquationSystem::compute_f_one_blending()
 }
 
 void
+ShearStressTransportEquationSystem::pre_iter_work()
+{
+  const auto turbModel = realm_.solutionOptions_->turbulenceModel_;
+  if (turbModel == SST_IDDES) {
+    const auto& fieldMgr = realm_.ngp_field_manager();
+    const auto& meta = realm_.meta_data();
+    auto& bulk = realm_.bulk_data();
+
+    auto ngpIddesRans = fieldMgr.get_field<double>(
+      get_field_ordinal(meta, "iddes_rans_indicator"));
+    ngpIddesRans.sync_to_device();
+  }
+}
+
+void
 ShearStressTransportEquationSystem::post_iter_work()
 {
   const auto turbModel = realm_.solutionOptions_->turbulenceModel_;
@@ -524,6 +539,7 @@ ShearStressTransportEquationSystem::post_iter_work()
 
     auto ngpIddesRans = fieldMgr.get_field<double>(
       get_field_ordinal(meta, "iddes_rans_indicator"));
+    ngpIddesRans.modify_on_device();
     ngpIddesRans.sync_to_host();
 
     ScalarFieldType* iddesRansInd = meta.get_field<ScalarFieldType>(

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -80,6 +80,7 @@ SolutionOptions::SolutionOptions()
     latitude_(0.0),
     raBoussinesqTimeScale_(-1.0),
     symmetryBcPenaltyFactor_(0.0),
+    useStreletsUpwinding_(false),
     activateOpenMdotCorrection_(false),
     mdotAlgOpenCorrection_(0.0),
     explicitlyZeroOpenPressureGradient_(false),
@@ -193,6 +194,11 @@ SolutionOptions::load(const YAML::Node & y_node)
     }
     if ( turbulenceModel_ != LAMINAR ) {
       isTurbulent_ = true;
+    }
+    if (turbulenceModel_ == SST_IDDES) {
+      get_if_present(
+        y_solution_options, "strelets_upwinding", useStreletsUpwinding_,
+        useStreletsUpwinding_);
     }
     // initialize turbuelnce constants since some laminar models may need such variables, e.g., kappa
     initialize_turbulence_constants();

--- a/src/node_kernels/TKESSTIDDESNodeKernel.C
+++ b/src/node_kernels/TKESSTIDDESNodeKernel.C
@@ -48,8 +48,6 @@ TKESSTIDDESNodeKernel::setup(Realm& realm)
   maxLenScale_     = fieldMgr.get_field<double>(maxLenScaleID_);
   fOneBlend_ = fieldMgr.get_field<double>(fOneBlendID_);
   ransIndicator_ = fieldMgr.get_field<double>(ransIndicatorID_);
-  // call modify before this field gets modified in kernel execute phase
-  ransIndicator_.sync_to_device();
 
   const std::string dofName = "turbulent_ke";
   relaxFac_ = realm.solutionOptions_->get_relaxation_factor(dofName);

--- a/src/node_kernels/TKESSTIDDESNodeKernel.C
+++ b/src/node_kernels/TKESSTIDDESNodeKernel.C
@@ -49,7 +49,7 @@ TKESSTIDDESNodeKernel::setup(Realm& realm)
   fOneBlend_ = fieldMgr.get_field<double>(fOneBlendID_);
   ransIndicator_ = fieldMgr.get_field<double>(ransIndicatorID_);
   // call modify before this field gets modified in kernel execute phase
-  ransIndicator_.modify_on_device();
+  ransIndicator_.sync_to_device();
 
   const std::string dofName = "turbulent_ke";
   relaxFac_ = realm.solutionOptions_->get_relaxation_factor(dofName);


### PR DESCRIPTION
There appears to be a bug in the Strelets upwinding.  I believe it has to do with some terms not being computed on the first timestep. Possibly due to the order in which the algorithms are called.

However, since we haven't seen compelling evidence that we need the Strelets upwinding for our cases of interest, this PR
makes it so you have to explicitly turn it on when running IDDES with `strelets_upwinding: yes` in `solution_options`.
Other wise we use the default upwinding/Peclet blending methods in the code.
Users can only turn on Strelets upwinding with IDDES otherwise the parameter is ignored.

My advice for now: don't use Strelets upwinding.  I will try to debug it more in the coming weeks but this should enable IDDES for the blade resolved simulations.  @gantech now the linear solvers converge in 8 iterations when running the ellipse toy problem instead of maxing out at 200 iterations.  The scaled non-linear residuals go up a little past 1.0 in the second Picard iteration for the first 2-3 timesteps but then settle down to below 1 going forward. So far it seems this is just getting through the initial condition. The key differentiator is the linear solvers are doing just fine.

Additional fixes were required to get the sync/modified calls correct for IDDES specific fields similar to the work @alanw0 has been doing lately.


**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [x] MacOS
  - Compilers 
    - [ ] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [x] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
