### PR TITLE
Remove OFast build errors

### DIFF
--- a/src/actuator/ActuatorParsingFAST.C
+++ b/src/actuator/ActuatorParsingFAST.C
@@ -171,8 +171,9 @@ actuator_FAST_parse(const YAML::Node& y_node, const ActuatorMeta& actMeta)
     if (y_actuator["super_controller"]) {
       get_required(y_actuator, "super_controller", fi.scStatus);
       get_required(y_actuator, "sc_libFile", fi.scLibFile);
-      get_required(y_actuator, "num_sc_inputs", fi.numScInputs);
-      get_required(y_actuator, "num_sc_outputs", fi.numScOutputs);
+      // Removed inputs from fast API may want to if/def later
+      //get_required(y_actuator, "num_sc_inputs", fi.numScInputs);
+      //get_required(y_actuator, "num_sc_outputs", fi.numScOutputs);
     }
 
     fi.globTurbineData.resize(fi.nTurbinesGlob);


### PR DESCRIPTION
Removes build errors from nightly test. Does not fix regression and unit test issues with openfast input deck yet. I want to merge this so all the other tests can run though
