### PR TITLE
Hypre UVM Removal

### DIFF
--- a/include/HypreLinearSystem.h
+++ b/include/HypreLinearSystem.h
@@ -75,14 +75,6 @@ using MemoryMap =
   Kokkos::UnorderedMap<HypreIntType, unsigned, sierra::nalu::MemSpace>;
 using MemoryMapHost = MemoryMap::HostMirror;
 
-// UVM Views
-using DoubleViewUVM = Kokkos::View<double*, sierra::nalu::UVMSpace>;
-using DoubleView2DUVM =
-  Kokkos::View<double**, Kokkos::LayoutLeft, sierra::nalu::UVMSpace>;
-using HypreIntTypeViewUVM = Kokkos::View<HypreIntType*, sierra::nalu::UVMSpace>;
-using HypreIntTypeView2DUVM =
-  Kokkos::View<HypreIntType**, Kokkos::LayoutLeft, sierra::nalu::UVMSpace>;
-
 // Periodic Node Map
 using PeriodicNodeMap =
   Kokkos::UnorderedMap<HypreIntType, HypreIntType, sierra::nalu::MemSpace>;
@@ -146,10 +138,10 @@ public:
   HypreIntTypeViewHost cols_shared_host_;
   HypreIntTypeViewHost cols_host_;
 
-  HypreIntTypeViewUVM rows_uvm_;
+  HypreIntTypeView rows_dev_;
   HypreIntTypeViewHost rows_host_;  
 
-  HypreIntTypeView2DUVM rhs_rows_uvm_;
+  HypreIntTypeView2D rhs_rows_dev_;
   HypreIntTypeView2DHost rhs_rows_host_;  
 
 #ifdef HYPRE_LINEAR_SYSTEM_DEBUG
@@ -369,9 +361,9 @@ public:
 
     /* monolithic data structures for holding all the values for
        the owned and shared parts. Shared MUST come after owned. */
-    DoubleViewUVM values_uvm_;
-    HypreIntTypeViewUVM cols_uvm_;
-    DoubleView2DUVM rhs_uvm_;
+    DoubleView values_dev_;
+    HypreIntTypeView cols_dev_;
+    DoubleView2D rhs_dev_;
 
     //! Data structures for the owned CSR Matrix and RHS Vector(s)
     HypreIntType num_rows_owned_;
@@ -389,7 +381,7 @@ public:
     //! Random access views
     UnsignedViewRA mat_row_start_owned_ra_;
     UnsignedViewRA mat_row_start_shared_ra_;
-    HypreIntTypeViewRA cols_uvm_ra_;
+    HypreIntTypeViewRA cols_dev_ra_;
 
     //! Auxilliary Data structures
 


### PR DESCRIPTION
All Kokkos Views which previously had UVMspace for memory space have been moved to Memspace, which is device memory when compiled for GPU. I have tested this with 2 hypre builds, with and without UVM. Hypre regression tests run on summit for each.

**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
