### PR TITLE
Hypre/Kokkos compute-sanitizer fix

### DIFF
--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -2450,6 +2450,11 @@ HypreLinearSystem::copy_hypre_to_stk(stk::mesh::FieldBase* stkField)
 
   /********************/
   /* Compute RHS norm */
+#if 1
+  /* Use Hypre internal APIs */
+  double gblnorm2 = hypre_ParVectorInnerProd ( (hypre_ParVector*)hypre_IJVectorObject(rhs_),
+                                               (hypre_ParVector*)hypre_IJVectorObject(rhs_) );
+#else
   double rhsnorm2 = 0.0;
 
   /* use internal hypre APIs to get directly at the pointer to the owned RHS
@@ -2466,6 +2471,7 @@ HypreLinearSystem::copy_hypre_to_stk(stk::mesh::FieldBase* stkField)
 
   double gblnorm2 = 0.0;
   stk::all_reduce_sum(bulk.parallel(), &rhsnorm2, &gblnorm2, 1);
+#endif
 
 #ifdef HYPRE_LINEAR_SYSTEM_DEBUG
   scanBufferForBadValues(rhs_data, N, __FILE__,__FUNCTION__,__LINE__,"RHS");

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -592,6 +592,12 @@ HypreUVWLinearSystem::copy_hypre_to_stk(
   /* Compute RHS norm */
   std::vector<double> rhsnorm(nDim);
   std::fill(rhsnorm.begin(), rhsnorm.end(), 0);
+#if 1
+   /* Use Hypre internal APIs */
+   for (unsigned d = 0; d < nDim; ++d)
+       rhsNorm[d] = hypre_ParVectorInnerProd ( (hypre_ParVector*)hypre_IJVectorObject(rhs_[d]),
+                                               (hypre_ParVector*)hypre_IJVectorObject(rhs_[d]) );
+#else
 
   for (unsigned d = 0; d < nDim; ++d) {
     double* rhs_data = hypre_VectorData(hypre_ParVectorLocalVector(
@@ -605,9 +611,9 @@ HypreUVWLinearSystem::copy_hypre_to_stk(
       rhsnorm[d]);
   }
 
-  /* initialize this */
-  std::fill(rhsNorm.begin(), rhsNorm.end(), 0);
   stk::all_reduce_sum(bulk.parallel(), rhsnorm.data(), rhsNorm.data(), nDim);
+#endif
+
   for (unsigned i = 0; i < nDim; ++i)
     rhsNorm[i] = std::sqrt(rhsNorm[i]);
 


### PR DESCRIPTION
Using internal hypre apis for performing vector reductions. This avoids the compute-sanitizer racecheck garbage seen in kokkos parallel reduce


**Pull-request type:**
- [x] Bug fix 
- [ ] Documentation update
- [ ] Feature enhancement

## Description of the pull-request

*Provide a description of your proposed changes. If there is a related issue, please specify.**

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [ ] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [ ] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [x] NVIDIA CUDA
- [ ] Compiles without warnings
- [ ] Passes all unit tests
- [ ] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [ ] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
