### PR TITLE
Hypre Refactor

### DIFF
--- a/include/HypreLinearSystem.h
+++ b/include/HypreLinearSystem.h
@@ -513,8 +513,6 @@ protected:
    */
   virtual void beginLinearSystemConstruction();
 
-  virtual void finalizeSolver();
-
   virtual void loadCompleteSolver();
 
   /** Return the Hypre ID corresponding to the given STK node entity
@@ -556,10 +554,7 @@ protected:
   HypreIntType maxRowID_;
 
   //! Flag indicating whether IJMatrixAssemble has been called on the system
-  bool matrixAssembled_{false};
-
-  //! Flag indicating whether the linear system has been initialized
-  bool systemInitialized_{false};
+  bool hypreMatrixVectorsCreated_{false};
 
   //! Flag indicating whether the linear system has been initialized
   bool matrixStatsDumped_{false};

--- a/include/HypreNGP.h
+++ b/include/HypreNGP.h
@@ -22,6 +22,9 @@
 #include "_hypre_utilities.hpp"
 #endif
 
+#include "NaluParsing.h"
+#include <yaml-cpp/yaml.h>
+
 namespace nalu_hypre {
 
 #ifdef HYPRE_USING_CUDA
@@ -29,10 +32,62 @@ namespace nalu_hypre {
 inline void hypre_initialize()
 {
   HYPRE_Init();
+}
+
+
+inline void hypre_set_params(YAML::Node nodes)
+{
+#ifdef HYPRE_USING_DEVICE_POOL
+  /* device pool allocator */
+  hypre_uint mempool_bin_growth   = 8,
+             mempool_min_bin      = 3,
+             mempool_max_bin      = 9;
+  size_t mempool_max_cached_bytes = 2000LL * 1024 * 1024;
+#endif
+  bool use_cusparse_sgemm = false;
+
+  const YAML::Node node = nodes["hypre_config"];
+  if ( node ) {
+    int memory_pool_mbs=2000;
+    sierra::nalu::get_if_present(node, "memory_pool_mbs", memory_pool_mbs, memory_pool_mbs);
+    mempool_max_cached_bytes = ((size_t)memory_pool_mbs) * 1024 * 1024;
+
+    sierra::nalu::get_if_present(node, "use_cusparse_sgemm", use_cusparse_sgemm, use_cusparse_sgemm);
+  }
+
+#ifdef HYPRE_USING_DEVICE_POOL
+    /* To be effective, hypre_SetCubMemPoolSize must immediately follow HYPRE_Init */
+    HYPRE_SetGPUMemoryPoolSize( mempool_bin_growth, mempool_min_bin,
+                                mempool_max_bin, mempool_max_cached_bytes );
+#endif
+
+  HYPRE_SetSpGemmUseCusparse(use_cusparse_sgemm);
   HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE);
   HYPRE_SetExecutionPolicy(HYPRE_EXEC_DEVICE);
   HYPRE_SetUseGpuRand(true);
 }
+
+
+inline void hypre_set_params()
+{
+#ifdef HYPRE_USING_DEVICE_POOL
+  /* device pool allocator */
+  hypre_uint mempool_bin_growth   = 8,
+             mempool_min_bin      = 3,
+             mempool_max_bin      = 9;
+  size_t mempool_max_cached_bytes = 2000LL * 1024 * 1024;
+
+  /* To be effective, hypre_SetCubMemPoolSize must immediately follow HYPRE_Init */
+  HYPRE_SetGPUMemoryPoolSize( mempool_bin_growth, mempool_min_bin,
+                              mempool_max_bin, mempool_max_cached_bytes );
+#endif
+
+  HYPRE_SetSpGemmUseCusparse(false);
+  HYPRE_SetMemoryLocation(HYPRE_MEMORY_DEVICE);
+  HYPRE_SetExecutionPolicy(HYPRE_EXEC_DEVICE);
+  HYPRE_SetUseGpuRand(true);
+}
+
 
 inline void hypre_finalize()
 {
@@ -43,6 +98,13 @@ inline void hypre_finalize()
 
 inline void hypre_initialize() {
 }
+
+inline void hypre_set_params(YAML::Node nodes) {
+}
+
+inline void hypre_set_params() {
+}
+
 inline void hypre_finalize() {
 }
 

--- a/include/HypreUVWLinearSystem.h
+++ b/include/HypreUVWLinearSystem.h
@@ -195,8 +195,6 @@ public:
 protected:
   virtual void finalizeLinearSystem();
 
-  virtual void finalizeSolver();
-
   virtual void loadCompleteSolver();
 
 private:

--- a/include/LinearSolverConfig.h
+++ b/include/LinearSolverConfig.h
@@ -146,9 +146,6 @@ public:
   inline bool getWritePreassemblyMatrixFiles() const
   { return writePreassemblyMatrixFiles_; }
 
-  inline bool getUseCusparseSGEMM() const
-  { return useCusparseSGEMM_; }
-
 protected:
   //! List of HYPRE API calls and corresponding arugments to configure solver
   //! and preconditioner after they are created.
@@ -191,7 +188,6 @@ protected:
   bool simpleHypreMatrixAssemble_{false};
   bool dumpHypreMatrixStats_{false};
   bool writePreassemblyMatrixFiles_{false};
-  bool useCusparseSGEMM_{false};
 
 private:
   void boomerAMG_solver_config(const YAML::Node&);

--- a/nalu.C
+++ b/nalu.C
@@ -82,7 +82,7 @@ int main( int argc, char ** argv )
   nalu_hypre::hypre_initialize();
 
   {
-  
+
   stk::diag::setEnabledTimerMetricsMask(stk::diag::METRICS_CPU_TIME | stk::diag::METRICS_WALL_TIME);
 
   sierra::nalu::Simulation::rootTimer().start();
@@ -163,6 +163,9 @@ int main( int argc, char ** argv )
     if (!naluEnv.parallel_rank())
       sierra::nalu::NaluParsingHelper::emit(std::cout, doc);
   }
+
+  // Hypre general parameter setting
+  nalu_hypre::hypre_set_params(doc);
 
   sierra::nalu::Simulation sim(doc);
   if (serializedIOGroupSize) {

--- a/reg_tests/hypre_settings/hypre_blade_resolved.yaml
+++ b/reg_tests/hypre_settings/hypre_blade_resolved.yaml
@@ -3,7 +3,6 @@ hypre_simple_precon:
   bamg_relax_type: 12 # Use 11 for Hypre master or v2.21 and later, 8 for earlier
   bamg_num_sweeps: 2
   bamg_relax_order: 0
-  bamg_use_cusparse_sgemm: no
 
 hypre_elliptic:
   bamg_max_levels: 7
@@ -22,4 +21,3 @@ hypre_elliptic:
   bamg_agg_pmax_elmts: 3
   bamg_pmax_elmts: 3
   bamg_strong_threshold: 0.25
-  bamg_use_cusparse_sgemm: no

--- a/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypre/ablNeutralNGPHypre.yaml
@@ -3,6 +3,10 @@ Simulations:
     time_integrator: ti_1
     optimizer: opt1
 
+# Hypre memory and other configurations
+hypre_config:
+    memory_pool_mbs: 1500
+    use_cusparse_sgemm: no
 
 # Specify the linear system solvers.
 linear_solvers:

--- a/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
+++ b/reg_tests/test_files/ablNeutralNGPHypreSegregated/ablNeutralNGPHypreSegregated.yaml
@@ -3,6 +3,10 @@ Simulations:
     time_integrator: ti_1
     optimizer: opt1
 
+# Hypre memory and other configurations
+hypre_config:
+    memory_pool_mbs: 1500
+    use_cusparse_sgemm: no
 
 # Specify the linear system solvers.
 linear_solvers:

--- a/reg_tests/test_files/airfoilRANSEdgeNGPHypre.rst/airfoilRANSEdgeNGPHypre.rst.yaml
+++ b/reg_tests/test_files/airfoilRANSEdgeNGPHypre.rst/airfoilRANSEdgeNGPHypre.rst.yaml
@@ -10,6 +10,11 @@ Simulations:
     time_integrator: ti_1
     optimizer: opt1
 
+# Hypre memory and other configurations
+hypre_config:
+    memory_pool_mbs: 1500
+    use_cusparse_sgemm: no
+
 linear_solvers:
 
   - name: solve_mom

--- a/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.yaml
+++ b/reg_tests/test_files/oversetRotCylNGPHypre/oversetRotCylNGPHypre.yaml
@@ -5,6 +5,11 @@ Simulations:
     time_integrator: ti_1
     optimizer: opt1
 
+# Hypre memory and other configurations
+hypre_config:
+    memory_pool_mbs: 1500
+    use_cusparse_sgemm: no
+
 linear_solvers:
 
   - name: solve_mom

--- a/src/HypreLinearSolverConfig.C
+++ b/src/HypreLinearSolverConfig.C
@@ -126,7 +126,6 @@ HypreLinearSolverConfig::boomerAMG_solver_config(const YAML::Node& node)
   get_if_present(node, "bamg_num_sweeps", bamgNumSweeps_, bamgNumSweeps_);
   get_if_present(node, "bamg_max_levels", bamgMaxLevels_, bamgMaxLevels_);
   get_if_present(node, "bamg_strong_threshold", bamgStrongThreshold_, bamgStrongThreshold_);
-  get_if_present(node, "bamg_use_cusparse_sgemm", useCusparseSGEMM_, useCusparseSGEMM_);
 
   // Setup AMG parameters
   funcParams_.resize(10);
@@ -192,7 +191,6 @@ HypreLinearSolverConfig::boomerAMG_precond_config(const YAML::Node& node)
   get_if_present(node, "bamg_output_level", output_level, output_level);
   get_if_present(node, "bamg_logging", logging, logging);
   get_if_present(node, "bamg_debug", debug, debug);
-  get_if_present(node, "bamg_use_cusparse_sgemm", useCusparseSGEMM_, useCusparseSGEMM_);
 
   funcParams_.push_back(Teuchos::rcp(new Ifpack2::FunctionParameter(
     Ifpack2::Hypre::Prec, &HYPRE_BoomerAMGSetPrintLevel,

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -42,11 +42,11 @@ HypreLinearSystem::HypreLinearSystem(
 
 HypreLinearSystem::~HypreLinearSystem()
 {
-  if (systemInitialized_) {
+  if (hypreMatrixVectorsCreated_) {
     HYPRE_IJMatrixDestroy(mat_);
     HYPRE_IJVectorDestroy(rhs_);
     HYPRE_IJVectorDestroy(sln_);
-    systemInitialized_ = false;
+    hypreMatrixVectorsCreated_ = false;
   }
 
 #ifdef HYPRE_LINEAR_SYSTEM_TIMER
@@ -852,9 +852,6 @@ HypreLinearSystem::finalizeLinearSystem()
   /* fill the various device data structures need in device coeff applier */
   buildCoeffApplierDeviceDataStructures();
 
-  /* Call finalize solver here */
-  finalizeSolver();
-
   /* compute the exact row sizes by reducing row counts at row indices across all ranks */
   computeRowSizes();
 
@@ -870,10 +867,6 @@ HypreLinearSystem::finalizeLinearSystem()
           used2 / 1.e9, total / 1.e9);
   fclose(output_);
 #endif
-
-  // At this stage the LHS and RHS data structures are ready for
-  // sumInto/assembly.
-  systemInitialized_ = true;
 
 #ifdef HYPRE_LINEAR_SYSTEM_TIMER
   gettimeofday(&_stop, NULL);
@@ -980,40 +973,6 @@ HypreLinearSystem::computeRowSizes()
 
   rhs_rows_dev_ = HypreIntTypeView2D("rhs_rows_dev", totalRhsElmts, hcApplier->nDim_);
   Kokkos::deep_copy(rhs_rows_dev_, rhs_rows_host_);
-}
-
-
-void
-HypreLinearSystem::finalizeSolver()
-{
-  MPI_Comm comm = realm_.bulk_data().parallel();
-
-  // Now perform HYPRE assembly so that the data structures are ready to be used
-  // by the solvers/preconditioners.
-  HypreDirectSolver* solver =
-    reinterpret_cast<HypreDirectSolver*>(linearSolver_);
-
-  if (systemInitialized_) {
-    HYPRE_IJMatrixDestroy(mat_);
-    HYPRE_IJVectorDestroy(rhs_);
-    HYPRE_IJVectorDestroy(sln_);
-    systemInitialized_ = false;
-  }
-
-  HYPRE_IJMatrixCreate(comm, iLower_, iUpper_, jLower_, jUpper_, &mat_);
-  HYPRE_IJMatrixSetObjectType(mat_, HYPRE_PARCSR);
-  HYPRE_IJMatrixInitialize(mat_);
-  HYPRE_IJMatrixGetObject(mat_, (void**)&(solver->parMat_));
-
-  HYPRE_IJVectorCreate(comm, iLower_, iUpper_, &rhs_);
-  HYPRE_IJVectorSetObjectType(rhs_, HYPRE_PARCSR);
-  HYPRE_IJVectorInitialize(rhs_);
-  HYPRE_IJVectorGetObject(rhs_, (void**)&(solver->parRhs_));
-
-  HYPRE_IJVectorCreate(comm, iLower_, iUpper_, &sln_);
-  HYPRE_IJVectorSetObjectType(sln_, HYPRE_PARCSR);
-  HYPRE_IJVectorInitialize(sln_);
-  HYPRE_IJVectorGetObject(sln_, (void**)&(solver->parSln_));
 }
 
 /**************************************************************/
@@ -1536,7 +1495,7 @@ HypreLinearSystem::hypreIJMatrixSetAddToValues()
   if (config->getWritePreassemblyMatrixFiles()) {
     MPI_Barrier(realm_.bulk_data().parallel());
 
-    char rank_str[5];
+    char rank_str[8];
     sprintf(rank_str, "%05d", rank_);
     std::string writeCounter = std::to_string(eqSys_->linsysWriteCounter_);
     const std::string matFileRows = eqSysName_ + ".IJM." + writeCounter + ".mat." + std::string(rank_str) + ".preassem.i";
@@ -1611,7 +1570,7 @@ HypreLinearSystem::hypreIJVectorSetAddToValues()
   if (config->getWritePreassemblyMatrixFiles()) {
     MPI_Barrier(realm_.bulk_data().parallel());
 
-    char rank_str[5];
+    char rank_str[8];
     sprintf(rank_str, "%05d", rank_);
     std::string writeCounter = std::to_string(eqSys_->linsysWriteCounter_);
     const std::string rhsFileRows = eqSysName_ + ".IJV." + writeCounter + ".rhs." + std::string(rank_str) + ".preassem.i";
@@ -1805,10 +1764,6 @@ HypreLinearSystem::loadCompleteSolver()
     dumpMatrixStats();
     matrixStatsDumped_ = true;
   }
-
-  // Set flag to indicate zeroSystem that the matrix must be reinitialized
-  // during the next invocation.
-  matrixAssembled_ = true;
 }
 
 void
@@ -1861,33 +1816,41 @@ HypreLinearSystem::zeroSystem()
   HypreDirectSolver* solver =
     reinterpret_cast<HypreDirectSolver*>(linearSolver_);
 
-#ifdef HYPRE_LINEAR_SYSTEM_DEBUG
-  sprintf(oname_,"debug_out_%d.txt",rank_);
-  output_ = fopen(oname_, "wt");
-  fprintf(output_, "rank_=%d EqnName=%s : %s %s %d\n",
-          rank_, name_.c_str(), __FILE__, __FUNCTION__, __LINE__);
-  fclose(output_);
-#endif
+  MPI_Comm comm = realm_.bulk_data().parallel();
 
-  // It is unsafe to call IJMatrixInitialize multiple times without intervening
-  // call to IJMatrixAssemble. This occurs during the first outer iteration (of
-  // first timestep in static application and every timestep in moving mesh
-  // applications) when the data structures have been created but never used and
-  // zeroSystem is called for a reset. Include a check to ensure we only
-  // initialize if it was previously assembled.
-  if (matrixAssembled_) {
-    HYPRE_IJMatrixInitialize(mat_);
-    HYPRE_IJVectorInitialize(rhs_);
-    HYPRE_IJVectorInitialize(sln_);
+   if (hypreMatrixVectorsCreated_) {
+ #ifdef HYPRE_LINEAR_SYSTEM_DEBUG
+       sprintf(oname_,"debug_out_%d.txt",rank_);
+       output_ = fopen(oname_, "wt");
+       fprintf(output_, "rank_=%d EqnName=%s : %s %s %d\n",
+               rank_, name_.c_str(), __FILE__, __FUNCTION__, __LINE__);
+       fclose(output_);
+ #endif
+     HYPRE_IJMatrixDestroy(mat_);
+     HYPRE_IJVectorDestroy(rhs_);
+     HYPRE_IJVectorDestroy(sln_);
+     hypreMatrixVectorsCreated_ = false;
+   }
 
-    // Set flag to false until next invocation of IJMatrixAssemble in
-    // loadComplete
-    matrixAssembled_ = false;
-  }
+   HYPRE_IJMatrixCreate(comm, iLower_, iUpper_, jLower_, jUpper_, &mat_);
+   HYPRE_IJMatrixSetObjectType(mat_, HYPRE_PARCSR);
+   HYPRE_IJMatrixInitialize(mat_);
+   HYPRE_IJMatrixGetObject(mat_, (void**)&(solver->parMat_));
+   HYPRE_IJMatrixSetConstantValues(mat_, 0.0);
 
-  HYPRE_IJMatrixSetConstantValues(mat_, 0.0);
-  HYPRE_ParVectorSetConstantValues(solver->parRhs_, 0.0);
-  HYPRE_ParVectorSetConstantValues(solver->parSln_, 0.0);
+   HYPRE_IJVectorCreate(comm, iLower_, iUpper_, &rhs_);
+   HYPRE_IJVectorSetObjectType(rhs_, HYPRE_PARCSR);
+   HYPRE_IJVectorInitialize(rhs_);
+   HYPRE_IJVectorGetObject(rhs_, (void**)&(solver->parRhs_));
+   HYPRE_ParVectorSetConstantValues(solver->parRhs_, 0.0);
+
+   HYPRE_IJVectorCreate(comm, iLower_, iUpper_, &sln_);
+   HYPRE_IJVectorSetObjectType(sln_, HYPRE_PARCSR);
+   HYPRE_IJVectorInitialize(sln_);
+   HYPRE_IJVectorGetObject(sln_, (void**)&(solver->parSln_));
+   HYPRE_ParVectorSetConstantValues(solver->parSln_, 0.0);
+
+   hypreMatrixVectorsCreated_ = true;
 }
 
 sierra::nalu::CoeffApplier*
@@ -2375,9 +2338,6 @@ HypreLinearSystem::solve(stk::mesh::FieldBase* linearSolutionField)
   // Call solve
   int status = 0;
 
-  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
-  HYPRE_SetSpGemmUseCusparse(config->getUseCusparseSGEMM());
-
 #ifdef HYPRE_LINEAR_SYSTEM_DEBUG
   output_ = fopen(oname_, "at");
   fprintf(output_, "%s %s %d %s : rank=%d\n",__FILE__,__FUNCTION__,__LINE__,eqSysName_.c_str(),rank_);
@@ -2398,6 +2358,8 @@ HypreLinearSystem::solve(stk::mesh::FieldBase* linearSolutionField)
     const std::string slnFile = eqSysName_ + ".IJV." + writeCounter + ".sln";
     HYPRE_IJVectorPrint(sln_, slnFile.c_str());
   }
+
+  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
   if (solver->getConfig()->getWriteMatrixFiles() || config->getWritePreassemblyMatrixFiles()) {
     ++eqSys_->linsysWriteCounter_;
   }

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -32,7 +32,7 @@ HypreUVWLinearSystem::HypreUVWLinearSystem(
 
 HypreUVWLinearSystem::~HypreUVWLinearSystem()
 {
-  if (systemInitialized_) {
+  if (hypreMatrixVectorsCreated_) {
     HYPRE_IJMatrixDestroy(mat_);
 
     for (unsigned i = 0; i < nDim_; ++i) {
@@ -40,7 +40,7 @@ HypreUVWLinearSystem::~HypreUVWLinearSystem()
       HYPRE_IJVectorDestroy(sln_[i]);
     }
   }
-  systemInitialized_ = false;
+  hypreMatrixVectorsCreated_ = false;
 }
 
 void
@@ -81,9 +81,6 @@ HypreUVWLinearSystem::finalizeLinearSystem()
   /* fill the various device data structures need in device coeff applier */
   buildCoeffApplierDeviceDataStructures();
 
-  /* Call finalize solver here */
-  finalizeSolver();
-
   /* compute the exact row sizes by reducing row counts at row indices across all ranks */
   computeRowSizes();
 
@@ -100,10 +97,6 @@ HypreUVWLinearSystem::finalizeLinearSystem()
   fclose(output_);
 #endif
 
-  // At this stage the LHS and RHS data structures are ready for
-  // sumInto/assembly.
-  systemInitialized_ = true;
-
 #ifdef HYPRE_LINEAR_SYSTEM_TIMER
   gettimeofday(&_stop, NULL);
   double msec = (double)(_stop.tv_usec - _start.tv_usec) / 1.e3 +
@@ -112,32 +105,6 @@ HypreUVWLinearSystem::finalizeLinearSystem()
 #endif
 }
 
-void
-HypreUVWLinearSystem::finalizeSolver()
-{
-
-  MPI_Comm comm = realm_.bulk_data().parallel();
-  // Now perform HYPRE assembly so that the data structures are ready to be used
-  // by the solvers/preconditioners.
-  HypreUVWSolver* solver = reinterpret_cast<HypreUVWSolver*>(linearSolver_);
-
-  HYPRE_IJMatrixCreate(comm, iLower_, iUpper_, jLower_, jUpper_, &mat_);
-  HYPRE_IJMatrixSetObjectType(mat_, HYPRE_PARCSR);
-  HYPRE_IJMatrixInitialize(mat_);
-  HYPRE_IJMatrixGetObject(mat_, (void**)&(solver->parMat_));
-
-  for (unsigned i = 0; i < nDim_; ++i) {
-    HYPRE_IJVectorCreate(comm, iLower_, iUpper_, &rhs_[i]);
-    HYPRE_IJVectorSetObjectType(rhs_[i], HYPRE_PARCSR);
-    HYPRE_IJVectorInitialize(rhs_[i]);
-    HYPRE_IJVectorGetObject(rhs_[i], (void**)&(solver->parRhsU_[i]));
-
-    HYPRE_IJVectorCreate(comm, iLower_, iUpper_, &sln_[i]);
-    HYPRE_IJVectorSetObjectType(sln_[i], HYPRE_PARCSR);
-    HYPRE_IJVectorInitialize(sln_[i]);
-    HYPRE_IJVectorGetObject(sln_[i], (void**)&(solver->parSlnU_[i]));
-  }
-}
 
 void
 HypreUVWLinearSystem::hypreIJVectorSetAddToValues()
@@ -164,7 +131,7 @@ HypreUVWLinearSystem::hypreIJVectorSetAddToValues()
     if (config->getWritePreassemblyMatrixFiles()) {
       MPI_Barrier(realm_.bulk_data().parallel());
 
-      char rank_str[5];
+      char rank_str[8];
       sprintf(rank_str, "%05d", rank_);
       std::string writeCounter = std::to_string(eqSys_->linsysWriteCounter_);
       const std::string rhsFileRows = eqSysName_ + std::to_string(i) +  ".IJV." + writeCounter + ".rhs." + std::string(rank_str) + ".preassem.i";
@@ -327,8 +294,6 @@ HypreUVWLinearSystem::loadCompleteSolver()
     dumpMatrixStats();
     matrixStatsDumped_ = true;
   }
-
-  matrixAssembled_ = true;
 }
 
 void
@@ -336,29 +301,45 @@ HypreUVWLinearSystem::zeroSystem()
 {
   HypreUVWSolver* solver = reinterpret_cast<HypreUVWSolver*>(linearSolver_);
 
-#ifdef HYPRE_LINEAR_SYSTEM_DEBUG
-  sprintf(oname_,"debug_out_%d.txt",rank_);
-  output_ = fopen(oname_, "wt");
-  fprintf(output_, "rank_=%d EqnName=%s : %s %s %d\n",
-          rank_, name_.c_str(), __FILE__, __FUNCTION__, __LINE__);
-  fclose(output_);
-#endif
+  MPI_Comm comm = realm_.bulk_data().parallel();
 
-  if (matrixAssembled_) {
-    HYPRE_IJMatrixInitialize(mat_);
-    for (unsigned i = 0; i < nDim_; ++i) {
-      HYPRE_IJVectorInitialize(rhs_[i]);
-      HYPRE_IJVectorInitialize(sln_[i]);
-    }
+   if (hypreMatrixVectorsCreated_) {
+ #ifdef HYPRE_LINEAR_SYSTEM_DEBUG
+       sprintf(oname_,"debug_out_%d.txt",rank_);
+       output_ = fopen(oname_, "wt");
+       fprintf(output_, "rank_=%d EqnName=%s : %s %s %d\n",
+               rank_, name_.c_str(), __FILE__, __FUNCTION__, __LINE__);
+       fclose(output_);
+ #endif
+     HYPRE_IJMatrixDestroy(mat_);
+     for (unsigned i = 0; i < nDim_; ++i) {
+       HYPRE_IJVectorDestroy(rhs_[i]);
+       HYPRE_IJVectorDestroy(sln_[i]);
+     }
+     hypreMatrixVectorsCreated_ = false;
+   }
 
-    matrixAssembled_ = false;
-  }
 
-  HYPRE_IJMatrixSetConstantValues(mat_, 0.0);
-  for (unsigned i = 0; i < nDim_; ++i) {
-    HYPRE_ParVectorSetConstantValues((solver->parRhsU_[i]), 0.0);
-    HYPRE_ParVectorSetConstantValues((solver->parSlnU_[i]), 0.0);
-  }
+   HYPRE_IJMatrixCreate(comm, iLower_, iUpper_, jLower_, jUpper_, &mat_);
+   HYPRE_IJMatrixSetObjectType(mat_, HYPRE_PARCSR);
+   HYPRE_IJMatrixInitialize(mat_);
+   HYPRE_IJMatrixGetObject(mat_, (void**)&(solver->parMat_));
+   HYPRE_IJMatrixSetConstantValues(mat_, 0.0);
+
+   for (unsigned i = 0; i < nDim_; ++i) {
+     HYPRE_IJVectorCreate(comm, iLower_, iUpper_, &rhs_[i]);
+     HYPRE_IJVectorSetObjectType(rhs_[i], HYPRE_PARCSR);
+     HYPRE_IJVectorInitialize(rhs_[i]);
+     HYPRE_IJVectorGetObject(rhs_[i], (void**)&(solver->parRhsU_[i]));
+     HYPRE_ParVectorSetConstantValues((solver->parRhsU_[i]), 0.0);
+
+     HYPRE_IJVectorCreate(comm, iLower_, iUpper_, &sln_[i]);
+     HYPRE_IJVectorSetObjectType(sln_[i], HYPRE_PARCSR);
+     HYPRE_IJVectorInitialize(sln_[i]);
+     HYPRE_IJVectorGetObject(sln_[i], (void**)&(solver->parSlnU_[i]));
+     HYPRE_ParVectorSetConstantValues((solver->parSlnU_[i]), 0.0);
+   }
+   hypreMatrixVectorsCreated_ = true;
 }
 
 void
@@ -436,9 +417,6 @@ HypreUVWLinearSystem::solve(stk::mesh::FieldBase* slnField)
   std::vector<double> finalNorm(nDim_, 1.0);
   std::vector<double> rhsNorm(nDim_, std::numeric_limits<double>::max());
 
-  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
-  HYPRE_SetSpGemmUseCusparse(config->getUseCusparseSGEMM());
-
 #ifdef HYPRE_LINEAR_SYSTEM_DEBUG
   output_ = fopen(oname_, "at");
   fprintf(output_, "%s %s %d %s : rank=%d\n",__FILE__,__FUNCTION__,__LINE__,eqSysName_.c_str(),rank_);
@@ -467,6 +445,8 @@ HypreUVWLinearSystem::solve(stk::mesh::FieldBase* slnField)
       HYPRE_IJVectorPrint(sln_[d], slnFile.c_str());
     }
   }
+
+  HypreLinearSolverConfig* config = reinterpret_cast<HypreLinearSolverConfig*>(solver->getConfig());
   if (solver->getConfig()->getWriteMatrixFiles() || config->getWritePreassemblyMatrixFiles()) {
     ++eqSys_->linsysWriteCounter_;
   }


### PR DESCRIPTION
In the previous model, Hypre matrices and vectors were created only once. We attempted to reuse these data structures, in subsequent time steps or picard iters, by calling HYPRE_IJMatrixInitialize and then HYPRE_IJMatrixAssemble. However, recent nrel5mw sims have shown that certain MPI/GPU communication data structures, internal to Hypre, lose their validity between different assemble calls at different time steps. Nonetheless, HYPRE routines like SpMV try to use these data structures and seg fault.  These sims shows changes in the size of the matrices/vectors that needs new versions of these Hypre communicators. Ideally, recalling HYPRE_IJMatrixInitialize should rebuild these however I have not been able to make that work. The alternative is let the application delete and rebuild the HYPRE matrices and vectors every time Hypre Assembly is needed. This isn't that big an issue as these routines are cheap especially when using device memory pools. Essentially, I moved matrix/vector creation and initialization inside zeroSystem and eliminated finalizeSolver. This guarantees that we have clean internal Hypre data structures.


**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
