### PR TITLE
Omit GCL computation from non-hex blocks

### DIFF
--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1001,13 +1001,13 @@ Realm::setup_interior_algorithms()
   if (has_mesh_deformation()) {
     const AlgorithmType algType = INTERIOR;
     stk::mesh::PartVector mmPartVec = meshMotionAlg_->get_partvec();
-    if (realmUsesEdges_) {
-      for (auto p : mmPartVec) {
+    for (auto p : mmPartVec) {
+      if (p->topology() != stk::topology::HEX_8)
+        continue;
+      if (realmUsesEdges_) {
         geometryAlgDriver_->register_elem_algorithm<MeshVelocityEdgeAlg>(
           algType, p, "mesh_vel");
-      }
-    } else {
-      for (auto p : mmPartVec) {
+      } else {
         geometryAlgDriver_->register_elem_algorithm<MeshVelocityAlg>(
           algType, p, "mesh_vel");
       }

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1002,8 +1002,14 @@ Realm::setup_interior_algorithms()
     const AlgorithmType algType = INTERIOR;
     stk::mesh::PartVector mmPartVec = meshMotionAlg_->get_partvec();
     for (auto p : mmPartVec) {
-      if (p->topology() != stk::topology::HEX_8)
+      if (p->topology() != stk::topology::HEX_8) {
+        NaluEnv::self().naluOutputP0()
+          << "Skipping registration of MeshVelocityEdgeAlg on part "
+          << p->name()
+          << ". GCL operations are currently only supported on HEX_8 "
+             "elemeents.\n";
         continue;
+      }
       if (realmUsesEdges_) {
         geometryAlgDriver_->register_elem_algorithm<MeshVelocityEdgeAlg>(
           algType, p, "mesh_vel");


### PR DESCRIPTION
Omit registering GCL mesh velocity algorithms on any non-hex parts.  This will allow us to mesh the hub with non hex elements since there is no deformation.  

Adding as a draft since I haven't tested it yet and I think we should add some checks/flags for the input deck to specifically enable this capability