### PR TITLE
isolate the nonlinear iteration to call from exawind driver

### DIFF
--- a/include/InputOutputRealm.h
+++ b/include/InputOutputRealm.h
@@ -71,6 +71,7 @@ public:
   void pre_timestep_work() {}  
   void output_banner() {}
   void advance_time_step() {}
+  void nonlinear_iteration(const int) {}
   double populate_restart( double &timeStepNm1, int &timeStepCount);
   void populate_external_variables_from_input(const double currentTime);
  

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -275,7 +275,7 @@ class Realm {
   virtual void pre_timestep_work_epilog();
   virtual void output_banner();
   virtual void advance_time_step();
- 
+  virtual void nonlinear_iteration(const int); 
   virtual void initial_work();
   
   void set_global_id();

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -275,7 +275,7 @@ class Realm {
   virtual void pre_timestep_work_epilog();
   virtual void output_banner();
   virtual void advance_time_step();
-  virtual void nonlinear_iteration(const int); 
+  virtual void nonlinear_iterations(const int);
   virtual void initial_work();
   
   void set_global_id();

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1798,6 +1798,24 @@ Realm::advance_time_step()
   }
 
 }
+void Realm::nonlinear_iteration(const int numNonLinearIterations){
+
+for ( int i = 0; i < numNonLinearIterations; ++i ) {
+   currentNonlinearIteration_ = i+1;
+    NaluEnv::self().naluOutputP0()
+      << currentNonlinearIteration_
+      << "/" << numNonLinearIterations
+      << std::setw(29) << std::right << "Equation System Iteration" << std::endl;
+    const bool isConverged = equationSystems_.solve_and_update();
+    evaluate_properties();
+     if ( isConverged ) {
+      NaluEnv::self().naluOutputP0() << "norm convergence criteria met for all equation systems: " << std::endl;
+      NaluEnv::self().naluOutputP0() << "max scaled norm is: " << equationSystems_.provide_system_norm() << std::endl;
+      break;
+     }
+  }
+
+}
 
 //--------------------------------------------------------------------------
 //-------- output_converged_results ----------------------------------------

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1775,46 +1775,30 @@ Realm::advance_time_step()
     ablForcingAlg_->execute();
   }
 
-  const int numNonLinearIterations = equationSystems_.maxIterations_;
-  for ( int i = 0; i < numNonLinearIterations; ++i ) {
-    currentNonlinearIteration_ = i+1;
-    NaluEnv::self().naluOutputP0()
-      << currentNonlinearIteration_
-      << "/" << numNonLinearIterations
-      << std::setw(29) << std::right << "Equation System Iteration" << std::endl;
-
-    isFinalOuterIter_ = ((i+1) == numNonLinearIterations);
-
-    const bool isConverged = equationSystems_.solve_and_update();
-
-    // evaluate properties based on latest np1 solution
-    evaluate_properties();
-
-    if ( isConverged ) {
-      NaluEnv::self().naluOutputP0() << "norm convergence criteria met for all equation systems: " << std::endl;
-      NaluEnv::self().naluOutputP0() << "max scaled norm is: " << equationSystems_.provide_system_norm() << std::endl;
-      break;
-    }
-  }
-
+  nonlinear_iterations(equationSystems_.maxIterations_);
 }
-void Realm::nonlinear_iteration(const int numNonLinearIterations){
 
-for ( int i = 0; i < numNonLinearIterations; ++i ) {
-   currentNonlinearIteration_ = i+1;
-    NaluEnv::self().naluOutputP0()
-      << currentNonlinearIteration_
-      << "/" << numNonLinearIterations
-      << std::setw(29) << std::right << "Equation System Iteration" << std::endl;
-    const bool isConverged = equationSystems_.solve_and_update();
-    evaluate_properties();
-     if ( isConverged ) {
-      NaluEnv::self().naluOutputP0() << "norm convergence criteria met for all equation systems: " << std::endl;
-      NaluEnv::self().naluOutputP0() << "max scaled norm is: " << equationSystems_.provide_system_norm() << std::endl;
-      break;
-     }
-  }
+void Realm::nonlinear_iterations(const int numNonLinearIterations){
+    for ( int i = 0; i < numNonLinearIterations; ++i ) {
+      currentNonlinearIteration_ = i+1;
+      NaluEnv::self().naluOutputP0()
+        << currentNonlinearIteration_
+        << "/" << numNonLinearIterations
+        << std::setw(29) << std::right << "Equation System Iteration" << std::endl;
 
+      isFinalOuterIter_ = ((i+1) == numNonLinearIterations);
+
+      const bool isConverged = equationSystems_.solve_and_update();
+
+      // evaluate properties based on latest np1 solution
+      evaluate_properties();
+
+      if ( isConverged ) {
+        NaluEnv::self().naluOutputP0() << "norm convergence criteria met for all equation systems: " << std::endl;
+        NaluEnv::self().naluOutputP0() << "max scaled norm is: " << equationSystems_.provide_system_norm() << std::endl;
+        break;
+      }
+    }
 }
 
 //--------------------------------------------------------------------------


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

Isolating the call to picard iterations such that it can be called from the exawind-driver for additional non-linear iterations.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [x] MacOS
  - Compilers 
    - [x] GCC
    - [x] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
