### PR TITLE
HYPRE Matrix/Vector Creation/Initialize refactor

### DIFF
--- a/include/HypreLinearSystem.h
+++ b/include/HypreLinearSystem.h
@@ -513,8 +513,6 @@ protected:
    */
   virtual void beginLinearSystemConstruction();
 
-  virtual void finalizeSolver();
-
   virtual void loadCompleteSolver();
 
   /** Return the Hypre ID corresponding to the given STK node entity
@@ -555,11 +553,8 @@ protected:
   //! Maximum Row ID in the Hypre linear system
   HypreIntType maxRowID_;
 
-  //! Flag indicating whether IJMatrixAssemble has been called on the system
-  bool matrixAssembled_{false};
-
-  //! Flag indicating whether the linear system has been initialized
-  bool systemInitialized_{false};
+  //! Flag indicating whether the linear system has been created and initialized
+  bool hypreMatrixVectorCreated_{false};
 
   //! Flag indicating whether the linear system has been initialized
   bool matrixStatsDumped_{false};

--- a/include/HypreUVWLinearSystem.h
+++ b/include/HypreUVWLinearSystem.h
@@ -195,8 +195,6 @@ public:
 protected:
   virtual void finalizeLinearSystem();
 
-  virtual void finalizeSolver();
-
   virtual void loadCompleteSolver();
 
 private:


### PR DESCRIPTION
In the previous, model Hypre matrices and vectors were created only once. We attempted to reuse these data structures, in subsequent time steps or picard iters, by calling HYPRE_IJMatrixInitialize. However, hybrid sims have shown that certain MPI/GPU communication data structures, internal to Hypre, are no longer valid in subsequent time steps. This is because the size of the matrices changes and thus need new communicator data structures. Nonetheless, HYPRE routines like SpMV try to reuse these comm data structures and seg fault.

Ideally, recalling HYPRE_IJMatrixInitialize should rebuild these however I have not been able to make that work. The alternative is to let the application delete and rebuild the HYPRE matrices and vectors every time Hypre Assembly is needed. This isn't that big an issue as these routines are cheap. Essentially, I moved matrix/vector creation and initialization inside zeroSystem. This guarantees that we have clean internal Hypre data structures.

I've tested this on CPU and GPU builds. All reg tests run successfully on summit.

**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
