### PR TITLE
MasterElement nodes_per_entity Workaround

### DIFF
--- a/include/AssembleElemSolverAlgorithm.h
+++ b/include/AssembleElemSolverAlgorithm.h
@@ -67,7 +67,7 @@ public:
     const int bytes_per_team = 0;
     const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(
       lhsSize, rhsSize_, scratchIdsSize, meta_data.spatial_dimension(),
-      dataNeededNGP, reqType);
+      nodesPerEntity_, dataNeededNGP, reqType);
 
     stk::mesh::Selector elemSelector = meta_data.locally_owned_part() &
                                        stk::mesh::selectUnion(partVec_) &

--- a/include/AssembleFaceElemSolverAlgorithm.h
+++ b/include/AssembleFaceElemSolverAlgorithm.h
@@ -65,7 +65,7 @@ public:
 
       const int bytes_per_team = 0;
       const int bytes_per_thread = calculate_shared_mem_bytes_per_thread(
-        lhsSize, rhsSize, scratchIdsSize, nDim, faceDataNGP, elemDataNGP);
+          lhsSize, rhsSize, scratchIdsSize, nDim, faceDataNeeded_.nodesPerElement_, elemDataNeeded_.nodesPerElement_, faceDataNGP, elemDataNGP);
 
       const auto nodesPerFace = nodesPerFace_;
       const auto nodesPerElem = nodesPerElem_;

--- a/include/ElemDataRequests.h
+++ b/include/ElemDataRequests.h
@@ -216,6 +216,11 @@ public:
   MasterElement *get_cvfem_surface_me() const {return meSCS_;}
   MasterElement *get_fem_volume_me() const {return meFEM_;}
 
+  void addNodesPerElement(const int nodesPerElement) {
+      nodesPerElement_=nodesPerElement;
+  }
+  int nodesPerElement_ = -1;
+
 private:
   const stk::mesh::MetaData& meta_;
   std::array<std::set<ELEM_DATA_NEEDED>, MAX_COORDS_TYPES> dataEnums;

--- a/include/ElemDataRequestsGPU.h
+++ b/include/ElemDataRequestsGPU.h
@@ -191,10 +191,10 @@ private:
   FieldInfoView fields;
   FieldInfoView::HostMirror hostFields;
 
-  MasterElement *meFC_;
-  MasterElement *meSCS_;
-  MasterElement *meSCV_;
-  MasterElement *meFEM_;
+  MasterElement *meFC_=nullptr;
+  MasterElement *meSCS_=nullptr;
+  MasterElement *meSCV_=nullptr;
+  MasterElement *meFEM_=nullptr;
 };
 
 } // namespace nalu

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -60,9 +60,9 @@ ngp_mesh_team_policy(
 template<typename T, typename DataReqType>
 inline int
 ngp_calc_thread_shmem_size(
-  int ndim, const DataReqType& dataReq, const ElemReqType reqType)
+    int ndim, const DataReqType& dataReq, int nodesPerElement, const ElemReqType reqType)
 {
-  int preReqSize = get_num_bytes_pre_req_data<T>(dataReq, ndim, reqType);
+    int preReqSize = get_num_bytes_pre_req_data<T>(dataReq, ndim, nodesPerElement, reqType);
   int mdvSize = MultiDimViews<T>::bytes_needed(
     dataReq.get_total_num_fields(),
     count_needed_field_views(dataReq.get_host_fields()));
@@ -87,13 +87,15 @@ ngp_calc_thread_shmem_size(
 template<typename T, typename DataReqType>
 inline int ngp_calc_thread_shmem_size(
   int ndim,
+  int nodesPerFace,
+  int nodesPerElement,
   const DataReqType& faceDataReq,
   const DataReqType& elemDataReq)
 {
   const int faceMemSize =
-    ngp_calc_thread_shmem_size<T>(ndim, faceDataReq, ElemReqType::FACE);
+      ngp_calc_thread_shmem_size<T>(ndim, faceDataReq, nodesPerFace, ElemReqType::FACE);
   const int elemMemSize =
-    ngp_calc_thread_shmem_size<T>(ndim, elemDataReq, ElemReqType::ELEM);
+      ngp_calc_thread_shmem_size<T>(ndim, elemDataReq, nodesPerElement, ElemReqType::ELEM);
 
   return (faceMemSize + elemMemSize);
 }
@@ -345,7 +347,8 @@ void run_elem_algorithm(
 
   ElemDataRequestsGPU dataReqNGP(fieldMgr, dataReqs, meshInfo.num_fields());
 
-  const int nodesPerElement = nodes_per_entity(dataReqNGP);
+  //const int nodesPerElement = nodes_per_entity(dataReqNGP);
+  const int nodesPerElement = dataReqs.nodesPerElement_;
   NGP_ThrowRequire(nodesPerElement != 0);
 
   const auto reqType = (rank == stk::topology::ELEM_RANK)
@@ -353,7 +356,7 @@ void run_elem_algorithm(
   const int bytes_per_team = 0;
   const int bytes_per_thread =
     impl::ngp_calc_thread_shmem_size<sierra::nalu::DoubleType>(
-      ndim, dataReqNGP, reqType);
+        ndim, dataReqNGP, nodesPerElement, reqType);
 
   const auto& buckets = ngpMesh.get_bucket_ids(rank, sel);
   auto team_exec = impl::ngp_mesh_team_policy<TeamPolicy>(
@@ -440,7 +443,8 @@ void run_elem_par_reduce(
 
   ElemDataRequestsGPU dataReqNGP(fieldMgr, dataReqs, meshInfo.num_fields());
 
-  const int nodesPerElement = nodes_per_entity(dataReqNGP);
+  //const int nodesPerElement = nodes_per_entity(dataReqNGP);
+  const int nodesPerElement = dataReqs.nodesPerElement_;
   NGP_ThrowRequire(nodesPerElement != 0);
 
   const auto reqType = (rank == stk::topology::ELEM_RANK)
@@ -448,7 +452,7 @@ void run_elem_par_reduce(
   const int bytes_per_team = 0;
   const int bytes_per_thread =
     impl::ngp_calc_thread_shmem_size<sierra::nalu::DoubleType>(
-      ndim, dataReqNGP, reqType);
+      ndim, dataReqNGP, nodesPerElement, reqType);
 
   const auto& buckets = ngpMesh.get_bucket_ids(rank, sel);
   auto team_exec = impl::ngp_mesh_team_policy<TeamPolicy>(
@@ -527,15 +531,18 @@ void run_face_elem_algorithm(
   ElemDataRequestsGPU faceDataNGP(fieldMgr, faceDataReqs, numFields);
   ElemDataRequestsGPU elemDataNGP(fieldMgr, elemDataReqs, numFields);
 
-  const int nodesPerElement = nodes_per_entity(elemDataNGP);
-  const int nodesPerFace = nodes_per_entity(faceDataNGP, METype::FACE);
+  //const int nodesPerElement = nodes_per_entity(elemDataNGP);
+  //const int nodesPerFace = nodes_per_entity(faceDataNGP, METype::FACE);
+  const int nodesPerElement = elemDataReqs.nodesPerElement_;
+  const int nodesPerFace = faceDataReqs.nodesPerElement_;
+
   NGP_ThrowRequire(nodesPerElement != 0);
   NGP_ThrowRequire(nodesPerFace != 0);
 
   const int bytes_per_team = 0;
   const int bytes_per_thread =
     impl::ngp_calc_thread_shmem_size<sierra::nalu::DoubleType>(
-      ndim, faceDataNGP, elemDataNGP);
+      ndim, nodesPerFace, nodesPerElement, faceDataNGP, elemDataNGP);
 
   const auto& buckets = ngpMesh.get_bucket_ids(sideRank, sel);
   auto team_exec = impl::ngp_mesh_team_policy<TeamPolicy>(
@@ -651,15 +658,18 @@ void run_face_elem_par_reduce(
   ElemDataRequestsGPU faceDataNGP(fieldMgr, faceDataReqs, numFields);
   ElemDataRequestsGPU elemDataNGP(fieldMgr, elemDataReqs, numFields);
 
-  const int nodesPerElement = nodes_per_entity(elemDataNGP);
-  const int nodesPerFace = nodes_per_entity(faceDataNGP, METype::FACE);
+  //const int nodesPerElement = nodes_per_entity(elemDataNGP);
+  //const int nodesPerFace = nodes_per_entity(faceDataNGP, METype::FACE);
+  const int nodesPerElement = elemDataReqs.nodesPerElement_;
+  const int nodesPerFace = faceDataReqs.nodesPerElement_;
+
   NGP_ThrowRequire(nodesPerElement != 0);
   NGP_ThrowRequire(nodesPerFace != 0);
 
   const int bytes_per_team = 0;
   const int bytes_per_thread =
     impl::ngp_calc_thread_shmem_size<sierra::nalu::DoubleType>(
-      ndim, faceDataNGP, elemDataNGP);
+      ndim, nodesPerFace, nodesPerElement, faceDataNGP, elemDataNGP);
 
   const auto& buckets = ngpMesh.get_bucket_ids(sideRank, sel);
   auto team_exec = impl::ngp_mesh_team_policy<TeamPolicy>(
@@ -779,14 +789,17 @@ void run_face_elem_algorithm_nosimd(
   ElemDataRequestsGPU faceDataNGP(fieldMgr, faceDataReqs, numFields);
   ElemDataRequestsGPU elemDataNGP(fieldMgr, elemDataReqs, numFields);
 
-  const int nodesPerElement = nodes_per_entity(elemDataNGP);
-  const int nodesPerFace = nodes_per_entity(faceDataNGP, METype::FACE);
+  //const int nodesPerElement = nodes_per_entity(elemDataNGP);
+  //const int nodesPerFace = nodes_per_entity(faceDataNGP, METype::FACE);
+  const int nodesPerElement = elemDataReqs.nodesPerElement_;
+  const int nodesPerFace = faceDataReqs.nodesPerElement_;
+
   NGP_ThrowRequire(nodesPerElement != 0);
   NGP_ThrowRequire(nodesPerFace != 0);
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = impl::ngp_calc_thread_shmem_size<double>(
-    ndim, faceDataNGP, elemDataNGP);
+    ndim, nodesPerFace, nodesPerElement, faceDataNGP, elemDataNGP);
 
   const auto& buckets = ngpMesh.get_bucket_ids(sideRank, sel);
   auto team_exec = impl::ngp_mesh_team_policy<TeamPolicy>(

--- a/src/ScratchViews.C
+++ b/src/ScratchViews.C
@@ -186,7 +186,7 @@ void gather_elem_node_field(const stk::mesh::FieldBase& field,
 }
 
 int get_num_scalars_pre_req_data(
-  const ElemDataRequestsGPU& dataNeeded, int nDim, const ElemReqType reqType)
+  const ElemDataRequestsGPU& dataNeeded, int nDim, int nodesPerElement, const ElemReqType reqType)
 {
   /* master elements are allowed to be null if they are not required */
   MasterElement *meFC  = dataNeeded.get_cvfem_face_me();
@@ -223,7 +223,10 @@ int get_num_scalars_pre_req_data(
 
   // The previous check guarantees that we get the correct nodesPerEntity for
   // all request types
-  const int nodesPerEntity = nodes_per_entity(dataNeeded);
+
+  //const int nodesPerEntity = nodes_per_entity(dataNeeded);
+  //NGP_ThrowRequire(nodesPerElement == nodesPerEntity);
+  const int nodesPerEntity = nodesPerElement;
 
   int numScalars = 0;
 

--- a/src/edge_kernels/ContinuityOpenEdgeKernel.C
+++ b/src/edge_kernels/ContinuityOpenEdgeKernel.C
@@ -52,6 +52,8 @@ ContinuityOpenEdgeKernel<BcAlgTraits>::ContinuityOpenEdgeKernel(
 {
   faceData.add_cvfem_face_me(meFC_);
   elemData.add_cvfem_surface_me(meSCS_);
+  faceData.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemData.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceData.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
   faceData.add_face_field(dynPress_, BcAlgTraits::numFaceIp_);

--- a/src/edge_kernels/MomentumABLWallShearStressEdgeKernel.C
+++ b/src/edge_kernels/MomentumABLWallShearStressEdgeKernel.C
@@ -38,6 +38,8 @@ MomentumABLWallShearStressEdgeKernel<BcAlgTraits>::MomentumABLWallShearStressEdg
 {
   faceDataPreReqs.add_cvfem_face_me(meFC_);
   elemData.add_cvfem_surface_me(meSCS_);
+  faceDataPreReqs.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemData.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceDataPreReqs.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
   faceDataPreReqs.add_face_field(wallShearStress_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);

--- a/src/edge_kernels/MomentumOpenEdgeKernel.C
+++ b/src/edge_kernels/MomentumOpenEdgeKernel.C
@@ -57,6 +57,8 @@ MomentumOpenEdgeKernel<BcAlgTraits>::MomentumOpenEdgeKernel(
 {
   faceData.add_cvfem_face_me(meFC_);
   elemData.add_cvfem_surface_me(meSCS_);
+  faceData.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemData.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceData.add_gathered_nodal_field(dudx_, BcAlgTraits::nDim_, BcAlgTraits::nDim_);
   faceData.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);

--- a/src/edge_kernels/MomentumSymmetryEdgeKernel.C
+++ b/src/edge_kernels/MomentumSymmetryEdgeKernel.C
@@ -48,6 +48,8 @@ MomentumSymmetryEdgeKernel<BcAlgTraits>::MomentumSymmetryEdgeKernel(
 {
   faceDataPreReqs.add_cvfem_face_me(meFC_);
   elemDataPreReqs.add_cvfem_surface_me(meSCS_);
+  faceDataPreReqs.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemDataPreReqs.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceDataPreReqs.add_gathered_nodal_field(viscosity_, 1);
   faceDataPreReqs.add_gathered_nodal_field(dudx_, BcAlgTraits::nDim_, BcAlgTraits::nDim_);

--- a/src/edge_kernels/ScalarEdgeOpenSolverAlg.C
+++ b/src/edge_kernels/ScalarEdgeOpenSolverAlg.C
@@ -47,6 +47,8 @@ ScalarEdgeOpenSolverAlg<BcAlgTraits>::ScalarEdgeOpenSolverAlg(
 {
   faceDataPreReqs.add_cvfem_face_me(meFC_);
   elemDataPreReqs.add_cvfem_surface_me(meSCS_);
+  faceDataPreReqs.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemDataPreReqs.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceDataPreReqs.add_gathered_nodal_field(diffFluxCoeff_, 1);
   faceDataPreReqs.add_face_field(openMassFlowRate_, BcAlgTraits::numFaceIp_);

--- a/src/edge_kernels/ScalarOpenEdgeKernel.C
+++ b/src/edge_kernels/ScalarOpenEdgeKernel.C
@@ -35,6 +35,7 @@ ScalarOpenEdgeKernel<BcAlgTraits>::ScalarOpenEdgeKernel(
     meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element<BcAlgTraits>())
 {
   faceData.add_cvfem_face_me(meFC_);
+  faceData.addNodesPerElement(BcAlgTraits::nodesPerElement_);
 
   faceData.add_gathered_nodal_field(scalarQ_, 1);
   faceData.add_gathered_nodal_field(bcScalarQ_, 1);

--- a/src/gcl/MeshVelocityAlg.C
+++ b/src/gcl/MeshVelocityAlg.C
@@ -59,6 +59,7 @@ MeshVelocityAlg<AlgTraits>::MeshVelocityAlg(Realm& realm, stk::mesh::Part* part)
   }
 
   elemData_.add_cvfem_surface_me(meSCS_);
+  elemData_.addNodesPerElement(AlgTraits::nodesPerElement_);
 
   elemData_.add_coordinates_field(
     modelCoords_, AlgTraits::nDim_, MODEL_COORDINATES);

--- a/src/gcl/MeshVelocityEdgeAlg.C
+++ b/src/gcl/MeshVelocityEdgeAlg.C
@@ -52,6 +52,7 @@ MeshVelocityEdgeAlg<AlgTraits>::MeshVelocityEdgeAlg(
 {
 
   elemData_.add_cvfem_surface_me(meSCS_);
+  elemData_.addNodesPerElement(AlgTraits::nodesPerElement_);
 
   elemData_.add_coordinates_field(
     modelCoords_, AlgTraits::nDim_, MODEL_COORDINATES);

--- a/src/kernel/ContinuityInflowElemKernel.C
+++ b/src/kernel/ContinuityInflowElemKernel.C
@@ -50,6 +50,7 @@ ContinuityInflowElemKernel<BcAlgTraits>::ContinuityInflowElemKernel(
 
   // add master elements
   dataPreReqs.add_cvfem_face_me(meFC_);
+  dataPreReqs.addNodesPerElement(BcAlgTraits::nodesPerElement_);
 
   // required fields
   dataPreReqs.add_coordinates_field(

--- a/src/kernel/EnthalpyTGradBCElemKernel.C
+++ b/src/kernel/EnthalpyTGradBCElemKernel.C
@@ -44,6 +44,7 @@ EnthalpyTGradBCElemKernel<BcAlgTraits>::EnthalpyTGradBCElemKernel(
 {
   // Register necessary data for use in execute method
   faceDataPreReqs.add_cvfem_face_me(meFC_);
+  faceDataPreReqs.addNodesPerElement(BcAlgTraits::nodesPerElement_);
 
   faceDataPreReqs.add_coordinates_field(
     coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);

--- a/src/kernel/ScalarFluxBCElemKernel.C
+++ b/src/kernel/ScalarFluxBCElemKernel.C
@@ -40,6 +40,7 @@ ScalarFluxBCElemKernel<BcAlgTraits>::ScalarFluxBCElemKernel(
 {
   // Register necessary data for use in execute method
   faceDataPreReqs.add_cvfem_face_me(meFC_);
+  faceDataPreReqs.addNodesPerElement(BcAlgTraits::nodesPerElement_);
 
   faceDataPreReqs.add_coordinates_field(
     coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);

--- a/src/kernel/WallDistElemKernel.C
+++ b/src/kernel/WallDistElemKernel.C
@@ -40,6 +40,7 @@ WallDistElemKernel<AlgTraits>::WallDistElemKernel(
 
   dataPreReqs.add_cvfem_surface_me(meSCS_);
   dataPreReqs.add_cvfem_volume_me(meSCV_);
+  dataPreReqs.addNodesPerElement(AlgTraits::nodesPerElement_);
   dataPreReqs.add_coordinates_field(
     coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   dataPreReqs.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);

--- a/src/ngp_algorithms/ABLWallFluxesAlg.C
+++ b/src/ngp_algorithms/ABLWallFluxesAlg.C
@@ -172,6 +172,8 @@ ABLWallFluxesAlg<BcAlgTraits>::ABLWallFluxesAlg(
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);
+  faceData_.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemData_.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceData_.add_coordinates_field(
     coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -143,6 +143,7 @@ ABLWallFrictionVelAlg<BcAlgTraits>::ABLWallFrictionVelAlg(
           BcAlgTraits>())
 {
   faceData_.add_cvfem_face_me(meFC_);
+  faceData_.addNodesPerElement(BcAlgTraits::nodesPerElement_);
 
   faceData_.add_coordinates_field(
     get_field_ordinal(realm_.meta_data(), realm_.get_coordinates_name()),

--- a/src/ngp_algorithms/CourantReAlg.C
+++ b/src/ngp_algorithms/CourantReAlg.C
@@ -56,6 +56,7 @@ CourantReAlg<AlgTraits>::CourantReAlg(
     meSCS_(MasterElementRepo::get_surface_master_element<AlgTraits>())
 {
   elemData_.add_cvfem_surface_me(meSCS_);
+  elemData_.addNodesPerElement(AlgTraits::nodesPerElement_);
 
   elemData_.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   elemData_.add_gathered_nodal_field(density_, 1);

--- a/src/ngp_algorithms/DynamicPressureOpenAlg.C
+++ b/src/ngp_algorithms/DynamicPressureOpenAlg.C
@@ -49,6 +49,7 @@ DynamicPressureOpenAlg<BcAlgTraits>::DynamicPressureOpenAlg(
     meFC_(MasterElementRepo::get_surface_master_element<BcAlgTraits>())
 {
   faceData_.add_cvfem_face_me(meFC_);
+  faceData_.addNodesPerElement(BcAlgTraits::nodesPerElement_);
   faceData_.add_coordinates_field(
     get_field_ordinal(realm_.meta_data(), realm_.get_coordinates_name()),
     BcAlgTraits::nDim_, CURRENT_COORDINATES);

--- a/src/ngp_algorithms/GeometryBoundaryAlg.C
+++ b/src/ngp_algorithms/GeometryBoundaryAlg.C
@@ -36,6 +36,8 @@ GeometryBoundaryAlg<AlgTraits>::GeometryBoundaryAlg(
     meSCS_(MasterElementRepo::get_surface_master_element<AlgTraits>())
 {
   dataNeeded_.add_cvfem_surface_me(meSCS_);
+  dataNeeded_.addNodesPerElement(AlgTraits::nodesPerElement_);
+
   const auto coordID = get_field_ordinal(
     realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());
   dataNeeded_.add_coordinates_field(coordID, AlgTraits::nDim_, CURRENT_COORDINATES);

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -39,6 +39,7 @@ GeometryInteriorAlg<AlgTraits>::GeometryInteriorAlg(
 {
   dataNeeded_.add_cvfem_volume_me(meSCV_);
   dataNeeded_.add_cvfem_surface_me(meSCS_);
+  dataNeeded_.addNodesPerElement(AlgTraits::nodesPerElement_);
 
   const auto coordID = get_field_ordinal(
     realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());

--- a/src/ngp_algorithms/MdotDensityAccumAlg.C
+++ b/src/ngp_algorithms/MdotDensityAccumAlg.C
@@ -43,6 +43,7 @@ MdotDensityAccumAlg<AlgTraits>::MdotDensityAccumAlg(
     lumpedMass_(lumpedMass)
 {
   elemData_.add_cvfem_volume_me(meSCV_);
+  elemData_.addNodesPerElement(AlgTraits::nodesPerElement_);
 
   const auto coordID = get_field_ordinal(
     realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());

--- a/src/ngp_algorithms/MdotInflowAlg.C
+++ b/src/ngp_algorithms/MdotInflowAlg.C
@@ -42,6 +42,7 @@ MdotInflowAlg<BcAlgTraits>::MdotInflowAlg(
     meFC_(MasterElementRepo::get_surface_master_element<BcAlgTraits>())
 {
   faceData_.add_cvfem_surface_me(meFC_);
+  faceData_.addNodesPerElement(BcAlgTraits::nodesPerElement_);
 
   const auto coordID = get_field_ordinal(
     realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());

--- a/src/ngp_algorithms/MdotOpenEdgeAlg.C
+++ b/src/ngp_algorithms/MdotOpenEdgeAlg.C
@@ -62,6 +62,8 @@ MdotOpenEdgeAlg<BcAlgTraits>::MdotOpenEdgeAlg(
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);
+  faceData_.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemData_.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceData_.add_coordinates_field(coordinates_, BcAlgTraits::nDim_ , CURRENT_COORDINATES);
   faceData_.add_face_field(exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);

--- a/src/ngp_algorithms/MetricTensorElemAlg.C
+++ b/src/ngp_algorithms/MetricTensorElemAlg.C
@@ -35,6 +35,7 @@ MetricTensorElemAlg<AlgTraits>::MetricTensorElemAlg(
     meSCV_(MasterElementRepo::get_volume_master_element<AlgTraits>())
 {
   dataNeeded_.add_cvfem_volume_me(meSCV_);
+  dataNeeded_.addNodesPerElement(AlgTraits::nodesPerElement_);
 
   const auto coordID = get_field_ordinal(
     realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());

--- a/src/ngp_algorithms/NodalGradBndryElemAlg.C
+++ b/src/ngp_algorithms/NodalGradBndryElemAlg.C
@@ -45,6 +45,7 @@ NodalGradBndryElemAlg<AlgTraits, PhiType, GradPhiType>::NodalGradBndryElemAlg(
     meFC_(MasterElementRepo::get_surface_master_element<AlgTraits>())
 {
   dataNeeded_.add_cvfem_face_me(meFC_);
+  dataNeeded_.addNodesPerElement(AlgTraits::nodesPerElement_);
 
   const auto coordID = get_field_ordinal(
     realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());

--- a/src/ngp_algorithms/NodalGradElemAlg.C
+++ b/src/ngp_algorithms/NodalGradElemAlg.C
@@ -42,6 +42,7 @@ NodalGradElemAlg<AlgTraits, PhiType, GradPhiType>::NodalGradElemAlg(
     meSCS_(MasterElementRepo::get_surface_master_element<AlgTraits>())
 {
   dataNeeded_.add_cvfem_surface_me(meSCS_);
+  dataNeeded_.addNodesPerElement(AlgTraits::nodesPerElement_);
 
   const auto coordID = get_field_ordinal(
     realm_.meta_data(), realm_.solutionOptions_->get_coordinates_name());

--- a/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
+++ b/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
@@ -54,6 +54,8 @@ NodalGradPOpenBoundary<AlgTraits>::NodalGradPOpenBoundary(
     faceData_(realm.meta_data()),
     elemData_(realm.meta_data())
 {
+  faceData_.addNodesPerElement(AlgTraits::FaceTraits::nodesPerFace_);
+  elemData_.addNodesPerElement(AlgTraits::ElemTraits::nodesPerElement_);
   faceData_.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   elemData_.add_coordinates_field(coordinates_, AlgTraits::nDim_, CURRENT_COORDINATES);
   faceData_.add_cvfem_face_me   (meFC_);

--- a/src/ngp_algorithms/SDRLowReWallAlg.C
+++ b/src/ngp_algorithms/SDRLowReWallAlg.C
@@ -45,6 +45,8 @@ SDRLowReWallAlg<BcAlgTraits>::SDRLowReWallAlg(
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);
+  faceData_.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemData_.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceData_.add_coordinates_field(
     coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);

--- a/src/ngp_algorithms/SDRWallFuncAlg.C
+++ b/src/ngp_algorithms/SDRWallFuncAlg.C
@@ -51,6 +51,8 @@ SDRWallFuncAlg<BcAlgTraits>::SDRWallFuncAlg(
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);
+  faceData_.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemData_.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceData_.add_coordinates_field(
     coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);

--- a/src/ngp_algorithms/TKEWallFuncAlg.C
+++ b/src/ngp_algorithms/TKEWallFuncAlg.C
@@ -43,6 +43,7 @@ TKEWallFuncAlg<BcAlgTraits>::TKEWallFuncAlg(Realm& realm, stk::mesh::Part* part)
           BcAlgTraits>())
 {
   faceData_.add_cvfem_face_me(meFC_);
+  faceData_.addNodesPerElement(BcAlgTraits::nodesPerElement_);
 
   faceData_.add_coordinates_field(
     get_field_ordinal(realm.meta_data(), realm.get_coordinates_name()),

--- a/src/ngp_algorithms/WallFuncGeometryAlg.C
+++ b/src/ngp_algorithms/WallFuncGeometryAlg.C
@@ -50,6 +50,8 @@ WallFuncGeometryAlg<BcAlgTraits>::WallFuncGeometryAlg(
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);
+  faceData_.addNodesPerElement(BcAlgTraits::FaceTraits::nodesPerFace_);
+  elemData_.addNodesPerElement(BcAlgTraits::ElemTraits::nodesPerElement_);
 
   faceData_.add_coordinates_field(
     coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -81,7 +81,7 @@ void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* press
   const int nodesPerElement = sierra::nalu::AlgTraitsHex8::nodesPerElement_;
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
   dataReq.add_cvfem_volume_me(meSCV);
-
+  dataReq.addNodesPerElement(nodesPerElement);
   auto* coordsField = bulk.mesh_meta_data().coordinate_field();
 
   dataReq.add_coordinates_field(*coordsField, 3, sierra::nalu::CURRENT_COORDINATES);
@@ -106,7 +106,7 @@ void do_the_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType* press
   const int bytes_per_team = 0;
   const int bytes_per_thread =
     (sierra::nalu::calculate_shared_mem_bytes_per_thread(
-       lhsSize, rhsSize, rhsSize, meta.spatial_dimension(), dataNGP) +
+        lhsSize, rhsSize, rhsSize, dataReq.nodesPerElement_, meta.spatial_dimension(), dataNGP) +
      (rhsSize + lhsSize) * sizeof(double) * sierra::nalu::simdLen);
 
   int numResults = 5;
@@ -236,6 +236,7 @@ void do_the_smdata_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType
   sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
   dataReq.add_cvfem_volume_me(meSCV);
+  dataReq.addNodesPerElement(sierra::nalu::AlgTraitsHex8::nodesPerElement_);
 
   auto* coordsField = bulk.mesh_meta_data().coordinate_field();
 
@@ -261,7 +262,7 @@ void do_the_smdata_test(stk::mesh::BulkData& bulk, sierra::nalu::ScalarFieldType
   const int bytes_per_team = 0;
   const int bytes_per_thread =
     (sierra::nalu::calculate_shared_mem_bytes_per_thread(
-       lhsSize, rhsSize, rhsSize, meta.spatial_dimension(), dataNGP) +
+       lhsSize, rhsSize, rhsSize, meta.spatial_dimension(), dataReq.nodesPerElement_, dataNGP) +
      (rhsSize + lhsSize) * sizeof(double) * sierra::nalu::simdLen);
 
   int numResults = sierra::nalu::AlgTraitsHex8::numScvIp_;


### PR DESCRIPTION

ElemDataRequests is used to construct/initialize ElemDataRequestsGPU. A handoff of MasterElement pointers occurs during this construction. We used MasterElement pointers to the get nodes_per_entity value, depending on the MasterElement pointer type, through a Kokkos parallel_reduce. This call attempts to deference a null pointer when doing Release build types.

I find it a bit strange that we have this complex machinery for pulling a single value of GPU-class data back to the host.
The workaround is to just add data members and interfaces to ElemDataRequests that adds these data members, as host data, and initializes properly from AlgTraits, which stores the data for each element type.

**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
