### PR TITLE
Fix the unit test LowMachKernelHex8Mesh.NGP_nodal_grad_popen

### DIFF
--- a/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
+++ b/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
@@ -163,6 +163,7 @@ NodalGradPOpenBoundary<AlgTraits>::execute()
       }
     }
   );
+  gradP.modify_on_device();
 }
 
 INSTANTIATE_KERNEL_FACE_ELEMENT(NodalGradPOpenBoundary)


### PR DESCRIPTION
This has been failing on the dashboard because the values coming
back from the device algorithm were zero when checked by the
unit test.
The reason is because the field being modified wasn't being
marked as modified by the 'modify_on_device()' method, and then
the values were being lost by a sync_to_host/modify_on_host
sequence that occurs when the nodal-grad execute() returns.

It is possible that this is responsible for correctness issues in
regression tests, I'm not positive...


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
