### PR TITLE
Fix unit-tests that were segfaulting for AVX2 builds.

### DIFF
--- a/unit_tests/UnitTestMijTensor.C
+++ b/unit_tests/UnitTestMijTensor.C
@@ -319,7 +319,7 @@ TEST(MijTensorNGP, hex27_simd) {
           mij_ev[i][2] * mij_ev[j][2] * stk::math::sqrt(mij_evals[2][2]);
 
   using AlgTraits = sierra::nalu::AlgTraitsHex27;
-  DoubleType QDT[9];
+  NALU_ALIGNED DoubleType QDT[9];
   for (int i = 0; i < 9; i++)
     QDT[i] = Q[i];
   const auto &coordField =
@@ -330,11 +330,12 @@ TEST(MijTensorNGP, hex27_simd) {
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double *coords = stk::mesh::field_data(coordField, nodes[j]);
 
-    std::vector<DoubleType> coordsDT(dim);
-    for (int k = 0; k < dim; ++k)
+    NALU_ALIGNED DoubleType coordsDT[3/*dim*/];
+    for (int k = 0; k < dim; ++k) {
       coordsDT[k] = coords[k];
+    }
 
-    sierra::nalu::matvec33(QDT, coordsDT.data(), &v_coords(j, 0));
+    sierra::nalu::matvec33(QDT, &coordsDT[0], &v_coords(j, 0));
   }
 
   Kokkos::View<DoubleType ***> mij_tensor("mij_tensor", AlgTraits::numScsIp_,

--- a/unit_tests/UnitTestPecletFunction.C
+++ b/unit_tests/UnitTestPecletFunction.C
@@ -56,7 +56,7 @@ TEST(PecletFunction, NGP_classic_simd)
 {
   const DoubleType A = 5.0;
   const DoubleType hybridFactor = 1.0;
-  std::vector<DoubleType> pecletNumbers = {0.0, 1.0, std::sqrt(5.0), 1e5};
+  NALU_ALIGNED DoubleType pecletNumbers[] = {0.0, 1.0, std::sqrt(5.0), 1e5};
   std::vector<double> pecletFactors = {0.0, 1.0/6.0, 0.5, 1.0};
 
   auto* pecFunc =
@@ -99,7 +99,7 @@ TEST(PecletFunction, NGP_tanh_simd)
 {
   const DoubleType c1 = 5000.0;
   const DoubleType c2 = 200.0;
-  std::vector<DoubleType> pecletNumbers = {-10.0 * c2, c1, c1 + 10.0 * c2};
+  NALU_ALIGNED DoubleType pecletNumbers[] = {-10.0 * c2, c1, c1 + 10.0 * c2};
   std::vector<double> pecletFactors = {0.0, 0.5, 1.0};
 
   auto* pecFunc =


### PR DESCRIPTION
Apparently it's bad to put simd-types (DoubleType) in std::vector.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
