### PR TITLE
NgpMEUtils fix

### DIFF
--- a/include/ngp_utils/NgpMEUtils.h
+++ b/include/ngp_utils/NgpMEUtils.h
@@ -73,13 +73,11 @@ int nodes_per_entity(const DataReqType& dataReq, const METype meType)
   // Return immediately if ME is not registered
   if (me == nullptr) return 0;
 
-  int npe = 0;
-  Kokkos::parallel_reduce(
-    1, KOKKOS_LAMBDA(int, int& n) {
-      n = me->nodesPerElement_;
-    }, npe);
-
-  return npe;
+  Kokkos::View<int*, sierra::nalu::MemSpace> npe("npe", 1);
+  Kokkos::parallel_for("get_nodes_per_element", 1, KOKKOS_LAMBDA(const int i) { npe(i) = me->nodesPerElement_; } );
+  Kokkos::View<int*, sierra::nalu::MemSpace>::HostMirror npe_host("npe", 1);
+  Kokkos::deep_copy(npe_host, npe);
+  return npe_host(0);
 }
 
 template<typename DataReqType>
@@ -90,13 +88,11 @@ int num_integration_points(const DataReqType& dataReq, const METype meType)
   // Return immediately if ME is not registered
   if (me == nullptr) return 0;
 
-  int nips = 0;
-  Kokkos::parallel_reduce(
-    1, KOKKOS_LAMBDA(int, int& n) {
-      n = me->num_integration_points();
-    }, nips);
-
-  return nips;
+  Kokkos::View<int*, sierra::nalu::MemSpace> nips("nips", 1);
+  Kokkos::parallel_for("get_num_integration_points", 1, KOKKOS_LAMBDA(const int i) { nips(i) = me->num_integration_points(); } );
+  Kokkos::View<int*, sierra::nalu::MemSpace>::HostMirror nips_host("nips", 1);
+  Kokkos::deep_copy(nips_host, nips);
+  return nips_host(0);
 }
 
 template<typename DataReqType>


### PR DESCRIPTION
In order to retrieve scalar class data from device classes, I've replaced the parallel_reduce with the use of Kokkos views, parallel_for and explicit device copies.

I think there might be a problem Kokkos::parallel_reduce over 1 item. The compute-sanitizer suggests as much with all those race check errors I saw.


**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
