### PR TITLE
Add subsampling spinnerlidar

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -81,6 +81,7 @@ class SolutionNormPostProcessing;
 class SideWriterContainer;
 class TurbulenceAveragingPostProcessing;
 class DataProbePostProcessing;
+class LidarLineOfSite;
 struct ActuatorModel;
 class ABLForcingAlgorithm;
 class BdyLayerStatistics;
@@ -455,6 +456,7 @@ class Realm {
   BdyLayerStatistics* bdyLayerStats_{nullptr};
   std::unique_ptr<MeshMotionAlg> meshMotionAlg_;
   std::unique_ptr<MeshTransformationAlg> meshTransformationAlg_;
+  std::unique_ptr<LidarLineOfSite> lidarLOS_;
 
   std::vector<Algorithm *> propertyAlg_;
   std::map<PropertyIdentifier, ScalarFieldType *> propertyMap_;

--- a/include/wind_energy/SyntheticLidar.h
+++ b/include/wind_energy/SyntheticLidar.h
@@ -1,8 +1,18 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
 
 #ifndef SyntheticLidar_H
 #define SyntheticLidar_H
 
 #include <DataProbePostProcessing.h>
+
+#include "xfer/LocalVolumeSearch.h"
 
 #include <memory>
 #include <array>
@@ -13,46 +23,58 @@ namespace nalu {
 struct Segment
 {
   Segment() = default;
-  Segment(std::array<double, 3> tip, std::array<double,3> tail)
-  : tip_(tip), tail_(tail) {};
+  Segment(std::array<double, 3> tip, std::array<double, 3> tail)
+    : tip_(tip), tail_(tail){};
 
   std::array<double, 3> tip_{{}};
   std::array<double, 3> tail_{{}};
 };
 
-struct PrismParameters{
+struct PrismParameters
+{
   PrismParameters() = default;
   PrismParameters(double theta0, double rot, double azimuth)
-  : theta0_{theta0}, rot_{rot}, azimuth_{azimuth}
-  {};
+    : theta0_{theta0}, rot_{rot}, azimuth_{azimuth} {};
 
-  double theta0_{0}; // rad
-  double rot_{0}; // rad / s
+  double theta0_{0};  // rad
+  double rot_{0};     // rad / s
   double azimuth_{0}; // rad
 };
 
 class SpinnerLidarSegmentGenerator
 {
 public:
-
   SpinnerLidarSegmentGenerator() = default;
 
   SpinnerLidarSegmentGenerator(
-    PrismParameters inner,
-    PrismParameters outer,
-    double in_beamLength);
+    PrismParameters inner, PrismParameters outer, double in_beamLength);
 
   void load(const YAML::Node& node);
 
   Segment generate_path_segment(double time) const;
 
   void set_inner_prism(PrismParameters innerPrism) { innerPrism_ = innerPrism; }
-  void set_inner_prism(double theta0, double rot, double azi) { innerPrism_ = {theta0, rot, azi}; }
+  void set_inner_prism(double theta0, double rot, double azi)
+  {
+    innerPrism_ = {theta0, rot, azi};
+  }
   void set_outer_prism(PrismParameters outerPrism) { outerPrism_ = outerPrism; }
-  void set_outer_prism(double theta0, double rot, double azi) { outerPrism_ = {theta0, rot, azi}; }
-  void set_lidar_center(Coordinates lidarCenter) { lidarCenter_ = {{lidarCenter.x_, lidarCenter.y_, lidarCenter.z_}}; }
-  void set_laser_axis(Coordinates laserAxis) { laserAxis_ = {{laserAxis.x_, laserAxis.y_, laserAxis.z_}}; }
-  void set_ground_normal(Coordinates gNormal) { groundNormal_ = {{gNormal.x_, gNormal.y_, gNormal.z_}}; }
+  void set_outer_prism(double theta0, double rot, double azi)
+  {
+    outerPrism_ = {theta0, rot, azi};
+  }
+  void set_lidar_center(Coordinates lidarCenter)
+  {
+    lidarCenter_ = {{lidarCenter.x_, lidarCenter.y_, lidarCenter.z_}};
+  }
+  void set_laser_axis(Coordinates laserAxis)
+  {
+    laserAxis_ = {{laserAxis.x_, laserAxis.y_, laserAxis.z_}};
+  }
+  void set_ground_normal(Coordinates gNormal)
+  {
+    groundNormal_ = {{gNormal.x_, gNormal.y_, gNormal.z_}};
+  }
   void set_beam_length(double beamLength) { beamLength_ = beamLength; }
 
 private:
@@ -60,33 +82,59 @@ private:
   PrismParameters outerPrism_;
   double beamLength_{1.0};
 
-  std::array<double, 3> lidarCenter_{{0,0,0}};
-  std::array<double, 3> laserAxis_{{1,0,0}};
-  std::array<double, 3> groundNormal_{{0,0,1}};
+  std::array<double, 3> lidarCenter_{{0, 0, 0}};
+  std::array<double, 3> laserAxis_{{1, 0, 0}};
+  std::array<double, 3> groundNormal_{{0, 0, 1}};
 };
 
 class LidarLineOfSite
 {
 public:
   LidarLineOfSite() = default;
-  std::unique_ptr<DataProbeSpecInfo> determine_line_of_site_info(const YAML::Node& node);
-private:
   void load(const YAML::Node& node);
 
+  std::unique_ptr<DataProbeSpecInfo>
+  determine_line_of_site_info(const YAML::Node& node);
+
+  double time() { return lidar_time_; }
+  void set_time(double t) { lidar_time_ = t; }
+  void increment_time() { lidar_time_ += lidar_dt_; }
+
+  void output(
+    const stk::mesh::BulkData& bulk,
+    const stk::mesh::Selector& active,
+    const std::string& coordinates_name,
+    double dtratio);
+
+private:
+  enum class Output { NETCDF, TEXT, DATAPROBE } output_type_{Output::NETCDF};
   SpinnerLidarSegmentGenerator segGen;
 
+  void prepare_nc_file();
+  void output_nc(
+    double time,
+    const std::vector<std::array<double, 3>>& x,
+    const std::vector<std::array<double, 3>>& u);
+  void output_txt(
+    double time,
+    const std::vector<std::array<double, 3>>& x,
+    const std::vector<std::array<double, 3>>& u);
+  std::map<std::string, int> ncVarIDs_;
+
+  mutable double lidar_time_{0};
+  mutable size_t internal_output_counter_{0};
+  std::unique_ptr<LocalVolumeSearchData> search_data_;
+
+  double lidar_dt_{2. / 984};
   double scanTime_{2};
   int nsamples_{984};
   int npoints_{100};
   std::vector<std::string> fromTargetNames_;
 
-  std::string name_{"lidar_line"};
-
+  std::string name_{"lidar-los"};
 };
 
-
-
-}
-}
+} // namespace nalu
+} // namespace sierra
 
 #endif

--- a/include/xfer/LocalVolumeSearch.h
+++ b/include/xfer/LocalVolumeSearch.h
@@ -1,0 +1,69 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef LOCAL_VOLUME_SEARCH_H
+#define LOCAL_VOLUME_SEARCH_H
+
+#include "stk_mesh/base/Field.hpp"
+#include "stk_mesh/base/CoordinateSystems.hpp"
+
+#include "stk_search/BoundingBox.hpp"
+#include "stk_search/IdentProc.hpp"
+
+#include <array>
+#include <vector>
+
+namespace stk {
+namespace mesh {
+class BulkData;
+class Selector;
+} // namespace mesh
+} // namespace stk
+
+namespace sierra {
+namespace nalu {
+
+// reusable allocation assuming fixed mesh graph/fixed number of points
+struct LocalVolumeSearchData
+{
+  LocalVolumeSearchData(
+    const stk::mesh::BulkData& bulk,
+    const stk::mesh::Selector& sel,
+    int npoints);
+
+  using sphere_t = stk::search::Sphere<double>;
+  using box_t = stk::search::Box<double>;
+  using ident_t = stk::search::IdentProc<stk::mesh::EntityId, int>;
+
+  std::vector<std::pair<sphere_t, ident_t>> search_points;
+  std::vector<std::pair<box_t, ident_t>> search_boxes;
+  std::vector<std::pair<ident_t, ident_t>> search_matches;
+  std::vector<std::array<double, 3>> interpolated_values;
+  std::vector<double> dist;
+  std::vector<int> ownership;
+};
+
+// interpolate to a collection of points locally
+// if the process contains the point then that the element of the second return
+// vector is marked 1
+void
+local_field_interpolation(
+  const stk::mesh::BulkData& bulk,
+  const stk::mesh::Selector& active,
+  const std::vector<std::array<double, 3>>& points,
+  const stk::mesh::Field<double, stk::mesh::Cartesian3d>& coord_field,
+  const stk::mesh::Field<double, stk::mesh::Cartesian3d>& field_nm1,
+  const stk::mesh::Field<double, stk::mesh::Cartesian3d>& field,
+  double dtratio,
+  LocalVolumeSearchData& data);
+
+} // namespace nalu
+} // namespace sierra
+
+#endif

--- a/reg_tests/test_files/ablUnstableEdge/ablUnstableEdge.yaml
+++ b/reg_tests/test_files/ablUnstableEdge/ablUnstableEdge.yaml
@@ -231,7 +231,6 @@ realms:
       search_method: stk_kdtree
       search_tolerance: 1.0e-3
       search_expansion_factor: 2.0
-
       lidar_specifications:
         from_target_part: [fluid_part]
         inner_prism_initial_theta: 90
@@ -240,13 +239,14 @@ realms:
         outer_prism_initial_theta: 90
         outer_prism_rotation_rate: 6.5
         outer_prism_azimuth: 15.2
-        scan_time: 2 #seconds
-        number_of_samples: 2
-        points_along_line: 1
+        scan_time: 2.0
+        number_of_samples: 984
+        points_along_line: 100
         center: [500,500,100]
-        beam_length: 1.0
+        beam_length: 200.0
         axis: [1,0,0]
         ground_direction: [0,0,1]
+        output: netcdf
 
 Time_Integrators:
   - StandardTimeIntegrator:

--- a/src/wind_energy/SyntheticLidar.C
+++ b/src/wind_energy/SyntheticLidar.C
@@ -1,28 +1,40 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
 
-#include <wind_energy/SyntheticLidar.h>
+#include "wind_energy/SyntheticLidar.h"
 
-#include <NaluParsing.h>
-#include <master_element/TensorOps.h>
+#include "NaluParsing.h"
+#include "master_element/TensorOps.h"
 
-#include <xfer/Transfer.h>
+#include "xfer/Transfer.h"
+#include "xfer/LocalVolumeSearch.h"
+#include "netcdf.h"
+#include "Ioss_FileInfo.h"
+
 #include <memory>
 
 namespace sierra {
 namespace nalu {
 
+constexpr int dim = 3;
+
 SpinnerLidarSegmentGenerator::SpinnerLidarSegmentGenerator(
-  PrismParameters inner,
-  PrismParameters outer,
-  double in_beamLength)
-: innerPrism_(inner),
-  outerPrism_(outer),
-  beamLength_(in_beamLength)
-{}
+  PrismParameters inner, PrismParameters outer, double in_beamLength)
+  : innerPrism_(inner), outerPrism_(outer), beamLength_(in_beamLength)
+{
+}
 
 void
 SpinnerLidarSegmentGenerator::load(const YAML::Node& node)
 {
-  NaluEnv::self().naluOutputP0() << "LidarLineOfSite::SpinnerLidarSegmentGenerator::load" << std::endl;
+  NaluEnv::self().naluOutputP0()
+    << "LidarLineOfSite::SpinnerLidarSegmentGenerator::load" << std::endl;
 
   ThrowRequireMsg(node["center"], "Lidar center must be provided");
   set_lidar_center(node["center"].as<Coordinates>());
@@ -31,7 +43,8 @@ SpinnerLidarSegmentGenerator::load(const YAML::Node& node)
   set_laser_axis(node["axis"].as<Coordinates>());
 
   double innerPrismTheta0 = 90;
-  get_if_present(node, "inner_prism_initial_theta", innerPrismTheta0, innerPrismTheta0);
+  get_if_present(
+    node, "inner_prism_initial_theta", innerPrismTheta0, innerPrismTheta0);
   innerPrismTheta0 *= M_PI / 180;
 
   double innerPrismRot = 3.5;
@@ -66,35 +79,34 @@ SpinnerLidarSegmentGenerator::load(const YAML::Node& node)
     set_ground_normal(node["ground_direction"].as<Coordinates>());
   }
 
-  ThrowRequireMsg(std::abs(ddot(groundNormal_.data(), laserAxis_.data(),3)) < small_positive_value(),
+  ThrowRequireMsg(
+    std::abs(ddot(groundNormal_.data(), laserAxis_.data(), 3)) <
+      small_positive_value(),
     "Ground and laser axes must be orthogonal");
 }
 
 namespace {
-std::array<double,3>
-rotate_euler_vec(const std::array<double, 3>& axis, double angle, std::array<double, 3> vec)
+std::array<double, 3>
+rotate_euler_vec(
+  const std::array<double, 3>& axis, double angle, std::array<double, 3> vec)
 {
-  enum {XH = 0, YH = 1, ZH = 2};
+  enum { XH = 0, YH = 1, ZH = 2 };
 
   normalize_vec3(vec.data());
 
-  std::array<double, 9> nX = {{
-      0, -axis[ZH], +axis[YH],
-      +axis[ZH], 0, -axis[XH],
-      -axis[YH], +axis[XH], 0
-  }};
+  std::array<double, 9> nX = {
+    {0, -axis[ZH], +axis[YH], +axis[ZH], 0, -axis[XH], -axis[YH], +axis[XH],
+     0}};
   const double cosTheta = std::cos(angle);
 
-  std::array<double, 9> rot = {{
-      cosTheta, 0, 0,
-      0, cosTheta, 0,
-      0, 0, cosTheta
-  }};
+  std::array<double, 9> rot = {
+    {cosTheta, 0, 0, 0, cosTheta, 0, 0, 0, cosTheta}};
 
   const double sinTheta = std::sin(angle);
   for (int j = 0; j < 3; ++j) {
     for (int i = 0; i < 3; ++i) {
-      rot[j * 3 + i] += (1 - cosTheta) * axis[i] * axis[j] + sinTheta * nX[j * 3 + i];
+      rot[j * 3 + i] +=
+        (1 - cosTheta) * axis[i] * axis[j] + sinTheta * nX[j * 3 + i];
     }
   }
 
@@ -104,21 +116,23 @@ rotate_euler_vec(const std::array<double, 3>& axis, double angle, std::array<dou
 }
 
 std::array<double, 3>
-reflect(const std::array<double, 3>& line, const std::array<double ,3>& vec)
+reflect(const std::array<double, 3>& line, const std::array<double, 3>& vec)
 {
-  enum {XH = 0, YH = 1, ZH = 2};
+  enum { XH = 0, YH = 1, ZH = 2 };
 
-  std::array<double, 9> ref = {{
-      1 - 2 * line[XH] * line[XH],   - 2 * line[XH] * line[YH],   - 2 * line[XH] * line[ZH],
-        - 2 * line[YH] * line[XH], 1 - 2 * line[YH] * line[YH],   - 2 * line[YH] * line[ZH],
-        - 2 * line[ZH] * line[XH],   - 2 * line[ZH] * line[YH], 1 - 2 * line[ZH] * line[ZH]
-  }};
+  std::array<double, 9> ref = {
+    {1 - 2 * line[XH] * line[XH], -2 * line[XH] * line[YH],
+     -2 * line[XH] * line[ZH], -2 * line[YH] * line[XH],
+     1 - 2 * line[YH] * line[YH], -2 * line[YH] * line[ZH],
+     -2 * line[ZH] * line[XH], -2 * line[ZH] * line[YH],
+     1 - 2 * line[ZH] * line[ZH]}};
 
   std::array<double, 3> result;
   matvec33(ref.data(), vec.data(), result.data());
   return result;
 }
-}
+
+} // namespace
 
 Segment
 SpinnerLidarSegmentGenerator::generate_path_segment(double time) const
@@ -130,21 +144,18 @@ SpinnerLidarSegmentGenerator::generate_path_segment(double time) const
   const double outerTheta = outerPrism_.theta0_ + outerPrism_.rot_ * time;
 
   const auto reflection_1 = rotate_euler_vec(
-    axis,
-    innerTheta,
-    rotate_euler_vec(groundNormal_, -(innerPrism_.azimuth_/2 + M_PI/2), axis )
-  );
+    axis, innerTheta,
+    rotate_euler_vec(
+      groundNormal_, -(innerPrism_.azimuth_ / 2 + M_PI / 2), axis));
 
   const auto reflection_2 = rotate_euler_vec(
-    axis,
-    outerTheta,
-    rotate_euler_vec(groundNormal_, outerPrism_.azimuth_/2, axis)
-  );
+    axis, outerTheta,
+    rotate_euler_vec(groundNormal_, outerPrism_.azimuth_ / 2, axis));
 
   Segment current;
-  current.tail_ =  lidarCenter_;
+  current.tail_ = lidarCenter_;
 
-  std::array<double,3 > reversedAxis = {{-axis[0], -axis[1], -axis[2]}};
+  std::array<double, 3> reversedAxis = {{-axis[0], -axis[1], -axis[2]}};
   current.tip_ = reflect(reflection_2, reflect(reflection_1, reversedAxis));
 
   for (int d = 0; d < 3; ++d) {
@@ -158,26 +169,264 @@ void
 LidarLineOfSite::load(const YAML::Node& node)
 {
   NaluEnv::self().naluOutputP0() << "LidarLineOfSite::load" << std::endl;
-  get_required(node, "scan_time", scanTime_);
-  get_required(node, "number_of_samples", nsamples_);
-  get_required(node, "points_along_line", npoints_);
 
+  if (node["output"]) {
+    const auto type = node["output"].as<std::string>();
+    if (type == "text") {
+      output_type_ = Output::TEXT;
+    } else if (type == "netcdf") {
+      output_type_ = Output::NETCDF;
+    } else if ("dataprobes") {
+      output_type_ = Output::DATAPROBE;
+    }
+  }
+
+  get_required(node, "points_along_line", npoints_);
   if (node["name"]) {
     name_ = node["name"].as<std::string>();
+  }
+
+  if (node["time_step"] && output_type_ != Output::DATAPROBE) {
+    lidar_dt_ = node["time_step"].as<double>();
+  } else {
+    get_required(node, "scan_time", scanTime_);
+    get_required(node, "number_of_samples", nsamples_);
+    lidar_dt_ = scanTime_ / nsamples_;
   }
 
   const YAML::Node fromTargets = node["from_target_part"];
   if (fromTargets.Type() == YAML::NodeType::Scalar) {
     fromTargetNames_.push_back(fromTargets.as<std::string>());
-  }
-  else {
-    for (const auto& target : fromTargets){
+  } else {
+    for (const auto& target : fromTargets) {
       fromTargetNames_.push_back(target.as<std::string>());
     }
   }
+
   segGen.load(node);
 }
 
+bool
+is_root(MPI_Comm comm, int root)
+{
+  int rank;
+  MPI_Comm_rank(comm, &rank);
+  return rank == root;
+}
+void
+check_nc_error(int code)
+{
+
+  if (code != 0) {
+    throw std::runtime_error(
+      "SyntheticLidar NetCDF error: " + std::string(nc_strerror(code)));
+  }
+}
+
+void
+LidarLineOfSite::prepare_nc_file()
+{
+  int ncid;
+  const auto fname = name_ + ".nc";
+  int ierr = nc_create(fname.c_str(), NC_CLOBBER, &ncid);
+  check_nc_error(ierr);
+
+  // Define dimensions for the NetCDF file
+  int tDim;
+  ierr = nc_def_dim(ncid, "num_timesteps", NC_UNLIMITED, &tDim);
+  check_nc_error(ierr);
+
+  int pDim;
+  ierr = nc_def_dim(ncid, "num_points", npoints_, &pDim);
+  check_nc_error(ierr);
+
+  int vDim;
+  ierr = nc_def_dim(ncid, "vec_dim", 3, &vDim);
+  check_nc_error(ierr);
+
+  const int vec_dim[3] = {tDim, pDim, vDim};
+
+  {
+    int varid;
+    ierr = nc_def_var(ncid, "step", NC_INT, 1, &tDim, &varid);
+    check_nc_error(ierr);
+    ncVarIDs_["step"] = varid;
+  }
+
+  auto add_ncvar = [&](std::string name, int dim, const int* const dims) {
+    int varid;
+    ierr = nc_def_var(ncid, name.c_str(), NC_DOUBLE, dim, dims, &varid);
+    check_nc_error(ierr);
+    ncVarIDs_[name] = varid;
+  };
+
+  add_ncvar("time", 1, &tDim);
+  add_ncvar("coordinates", 3, vec_dim);
+  add_ncvar("velocity", 3, vec_dim);
+
+  //! Indicate that we are done defining variables, ready to write data
+  ierr = nc_enddef(ncid);
+  check_nc_error(ierr);
+
+  ierr = nc_close(ncid);
+  check_nc_error(ierr);
+}
+
+void
+LidarLineOfSite::output_nc(
+  double time,
+  const std::vector<std::array<double, 3>>& x,
+  const std::vector<std::array<double, 3>>& u)
+{
+  if (internal_output_counter_ == 0) {
+    prepare_nc_file();
+  }
+
+  int ncid, ierr;
+  const auto fname = name_ + ".nc";
+  ierr = nc_open(fname.c_str(), NC_WRITE, &ncid);
+  check_nc_error(ierr);
+
+  size_t scalar = 1;
+  const size_t vector_list_start[] = {internal_output_counter_, 0, 0};
+  const size_t vector_list_count[] = {1, static_cast<size_t>(npoints_), 3};
+
+  const int step = static_cast<int>(internal_output_counter_);
+  ierr = nc_put_vara_int(
+    ncid, ncVarIDs_["step"], &internal_output_counter_, &scalar, &step);
+  check_nc_error(ierr);
+
+  ierr = nc_put_vara_double(
+    ncid, ncVarIDs_["time"], &internal_output_counter_, &scalar, &time);
+  check_nc_error(ierr);
+
+  ierr = nc_put_vara_double(
+    ncid, ncVarIDs_["coordinates"], vector_list_start, vector_list_count,
+    &x[0][0]);
+  check_nc_error(ierr);
+
+  ierr = nc_put_vara_double(
+    ncid, ncVarIDs_["velocity"], vector_list_start, vector_list_count,
+    &u[0][0]);
+  check_nc_error(ierr);
+
+  ierr = nc_close(ncid);
+  check_nc_error(ierr);
+
+  ++internal_output_counter_;
+}
+
+void
+LidarLineOfSite::output_txt(
+  double time,
+  const std::vector<std::array<double, 3>>& x,
+  const std::vector<std::array<double, 3>>& u)
+{
+  const auto fname = name_ + ".txt";
+  if (internal_output_counter_ == 0) {
+    Ioss::FileInfo::create_path(fname);
+    std::ofstream file{fname, std::ios_base::out};
+    file.open(fname);
+    file << "t,x,y,z,u,v,w" << std::endl;
+    file.close();
+  }
+
+  std::ofstream file;
+  file.exceptions(file.exceptions() | std::ios::failbit);
+  file.open(fname, std::ios::out | std::ios::app);
+  if (file.fail()) {
+    throw std::ios_base::failure(std::strerror(errno));
+  }
+  for (size_t j = 0; j < x.size(); ++j) {
+    file << std::setprecision(15) << time << "," << x.at(j)[0] << ","
+         << x.at(j)[1] << "," << x.at(j)[2] << "," << u.at(j)[0] << ","
+         << u.at(j)[1] << "," << u.at(j)[2] << std::endl;
+  }
+  file.close();
+
+  ++internal_output_counter_;
+}
+
+void
+LidarLineOfSite::output(
+  const stk::mesh::BulkData& bulk,
+  const stk::mesh::Selector& active,
+  const std::string& coordinates_name,
+  double dtratio)
+{
+  if (output_type_ == Output::DATAPROBE) {
+    return;
+  }
+
+  if (internal_output_counter_ == 0) {
+    Ioss::FileInfo::create_path(name_);
+    search_data_ =
+      std::make_unique<LocalVolumeSearchData>(bulk, active, npoints_);
+  }
+
+  const auto seg = segGen.generate_path_segment(time());
+  const std::array<double, 3> dx{
+    {(seg.tip_[0] - seg.tail_[0]) / (npoints_ > 1 ? (npoints_ - 1) : 1),
+     (seg.tip_[1] - seg.tail_[1]) / (npoints_ > 1 ? (npoints_ - 1) : 1),
+     (seg.tip_[2] - seg.tail_[2]) / (npoints_ > 1 ? (npoints_ - 1) : 1)}};
+
+  std::vector<std::array<double, 3>> points(npoints_);
+  for (int j = 0; j < npoints_; ++j) {
+    points[j] = {
+      {seg.tail_[0] + j * dx[0], seg.tail_[1] + j * dx[1],
+       seg.tail_[2] + j * dx[2]}};
+  }
+  const auto& coord_field =
+    *bulk.mesh_meta_data()
+       .get_field<stk::mesh::Field<double, stk::mesh::Cartesian3d>>(
+         stk::topology::NODE_RANK, coordinates_name);
+
+  const auto& velocity_field =
+    bulk.mesh_meta_data()
+      .get_field<stk::mesh::Field<double, stk::mesh::Cartesian3d>>(
+        stk::topology::NODE_RANK, "velocity")
+      ->field_of_state(stk::mesh::StateNP1);
+  const auto& velocity_prev =
+    bulk.mesh_meta_data()
+      .get_field<stk::mesh::Field<double, stk::mesh::Cartesian3d>>(
+        stk::topology::NODE_RANK, "velocity")
+      ->field_of_state(stk::mesh::StateN);
+  local_field_interpolation(
+    bulk, active, points, coord_field, velocity_prev, velocity_field, dtratio,
+    *search_data_);
+
+  const auto lcl_velocity = search_data_->interpolated_values;
+  const auto lcl_ownership = search_data_->ownership;
+  auto comm = bulk.parallel();
+  const int root = 0;
+
+  std::vector<std::array<double, 3>> velocity(npoints_, {0, 0, 0});
+  MPI_Reduce(
+    lcl_velocity.data(), velocity.data(), 3 * npoints_, MPI_DOUBLE, MPI_SUM,
+    root, comm);
+
+  // parallel reconciliation for points along processor boundaries is to
+  // do an arithmetic average, assuming continuity.
+  std::vector<int> degree(npoints_, 0);
+  MPI_Reduce(
+    lcl_ownership.data(), degree.data(), npoints_, MPI_INT, MPI_SUM, root,
+    comm);
+
+  if (is_root(comm, root)) {
+    for (int j = 0; j < npoints_; ++j) {
+      const double inv_deg = (degree.at(j) > 0) ? 1 / degree[j] : 0;
+      for (int d = 0; d < 3; ++d) {
+        velocity.at(j)[d] *= inv_deg;
+      }
+    }
+  }
+  if (is_root(comm, root) && output_type_ == Output::TEXT) {
+    output_txt(time(), points, velocity);
+  }
+  if (is_root(comm, root) && output_type_ == Output::NETCDF) {
+    output_nc(time(), points, velocity);
+  }
+}
 
 std::unique_ptr<DataProbeSpecInfo>
 LidarLineOfSite::determine_line_of_site_info(const YAML::Node& node)
@@ -206,7 +455,7 @@ LidarLineOfSite::determine_line_of_site_info(const YAML::Node& node)
   probeInfo->geomType_.resize(nsamples_);
 
   const int numProcs = NaluEnv::self().parallel_size();
-  const int divProcProbe = std::max(numProcs/nsamples_, numProcs);
+  const int divProcProbe = std::max(numProcs / nsamples_, numProcs);
 
   for (int ilos = 0; ilos < nsamples_; ilos++) {
     const double lidarTime = scanTime_ / (double)nsamples_ * ilos;
@@ -229,7 +478,6 @@ LidarLineOfSite::determine_line_of_site_info(const YAML::Node& node)
 
   return lidarLOSInfo;
 }
-
 
 } // namespace nalu
 } // namespace sierra

--- a/src/xfer/CMakeLists.txt
+++ b/src/xfer/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(nalu PRIVATE
+   ${CMAKE_CURRENT_SOURCE_DIR}/LocalVolumeSearch.C
    ${CMAKE_CURRENT_SOURCE_DIR}/Transfer.C
    ${CMAKE_CURRENT_SOURCE_DIR}/Transfers.C
 )

--- a/src/xfer/LocalVolumeSearch.C
+++ b/src/xfer/LocalVolumeSearch.C
@@ -1,0 +1,350 @@
+#include "xfer/LocalVolumeSearch.h"
+#include "master_element/MasterElement.h"
+#include "master_element/MasterElementFactory.h"
+#include "AlgTraits.h"
+
+#include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/Field.hpp"
+
+#include "stk_search/BoundingBox.hpp"
+#include "stk_search/IdentProc.hpp"
+#include "stk_search/SearchMethod.hpp"
+#include "stk_mesh/base/MetaData.hpp"
+#include "stk_search/CoarseSearch.hpp"
+
+#include "mpi.h"
+
+namespace sierra {
+namespace nalu {
+
+namespace {
+
+constexpr int dim = 3;
+using vector_field_type = stk::mesh::Field<double, stk::mesh::Cartesian3d>;
+using sphere_t = LocalVolumeSearchData::sphere_t;
+using box_t = LocalVolumeSearchData::box_t;
+using ident_t = LocalVolumeSearchData::ident_t;
+
+auto
+as_search_point(const std::array<double, dim>& x)
+{
+  return stk::search::Point<double>(x[0], x[1], x[2]);
+}
+
+auto
+as_search_sphere(const std::array<double, dim>& x, double rad)
+{
+  return stk::search::Sphere<double>(as_search_point(x), rad);
+}
+
+auto
+as_search_box(
+  const stk::mesh::BulkData& bulk,
+  const stk::mesh::Entity elem,
+  const vector_field_type& coord_field)
+{
+  constexpr auto max_double = std::numeric_limits<double>::max();
+  auto min_box = as_search_point({max_double, max_double, max_double});
+
+  constexpr auto min_double = std::numeric_limits<double>::lowest();
+  auto max_box = as_search_point({min_double, min_double, min_double});
+
+  const int nnodes = static_cast<int>(bulk.num_nodes(elem));
+  const auto* nodes = bulk.begin_nodes(elem);
+  for (int n = 0; n < nnodes; ++n) {
+    const auto* coord = stk::mesh::field_data(coord_field, nodes[n]);
+    for (int j = 0; j < dim; ++j) {
+      min_box[j] = std::min(min_box[j], coord[j]);
+      max_box[j] = std::max(max_box[j], coord[j]);
+    }
+  }
+  return stk::search::Box<double>(min_box, max_box);
+}
+
+void
+fill_search_points(
+  const std::vector<std::array<double, dim>>& points,
+  double tol,
+  std::vector<std::pair<sphere_t, ident_t>>& search_points)
+{
+  for (size_t j = 0; j < points.size(); ++j) {
+    search_points[j] = std::make_pair(
+      as_search_sphere(points[j], tol), ident_t(stk::mesh::EntityId(j), 0));
+  }
+}
+
+void
+fill_search_boxes(
+  const stk::mesh::BulkData& bulk,
+  const stk::mesh::Selector& active,
+  const vector_field_type& coord_field,
+  std::vector<std::pair<box_t, ident_t>>& box_list)
+{
+  box_list.clear();
+  const auto& buckets = bulk.get_buckets(stk::topology::ELEM_RANK, active);
+  for (const auto* ib : buckets) {
+    for (auto elem : *ib) {
+      box_list.emplace_back(
+        as_search_box(bulk, elem, coord_field),
+        ident_t(bulk.identifier(elem), 0));
+    }
+  }
+}
+
+double
+determine_tolerance(const std::vector<std::pair<box_t, ident_t>>& search_boxes)
+{
+  double min_element_diameter = std::numeric_limits<double>::max();
+  for (const auto& box_pair : search_boxes) {
+    const auto& box = box_pair.first;
+    const auto dx = box.get_x_max() - box.get_x_min();
+    const auto dy = box.get_y_max() - box.get_y_min();
+    const auto dz = box.get_z_max() - box.get_z_min();
+    min_element_diameter =
+      std::min(std::sqrt(dx * dx + dy * dy + dz * dz), min_element_diameter);
+  }
+  return min_element_diameter / 10;
+}
+
+void
+local_coarse_search(
+  const stk::mesh::BulkData& bulk,
+  const stk::mesh::Selector& active,
+  const vector_field_type& coord_field,
+  const std::vector<std::array<double, dim>>& points,
+  LocalVolumeSearchData& data)
+{
+  fill_search_boxes(bulk, active, coord_field, data.search_boxes);
+  fill_search_points(
+    points, determine_tolerance(data.search_boxes), data.search_points);
+
+  data.search_matches.clear();
+  stk::search::coarse_search(
+    data.search_points, data.search_boxes, stk::search::SearchMethod::KDTREE,
+    MPI_COMM_SELF, data.search_matches);
+}
+
+MasterElement&
+master_element(const stk::mesh::BulkData& bulk, stk::mesh::Entity elem)
+{
+  return *MasterElementRepo::get_surface_master_element(
+    bulk.bucket(elem).topology());
+}
+
+template <int nnodes>
+auto
+elem_gather(
+  const stk::mesh::BulkData& bulk,
+  stk::mesh::Entity elem,
+  const vector_field_type& u)
+{
+  const auto* nodes = bulk.begin_nodes(elem);
+  std::array<double, nnodes * dim> xc;
+  for (size_t n = 0; n < bulk.num_nodes(elem); ++n) {
+    const auto* xptr = stk::mesh::field_data(u, nodes[n]);
+    for (int d = 0; d < dim; ++d) {
+      xc[nnodes * d + n] = xptr[d];
+    }
+  }
+  return xc;
+}
+
+template <int nnodes>
+auto
+extrapolated_elem_gather(
+  const stk::mesh::BulkData& bulk,
+  stk::mesh::Entity elem,
+  const vector_field_type& unm1,
+  const vector_field_type& u,
+  double dtratio)
+{
+  const auto* nodes = bulk.begin_nodes(elem);
+  std::array<double, nnodes * dim> xc;
+  for (size_t n = 0; n < bulk.num_nodes(elem); ++n) {
+    const auto* xold_ptr = stk::mesh::field_data(unm1, nodes[n]);
+    const auto* xptr = stk::mesh::field_data(u, nodes[n]);
+    for (int d = 0; d < dim; ++d) {
+      xc[nnodes * d + n] = (1 + dtratio) * xptr[d] - dtratio * xold_ptr[d];
+    }
+  }
+  return xc;
+}
+
+template <typename AlgTraits>
+auto
+compute_local_coordinates_t(
+  const stk::mesh::BulkData& bulk,
+  const vector_field_type& coord_field,
+  stk::mesh::Entity elem,
+  std::array<double, dim> point)
+{
+  const auto nodal_x =
+    elem_gather<AlgTraits::nodesPerElement_>(bulk, elem, coord_field);
+
+  auto& me = master_element(bulk, elem);
+  std::array<double, dim> elem_x{};
+  const auto dist = me.isInElement(nodal_x.data(), point.data(), elem_x.data());
+  return std::make_pair(elem_x, dist);
+}
+
+auto
+compute_local_coordinates(
+  const stk::mesh::BulkData& bulk,
+  const vector_field_type& coord_field,
+  stk::mesh::Entity elem,
+  std::array<double, dim> point)
+{
+  const stk::topology::topology_t topo = bulk.bucket(elem).topology();
+  switch (topo) {
+  case stk::topology::TET_4:
+    return compute_local_coordinates_t<AlgTraitsTet4>(
+      bulk, coord_field, elem, point);
+  case stk::topology::WEDGE_6:
+    return compute_local_coordinates_t<AlgTraitsWed6>(
+      bulk, coord_field, elem, point);
+  case stk::topology::HEX_8:
+    return compute_local_coordinates_t<AlgTraitsHex8>(
+      bulk, coord_field, elem, point);
+  case stk::topology::HEX_27:
+    return compute_local_coordinates_t<AlgTraitsHex27>(
+      bulk, coord_field, elem, point);
+  default: {
+    ThrowRequire(topo == stk::topology::PYRAMID_5);
+    return compute_local_coordinates_t<AlgTraitsPyr5>(
+      bulk, coord_field, elem, point);
+  }
+  }
+}
+
+template <typename AlgTraits>
+auto
+interpolate_field_t(
+  const stk::mesh::BulkData& bulk,
+  stk::mesh::Entity elem,
+  const vector_field_type& field,
+  const std::array<double, dim>& x)
+{
+  auto& me = master_element(bulk, elem);
+
+  constexpr int nn = AlgTraits::nodesPerElement_;
+  const auto& nodal_field = elem_gather<nn>(bulk, elem, field);
+  std::array<double, dim> vel;
+  me.interpolatePoint(dim, x.data(), nodal_field.data(), vel.data());
+  return vel;
+}
+
+template <typename AlgTraits>
+auto
+interpolate_field_t(
+  const stk::mesh::BulkData& bulk,
+  stk::mesh::Entity elem,
+  const vector_field_type& field_prev,
+  const vector_field_type& field,
+  const std::array<double, dim>& x,
+  double dtratio)
+{
+  auto& me = master_element(bulk, elem);
+
+  constexpr int nn = AlgTraits::nodesPerElement_;
+  const auto& nodal_field =
+    extrapolated_elem_gather<nn>(bulk, elem, field_prev, field, dtratio);
+  std::array<double, dim> vel;
+  me.interpolatePoint(dim, x.data(), nodal_field.data(), vel.data());
+  return vel;
+}
+
+auto
+interpolate_field(
+  const stk::mesh::BulkData& bulk,
+  stk::mesh::Entity elem,
+  const vector_field_type& field_prev,
+  const vector_field_type& field,
+  const std::array<double, dim>& x,
+  double dtratio)
+{
+  const stk::topology::topology_t topo = bulk.bucket(elem).topology();
+  switch (topo) {
+  case stk::topology::TET_4:
+    return interpolate_field_t<AlgTraitsTet4>(
+      bulk, elem, field_prev, field, x, dtratio);
+  case stk::topology::WEDGE_6:
+    return interpolate_field_t<AlgTraitsWed6>(
+      bulk, elem, field_prev, field, x, dtratio);
+  case stk::topology::HEX_8:
+    return interpolate_field_t<AlgTraitsHex8>(
+      bulk, elem, field_prev, field, x, dtratio);
+  case stk::topology::HEX_27:
+    return interpolate_field_t<AlgTraitsHex27>(
+      bulk, elem, field_prev, field, x, dtratio);
+  default: {
+    ThrowRequire(topo == stk::topology::PYRAMID_5);
+    return interpolate_field_t<AlgTraitsPyr5>(
+      bulk, elem, field_prev, field, x, dtratio);
+  }
+  }
+}
+
+} // namespace
+
+LocalVolumeSearchData::LocalVolumeSearchData(
+  const stk::mesh::BulkData& bulk, const stk::mesh::Selector& sel, int npoints)
+  : search_points(npoints),
+    interpolated_values(npoints),
+    dist(npoints),
+    ownership(npoints)
+{
+  const auto& elem_buckets = bulk.get_buckets(stk::topology::ELEM_RANK, sel);
+  int elem_count = 0;
+  for (const auto* ib : elem_buckets) {
+    elem_count += ib->size();
+  }
+  search_boxes.reserve(elem_count);
+
+  const auto& node_buckets = bulk.get_buckets(stk::topology::NODE_RANK, sel);
+  int max_connections = -1;
+  for (const auto* ib : node_buckets) {
+    for (const auto& node : *ib) {
+      max_connections =
+        std::max(max_connections, static_cast<int>(bulk.num_elements(node)));
+    }
+  }
+  search_matches.reserve(2 * max_connections * npoints);
+}
+
+void
+local_field_interpolation(
+  const stk::mesh::BulkData& bulk,
+  const stk::mesh::Selector& active,
+  const std::vector<std::array<double, 3>>& points,
+  const stk::mesh::Field<double, stk::mesh::Cartesian3d>& x_field,
+  const stk::mesh::Field<double, stk::mesh::Cartesian3d>& field_prev,
+  const stk::mesh::Field<double, stk::mesh::Cartesian3d>& field,
+  double dtratio,
+  LocalVolumeSearchData& data)
+{
+  local_coarse_search(bulk, active, x_field, points, data);
+  std::fill(
+    data.interpolated_values.begin(), data.interpolated_values.end(),
+    std::array<double, dim>{0, 0, 0});
+  std::fill(
+    data.dist.begin(), data.dist.end(), std::numeric_limits<double>::max());
+  std::fill(data.ownership.begin(), data.ownership.end(), 0);
+
+  for (const auto& match : data.search_matches) {
+    auto point_id = match.first.id();
+    auto point = points[point_id];
+    auto elem = bulk.get_entity(stk::topology::ELEM_RANK, match.second.id());
+    const auto& x_dist = compute_local_coordinates(bulk, x_field, elem, point);
+    if (
+      x_dist.second < 1 + std::numeric_limits<double>::epsilon() &&
+      x_dist.second < data.dist[point_id]) {
+      data.dist.at(point_id) = x_dist.second;
+      data.interpolated_values.at(point_id) =
+        interpolate_field(bulk, elem, field_prev, field, x_dist.first, dtratio);
+      data.ownership.at(point_id) = 1;
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/unit_tests/UnitTestSpinnerLidarPattern.C
+++ b/unit_tests/UnitTestSpinnerLidarPattern.C
@@ -12,24 +12,27 @@
 namespace sierra {
 namespace nalu {
 
+const std::string lidarSpec =
+  "lidar_specifications:                                  \n"
+  "  from_target_part: [unused]                           \n"
+  "  inner_prism_initial_theta: 90                        \n"
+  "  inner_prism_rotation_rate: 3.5                       \n"
+  "  inner_prism_azimuth: 15.2                            \n"
+  "  outer_prism_initial_theta: 90                        \n"
+  "  outer_prism_rotation_rate: 6.5                       \n"
+  "  outer_prism_azimuth: 15.2                            \n"
+  "  scan_time: 2 #seconds                                \n"
+  "  number_of_samples: 984                               \n"
+  "  points_along_line: 4                                 \n"
+  "  center: [500,500,100]                                \n"
+  "  beam_length: 50.                                     \n"
+  "  axis: [1,1,0]                                        \n"
+  "  ground_direction: [0,0,1]                            \n"
+  "  output: text                                         \n"
+  "  name: lidar-los                                      \n";
+
 TEST(SpinnerLidar, print_tip_location)
 {
-  const std::string lidarSpec =
-     "lidar_specifications:                                  \n"
-     "  from_target_part: [unused]                           \n"
-     "  inner_prism_initial_theta: 90                        \n"
-     "  inner_prism_rotation_rate: 3.5                       \n"
-     "  inner_prism_azimuth: 15.2                            \n"
-     "  outer_prism_initial_theta: 90                        \n"
-     "  outer_prism_rotation_rate: 6.5                       \n"
-     "  outer_prism_azimuth: 15.2                            \n"
-     "  scan_time: 2 #seconds                                \n"
-     "  number_of_samples: 984                               \n"
-     "  points_along_line: 100                               \n"
-     "  center: [500,500,100]                                \n"
-     "  beam_length: 1.0                                     \n"
-     "  axis: [1,1,0]                                        \n"
-     "  ground_direction: [0,0,1]                            \n";
 
   YAML::Node lidarSpecNode = YAML::Load(lidarSpec)["lidar_specifications"];
 
@@ -48,14 +51,142 @@ TEST(SpinnerLidar, print_tip_location)
     ASSERT_TRUE(seg.tip_.at(1) > seg.tail_.at(1));
     ASSERT_DOUBLE_EQ(seg.tail_.at(0), 500);
     ASSERT_DOUBLE_EQ(seg.tail_.at(1), 500);
-    outputFile
-     << seg.tip_.at(0)
-     << ", "
-     << seg.tip_.at(1)
-     << ", "
-     << seg.tip_.at(2)
-     << std::endl;
+    outputFile << seg.tip_.at(0) << ", " << seg.tip_.at(1) << ", "
+               << seg.tip_.at(2) << std::endl;
   }
 }
 
-}}
+std::array<double, 3>
+velocity_func(const double* x, double time)
+{
+  return {
+    time + 1 + 2.1 * x[0] / 500 + 3.2 * x[1] / 500 + 4.3 * x[2] / 100,
+    time - 2 + 1.2 * x[0] / 500 + 2.3 * x[1] / 500 + 3.4 * x[2] / 100,
+    time + 3 - 2.1 * x[0] / 500 + 3.2 * x[1] / 500 - 4.3 * x[2] / 100};
+}
+
+TEST(SpinnerLidar, volume_interp)
+{
+  stk::mesh::MetaData meta(3u);
+  stk::mesh::BulkData bulk(
+    meta, MPI_COMM_WORLD, stk::mesh::BulkData::NO_AUTO_AURA);
+  stk::io::StkMeshIoBroker io(bulk.parallel());
+
+  io.set_bulk_data(bulk);
+
+  const int n = 64;
+  const auto nx = std::to_string(n);
+  const auto ny = std::to_string(n);
+  const auto nz = std::to_string(n / 2);
+  auto mesh_name = "generated:" + nx + "x" + ny + "x" + nz +
+                   "|bbox:-1000,-1000,0,1000,1000,1000|sideset:xXyYzZ";
+  io.add_mesh_database(mesh_name, stk::io::READ_MESH);
+  io.create_input_mesh();
+
+  using vector_field_type = stk::mesh::Field<double, stk::mesh::Cartesian3d>;
+  auto node_rank = stk::topology::NODE_RANK;
+  auto& vel_field =
+    meta.declare_field<vector_field_type>(node_rank, "velocity", 2);
+  stk::mesh::put_field_on_entire_mesh(vel_field);
+  io.populate_bulk_data();
+
+  auto& vel_field_old = vel_field.field_of_state(stk::mesh::StateN);
+
+  const auto& coord_field =
+    *dynamic_cast<const vector_field_type*>(meta.coordinate_field());
+
+  const auto& node_buckets =
+    bulk.get_buckets(stk::topology::NODE_RANK, meta.universal_part());
+  for (const auto* ib : node_buckets) {
+    for (const auto& node : *ib) {
+      auto* uptr = stk::mesh::field_data(vel_field, node);
+      auto* uptr_old = stk::mesh::field_data(vel_field_old, node);
+
+      const auto* xptr = stk::mesh::field_data(coord_field, node);
+      const auto vel_at_x = velocity_func(xptr, 0);
+      for (int d = 0; d < 3; ++d) {
+        uptr[d] = vel_at_x[d];
+        uptr_old[d] = uptr[d];
+      }
+    }
+  }
+
+  {
+    LidarLineOfSite los;
+    los.load(YAML::Load(lidarSpec)["lidar_specifications"]);
+    los.set_time(0);
+    los.output(bulk, meta.universal_part(), "coordinates", 0);
+
+    if (bulk.parallel_rank() == 0) {
+      std::string line;
+      std::ifstream myfile("lidar-los.txt");
+      if (myfile.is_open()) {
+        while (std::getline(myfile, line)) {
+          std::stringstream iline(line);
+          std::string word;
+          if (line.find('t') == 0) {
+            continue;
+          }
+          std::vector<double> values;
+          while (std::getline(iline, word, ',')) {
+            values.push_back(std::stod(word));
+          }
+          ASSERT_EQ(values.size(), 7u);
+
+          constexpr int coord_start = 1;
+          constexpr int vel_start = 4;
+
+          const auto& exact_vel = velocity_func(&values[coord_start], 0);
+          EXPECT_NEAR(exact_vel.at(0), values.at(vel_start + 0), 1e-10);
+          EXPECT_NEAR(exact_vel[1], values.at(vel_start + 1), 1e-10);
+          EXPECT_NEAR(exact_vel[2], values.at(vel_start + 2), 1e-10);
+        }
+        myfile.close();
+      }
+    }
+  }
+
+  {
+    const std::string lidar_nc =
+      "lidar_specifications:                                  \n"
+      "  from_target_part: [unused]                           \n"
+      "  inner_prism_initial_theta: 90                        \n"
+      "  inner_prism_rotation_rate: 3.5                       \n"
+      "  inner_prism_azimuth: 15.2                            \n"
+      "  outer_prism_initial_theta: 90                        \n"
+      "  outer_prism_rotation_rate: 6.5                       \n"
+      "  outer_prism_azimuth: 15.2                            \n"
+      "  scan_time: 2 #seconds                                \n"
+      "  number_of_samples: 984                               \n"
+      "  points_along_line: 4                                 \n"
+      "  center: [500,500,100]                                \n"
+      "  beam_length: 500.                                    \n"
+      "  axis: [1,1,0]                                        \n"
+      "  ground_direction: [0,0,1]                            \n"
+      "  output: netcdf                                       \n"
+      "  time_step: 0.01                                      \n"
+      "  name: lidar/lidar-1                                  \n";
+
+    LidarLineOfSite los;
+    los.load(YAML::Load(lidar_nc)["lidar_specifications"]);
+    los.set_time(0);
+
+      for (int j = 0; j < 984; ++j) {
+        for (const auto* ib : node_buckets) {
+          for (const auto& node : *ib) {
+            auto* uptr = stk::mesh::field_data(vel_field, node);
+            const auto* xptr = stk::mesh::field_data(coord_field, node);
+            const auto vel_at_x = velocity_func(xptr, los.time());
+            ASSERT_NEAR(los.time(), j * 0.01, 1e-12);
+            for (int d = 0; d < 3; ++d) {
+              uptr[d] = vel_at_x[d];
+            }
+          }
+        }
+        los.output(bulk, !stk::mesh::Selector{}, "coordinates", 0);
+        los.increment_time();
+      }
+  }
+}
+} // namespace nalu
+} // namespace sierra

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -458,7 +458,7 @@ double initialize_linear_scalar_field(
   const VectorFieldType& coordField,
   const ScalarFieldType& qField)
 {
-  // q = a + b^T x + 1/2 x^T H x
+  // q = a + b^T x
   std::mt19937 rng;
   rng.seed(0); // fixed seed
   std::uniform_real_distribution<double> coeff(-1.0, 1.0);


### PR DESCRIPTION
**Pull-request type:**
- [ ] Bug fix 
- [ ] Documentation update
- [x] Feature enhancement

## Description of the pull-request

Adds a subsampling version of the spinner lidar sampling with a timestep independent from the fluid solve. The solution velocity is interpolated to a line of size ~100 points, linearly extrapolated in time from the nearest fluid timesteps.  Slow if the spinner lidar timestep << fluid timestep but otherwise should limit the size of the data output.

Switching the output type to "dataprobes" will get the previous behavior.  This changes the default to netcdf output, though plain ascii is also available.

## Checklist

**NOTE** The checklist below is a suggestion and not mandatory. You don't have
to _check all boxes_ to submit a pull request. However, please add a brief
explanation in your pull request summary explaining the omission for the benefit
of reviewers and developers.

*All pull requests*
- [x] Builds successfully (*must test on at least one system/compiler combination*)
  - Operating systems 
    - [x] Linux
    - [ ] MacOS
  - Compilers 
    - [x] GCC
    - [ ] LLVM/Clang
    - [ ] Intel compilers
    - [ ] NVIDIA CUDA
- [x] Compiles without warnings
- [x] Passes all unit tests
- [x] Passes all regression tests
- [ ] Documentation builds without errors

*For new code updates*
- [ ] Documentation updates - additions to user, theory, and verification manuals
- [x] New unit tests providing coverage for new code, bug fixes etc.
- [ ] New regression tests exercising the new code
