### PR TITLE
Hypre Solver Block Params

### DIFF
--- a/include/HypreNGP.h
+++ b/include/HypreNGP.h
@@ -29,8 +29,9 @@ namespace nalu_hypre {
 inline void hypre_initialize()
 {
   HYPRE_Init();
-  hypre_HandleDefaultExecPolicy(hypre_handle()) = HYPRE_EXEC_DEVICE;
-  hypre_HandleSpgemmUseCusparse(hypre_handle()) = 0;
+  HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE);
+  HYPRE_SetExecutionPolicy(HYPRE_EXEC_DEVICE);
+  HYPRE_SetUseGpuRand(true);
 }
 
 inline void hypre_finalize()
@@ -40,8 +41,12 @@ inline void hypre_finalize()
 
 #else
 
-inline void hypre_initialize() {}
-inline void hypre_finalize() {}
+inline void hypre_initialize() {
+  HYPRE_Init();
+}
+inline void hypre_finalize() {
+  HYPRE_Finalize();
+}
 
 #endif
 }

--- a/include/LinearSolverConfig.h
+++ b/include/LinearSolverConfig.h
@@ -143,6 +143,12 @@ public:
   inline bool dumpHypreMatrixStats() const
   { return dumpHypreMatrixStats_; }
 
+  inline bool getWritePreassemblyMatrixFiles() const
+  { return writePreassemblyMatrixFiles_; }
+
+  inline bool getUseCusparseSGEMM() const
+  { return useCusparseSGEMM_; }
+
 protected:
   //! List of HYPRE API calls and corresponding arugments to configure solver
   //! and preconditioner after they are created.
@@ -184,6 +190,8 @@ protected:
   bool useSegregatedSolver_{false};
   bool simpleHypreMatrixAssemble_{false};
   bool dumpHypreMatrixStats_{false};
+  bool writePreassemblyMatrixFiles_{false};
+  bool useCusparseSGEMM_{false};
 
 private:
   void boomerAMG_solver_config(const YAML::Node&);

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -66,7 +66,7 @@ function(add_test_r_rst testname np)
     set_tests_properties(${testname} PROPERTIES LABELS "regression")
 endfunction(add_test_r_rst)
 
-# Regression test with postprocessing 
+# Regression test with postprocessing
 function(add_test_r_post testname np)
     setup_test(${testname} ${np})
     add_test(${testname} sh -c "${RUN_COMMAND}${COMPARE_GOLDS_COMMAND_NC}")
@@ -110,7 +110,7 @@ function(add_test_u testname np)
     set_properties(${testname})
     set_tests_properties(${testname} PROPERTIES LABELS "unit")
     if(ENABLE_OPENFAST)
-      # create symlink to nrelmw.fst 
+      # create symlink to nrelmw.fst
       execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
         ${CMAKE_BINARY_DIR}/reg_tests/test_files/nrel5MWactuatorLine/nrel5mw.fst
         ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}/nrel5mw.fst
@@ -126,7 +126,7 @@ function(add_test_u_gpu testname np)
     set_properties(${testname})
     set_tests_properties(${testname} PROPERTIES LABELS "unit")
     if(ENABLE_OPENFAST)
-      # create symlink to nrelmw.fst 
+      # create symlink to nrelmw.fst
       execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
         ${CMAKE_BINARY_DIR}/reg_tests/test_files/nrel5MWactuatorLine/nrel5mw.fst
         ${CMAKE_CURRENT_BINARY_DIR}/test_files/${testname}/nrel5mw.fst
@@ -240,7 +240,7 @@ if(NOT ENABLE_CUDA)
   # Convergence tests
   #=============================================================================
   add_test_v2(BoussinesqNonIso 8)
-  
+
   #=============================================================================
   # Unit tests
   #=============================================================================
@@ -284,7 +284,7 @@ else(NOT ENABLE_CUDA)
   if (ENABLE_TIOGA AND ENABLE_HYPRE)
     add_test_r(oversetRotCylNGPHypre 2)
   endif()
-  
+
   #=============================================================================
   # Comparing solution norm tests
   #=============================================================================

--- a/reg_tests/hypre_settings/hypre_blade_resolved.yaml
+++ b/reg_tests/hypre_settings/hypre_blade_resolved.yaml
@@ -3,6 +3,7 @@ hypre_simple_precon:
   bamg_relax_type: 12 # Use 11 for Hypre master or v2.21 and later, 8 for earlier
   bamg_num_sweeps: 2
   bamg_relax_order: 0
+  bamg_use_cusparse_sgemm: no
 
 hypre_elliptic:
   bamg_max_levels: 7
@@ -21,3 +22,4 @@ hypre_elliptic:
   bamg_agg_pmax_elmts: 3
   bamg_pmax_elmts: 3
   bamg_strong_threshold: 0.25
+  bamg_use_cusparse_sgemm: no

--- a/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
@@ -21,6 +21,7 @@ linear_solvers:
     recompute_preconditioner_frequency: 100
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -40,6 +41,7 @@ linear_solvers:
     recompute_preconditioner_frequency: 100
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -59,6 +61,7 @@ linear_solvers:
     recompute_preconditioner_frequency: 100
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml

--- a/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
@@ -21,6 +21,7 @@ linear_solvers:
     recompute_preconditioner_frequency: 100
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -40,6 +41,7 @@ linear_solvers:
     recompute_preconditioner_frequency: 100
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -59,6 +61,7 @@ linear_solvers:
     recompute_preconditioner_frequency: 100
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml

--- a/reg_tests/test_files/airfoilRANSEdgeNGPHypre.rst/airfoilRANSEdgeNGPHypre.rst.yaml
+++ b/reg_tests/test_files/airfoilRANSEdgeNGPHypre.rst/airfoilRANSEdgeNGPHypre.rst.yaml
@@ -24,6 +24,9 @@ linear_solvers:
     write_matrix_files: no
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    recompute_preconditioner_frequency: 1
+    reuse_linear_system: yes
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -41,6 +44,9 @@ linear_solvers:
     write_matrix_files: no
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    recompute_preconditioner_frequency: 1
+    reuse_linear_system: yes
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -58,6 +64,9 @@ linear_solvers:
     write_matrix_files: no
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    recompute_preconditioner_frequency: 1
+    reuse_linear_system: yes
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml

--- a/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.yaml
+++ b/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.yaml
@@ -19,6 +19,9 @@ linear_solvers:
     write_matrix_files: no
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    recompute_preconditioner_frequency: 1
+    reuse_linear_system: yes
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml
@@ -36,6 +39,9 @@ linear_solvers:
     write_matrix_files: no
     simple_hypre_matrix_assemble: no
     dump_hypre_matrix_stats: no
+    recompute_preconditioner_frequency: 1
+    reuse_linear_system: yes
+    write_preassembly_matrix_files: no
 
     # File containing hypre specific configuration options
     hypre_cfg_file: ../../hypre_settings/hypre_blade_resolved.yaml

--- a/src/HypreLinearSolverConfig.C
+++ b/src/HypreLinearSolverConfig.C
@@ -58,6 +58,7 @@ HypreLinearSolverConfig::load(const YAML::Node& node)
   get_if_present(node, "simple_hypre_matrix_assemble", simpleHypreMatrixAssemble_, simpleHypreMatrixAssemble_);
   get_if_present(node, "dump_hypre_matrix_stats", dumpHypreMatrixStats_, dumpHypreMatrixStats_);
   get_if_present(node, "reuse_linear_system", reuseLinSysIfPossible_, reuseLinSysIfPossible_);
+  get_if_present(node, "write_preassembly_matrix_files", writePreassemblyMatrixFiles_, writePreassemblyMatrixFiles_);
 
   if (node["absolute_tolerance"]) {
     hasAbsTol_ = true;
@@ -125,6 +126,7 @@ HypreLinearSolverConfig::boomerAMG_solver_config(const YAML::Node& node)
   get_if_present(node, "bamg_num_sweeps", bamgNumSweeps_, bamgNumSweeps_);
   get_if_present(node, "bamg_max_levels", bamgMaxLevels_, bamgMaxLevels_);
   get_if_present(node, "bamg_strong_threshold", bamgStrongThreshold_, bamgStrongThreshold_);
+  get_if_present(node, "bamg_use_cusparse_sgemm", useCusparseSGEMM_, useCusparseSGEMM_);
 
   // Setup AMG parameters
   funcParams_.resize(10);
@@ -174,6 +176,8 @@ void
 HypreLinearSolverConfig::boomerAMG_precond_config(const YAML::Node& node)
 {
   int output_level = 0;
+  int logging = 0;
+  int debug = 0;
 
   get_if_present(node, "bamg_coarsen_type", bamgCoarsenType_, bamgCoarsenType_);
   get_if_present(node, "bamg_cycle_type", bamgCycleType_, bamgCycleType_);
@@ -186,10 +190,19 @@ HypreLinearSolverConfig::boomerAMG_precond_config(const YAML::Node& node)
   get_if_present(node, "bamg_max_levels", bamgMaxLevels_, bamgMaxLevels_);
   get_if_present(node, "bamg_strong_threshold", bamgStrongThreshold_, bamgStrongThreshold_);
   get_if_present(node, "bamg_output_level", output_level, output_level);
+  get_if_present(node, "bamg_logging", logging, logging);
+  get_if_present(node, "bamg_debug", debug, debug);
+  get_if_present(node, "bamg_use_cusparse_sgemm", useCusparseSGEMM_, useCusparseSGEMM_);
 
   funcParams_.push_back(Teuchos::rcp(new Ifpack2::FunctionParameter(
     Ifpack2::Hypre::Prec, &HYPRE_BoomerAMGSetPrintLevel,
     output_level))); // print AMG solution info
+  funcParams_.push_back(Teuchos::rcp(new Ifpack2::FunctionParameter(
+    Ifpack2::Hypre::Prec, &HYPRE_BoomerAMGSetLogging,
+    logging))); // print AMG solution info
+  funcParams_.push_back(Teuchos::rcp(new Ifpack2::FunctionParameter(
+    Ifpack2::Hypre::Prec, &HYPRE_BoomerAMGSetDebugFlag,
+    debug))); // set debug flag
   funcParams_.push_back(Teuchos::rcp(new Ifpack2::FunctionParameter(
     Ifpack2::Hypre::Prec, &HYPRE_BoomerAMGSetLogging,
     output_level))); // print AMG solution info


### PR DESCRIPTION
This PR adds 2 new parameters to hypre solver blocks.
1) write_preassembly_matrix_files: This parameter dumps the arrays generated by the Nalu assembly algorithms (just prior to AddTo/SetValues and Assemble)
2) bamg_use_cusparse_sgemm: This parameter allows one to control the sgemm algorithm used in BoomerAMG. Nvidia and AMD will require different values for this parameter so we need to have it be flexible.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
