### PR TITLE
Bug fix: OpenFAST ServoDyn input file syntax

### DIFF
--- a/reg_tests/test_files/nrel5MWactuatorLine/NRELOffshrBsline5MW_Onshore_ServoDyn.dat.in
+++ b/reg_tests/test_files/nrel5MWactuatorLine/NRELOffshrBsline5MW_Onshore_ServoDyn.dat.in
@@ -73,11 +73,6 @@ True          GenTiStp     - Method to stop the generator {T: timed using TimGen
 "unused"      SStCfiles    - Name of the files for substructure structural controllers (quoted strings) [unused when NumSStC==0]
 ---------------------- CABLE CONTROL -------------------------------------------
           0   CCmode       - Cable control mode {0: none, 4: user-defined from Simulink/Labview, 5: user-defined from Bladed-style DLL} (switch)
----------------------- TUNED MASS DAMPER ---------------------------------------
-False         CompNTMD     - Compute nacelle tuned mass damper {true/false} (flag)
-"NRELOffshrBsline5MW_ServoDyn_TMD.dat"    NTMDfile     - Name of the file for nacelle tuned mass damper (quoted string) [unused when CompNTMD is false]
-False         CompTTMD     - Compute tower tuned mass damper {true/false} (flag)
-"NRELOffshrBsline5MW_ServoDyn_TMD.dat"    TTMDfile     - Name of the file for tower tuned mass damper (quoted string) [unused when CompTTMD is false]
 ---------------------- BLADED INTERFACE ---------------------------------------- [used only with Bladed Interface]
 "ServoData/@NREL5MW_DISCON_LIB@"    DLL_FileName - Name/location of the dynamic library {.dll [Windows] or .so [Linux]} in the Bladed-DLL format (-) [used only with Bladed Interface]
 "DISCON.IN"    DLL_InFile   - Name of input file sent to the DLL (-) [used only with Bladed Interface]


### PR DESCRIPTION
**Pull-request type:**
- [X] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

Removes an extra and invalid section of the ServoDyn input file for the OpenFAST-coupled regression tests.

Tested with OpenFAST standalone (switched the inflow conditions to steady wind) and it runs successfully after compiling the controller library.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [ ] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
