### PR TITLE
Fix a wall BC field type in the SST EqSys

### DIFF
--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -221,7 +221,7 @@ ShearStressTransportEquationSystem::register_wall_bc(
   auto& assembledWallNormDist = meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "assembled_wall_normal_distance");
   stk::mesh::put_field_on_mesh(assembledWallNormDist, *part, nullptr);
-  auto& wallNormDistBip = meta.declare_field<ScalarFieldType>(
+  auto& wallNormDistBip = meta.declare_field<GenericFieldType>(
     meta.side_rank(), "wall_normal_distance_bip");
   auto* meFC = MasterElementRepo::get_surface_master_element(partTopo);
   const int numScsBip = meFC->num_integration_points();


### PR DESCRIPTION
Turns out the `wall_normal_distance_bip` field was declared in `LowMachEquationSystem` with type `GenericFieldType` and in `ShearStressTransportEquationSystem` with `ScalarFieldType`.  These two types are treated largely the same in practice by STK Mesh, but the differing template parameters cause issues for STK Mesh.  In simulations such as the one @janiadcock was running where both equation systems are used, the specified field types need to match in both `declare_field` calls inside `register_wall_bc`.

This PR assumes the `GenericFieldType` is more descriptive, since the field is clearly not scalar, but is being declared with length `numScsBip`.

FYI @janiadcock @psakievich @jrood-nrel @alanw0
