### PR TITLE
Fix scalar_open_edge unit-test.

### DIFF
--- a/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
@@ -51,8 +51,8 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_edge_open_solver_alg)
   unit_test_utils::FaceElemHelperObjects helperObjs(
     bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
 
-  std::unique_ptr<sierra::nalu::Kernel> kernel(
-    new sierra::nalu::ScalarEdgeOpenSolverAlg<
+  std::unique_ptr<sierra::nalu::ScalarEdgeOpenSolverAlg<sierra::nalu::AlgTraitsQuad4Hex8>>
+    kernel (new sierra::nalu::ScalarEdgeOpenSolverAlg<
       sierra::nalu::AlgTraitsQuad4Hex8>(
       meta_, solnOpts_, tke_, tkebc_, dkdx_, tvisc_, 
       helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,


### PR DESCRIPTION
This test was seg-faulting on certain platforms. According to valgrind
there was a mis-matched free/delete which apparently was due to
templating a unique_ptr on the base-class instead of the derived class.
Anyway, valgrind says it's ok now.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
