### PR TITLE
stk::mesh::MeshBuilder Conversion

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -414,8 +414,7 @@ class Realm {
   double l2Scaling_;
 
   // ioBroker, meta and bulk data
-  stk::mesh::MetaData *metaData_;
-  stk::mesh::BulkData *bulkData_;
+  std::shared_ptr<stk::mesh::BulkData> bulkData_;
   stk::io::StkMeshIoBroker *ioBroker_;
   std::unique_ptr<SideWriterContainer> sideWriters_;
 

--- a/src/InputOutputRealm.C
+++ b/src/InputOutputRealm.C
@@ -94,18 +94,18 @@ InputOutputRealm::register_io_fields() {
     // loop over target parts and declare/put the field
     for ( size_t j = 0; j < targetNames.size(); ++j ) {
       const std::string targetName = targetNames[j];
-      stk::mesh::Part *targetPart = metaData_->get_part(targetName);
+      stk::mesh::Part *targetPart = meta_data().get_part(targetName);
       if ( NULL == targetPart ) {
         throw std::runtime_error("Sorry, no part name found by the name: " + targetName + " for field: " + fieldName);
       }
       else { 
         if ( fieldName.find(velocityName) != std::string::npos ) { //FIXME: require FieldType?
-          VectorFieldType *velocity = &(metaData_->declare_field<VectorFieldType>(stk::topology::NODE_RANK, fieldName));
+          VectorFieldType *velocity = &(meta_data().declare_field<VectorFieldType>(stk::topology::NODE_RANK, fieldName));
           stk::mesh::put_field_on_mesh(*velocity, *targetPart, fieldSize, nullptr);
         }
         else {
           stk::mesh::FieldBase *theField 
-            = &(metaData_->declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, fieldName));
+            = &(meta_data().declare_field< stk::mesh::Field<double, stk::mesh::SimpleArrayTag> >(stk::topology::NODE_RANK, fieldName));
           stk::mesh::put_field_on_mesh(*theField,*targetPart,fieldSize, nullptr);
         }
       }

--- a/unit_tests/UnitTest1ElemCoordCheck.C
+++ b/unit_tests/UnitTest1ElemCoordCheck.C
@@ -59,13 +59,14 @@ TEST(Basic, CheckCoords1Elem)
     stk::ParallelMachine comm = MPI_COMM_WORLD;
 
     unsigned spatialDimension = 3;
-    stk::mesh::MetaData meta(spatialDimension);
-    stk::mesh::BulkData bulk(meta, comm);
+    stk::mesh::MeshBuilder meshBuilder(comm);
+    meshBuilder.set_spatial_dimension(spatialDimension);
+    auto bulk = meshBuilder.create();
 
-    unit_test_utils::fill_mesh_1_elem_per_proc_hex8(bulk);
+    unit_test_utils::fill_mesh_1_elem_per_proc_hex8(*bulk);
 
-    EXPECT_EQ(1u, count_locally_owned_elems(bulk));
+    EXPECT_EQ(1u, count_locally_owned_elems(*bulk));
 
-    verify_elems_are_unit_cubes(bulk);
+    verify_elems_are_unit_cubes(*bulk);
 }
 

--- a/unit_tests/UnitTestElemDataRequests.C
+++ b/unit_tests/UnitTestElemDataRequests.C
@@ -58,18 +58,18 @@ TEST_F(Hex8MeshWithNSOFields, NGPElemDataRequests)
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
   stk::topology elemTopo = stk::topology::HEX_8;
 
-  sierra::nalu::ElemDataRequests dataReq(bulk.mesh_meta_data());
+  sierra::nalu::ElemDataRequests dataReq(bulk->mesh_meta_data());
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element(elemTopo);
   dataReq.add_cvfem_volume_me(meSCV);
 
   dataReq.add_gathered_nodal_field(*velocity, 3);
   dataReq.add_gathered_nodal_field(*pressure, 1);
 
-  dataReq.add_coordinates_field(*bulk.mesh_meta_data().coordinate_field(), 3, sierra::nalu::CURRENT_COORDINATES);
-  dataReq.add_coordinates_field(*bulk.mesh_meta_data().coordinate_field(), 3, sierra::nalu::MODEL_COORDINATES);
+  dataReq.add_coordinates_field(*bulk->mesh_meta_data().coordinate_field(), 3, sierra::nalu::CURRENT_COORDINATES);
+  dataReq.add_coordinates_field(*bulk->mesh_meta_data().coordinate_field(), 3, sierra::nalu::MODEL_COORDINATES);
 
   EXPECT_EQ(3u, dataReq.get_fields().size());
 
-  do_the_test_gpu(dataReq, bulk);
+  do_the_test_gpu(dataReq, *bulk);
 }
 

--- a/unit_tests/UnitTestElemSuppAlg.C
+++ b/unit_tests/UnitTestElemSuppAlg.C
@@ -169,7 +169,7 @@ TEST_F(Hex8Mesh, elem_supp_alg_views)
 {
     fill_mesh_and_initialize_test_fields("generated:20x20x20");
 
-    TestElemAlgorithmWithSuppAlgViews testAlgorithm(bulk);
+    TestElemAlgorithmWithSuppAlgViews testAlgorithm(*bulk);
 
     //DiscreteLapacianSuppAlg constructor says which data it needs, by inserting
     //things into the 'dataNeededByKernels_' container.

--- a/unit_tests/UnitTestGetDofStatus.C
+++ b/unit_tests/UnitTestGetDofStatus.C
@@ -16,11 +16,11 @@ TEST_F(DofStatusHex8Mesh, getDofStatus_basic)
 {
   fill_mesh_and_initialize_test_fields("generated:1x1x2");
 
-  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
 
-  stk::mesh::Entity node1 = bulk.get_entity(stk::topology::NODE_RANK, 1);
-  if (bulk.is_valid(node1)) {
-    if (bulk.bucket(node1).owned()) {
+  stk::mesh::Entity node1 = bulk->get_entity(stk::topology::NODE_RANK, 1);
+  if (bulk->is_valid(node1)) {
+    if (bulk->bucket(node1).owned()) {
       EXPECT_EQ(sierra::nalu::DS_OwnedDOF, sierra::nalu::getDofStatus_impl(node1, helperObjs.realm));
     }
   }
@@ -30,10 +30,10 @@ TEST_F(DofStatusHex8Mesh, getDofStatus_shared)
 {
   fill_mesh_and_initialize_test_fields("generated:10x10x10");
 
-  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
 
-  stk::mesh::Selector shared = bulk.mesh_meta_data().globally_shared_part();
-  const stk::mesh::BucketVector& sharedBuckets = bulk.get_buckets(stk::topology::NODE_RANK, shared);
+  stk::mesh::Selector shared = bulk->mesh_meta_data().globally_shared_part();
+  const stk::mesh::BucketVector& sharedBuckets = bulk->get_buckets(stk::topology::NODE_RANK, shared);
 
   for(const stk::mesh::Bucket* bptr : sharedBuckets) {
       const stk::mesh::Bucket& bucket = *bptr;

--- a/unit_tests/UnitTestGetDofStatus.C
+++ b/unit_tests/UnitTestGetDofStatus.C
@@ -16,7 +16,7 @@ TEST_F(DofStatusHex8Mesh, getDofStatus_basic)
 {
   fill_mesh_and_initialize_test_fields("generated:1x1x2");
 
-  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
 
   stk::mesh::Entity node1 = bulk->get_entity(stk::topology::NODE_RANK, 1);
   if (bulk->is_valid(node1)) {
@@ -30,7 +30,7 @@ TEST_F(DofStatusHex8Mesh, getDofStatus_shared)
 {
   fill_mesh_and_initialize_test_fields("generated:10x10x10");
 
-  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
 
   stk::mesh::Selector shared = bulk->mesh_meta_data().globally_shared_part();
   const stk::mesh::BucketVector& sharedBuckets = bulk->get_buckets(stk::topology::NODE_RANK, shared);

--- a/unit_tests/UnitTestHelperObjects.h
+++ b/unit_tests/UnitTestHelperObjects.h
@@ -22,7 +22,7 @@ namespace unit_test_utils {
 struct HelperObjectsBase
 {
   HelperObjectsBase(
-    stk::mesh::BulkData& bulk,
+    std::shared_ptr<stk::mesh::BulkData> bulk,
     YAML::Node yaml_node = unit_test_utils::get_default_inputs(),
     YAML::Node realm_node = unit_test_utils::get_realm_default_node())
     : yamlNode(yaml_node),
@@ -32,15 +32,11 @@ struct HelperObjectsBase
       eqSystems(realm),
       eqSystem(eqSystems)
   {
-    realm.metaData_ = &bulk.mesh_meta_data();
-    realm.bulkData_ = &bulk;
+    realm.bulkData_ = bulk;
   }
 
   virtual ~HelperObjectsBase()
   {
-    realm.metaData_ = nullptr;
-    realm.bulkData_ = nullptr;
-
     delete naluObj;
   }
 
@@ -78,7 +74,7 @@ struct HelperObjectsBase
 struct HelperObjects : public HelperObjectsBase
 {
   HelperObjects(
-    stk::mesh::BulkData& bulk,
+    std::shared_ptr<stk::mesh::BulkData> bulk,
     stk::topology topo,
     int numDof,
     stk::mesh::Part* part,
@@ -152,7 +148,7 @@ struct HelperObjects : public HelperObjectsBase
 };
 
 struct FaceElemHelperObjects : HelperObjects {
-  FaceElemHelperObjects(stk::mesh::BulkData& bulk, stk::topology faceTopo, stk::topology elemTopo, int numDof, stk::mesh::Part* part, bool isEdge = false)
+  FaceElemHelperObjects(std::shared_ptr<stk::mesh::BulkData> bulk, stk::topology faceTopo, stk::topology elemTopo, int numDof, stk::mesh::Part* part, bool isEdge = false)
     : HelperObjects(bulk, elemTopo, numDof, part, isEdge)
   {
     assembleFaceElemSolverAlg = new sierra::nalu::AssembleFaceElemSolverAlgorithm(realm, part, &eqSystem, faceTopo.num_nodes(), elemTopo.num_nodes());
@@ -181,7 +177,7 @@ struct FaceElemHelperObjects : HelperObjects {
 struct EdgeHelperObjects : public HelperObjectsBase
 {
   EdgeHelperObjects(
-    stk::mesh::BulkData& bulk,
+    std::shared_ptr<stk::mesh::BulkData> bulk,
     stk::topology topo,
     int numDof
   ) : HelperObjectsBase(bulk),
@@ -224,7 +220,7 @@ struct EdgeHelperObjects : public HelperObjectsBase
 struct EdgeKernelHelperObjects : public HelperObjectsBase
 {
   EdgeKernelHelperObjects(
-    stk::mesh::BulkData& bulk,
+    std::shared_ptr<stk::mesh::BulkData> bulk,
     stk::topology topo,
     int numDof,
     stk::mesh::Part* part
@@ -256,7 +252,7 @@ struct EdgeKernelHelperObjects : public HelperObjectsBase
 struct NodeHelperObjects : public HelperObjectsBase
 {
   NodeHelperObjects(
-    stk::mesh::BulkData& bulk,
+    std::shared_ptr<stk::mesh::BulkData> bulk,
     stk::topology topo,
     int numDof,
     stk::mesh::Part* part

--- a/unit_tests/UnitTestHex27FaceNodeOrdering.C
+++ b/unit_tests/UnitTestHex27FaceNodeOrdering.C
@@ -4,6 +4,7 @@
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
 
@@ -95,11 +96,12 @@ TEST(Hex27,creation)
   }
 
   unsigned spatialDimension = 3;
-  stk::mesh::MetaData meta(spatialDimension);
-  stk::mesh::BulkData bulk(meta, comm);
+  stk::mesh::MeshBuilder meshBuilder(comm);
+  meshBuilder.set_spatial_dimension(spatialDimension);
+  auto bulk = meshBuilder.create();
 
-  unit_test_utils::create_one_reference_element(bulk, stk::topology::HEX_27);
-  check_Hex27_creation(bulk);
+  unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEX_27);
+  check_Hex27_creation(*bulk);
 }
 
 TEST(Hex27, face_node_ordering)
@@ -110,11 +112,12 @@ TEST(Hex27, face_node_ordering)
   }
 
   unsigned spatialDimension = 3;
-  stk::mesh::MetaData meta(spatialDimension);
-  stk::mesh::BulkData bulk(meta, comm);
+  stk::mesh::MeshBuilder meshBuilder(comm);
+  meshBuilder.set_spatial_dimension(spatialDimension);
+  auto bulk = meshBuilder.create();
 
-  unit_test_utils::create_one_reference_element(bulk, stk::topology::HEX_27);
-  check_Hex27_face_ip_node_ordering(bulk);
+  unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEX_27);
+  check_Hex27_face_ip_node_ordering(*bulk);
 }
 
 

--- a/unit_tests/UnitTestHexMasterElements.C
+++ b/unit_tests/UnitTestHexMasterElements.C
@@ -261,7 +261,7 @@ protected:
     stk::ParallelMachine comm;
     unsigned spatialDimension;
     stk::mesh::MetaData* meta;
-    std::unique_ptr<stk::mesh::BulkData> bulk;
+    std::shared_ptr<stk::mesh::BulkData> bulk;
     unsigned poly_order;
     stk::topology topo;
 };

--- a/unit_tests/UnitTestHexMasterElementsNgp.C
+++ b/unit_tests/UnitTestHexMasterElementsNgp.C
@@ -357,7 +357,7 @@ protected:
     stk::ParallelMachine comm;
     unsigned spatialDimension;
     stk::mesh::MetaData* meta;
-    std::unique_ptr<stk::mesh::BulkData> bulk;
+    std::shared_ptr<stk::mesh::BulkData> bulk;
     stk::mesh::NgpMesh ngpMesh;
     unsigned poly_order;
     stk::topology topo;

--- a/unit_tests/UnitTestHexSCVDeterminant.C
+++ b/unit_tests/UnitTestHexSCVDeterminant.C
@@ -4,6 +4,7 @@
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
@@ -77,12 +78,13 @@ TEST(HexSCV, determinant)
     stk::ParallelMachine comm = MPI_COMM_WORLD;
 
     unsigned spatialDimension = 3;
-    stk::mesh::MetaData meta(spatialDimension);
-    stk::mesh::BulkData bulk(meta, comm);
+    stk::mesh::MeshBuilder meshBuilder(comm);
+    meshBuilder.set_spatial_dimension(spatialDimension);
+    auto bulk = meshBuilder.create();
 
-    unit_test_utils::fill_mesh_1_elem_per_proc_hex8(bulk);
+    unit_test_utils::fill_mesh_1_elem_per_proc_hex8(*bulk);
 
-    check_HexSCV_determinant(bulk);
+    check_HexSCV_determinant(*bulk);
 }
 
 TEST(HexSCV, grandyvol)
@@ -90,11 +92,12 @@ TEST(HexSCV, grandyvol)
   stk::ParallelMachine comm = MPI_COMM_WORLD;
 
   unsigned spatialDimension = 3;
-  stk::mesh::MetaData meta(spatialDimension);
-  stk::mesh::BulkData bulk(meta, comm);
+  stk::mesh::MeshBuilder meshBuilder(comm);
+  meshBuilder.set_spatial_dimension(spatialDimension);
+  auto bulk = meshBuilder.create();
 
-  unit_test_utils::fill_mesh_1_elem_per_proc_hex8(bulk);
-  const auto& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
+  unit_test_utils::fill_mesh_1_elem_per_proc_hex8(*bulk);
+  const auto& coordField = *static_cast<const VectorFieldType*>(bulk->mesh_meta_data().coordinate_field());
 
   double v_coords[8][3];
 
@@ -109,10 +112,10 @@ TEST(HexSCV, grandyvol)
   };
   double detQ = determinant33(Q);
 
-  for (auto* ib : bulk.get_buckets(stk::topology::ELEM_RANK, meta.universal_part())) {
+  for (auto* ib : bulk->get_buckets(stk::topology::ELEM_RANK, bulk->mesh_meta_data().universal_part())) {
     const auto& b = *ib;
     for (size_t k = 0u; k < b.size(); ++k) {
-      const auto* node_rels = bulk.begin_nodes(b[k]);
+      const auto* node_rels = bulk->begin_nodes(b[k]);
       for (int n = 0; n < 8; ++n) {
         for (int j = 0; j < 3; ++j) {
           v_coords[n][j] = 0.0;

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -65,7 +65,7 @@ public:
     EXPECT_TRUE(coordinates_ != nullptr);
 
     const int numDof = 1;
-    helperObjs_.reset(new HelperObjects(*bulk_, AlgTraits::topo_, numDof, partVec_[0]));
+    helperObjs_.reset(new HelperObjects(bulk_, AlgTraits::topo_, numDof, partVec_[0]));
     dataNeeded().add_coordinates_field(
       *coordinates_, AlgTraits::nDim_, sierra::nalu::CURRENT_COORDINATES);
   }
@@ -115,7 +115,7 @@ public:
 
   stk::ParallelMachine comm_;
   stk::mesh::MetaData* meta_;
-  std::unique_ptr<stk::mesh::BulkData> bulk_;
+  std::shared_ptr<stk::mesh::BulkData> bulk_;
   stk::mesh::PartVector partVec_;
   const VectorFieldType* coordinates_{nullptr};
 

--- a/unit_tests/UnitTestKokkosME.h
+++ b/unit_tests/UnitTestKokkosME.h
@@ -31,10 +31,12 @@ class KokkosMEViews
 {
 public:
   KokkosMEViews(bool doInit=true, bool doPerturb=false)
-    : comm_(MPI_COMM_WORLD),
-      meta_(AlgTraits::nDim_),
-      bulk_(meta_, comm_)
+    : comm_(MPI_COMM_WORLD)
   {
+    stk::mesh::MeshBuilder meshBuilder(comm_);
+    meshBuilder.set_spatial_dimension(AlgTraits::nDim_);
+    bulk_ = meshBuilder.create();
+    meta_ = &bulk_->mesh_meta_data();
     if (doInit)
       fill_mesh_and_init_data(doPerturb);
   }
@@ -52,18 +54,18 @@ public:
   void fill_mesh(bool doPerturb=false)
   {
     if (doPerturb)
-      unit_test_utils::create_one_perturbed_element(bulk_, AlgTraits::topo_);
+      unit_test_utils::create_one_perturbed_element(*bulk_, AlgTraits::topo_);
     else
-      unit_test_utils::create_one_reference_element(bulk_, AlgTraits::topo_);
+      unit_test_utils::create_one_reference_element(*bulk_, AlgTraits::topo_);
 
-    partVec_ = {meta_.get_part("block_1")};
+    partVec_ = {meta_->get_part("block_1")};
     coordinates_ = static_cast<const VectorFieldType*>(
-      meta_.coordinate_field());
+      meta_->coordinate_field());
 
     EXPECT_TRUE(coordinates_ != nullptr);
 
     const int numDof = 1;
-    helperObjs_.reset(new HelperObjects(bulk_, AlgTraits::topo_, numDof, partVec_[0]));
+    helperObjs_.reset(new HelperObjects(*bulk_, AlgTraits::topo_, numDof, partVec_[0]));
     dataNeeded().add_coordinates_field(
       *coordinates_, AlgTraits::nDim_, sierra::nalu::CURRENT_COORDINATES);
   }
@@ -104,7 +106,7 @@ public:
     ThrowAssertMsg(partVec_.size()==1, "KokkosMEViews unit-test assumes partVec_.size==1");
 
 #ifndef KOKKOS_ENABLE_CUDA
-    helperObjs_->assembleElemSolverAlg->run_algorithm(bulk_, func);
+    helperObjs_->assembleElemSolverAlg->run_algorithm(*bulk_, func);
 #endif
   }
 
@@ -112,8 +114,8 @@ public:
   { return helperObjs_->assembleElemSolverAlg->dataNeededByKernels_; }
 
   stk::ParallelMachine comm_;
-  stk::mesh::MetaData meta_;
-  stk::mesh::BulkData bulk_;
+  stk::mesh::MetaData* meta_;
+  std::unique_ptr<stk::mesh::BulkData> bulk_;
   stk::mesh::PartVector partVec_;
   const VectorFieldType* coordinates_{nullptr};
 

--- a/unit_tests/UnitTestKokkosMEBC.C
+++ b/unit_tests/UnitTestKokkosMEBC.C
@@ -91,8 +91,8 @@ void test_MEBC_views(int faceOrdinal,
   const std::vector<sierra::nalu::ELEM_DATA_NEEDED>& face_requests=std::vector<sierra::nalu::ELEM_DATA_NEEDED>())
 {
   unit_test_utils::KokkosMEBC<BcAlgTraits> driver(faceOrdinal, true, true);
-  ASSERT_TRUE((BcAlgTraits::nDim_ == 3 && driver.bulk_.buckets(stk::topology::FACE_RANK).size() > 0) 
-           || (BcAlgTraits::nDim_ == 2 && driver.bulk_.buckets(stk::topology::EDGE_RANK).size() > 0));
+  ASSERT_TRUE((BcAlgTraits::nDim_ == 3 && driver.bulk_->buckets(stk::topology::FACE_RANK).size() > 0) 
+           || (BcAlgTraits::nDim_ == 2 && driver.bulk_->buckets(stk::topology::EDGE_RANK).size() > 0));
 
   // Register ME data requests
   for(sierra::nalu::ELEM_DATA_NEEDED request : elem_requests) {

--- a/unit_tests/UnitTestKokkosMEBC.h
+++ b/unit_tests/UnitTestKokkosMEBC.h
@@ -67,7 +67,7 @@ public:
 
      const int numDof = 1;
      helperObjs_.reset(new FaceElemHelperObjects(
-       *bulk_, BcAlgTraits::faceTopo_, BcAlgTraits::elemTopo_, numDof,
+       bulk_, BcAlgTraits::faceTopo_, BcAlgTraits::elemTopo_, numDof,
        partVec_[0]));
 
      elemDataNeeded().add_coordinates_field(
@@ -113,7 +113,7 @@ public:
 
    stk::ParallelMachine comm_;
    stk::mesh::MetaData* meta_;
-   std::unique_ptr<stk::mesh::BulkData> bulk_;
+   std::shared_ptr<stk::mesh::BulkData> bulk_;
    int faceOrdinal_;
    stk::mesh::PartVector partVec_;
    const VectorFieldType* coordinates_{nullptr};

--- a/unit_tests/UnitTestKokkosViews.C
+++ b/unit_tests/UnitTestKokkosViews.C
@@ -370,7 +370,7 @@ TEST_F(Hex8Mesh, indexing_vectors)
 {
     fill_mesh_and_initialize_test_fields();
 
-    TestElemAlgorithmWithVectors testAlgorithm(bulk, coordField,
+    TestElemAlgorithmWithVectors testAlgorithm(*bulk, coordField,
                           discreteLaplacianOfPressure, nodalPressureField);
 
     testAlgorithm.execute();
@@ -382,7 +382,7 @@ TEST_F(Hex8Mesh, indexing_template_raw_arrays)
 {
     fill_mesh_and_initialize_test_fields();
 
-    TestElemAlgorithmWithTemplate testAlgorithm(bulk, coordField,
+    TestElemAlgorithmWithTemplate testAlgorithm(*bulk, coordField,
                           discreteLaplacianOfPressure, nodalPressureField);
 
     testAlgorithm.execute();
@@ -394,7 +394,7 @@ TEST_F(Hex8Mesh, indexing_views)
 {
     fill_mesh_and_initialize_test_fields();
 
-    TestElemAlgorithmWithViews testAlgorithm(bulk, coordField,
+    TestElemAlgorithmWithViews testAlgorithm(*bulk, coordField,
                           discreteLaplacianOfPressure, nodalPressureField);
 
     testAlgorithm.execute();

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -4,6 +4,7 @@
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
@@ -528,8 +529,10 @@ protected:
 
     void choose_topo(stk::topology topo)
     {
-      meta = std::unique_ptr<stk::mesh::MetaData>(new stk::mesh::MetaData(topo.dimension()));
-      bulk = std::unique_ptr<stk::mesh::BulkData>(new stk::mesh::BulkData(*meta, comm));
+      stk::mesh::MeshBuilder meshBuilder(comm);
+      meshBuilder.set_spatial_dimension(topo.dimension());
+      bulk = meshBuilder.create();
+      meta = &bulk->mesh_meta_data();
       elem = unit_test_utils::create_one_reference_element(*bulk, topo);
       meSS = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
       meSV = sierra::nalu::MasterElementRepo::get_volume_master_element(topo);
@@ -590,7 +593,7 @@ protected:
     }
 
     stk::ParallelMachine comm;
-    std::unique_ptr<stk::mesh::MetaData> meta;
+    stk::mesh::MetaData* meta;
     std::unique_ptr<stk::mesh::BulkData> bulk;
     stk::mesh::Entity elem;
     sierra::nalu::MasterElement* meSS;

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -594,7 +594,7 @@ protected:
 
     stk::ParallelMachine comm;
     stk::mesh::MetaData* meta;
-    std::unique_ptr<stk::mesh::BulkData> bulk;
+    std::shared_ptr<stk::mesh::BulkData> bulk;
     stk::mesh::Entity elem;
     sierra::nalu::MasterElement* meSS;
     sierra::nalu::MasterElement* meSV;

--- a/unit_tests/UnitTestMetricTensor.C
+++ b/unit_tests/UnitTestMetricTensor.C
@@ -9,6 +9,7 @@
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/Field.hpp>
@@ -51,9 +52,10 @@ void test_metric_for_topo_2D(stk::topology topo, double tol) {
   int dim = topo.dimension();
   ASSERT_EQ(dim, 2);
 
-  stk::mesh::MetaData meta(dim);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
-  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, topo);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(dim);
+  auto bulk = meshBuilder.create();
+  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, topo);
 
   auto* mescs = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
 
@@ -71,9 +73,9 @@ void test_metric_for_topo_2D(stk::topology topo, double tol) {
   sierra::nalu::mxm22(Q,Qt,metric_exact);
 
 
-  const auto& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
+  const auto& coordField = *static_cast<const VectorFieldType*>(bulk->mesh_meta_data().coordinate_field());
   std::vector<double> ws_coords(topo.num_nodes() * dim);
-  const auto* nodes = bulk.begin_nodes(elem);
+  const auto* nodes = bulk->begin_nodes(elem);
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double* coords = stk::mesh::field_data(coordField, nodes[j]);
     sierra::nalu::matvec22(Q, coords, &ws_coords[j*dim]);
@@ -97,9 +99,10 @@ void test_metric_for_topo_3D(stk::topology topo, double tol) {
   int dim = topo.dimension();
   ASSERT_EQ(dim,3);
 
-  stk::mesh::MetaData meta(dim);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
-  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, topo);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(dim);
+  auto bulk = meshBuilder.create();
+  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, topo);
 
   auto* mescs = sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
 
@@ -121,10 +124,10 @@ void test_metric_for_topo_3D(stk::topology topo, double tol) {
   sierra::nalu::mxm33(Q,Qt,metric_exact);
 
 
-  const auto& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
+  const auto& coordField = *static_cast<const VectorFieldType*>(bulk->mesh_meta_data().coordinate_field());
 
   std::vector<double> ws_coords(topo.num_nodes() * dim);
-  const auto* nodes = bulk.begin_nodes(elem);
+  const auto* nodes = bulk->begin_nodes(elem);
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double* coords = stk::mesh::field_data(coordField, nodes[j]);
     sierra::nalu::matvec33(Q, coords, &ws_coords[j*dim]);
@@ -193,9 +196,10 @@ TEST(MetricTensorNGP, hex27)
   int dim = topo.dimension();
   ASSERT_EQ(dim,3);
 
-  stk::mesh::MetaData meta(dim);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
-  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, topo);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(dim);
+  auto bulk = meshBuilder.create();
+  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, topo);
 
   sierra::nalu::Hex27SCS mescs;
 
@@ -216,10 +220,10 @@ TEST(MetricTensorNGP, hex27)
   double metric_exact[9];
   sierra::nalu::mxm33(Q,Qt,metric_exact);
 
-  const auto& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
+  const auto& coordField = *static_cast<const VectorFieldType*>(bulk->mesh_meta_data().coordinate_field());
 
   Kokkos::View<double**> v_coords("coords", 27, 3);
-  const auto* nodes = bulk.begin_nodes(elem);
+  const auto* nodes = bulk->begin_nodes(elem);
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double* coords = stk::mesh::field_data(coordField, nodes[j]);
     sierra::nalu::matvec33(Q, coords, &v_coords(j,0));

--- a/unit_tests/UnitTestMijTensor.C
+++ b/unit_tests/UnitTestMijTensor.C
@@ -8,6 +8,7 @@
 
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
@@ -53,10 +54,13 @@ void test_metric_for_topo_2D(stk::topology topo, double tol) {
   int dim = topo.dimension();
   ASSERT_EQ(dim, 2);
 
-  stk::mesh::MetaData meta(dim);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(dim);
+  auto bulk = meshBuilder.create();
+  auto& meta = bulk->mesh_meta_data();
+
   stk::mesh::Entity elem =
-      unit_test_utils::create_one_reference_element(bulk, topo);
+      unit_test_utils::create_one_reference_element(*bulk, topo);
 
   auto *mescs =
       sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
@@ -93,7 +97,7 @@ void test_metric_for_topo_2D(stk::topology topo, double tol) {
   const auto &coordField =
       *static_cast<const VectorFieldType *>(meta.coordinate_field());
   std::vector<double> ws_coords(topo.num_nodes() * dim);
-  const auto *nodes = bulk.begin_nodes(elem);
+  const auto *nodes = bulk->begin_nodes(elem);
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double *coords = stk::mesh::field_data(coordField, nodes[j]);
     sierra::nalu::matvec22(Q, coords, &ws_coords[j * dim]);
@@ -114,10 +118,13 @@ void test_metric_for_topo_3D(stk::topology topo, double tol) {
   int dim = topo.dimension();
   ASSERT_EQ(dim, 3);
 
-  stk::mesh::MetaData meta(dim);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(dim);
+  auto bulk = meshBuilder.create();
+  auto& meta = bulk->mesh_meta_data();
+
   stk::mesh::Entity elem =
-      unit_test_utils::create_one_reference_element(bulk, topo);
+      unit_test_utils::create_one_reference_element(*bulk, topo);
 
   auto *mescs =
       sierra::nalu::MasterElementRepo::get_surface_master_element(topo);
@@ -156,7 +163,7 @@ void test_metric_for_topo_3D(stk::topology topo, double tol) {
   const auto &coordField =
       *static_cast<const VectorFieldType *>(meta.coordinate_field());
   std::vector<double> ws_coords(topo.num_nodes() * dim);
-  const auto *nodes = bulk.begin_nodes(elem);
+  const auto *nodes = bulk->begin_nodes(elem);
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double *coords = stk::mesh::field_data(coordField, nodes[j]);
     sierra::nalu::matvec33(Q, coords, &ws_coords[j * dim]);
@@ -207,10 +214,13 @@ TEST(MijTensorNGP, hex27) {
   int dim = topo.dimension();
   ASSERT_EQ(dim, 3);
 
-  stk::mesh::MetaData meta(dim);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(dim);
+  auto bulk = meshBuilder.create();
+  auto& meta = bulk->mesh_meta_data();
+
   stk::mesh::Entity elem =
-      unit_test_utils::create_one_reference_element(bulk, topo);
+      unit_test_utils::create_one_reference_element(*bulk, topo);
 
   sierra::nalu::Hex27SCS mescs;
 
@@ -249,7 +259,7 @@ TEST(MijTensorNGP, hex27) {
   const auto &coordField =
       *static_cast<const VectorFieldType *>(meta.coordinate_field());
   Kokkos::View<double **> v_coords("coords", AlgTraits::nodesPerElement_, dim);
-  const auto *nodes = bulk.begin_nodes(elem);
+  const auto *nodes = bulk->begin_nodes(elem);
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double *coords = stk::mesh::field_data(coordField, nodes[j]);
     sierra::nalu::matvec33(Q, coords, &v_coords(j, 0));
@@ -280,10 +290,13 @@ TEST(MijTensorNGP, hex27_simd) {
   int dim = topo.dimension();
   ASSERT_EQ(dim, 3);
 
-  stk::mesh::MetaData meta(dim);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(dim);
+  auto bulk = meshBuilder.create();
+  auto& meta = bulk->mesh_meta_data();
+
   stk::mesh::Entity elem =
-      unit_test_utils::create_one_reference_element(bulk, topo);
+      unit_test_utils::create_one_reference_element(*bulk, topo);
 
   sierra::nalu::Hex27SCS mescs;
 
@@ -326,7 +339,7 @@ TEST(MijTensorNGP, hex27_simd) {
       *static_cast<const VectorFieldType *>(meta.coordinate_field());
   Kokkos::View<DoubleType **> v_coords("coords", AlgTraits::nodesPerElement_,
                                        dim);
-  const auto *nodes = bulk.begin_nodes(elem);
+  const auto *nodes = bulk->begin_nodes(elem);
   for (unsigned j = 0; j < topo.num_nodes(); ++j) {
     const double *coords = stk::mesh::field_data(coordField, nodes[j]);
 

--- a/unit_tests/UnitTestMovingAverage.C
+++ b/unit_tests/UnitTestMovingAverage.C
@@ -7,6 +7,7 @@
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
@@ -28,10 +29,14 @@ class PostProcessor : public ::testing::Test
 public:
   PostProcessor()
     : timeIntegrator_(),
-      meta_(2u),
-      bulk_(meta_, MPI_COMM_WORLD),
       numSteps(2000)
  {
+    auto numberOfDimensions = 2u;
+    stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+    meshBuilder.set_spatial_dimension(numberOfDimensions);
+    bulk_ = meshBuilder.create();
+    auto& meta_ = bulk_->mesh_meta_data();
+
     temperature_ = &meta_.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "temperature");
 
     raTemperature_ = &meta_.declare_field<ScalarFieldType>(
@@ -42,17 +47,16 @@ public:
     stk::mesh::put_field_on_mesh(*raTemperature_, meta_.universal_part(), nullptr);
     meta_.commit();
 
-    bulk_.modification_begin();
-    node = bulk_.declare_node(1u);
-    bulk_.modification_end();
+    bulk_->modification_begin();
+    node = bulk_->declare_node(1u);
+    bulk_->modification_end();
 
     const double final_time = 2.0 * std::acos(-1.0);
     timeIntegrator_.timeStepN_ = final_time/(numSteps);
  }
 
   sierra::nalu::TimeIntegrator timeIntegrator_;
-  stk::mesh::MetaData meta_;
-  stk::mesh::BulkData bulk_;
+  std::unique_ptr<stk::mesh::BulkData> bulk_;
   int numSteps;
 
   stk::mesh::Entity node;
@@ -67,7 +71,7 @@ TEST_F(PostProcessor, moving_average_constant)
     std::vector<double> constant_realization(numSteps, 10.0);
 
     double timeScale = 0.1;
-    sierra::nalu::MovingAveragePostProcessor avgPP(bulk_, timeIntegrator_, false);
+    sierra::nalu::MovingAveragePostProcessor avgPP(*bulk_, timeIntegrator_, false);
     avgPP.add_fields({"temperature"});
     avgPP.set_time_scale(timeScale);
 
@@ -113,7 +117,7 @@ TEST_F(PostProcessor, moving_average_ou)
     auto realization = ou_realization(1.0, dt, numSteps);
 
     double timeScale = 0.1;
-    sierra::nalu::MovingAveragePostProcessor avgPP(bulk_, timeIntegrator_, false);
+    sierra::nalu::MovingAveragePostProcessor avgPP(*bulk_, timeIntegrator_, false);
     avgPP.add_fields({"temperature"});
     avgPP.set_time_scale(timeScale);
 

--- a/unit_tests/UnitTestMovingAverage.C
+++ b/unit_tests/UnitTestMovingAverage.C
@@ -56,7 +56,7 @@ public:
  }
 
   sierra::nalu::TimeIntegrator timeIntegrator_;
-  std::unique_ptr<stk::mesh::BulkData> bulk_;
+  std::shared_ptr<stk::mesh::BulkData> bulk_;
   int numSteps;
 
   stk::mesh::Entity node;

--- a/unit_tests/UnitTestNGPMasterElements.C
+++ b/unit_tests/UnitTestNGPMasterElements.C
@@ -4,6 +4,7 @@
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
@@ -40,13 +41,14 @@ double linear_scalar_value(int dim, double a, const double* b, const double* x)
 #ifndef KOKKOS_ENABLE_CUDA
 TEST(MasterElementFunctions, generic_grad_op_3d_hex_27)
 {
-  stk::mesh::MetaData meta(3);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(3);
+  auto bulk = meshBuilder.create();
 
-  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, stk::topology::HEXAHEDRON_27);
-  const auto* node_rels = bulk.begin_nodes(elem);
+  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEXAHEDRON_27);
+  const auto* node_rels = bulk->begin_nodes(elem);
   sierra::nalu::Hex27SCS me;
-  auto& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
+  auto& coordField = *static_cast<const VectorFieldType*>(bulk->mesh_meta_data().coordinate_field());
   int dim = me.nDim_;
 
   std::mt19937 rng;
@@ -117,13 +119,14 @@ TEST(MasterElementFunctions, generic_grad_op_3d_hex_27)
 
 TEST(MasterElementFunctions, generic_grad_op_2d_tri_6)
 {
-  stk::mesh::MetaData meta(2);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(2);
+  auto bulk = meshBuilder.create();
 
-  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, stk::topology::TRIANGLE_3_2D);
-  const auto* node_rels = bulk.begin_nodes(elem);
+  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, stk::topology::TRIANGLE_3_2D);
+  const auto* node_rels = bulk->begin_nodes(elem);
   sierra::nalu::Tri32DSCS me;
-  auto& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
+  auto& coordField = *static_cast<const VectorFieldType*>(bulk->mesh_meta_data().coordinate_field());
   int dim = me.ndim();
 
   std::mt19937 rng;
@@ -201,13 +204,14 @@ TEST(MasterElementFunctions, generic_grad_op_2d_tri_6)
 #ifndef KOKKOS_ENABLE_CUDA
 TEST(Hex27SCV, detj)
 {
-  stk::mesh::MetaData meta(3);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(3);
+  auto bulk = meshBuilder.create();
 
-  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, stk::topology::HEXAHEDRON_27);
-  const auto* node_rels = bulk.begin_nodes(elem);
+  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEXAHEDRON_27);
+  const auto* node_rels = bulk->begin_nodes(elem);
   sierra::nalu::Hex27SCV me;
-  auto& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
+  auto& coordField = *static_cast<const VectorFieldType*>(bulk->mesh_meta_data().coordinate_field());
   int dim = me.nDim_;
 
   std::mt19937 rng;
@@ -285,11 +289,13 @@ TEST(Hex27SCV, detj)
 
 TEST(Hex27SCS, area_vec)
 {
-  stk::mesh::MetaData meta(3);
-  stk::mesh::BulkData bulk(meta, MPI_COMM_WORLD);
+  stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+  meshBuilder.set_spatial_dimension(3);
+  auto bulk = meshBuilder.create();
+  auto& meta = bulk->mesh_meta_data();
 
-  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(bulk, stk::topology::HEXAHEDRON_27);
-  const auto* node_rels = bulk.begin_nodes(elem);
+  stk::mesh::Entity elem = unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEXAHEDRON_27);
+  const auto* node_rels = bulk->begin_nodes(elem);
   sierra::nalu::Hex27SCS me;
   auto& coordField = *static_cast<const VectorFieldType*>(meta.coordinate_field());
   int dim = me.nDim_;

--- a/unit_tests/UnitTestNgpMesh1.C
+++ b/unit_tests/UnitTestNgpMesh1.C
@@ -155,5 +155,5 @@ TEST_F(Hex8MeshWithNSOFields, NGPMeshField)
 {
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  test_ngp_mesh_field_values(bulk, velocity, massFlowRate);
+  test_ngp_mesh_field_values(*bulk, velocity, massFlowRate);
 }

--- a/unit_tests/UnitTestRealm.C
+++ b/unit_tests/UnitTestRealm.C
@@ -161,8 +161,7 @@ NaluTest::create_realm(const YAML::Node& realm_node, const std::string realm_typ
   if (createMeshObjects) {
     stk::mesh::MeshBuilder meshBuilder(comm_);
     meshBuilder.set_spatial_dimension(spatialDim_);
-    realm->bulkData_ = meshBuilder.create().release();
-    realm->metaData_ = &realm->bulkData_->mesh_meta_data();
+    realm->bulkData_ = meshBuilder.create();
   }
   sim_.realms_->realmVector_.push_back(realm);
 

--- a/unit_tests/UnitTestRealm.C
+++ b/unit_tests/UnitTestRealm.C
@@ -159,8 +159,10 @@ NaluTest::create_realm(const YAML::Node& realm_node, const std::string realm_typ
 
   // Set-up mesh metadata and bulkdata ... let user fill mesh in test function
   if (createMeshObjects) {
-    realm->metaData_ = new stk::mesh::MetaData(spatialDim_);
-    realm->bulkData_ = new stk::mesh::BulkData(*realm->metaData_, comm_);
+    stk::mesh::MeshBuilder meshBuilder(comm_);
+    meshBuilder.set_spatial_dimension(spatialDim_);
+    realm->bulkData_ = meshBuilder.create().release();
+    realm->metaData_ = &realm->bulkData_->mesh_meta_data();
   }
   sim_.realms_->realmVector_.push_back(realm);
 

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -209,7 +209,7 @@ TEST_F(Hex8MeshWithNSOFields, NGPAssembleElemSolver)
 {
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 

--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -171,7 +171,7 @@ TEST_F(Hex8MeshWithNSOFields, NGPScratchViews)
   const double velVec[nDim] = {1.0, 0.0, 0.0};
 
   stk::mesh::EntityVector nodes;
-  stk::mesh::get_entities(bulk, stk::topology::NODE_RANK, nodes);
+  stk::mesh::get_entities(*bulk, stk::topology::NODE_RANK, nodes);
 
   for(stk::mesh::Entity node : nodes) {
     double* fieldData = static_cast<double*>(stk::mesh::field_data(*velocity, node));
@@ -180,7 +180,7 @@ TEST_F(Hex8MeshWithNSOFields, NGPScratchViews)
     }
   }
 
-  do_the_test(bulk, pressure, velocity);
+  do_the_test(*bulk, pressure, velocity);
 }
 
 void do_assemble_elem_solver_test(
@@ -209,13 +209,13 @@ TEST_F(Hex8MeshWithNSOFields, NGPAssembleElemSolver)
 {
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 
   auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
   dataNeeded.add_cvfem_volume_me(meSCV);
-  auto* coordsField = bulk.mesh_meta_data().coordinate_field();
+  auto* coordsField = bulk->mesh_meta_data().coordinate_field();
 
   dataNeeded.add_coordinates_field(*coordsField, 3, sierra::nalu::CURRENT_COORDINATES);
   dataNeeded.add_gathered_nodal_field(*velocity, 3);
@@ -226,7 +226,7 @@ TEST_F(Hex8MeshWithNSOFields, NGPAssembleElemSolver)
   EXPECT_EQ(3u, dataNeeded.get_fields().size());
 
   do_assemble_elem_solver_test(
-    bulk, *assembleElemSolverAlg, velocity->mesh_meta_data_ordinal(),
+    *bulk, *assembleElemSolverAlg, velocity->mesh_meta_data_ordinal(),
     pressure->mesh_meta_data_ordinal());
 }
 
@@ -323,7 +323,7 @@ TEST_F(Hex8MeshWithNSOFields, NGPSharedMemData)
   if (stk::parallel_machine_size(comm) == 1) {
     fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-    do_the_smdata_test(bulk, pressure, velocity);
+    do_the_smdata_test(*bulk, pressure, velocity);
   }
 }
 

--- a/unit_tests/UnitTestSideWriter.C
+++ b/unit_tests/UnitTestSideWriter.C
@@ -41,7 +41,7 @@ public:
   }
 
   stk::mesh::MetaData* meta;
-  std::unique_ptr<stk::mesh::BulkData> bulk;
+  std::shared_ptr<stk::mesh::BulkData> bulk;
   // stk::io::StkMeshIoBroker io;
   stk::mesh::Field<double>* test_field;
   stk::mesh::Field<double, stk::mesh::Cartesian3d>* test_vector_field;

--- a/unit_tests/UnitTestSuppAlgDataSharing.C
+++ b/unit_tests/UnitTestSuppAlgDataSharing.C
@@ -159,14 +159,14 @@ private:
 
 TEST_F(Hex8Mesh, supp_alg_data_sharing)
 {
-    ScalarFieldType& nodalScalarField = meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalScalarField");
-    VectorFieldType& nodalVectorField = meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "nodalVectorField");
-    TensorFieldType& nodalTensorField = meta.declare_field<TensorFieldType>(stk::topology::NODE_RANK, "nodalTensorField");
-    ScalarFieldType& elemScalarField = meta.declare_field<ScalarFieldType>(stk::topology::ELEM_RANK, "elemScalarField");
-    VectorFieldType& elemVectorField = meta.declare_field<VectorFieldType>(stk::topology::ELEM_RANK, "elemVectorField");
-    TensorFieldType& elemTensorField = meta.declare_field<TensorFieldType>(stk::topology::ELEM_RANK, "elemTensorField");
+    ScalarFieldType& nodalScalarField = meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalScalarField");
+    VectorFieldType& nodalVectorField = meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "nodalVectorField");
+    TensorFieldType& nodalTensorField = meta->declare_field<TensorFieldType>(stk::topology::NODE_RANK, "nodalTensorField");
+    ScalarFieldType& elemScalarField = meta->declare_field<ScalarFieldType>(stk::topology::ELEM_RANK, "elemScalarField");
+    VectorFieldType& elemVectorField = meta->declare_field<VectorFieldType>(stk::topology::ELEM_RANK, "elemVectorField");
+    TensorFieldType& elemTensorField = meta->declare_field<TensorFieldType>(stk::topology::ELEM_RANK, "elemTensorField");
 
-    const stk::mesh::Part& wholemesh = meta.universal_part();
+    const stk::mesh::Part& wholemesh = meta->universal_part();
 
     stk::mesh::put_field_on_mesh(nodalScalarField, wholemesh, nullptr);
     stk::mesh::put_field_on_mesh(nodalVectorField, wholemesh, 4, nullptr);
@@ -178,7 +178,7 @@ TEST_F(Hex8Mesh, supp_alg_data_sharing)
 
     fill_mesh("generated:10x10x10");
 
-    TestAlgorithm testAlgorithm(bulk);
+    TestAlgorithm testAlgorithm(*bulk);
 
     //TestSuppAlg constructor says which data it needs, by inserting
     //things into the 'dataNeededByKernels_' container.
@@ -196,12 +196,12 @@ TEST_F(Hex8Mesh, supp_alg_data_sharing)
 
 TEST_F(Hex8Mesh, inconsistent_field_requests)
 {
-    ScalarFieldType& nodalScalarField = meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalScalarField");
-    TensorFieldType& nodalTensorField = meta.declare_field<TensorFieldType>(stk::topology::NODE_RANK, "nodalTensorField");
-    ScalarFieldType& elemScalarField = meta.declare_field<ScalarFieldType>(stk::topology::ELEM_RANK, "elemScalarField");
-    TensorFieldType& elemTensorField = meta.declare_field<TensorFieldType>(stk::topology::ELEM_RANK, "elemTensorField");
+    ScalarFieldType& nodalScalarField = meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalScalarField");
+    TensorFieldType& nodalTensorField = meta->declare_field<TensorFieldType>(stk::topology::NODE_RANK, "nodalTensorField");
+    ScalarFieldType& elemScalarField = meta->declare_field<ScalarFieldType>(stk::topology::ELEM_RANK, "elemScalarField");
+    TensorFieldType& elemTensorField = meta->declare_field<TensorFieldType>(stk::topology::ELEM_RANK, "elemTensorField");
 
-    const stk::mesh::Part& wholemesh = meta.universal_part();
+    const stk::mesh::Part& wholemesh = meta->universal_part();
 
     stk::mesh::put_field_on_mesh(nodalScalarField, wholemesh, nullptr);
     stk::mesh::put_field_on_mesh(nodalTensorField, wholemesh, 3, 3, nullptr);
@@ -211,7 +211,7 @@ TEST_F(Hex8Mesh, inconsistent_field_requests)
 
     fill_mesh("generated:10x10x10");
 
-    sierra::nalu::ElemDataRequests prereqData(meta);
+    sierra::nalu::ElemDataRequests prereqData(*meta);
 
     prereqData.add_gathered_nodal_field(nodalScalarField, 1);
     EXPECT_THROW(prereqData.add_gathered_nodal_field(nodalScalarField, 2), std::logic_error);

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -620,11 +620,11 @@ std::array<double,9> random_linear_transformation(int dim, double scale, std::mt
 
 void Hex8Mesh::check_discrete_laplacian(double exactLaplacian)
 {
-   const stk::mesh::Selector selector = meta.locally_owned_part() & !meta.globally_shared_part();
-   const stk::mesh::BucketVector& nodeBuckets = bulk.get_buckets(stk::topology::NODE_RANK, selector);
+   const stk::mesh::Selector selector = meta->locally_owned_part() & !meta->globally_shared_part();
+   const stk::mesh::BucketVector& nodeBuckets = bulk->get_buckets(stk::topology::NODE_RANK, selector);
    kokkos_thread_team_bucket_loop(nodeBuckets, [&](stk::mesh::Entity node)
    {
-     if (bulk.num_elements(node) == 8) {
+     if (bulk->num_elements(node) == 8) {
          EXPECT_NEAR(*stk::mesh::field_data(*discreteLaplacianOfPressure, node), exactLaplacian    , tol);
      }
    });

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -8,6 +8,7 @@
 
 #include <SimdInterface.h>
 #include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_topology/topology.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
 #include <stk_mesh/base/Field.hpp>
@@ -67,33 +68,38 @@ class Hex8Mesh : public ::testing::Test
 protected:
     Hex8Mesh()
     : comm(MPI_COMM_WORLD), spatialDimension(3),
-      meta(spatialDimension), bulk(meta, comm),
       topo(stk::topology::HEX_8),
-      elemCentroidField(&meta.declare_field<VectorFieldType>(stk::topology::ELEM_RANK, "elemCentroid")),   
-      nodalPressureField(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalPressure")), 
-      discreteLaplacianOfPressure(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "discreteLaplacian")),
-      scalarQ(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalarQ")),
-      diffFluxCoeff(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "diffFluxCoeff")),
-      idField(&meta.declare_field<IdFieldType>(stk::topology::NODE_RANK, "idField")),
       partVec(),
       coordField(nullptr),
       exactLaplacian(0.0)
-    { 
-      stk::mesh::put_field_on_mesh(*elemCentroidField, meta.universal_part(), spatialDimension, (double*)nullptr); 
+    {
+      stk::mesh::MeshBuilder meshBuilder(comm);
+      meshBuilder.set_spatial_dimension(spatialDimension);
+      bulk = meshBuilder.create();
+      meta = &bulk->mesh_meta_data();
+
+      elemCentroidField = &meta->declare_field<VectorFieldType>(stk::topology::ELEM_RANK, "elemCentroid");
+      nodalPressureField = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "nodalPressure");
+      discreteLaplacianOfPressure = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "discreteLaplacian");
+      scalarQ = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalarQ");
+      diffFluxCoeff = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "diffFluxCoeff");
+      idField = &meta->declare_field<IdFieldType>(stk::topology::NODE_RANK, "idField");
+ 
+      stk::mesh::put_field_on_mesh(*elemCentroidField, meta->universal_part(), spatialDimension, (double*)nullptr); 
       double one = 1.0;
       double zero = 0.0;
-      stk::mesh::put_field_on_mesh(*nodalPressureField, meta.universal_part(), 1, &one);
-      stk::mesh::put_field_on_mesh(*discreteLaplacianOfPressure, meta.universal_part(), 1, &zero);
-      stk::mesh::put_field_on_mesh(*scalarQ, meta.universal_part(), 1, &zero);
-      stk::mesh::put_field_on_mesh(*diffFluxCoeff, meta.universal_part(), 1, &zero);
-      stk::mesh::put_field_on_mesh(*idField, meta.universal_part(), 1, nullptr);
+      stk::mesh::put_field_on_mesh(*nodalPressureField, meta->universal_part(), 1, &one);
+      stk::mesh::put_field_on_mesh(*discreteLaplacianOfPressure, meta->universal_part(), 1, &zero);
+      stk::mesh::put_field_on_mesh(*scalarQ, meta->universal_part(), 1, &zero);
+      stk::mesh::put_field_on_mesh(*diffFluxCoeff, meta->universal_part(), 1, &zero);
+      stk::mesh::put_field_on_mesh(*idField, meta->universal_part(), 1, nullptr);
     }
 
     ~Hex8Mesh() {}
 
     void fill_mesh(const std::string& meshSpec = "generated:20x20x20")
     { 
-      unit_test_utils::fill_hex8_mesh(meshSpec, bulk);
+      unit_test_utils::fill_hex8_mesh(meshSpec, *bulk);
     }
 
     void fill_mesh_and_initialize_test_fields(std::string meshSpec = "generated:20x20x20", 
@@ -103,12 +109,12 @@ protected:
 
         fill_mesh(meshSpec);
 
-        partVec = {meta.get_part("block_1")};
+        partVec = {meta->get_part("block_1")};
 
-        coordField = static_cast<const VectorFieldType*>(meta.coordinate_field());
+        coordField = static_cast<const VectorFieldType*>(meta->coordinate_field());
         EXPECT_TRUE(coordField != nullptr);
 
-        exactLaplacian = unit_test_utils::initialize_quadratic_scalar_field(bulk, *coordField, *nodalPressureField);
+        exactLaplacian = unit_test_utils::initialize_quadratic_scalar_field(*bulk, *coordField, *nodalPressureField);
         stk::mesh::field_fill(0.0, *discreteLaplacianOfPressure);
         stk::mesh::field_fill(0.1, *scalarQ);
         stk::mesh::field_fill(0.2, *diffFluxCoeff);
@@ -118,8 +124,8 @@ protected:
 
     stk::ParallelMachine comm;
     unsigned spatialDimension;
-    stk::mesh::MetaData meta;
-    stk::mesh::BulkData bulk;
+    stk::mesh::MetaData* meta;
+    std::unique_ptr<stk::mesh::BulkData> bulk;
     stk::topology topo; 
     VectorFieldType* elemCentroidField;
     ScalarFieldType* nodalPressureField;
@@ -136,35 +142,36 @@ class Hex8MeshWithNSOFields : public Hex8Mesh
 {
 protected:
     Hex8MeshWithNSOFields()
-    : Hex8Mesh(),
-      massFlowRate(&meta.declare_field<GenericFieldType>(stk::topology::ELEM_RANK, "mass_flow_rate_scs")),
-      Gju(&meta.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "Gju", 1/*num-states*/)), 
-      velocity(&meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity", 3/*num-states*/)), 
-      dpdx(&meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx", 3/*num-states*/)), 
-      exposedAreaVec(&meta.declare_field<GenericFieldType>(meta.side_rank(), "exposed_area_vector")),
-      density(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density", 3/*num-states*/)), 
-      viscosity(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity")),
-      pressure(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure")),
-      udiag(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "momentum_diag")),
-      dnvField(&meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume")) 
+    : Hex8Mesh()
     {
+      massFlowRate = &meta->declare_field<GenericFieldType>(stk::topology::ELEM_RANK, "mass_flow_rate_scs");
+      Gju = &meta->declare_field<GenericFieldType>(stk::topology::NODE_RANK, "Gju", 1/*num-states*/);
+      velocity = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity", 3/*num-states*/); 
+      dpdx = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dpdx", 3/*num-states*/);
+      exposedAreaVec = &meta->declare_field<GenericFieldType>(meta->side_rank(), "exposed_area_vector");
+      density = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density", 3/*num-states*/);
+      viscosity = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+      pressure = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pressure");
+      udiag = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "momentum_diag");
+      dnvField = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume"); 
+
       const double one = 1.0;
       const double two = 2.0;
       const double oneVecThree[3] = {one, one, one};
       const double oneVecTwelve[12] = {one, one, one, one, one, one, one, one, one, one, one, one};
       sierra::nalu::HexSCS hex8SCS;
       const std::vector<double> oneVecNInt(hex8SCS.num_integration_points(),one);
-      stk::mesh::put_field_on_mesh(*massFlowRate, meta.universal_part(), hex8SCS.num_integration_points(), oneVecNInt.data());
-      stk::mesh::put_field_on_mesh(*Gju, meta.universal_part(), 3, oneVecThree);
-      stk::mesh::put_field_on_mesh(*velocity, meta.universal_part(), 3, oneVecThree);
-      stk::mesh::put_field_on_mesh(*dpdx, meta.universal_part(), 3, oneVecThree);
+      stk::mesh::put_field_on_mesh(*massFlowRate, meta->universal_part(), hex8SCS.num_integration_points(), oneVecNInt.data());
+      stk::mesh::put_field_on_mesh(*Gju, meta->universal_part(), 3, oneVecThree);
+      stk::mesh::put_field_on_mesh(*velocity, meta->universal_part(), 3, oneVecThree);
+      stk::mesh::put_field_on_mesh(*dpdx, meta->universal_part(), 3, oneVecThree);
       const sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(stk::topology::QUAD_4);
-      stk::mesh::put_field_on_mesh(*exposedAreaVec, meta.universal_part(), 3*meFC->num_integration_points(), oneVecTwelve);
-      stk::mesh::put_field_on_mesh(*density, meta.universal_part(), 1, &one);
-      stk::mesh::put_field_on_mesh(*viscosity, meta.universal_part(), 1, &one);
-      stk::mesh::put_field_on_mesh(*pressure, meta.universal_part(), 1, &one);
-      stk::mesh::put_field_on_mesh(*udiag, meta.universal_part(), 1, &one);
-      stk::mesh::put_field_on_mesh(*dnvField, meta.universal_part(), 1, &two);
+      stk::mesh::put_field_on_mesh(*exposedAreaVec, meta->universal_part(), 3*meFC->num_integration_points(), oneVecTwelve);
+      stk::mesh::put_field_on_mesh(*density, meta->universal_part(), 1, &one);
+      stk::mesh::put_field_on_mesh(*viscosity, meta->universal_part(), 1, &one);
+      stk::mesh::put_field_on_mesh(*pressure, meta->universal_part(), 1, &one);
+      stk::mesh::put_field_on_mesh(*udiag, meta->universal_part(), 1, &one);
+      stk::mesh::put_field_on_mesh(*dnvField, meta->universal_part(), 1, &two);
     }
 
     GenericFieldType* massFlowRate;
@@ -182,73 +189,77 @@ protected:
 class Hex8ElementWithBCFields : public ::testing::Test
  {
  protected:
-    Hex8ElementWithBCFields()
-    : meta(3),
-      bulk(meta, MPI_COMM_WORLD),
-      velocity(meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity")),
-      bcVelocity(meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc")),
-      density(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density")),
-      viscosity(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity")),
-      bcHeatFlux(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_flux_bc")),
-      specificHeat(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat")),
-      exposedAreaVec(meta.declare_field<GenericFieldType>(meta.side_rank(), "exposed_area_vector")),
-      wallFrictionVelocityBip(meta.declare_field<GenericFieldType>(meta.side_rank(), "wall_friction_velocity_bip")),
-      wallNormalDistanceBip(meta.declare_field<GenericFieldType>(meta.side_rank(), "wall_normal_distance_bip")),
-      bcVelocityOpen(meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc")),
-      openMdot(meta.declare_field<GenericFieldType>(meta.side_rank(), "open_mass_flow_rate")),
-      Gjui(meta.declare_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx")),
-      scalarQ(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_q")),
-      bcScalarQ(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "bc_scalar_q")),
-      Gjq(meta.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "Gjq"))
+   Hex8ElementWithBCFields()
    {
     const double one = 1.0;
     const double oneVecThree[3] = {one, one, one};
     const double oneVecFour[4] = {one, one, -one, -one};
     const double oneVecNine[9] = {one, one, one, one, one, one, one, one, one};
     const double oneVecTwelve[12] = {one, one, one, one, one, one, one, one, one, one, one, one};
-    
-    stk::mesh::put_field_on_mesh(velocity, meta.universal_part(), 3, oneVecThree);
-    stk::mesh::put_field_on_mesh(bcVelocity, meta.universal_part(), 3, oneVecThree);
-    stk::mesh::put_field_on_mesh(density, meta.universal_part(), 1, nullptr);
-    stk::mesh::put_field_on_mesh(viscosity, meta.universal_part(), 1, &one);
-    stk::mesh::put_field_on_mesh(bcHeatFlux, meta.universal_part(), 1, nullptr);
-    stk::mesh::put_field_on_mesh(specificHeat, meta.universal_part(), 1, nullptr);    
+   
+    stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+    meshBuilder.set_spatial_dimension(3);
+    bulk = meshBuilder.create();
+    meta = &bulk->mesh_meta_data();
+ 
+    velocity = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
+    bcVelocity = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "wall_velocity_bc");
+    density = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+    viscosity = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "viscosity");
+    bcHeatFlux = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "heat_flux_bc");
+    specificHeat = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "specific_heat");
+    exposedAreaVec = &meta->declare_field<GenericFieldType>(meta->side_rank(), "exposed_area_vector");
+    wallFrictionVelocityBip = &meta->declare_field<GenericFieldType>(meta->side_rank(), "wall_friction_velocity_bip");
+    wallNormalDistanceBip = &meta->declare_field<GenericFieldType>(meta->side_rank(), "wall_normal_distance_bip");
+    bcVelocityOpen = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "open_velocity_bc");
+    openMdot = &meta->declare_field<GenericFieldType>(meta->side_rank(), "open_mass_flow_rate");
+    Gjui = &meta->declare_field<GenericFieldType>(stk::topology::NODE_RANK, "dudx");
+    scalarQ = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "scalar_q");
+    bcScalarQ = &meta->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "bc_scalar_q");
+    Gjq = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "Gjq");
+
+    stk::mesh::put_field_on_mesh(*velocity, meta->universal_part(), 3, oneVecThree);
+    stk::mesh::put_field_on_mesh(*bcVelocity, meta->universal_part(), 3, oneVecThree);
+    stk::mesh::put_field_on_mesh(*density, meta->universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*viscosity, meta->universal_part(), 1, &one);
+    stk::mesh::put_field_on_mesh(*bcHeatFlux, meta->universal_part(), 1, nullptr);
+    stk::mesh::put_field_on_mesh(*specificHeat, meta->universal_part(), 1, nullptr);    
     
     const sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(stk::topology::QUAD_4);
-    stk::mesh::put_field_on_mesh(exposedAreaVec, meta.universal_part(), 3*meFC->num_integration_points(), oneVecTwelve);
-    stk::mesh::put_field_on_mesh(wallFrictionVelocityBip, meta.universal_part(), meFC->num_integration_points(), nullptr);
-    stk::mesh::put_field_on_mesh(wallNormalDistanceBip, meta.universal_part(), meFC->num_integration_points(), nullptr);
+    stk::mesh::put_field_on_mesh(*exposedAreaVec, meta->universal_part(), 3*meFC->num_integration_points(), oneVecTwelve);
+    stk::mesh::put_field_on_mesh(*wallFrictionVelocityBip, meta->universal_part(), meFC->num_integration_points(), nullptr);
+    stk::mesh::put_field_on_mesh(*wallNormalDistanceBip, meta->universal_part(), meFC->num_integration_points(), nullptr);
     
-    stk::mesh::put_field_on_mesh(bcVelocityOpen, meta.universal_part(), 3, oneVecThree);
-    stk::mesh::put_field_on_mesh(openMdot, meta.universal_part(), 4, oneVecFour);
-    stk::mesh::put_field_on_mesh(Gjui, meta.universal_part(), 3*3, oneVecNine);
+    stk::mesh::put_field_on_mesh(*bcVelocityOpen, meta->universal_part(), 3, oneVecThree);
+    stk::mesh::put_field_on_mesh(*openMdot, meta->universal_part(), 4, oneVecFour);
+    stk::mesh::put_field_on_mesh(*Gjui, meta->universal_part(), 3*3, oneVecNine);
     
-    stk::mesh::put_field_on_mesh(scalarQ, meta.universal_part(), 1, &one);    
-    stk::mesh::put_field_on_mesh(bcScalarQ, meta.universal_part(), 1, &one);    
-    stk::mesh::put_field_on_mesh(Gjq, meta.universal_part(), 3, oneVecThree);    
+    stk::mesh::put_field_on_mesh(*scalarQ, meta->universal_part(), 1, &one);    
+    stk::mesh::put_field_on_mesh(*bcScalarQ, meta->universal_part(), 1, &one);    
+    stk::mesh::put_field_on_mesh(*Gjq, meta->universal_part(), 3, oneVecThree);    
     
-    unit_test_utils::create_one_reference_element(bulk, stk::topology::HEXAHEDRON_8);
+    unit_test_utils::create_one_reference_element(*bulk, stk::topology::HEXAHEDRON_8);
    }
 
   ~Hex8ElementWithBCFields() {}
 
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
-  VectorFieldType& velocity;
-  VectorFieldType& bcVelocity;
-  ScalarFieldType& density;
-  ScalarFieldType& viscosity;
-  ScalarFieldType& bcHeatFlux;
-  ScalarFieldType& specificHeat;
-  GenericFieldType& exposedAreaVec;
-  GenericFieldType& wallFrictionVelocityBip;
-  GenericFieldType& wallNormalDistanceBip;
-  VectorFieldType& bcVelocityOpen;
-  GenericFieldType& openMdot;
-  GenericFieldType& Gjui;
-  ScalarFieldType& scalarQ;
-  ScalarFieldType& bcScalarQ;
-  VectorFieldType& Gjq;
+  stk::mesh::MetaData* meta;
+  std::unique_ptr<stk::mesh::BulkData> bulk;
+  VectorFieldType* velocity;
+  VectorFieldType* bcVelocity;
+  ScalarFieldType* density;
+  ScalarFieldType* viscosity;
+  ScalarFieldType* bcHeatFlux;
+  ScalarFieldType* specificHeat;
+  GenericFieldType* exposedAreaVec;
+  GenericFieldType* wallFrictionVelocityBip;
+  GenericFieldType* wallNormalDistanceBip;
+  VectorFieldType* bcVelocityOpen;
+  GenericFieldType* openMdot;
+  GenericFieldType* Gjui;
+  ScalarFieldType* scalarQ;
+  ScalarFieldType* bcScalarQ;
+  VectorFieldType* Gjq;
  };
 
 class ABLWallFunctionHex8ElementWithBCFields : public Hex8ElementWithBCFields
@@ -272,18 +283,18 @@ class ABLWallFunctionHex8ElementWithBCFields : public Hex8ElementWithBCFields
    ypSpec_ = yp;
 
   // Assign some values to the nodal fields
-  for (const auto* ib : bulk.get_buckets(stk::topology::NODE_RANK, meta.universal_part())) {
+  for (const auto* ib : bulk->get_buckets(stk::topology::NODE_RANK, meta->universal_part())) {
     const auto& b = *ib;
     const size_t length = b.size();
     for (size_t k = 0; k < length; ++k) {
       stk::mesh::Entity node = b[k];
-      *stk::mesh::field_data(density, node) = rhoSpec_;
-      double *vel = stk::mesh::field_data(velocity, node);
+      *stk::mesh::field_data(*density, node) = rhoSpec_;
+      double *vel = stk::mesh::field_data(*velocity, node);
       vel[0] = upSpec_; vel[1] = 0.0; vel[2] = 0.0;
-      double *bcVel = stk::mesh::field_data(bcVelocity, node);
+      double *bcVel = stk::mesh::field_data(*bcVelocity, node);
       bcVel[0] = 0.0; bcVel[1] = 0.0; bcVel[3] = 0.0;
-      *stk::mesh::field_data(bcHeatFlux, node) = 0.0;
-      *stk::mesh::field_data(specificHeat, node) = 1000.0;
+      *stk::mesh::field_data(*bcHeatFlux, node) = 0.0;
+      *stk::mesh::field_data(*specificHeat, node) = 1000.0;
     }
   }
 
@@ -291,15 +302,15 @@ class ABLWallFunctionHex8ElementWithBCFields : public Hex8ElementWithBCFields
   const sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(stk::topology::QUAD_4);
   const int numScsBip = meFC->num_integration_points();
   stk::mesh::BucketVector const& face_buckets =
-    bulk.get_buckets( meta.side_rank(), meta.universal_part() );
+    bulk->get_buckets( meta->side_rank(), meta->universal_part() );
   for ( stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
         ib != face_buckets.end() ; ++ ib ) {
     stk::mesh::Bucket & b = **ib;
     const size_t length = b.size();
     for (size_t k=0; k < length; ++k) {
       stk::mesh::Entity face = b[k];
-      double *utauIp = stk::mesh::field_data(wallFrictionVelocityBip, face);
-      double *ypIp = stk::mesh::field_data(wallNormalDistanceBip, face);
+      double *utauIp = stk::mesh::field_data(*wallFrictionVelocityBip, face);
+      double *ypIp = stk::mesh::field_data(*wallNormalDistanceBip, face);
       for ( int ip = 0; ip < numScsBip; ++ip ) {
         utauIp[ip] = utauSpec_;
         ypIp[ip] = ypSpec_;

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -125,7 +125,7 @@ protected:
     stk::ParallelMachine comm;
     unsigned spatialDimension;
     stk::mesh::MetaData* meta;
-    std::unique_ptr<stk::mesh::BulkData> bulk;
+    std::shared_ptr<stk::mesh::BulkData> bulk;
     stk::topology topo; 
     VectorFieldType* elemCentroidField;
     ScalarFieldType* nodalPressureField;
@@ -244,7 +244,7 @@ class Hex8ElementWithBCFields : public ::testing::Test
   ~Hex8ElementWithBCFields() {}
 
   stk::mesh::MetaData* meta;
-  std::unique_ptr<stk::mesh::BulkData> bulk;
+  std::shared_ptr<stk::mesh::BulkData> bulk;
   VectorFieldType* velocity;
   VectorFieldType* bcVelocity;
   ScalarFieldType* density;

--- a/unit_tests/actuator/UnitTestActuatorFunctors.C
+++ b/unit_tests/actuator/UnitTestActuatorFunctors.C
@@ -168,7 +168,7 @@ protected:
 
     velocity_ = &stkMeta_->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity");
     actuatorForce_ = &stkMeta_->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "actuator_source");
-      dualNodalVolume_ = &stkMeta_->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
+    dualNodalVolume_ = &stkMeta_->declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "dual_nodal_volume");
 
     stk::mesh::put_field_on_mesh(
       *velocity_, stkMeta_->universal_part(), 3, nullptr);

--- a/unit_tests/actuator/UnitTestActuatorFunctors.C
+++ b/unit_tests/actuator/UnitTestActuatorFunctors.C
@@ -150,7 +150,7 @@ class ActuatorFunctorTests : public ::testing::Test
 protected:
   std::string inputFileSurrogate_;
   stk::mesh::MetaData* stkMeta_;
-  std::unique_ptr<stk::mesh::BulkData> stkBulk_;
+  std::shared_ptr<stk::mesh::BulkData> stkBulk_;
   const double tol_;
   const VectorFieldType* coordinates_{nullptr};
   VectorFieldType* velocity_{nullptr};

--- a/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
@@ -38,7 +38,7 @@ static constexpr double lhs[8][8] =
 
 TEST_F(ContinuityEdgeHex8Mesh, NGP_advection)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -48,7 +48,7 @@ TEST_F(ContinuityEdgeHex8Mesh, NGP_advection)
   solnOpts_.mdotInterpRhoUTogether_ = true;
 
   unit_test_utils::EdgeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1);
+    *bulk_, stk::topology::HEX_8, 1);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.gamma1_ = 1.0;

--- a/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
@@ -47,8 +47,7 @@ TEST_F(ContinuityEdgeHex8Mesh, NGP_advection)
   solnOpts_.externalMeshDeformation_ = false;
   solnOpts_.mdotInterpRhoUTogether_ = true;
 
-  unit_test_utils::EdgeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1);
+  unit_test_utils::EdgeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.gamma1_ = 1.0;

--- a/unit_tests/edge_kernels/UnitTestContinuityOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityOpenEdge.C
@@ -50,7 +50,7 @@ TEST_F(ContinuityKernelHex8Mesh,NGP_open_edge)
   const int numDof = 1;
   bool isEdge = true;
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, numDof, part, isEdge);
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, numDof, part, isEdge);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.gamma1_ = 1.0;

--- a/unit_tests/edge_kernels/UnitTestContinuityOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityOpenEdge.C
@@ -36,7 +36,7 @@ static constexpr double lhs[8][8] =
 
 TEST_F(ContinuityKernelHex8Mesh,NGP_open_edge)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -46,11 +46,11 @@ TEST_F(ContinuityKernelHex8Mesh,NGP_open_edge)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  auto* part = meta_.get_part("surface_2");
+  auto* part = meta_->get_part("surface_2");
   const int numDof = 1;
   bool isEdge = true;
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, numDof, part, isEdge);
+    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, numDof, part, isEdge);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.gamma1_ = 1.0;
@@ -60,7 +60,7 @@ TEST_F(ContinuityKernelHex8Mesh,NGP_open_edge)
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::ContinuityOpenEdgeKernel<sierra::nalu::AlgTraitsQuad4Hex8>(
-      meta_, &solnOpts_,
+      *meta_, &solnOpts_,
       helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
       helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_));
 

--- a/unit_tests/edge_kernels/UnitTestMomentumABLWallFuncEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumABLWallFuncEdge.C
@@ -18,7 +18,7 @@
 
 TEST_F(MomentumABLKernelHex8Mesh, NGP_abl_wall_func)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -28,13 +28,13 @@ TEST_F(MomentumABLKernelHex8Mesh, NGP_abl_wall_func)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, 3, part);
+    *bulk_, stk::topology::QUAD_4, 3, part);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::MomentumABLWallFuncEdgeKernel<sierra::nalu::AlgTraitsQuad4>(
-      meta_, gravity_, z0_, Tref_, kappa_,
+      *meta_, gravity_, z0_, Tref_, kappa_,
       helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
 
   helperObjs.assembleElemSolverAlg->activeKernels_.push_back(kernel.get());

--- a/unit_tests/edge_kernels/UnitTestMomentumABLWallFuncEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumABLWallFuncEdge.C
@@ -29,8 +29,7 @@ TEST_F(MomentumABLKernelHex8Mesh, NGP_abl_wall_func)
   solnOpts_.externalMeshDeformation_ = false;
 
   auto* part = meta_->get_part("surface_5");
-  unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, 3, part);
+  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::QUAD_4, 3, part);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::MomentumABLWallFuncEdgeKernel<sierra::nalu::AlgTraitsQuad4>(

--- a/unit_tests/edge_kernels/UnitTestMomentumAdvDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumAdvDiffEdge.C
@@ -77,7 +77,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_advection_diffusion)
   solnOpts_.alphaUpwMap_["velocity"] = 0.0;
   solnOpts_.upwMap_["velocity"] = 0.0;
 
-  unit_test_utils::EdgeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3);
+  unit_test_utils::EdgeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3);
 
   helperObjs.create<sierra::nalu::MomentumEdgeSolverAlg>(partVec_[0]);
 

--- a/unit_tests/edge_kernels/UnitTestMomentumAdvDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumAdvDiffEdge.C
@@ -66,7 +66,7 @@ static constexpr double lhs[24][24] = {
 
 TEST_F(MomentumEdgeHex8Mesh, NGP_advection_diffusion)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -77,7 +77,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_advection_diffusion)
   solnOpts_.alphaUpwMap_["velocity"] = 0.0;
   solnOpts_.upwMap_["velocity"] = 0.0;
 
-  unit_test_utils::EdgeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3);
+  unit_test_utils::EdgeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3);
 
   helperObjs.create<sierra::nalu::MomentumEdgeSolverAlg>(partVec_[0]);
 

--- a/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
@@ -53,7 +53,7 @@ static constexpr double lhs[24][24] = {
 
 TEST_F(MomentumEdgeHex8Mesh, NGP_open_edge)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -63,15 +63,15 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_open_edge)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  auto* part = meta_.get_part("surface_2");
+  auto* part = meta_->get_part("surface_2");
   bool isEdge = true;
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
+    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::MomentumOpenEdgeKernel<
       sierra::nalu::AlgTraitsQuad4Hex8>(
-      meta_, &solnOpts_, viscosity_,
+      *meta_, &solnOpts_, viscosity_,
       helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
       helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_,
       sierra::nalu::EntrainmentMethod::COMPUTED));

--- a/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
@@ -66,7 +66,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_open_edge)
   auto* part = meta_->get_part("surface_2");
   bool isEdge = true;
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::MomentumOpenEdgeKernel<

--- a/unit_tests/edge_kernels/UnitTestMomentumSSTAMSDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumSSTAMSDiffEdge.C
@@ -63,7 +63,7 @@ static constexpr double lhs[24][24] = {
 
 TEST_F(AMSKernelHex8Mesh, NGP_ams_diff)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -76,9 +76,9 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_diff)
   solnOpts_.upwMap_["velocity"] = 0.0;
   solnOpts_.initialize_turbulence_constants();
 
-  unit_test_utils::EdgeKernelHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+  unit_test_utils::EdgeKernelHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
-  helperObjs.edgeAlg->add_kernel<sierra::nalu::MomentumSSTAMSDiffEdgeKernel>(bulk_, solnOpts_);
+  helperObjs.edgeAlg->add_kernel<sierra::nalu::MomentumSSTAMSDiffEdgeKernel>(*bulk_, solnOpts_);
     
   helperObjs.execute();
 

--- a/unit_tests/edge_kernels/UnitTestMomentumSSTAMSDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumSSTAMSDiffEdge.C
@@ -76,7 +76,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_diff)
   solnOpts_.upwMap_["velocity"] = 0.0;
   solnOpts_.initialize_turbulence_constants();
 
-  unit_test_utils::EdgeKernelHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+  unit_test_utils::EdgeKernelHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.edgeAlg->add_kernel<sierra::nalu::MomentumSSTAMSDiffEdgeKernel>(*bulk_, solnOpts_);
     

--- a/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
@@ -87,7 +87,7 @@ static constexpr double lhs[24][24] = {
 
 TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -97,15 +97,15 @@ TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  auto* part = meta_.get_part("surface_2");
+  auto* part = meta_->get_part("surface_2");
   bool isEdge = true;
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
+    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::MomentumSymmetryEdgeKernel<
       sierra::nalu::AlgTraitsQuad4Hex8>(
-      meta_, solnOpts_, velocity_, viscosity_,
+      *meta_, solnOpts_, velocity_, viscosity_,
       helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
       helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_));
 
@@ -118,7 +118,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge)
 
 TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge_penalty)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -129,15 +129,15 @@ TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge_penalty)
   solnOpts_.externalMeshDeformation_ = false;
   solnOpts_.symmetryBcPenaltyFactor_ = 2.0;
 
-  auto* part = meta_.get_part("surface_2");
+  auto* part = meta_->get_part("surface_2");
   bool isEdge = true;
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
+    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::MomentumSymmetryEdgeKernel<
       sierra::nalu::AlgTraitsQuad4Hex8>(
-      meta_, solnOpts_, velocity_, viscosity_,
+      *meta_, solnOpts_, velocity_, viscosity_,
       helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
       helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_));
 

--- a/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
@@ -100,7 +100,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge)
   auto* part = meta_->get_part("surface_2");
   bool isEdge = true;
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::MomentumSymmetryEdgeKernel<
@@ -132,7 +132,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge_penalty)
   auto* part = meta_->get_part("surface_2");
   bool isEdge = true;
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 3, part, isEdge);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::MomentumSymmetryEdgeKernel<

--- a/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
@@ -92,7 +92,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
   solnOpts_.upwMap_["mixture_fraction"] = 0.0;
 
   const int numDof = 1;
-  unit_test_utils::TpetraHelperObjectsEdge helperObjs(*bulk_, numDof);
+  unit_test_utils::TpetraHelperObjectsEdge helperObjs(bulk_, numDof);
 
   helperObjs.realm.naluGlobalId_ = naluGlobalId_;
   helperObjs.realm.tpetGlobalId_ = tpetGlobalId_;
@@ -152,7 +152,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra_fix_pressure_at_n
   fill_mesh_and_init_fields();
 
   const int numDof = 1;
-  unit_test_utils::TpetraHelperObjectsEdge helperObjs(*bulk_, numDof);
+  unit_test_utils::TpetraHelperObjectsEdge helperObjs(bulk_, numDof);
 
   sierra::nalu::SolutionOptions* solnOpts = helperObjs.realm.solutionOptions_;
 
@@ -212,7 +212,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra_dirichlet)
   fill_mesh_and_init_fields();
 
   const int numDof = 1;
-  unit_test_utils::TpetraHelperObjectsEdge helperObjs(*bulk_, numDof);
+  unit_test_utils::TpetraHelperObjectsEdge helperObjs(bulk_, numDof);
 
   sierra::nalu::SolutionOptions* solnOpts = helperObjs.realm.solutionOptions_;
 

--- a/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
@@ -77,10 +77,10 @@ static const std::vector<double> dirichlet_rhs_P1 = {-2, -2, -2, -2};
 
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
 {
-  int numProcs = bulk_.parallel_size();
+  int numProcs = bulk_->parallel_size();
   if (numProcs > 2) return;
 
-  int myProc = bulk_.parallel_rank();
+  int myProc = bulk_->parallel_rank();
 
   fill_mesh_and_init_fields();
 
@@ -92,7 +92,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
   solnOpts_.upwMap_["mixture_fraction"] = 0.0;
 
   const int numDof = 1;
-  unit_test_utils::TpetraHelperObjectsEdge helperObjs(bulk_, numDof);
+  unit_test_utils::TpetraHelperObjectsEdge helperObjs(*bulk_, numDof);
 
   helperObjs.realm.naluGlobalId_ = naluGlobalId_;
   helperObjs.realm.tpetGlobalId_ = tpetGlobalId_;
@@ -131,8 +131,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
   auto ngpField = helperObjs.realm.ngp_field_manager().get_field<double>(mixFraction_->mesh_meta_data_ordinal());
   ngpField.sync_to_host();
 
-  const stk::mesh::BucketVector& buckets = bulk_.get_buckets(stk::topology::NODE_RANK,
-                                  bulk_.mesh_meta_data().locally_owned_part());
+  const stk::mesh::BucketVector& buckets = bulk_->get_buckets(stk::topology::NODE_RANK,
+                                  bulk_->mesh_meta_data().locally_owned_part());
   for(const stk::mesh::Bucket* bptr : buckets) {
     for(stk::mesh::Entity node : *bptr) {
       const double* data1 = static_cast<double*>(stk::mesh::field_data(*viscosity_, node));
@@ -144,15 +144,15 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
 
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra_fix_pressure_at_node)
 {
-  int numProcs = bulk_.parallel_size();
+  int numProcs = bulk_->parallel_size();
   if (numProcs > 2) return;
 
-  int myProc = bulk_.parallel_rank();
+  int myProc = bulk_->parallel_rank();
 
   fill_mesh_and_init_fields();
 
   const int numDof = 1;
-  unit_test_utils::TpetraHelperObjectsEdge helperObjs(bulk_, numDof);
+  unit_test_utils::TpetraHelperObjectsEdge helperObjs(*bulk_, numDof);
 
   sierra::nalu::SolutionOptions* solnOpts = helperObjs.realm.solutionOptions_;
 
@@ -206,13 +206,13 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra_fix_pressure_at_n
 
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra_dirichlet)
 {
-  int numProcs = bulk_.parallel_size();
+  int numProcs = bulk_->parallel_size();
   if (numProcs > 2) return;
 
   fill_mesh_and_init_fields();
 
   const int numDof = 1;
-  unit_test_utils::TpetraHelperObjectsEdge helperObjs(bulk_, numDof);
+  unit_test_utils::TpetraHelperObjectsEdge helperObjs(*bulk_, numDof);
 
   sierra::nalu::SolutionOptions* solnOpts = helperObjs.realm.solutionOptions_;
 
@@ -255,8 +255,8 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra_dirichlet)
   ngpSolutionField.modify_on_host();
   ngpBCValuesField.modify_on_host();
 
-  stk::mesh::Entity node1 = bulk_.get_entity(stk::topology::NODE_RANK, 1);
-  if (bulk_.is_valid(node1)) {
+  stk::mesh::Entity node1 = bulk_->get_entity(stk::topology::NODE_RANK, 1);
+  if (bulk_->is_valid(node1)) {
     double* node1value = static_cast<double*>(stk::mesh::field_data(*bcValuesField, node1));
     *node1value = 1.0;
   }
@@ -265,7 +265,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra_dirichlet)
 
   namespace golds = ::hex8_golds::adv_diff;
 
-  int myProc = bulk_.parallel_rank();
+  int myProc = bulk_->parallel_rank();
 
   if (numProcs == 1) {
     helperObjs.check_against_sparse_gold_values(golds::rowOffsets_serial, golds::cols_serial,

--- a/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
@@ -37,7 +37,7 @@ static constexpr double lhs[8][8] = {
 
 TEST_F(SSTKernelHex8Mesh, NGP_scalar_edge_open_solver_alg)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -47,14 +47,14 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_edge_open_solver_alg)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  auto* part = meta_.get_part("surface_2");
+  auto* part = meta_->get_part("surface_2");
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
+    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
 
   std::unique_ptr<sierra::nalu::ScalarEdgeOpenSolverAlg<sierra::nalu::AlgTraitsQuad4Hex8>>
     kernel (new sierra::nalu::ScalarEdgeOpenSolverAlg<
       sierra::nalu::AlgTraitsQuad4Hex8>(
-      meta_, solnOpts_, tke_, tkebc_, dkdx_, tvisc_, 
+      *meta_, solnOpts_, tke_, tkebc_, dkdx_, tvisc_, 
       helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
       helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_));
 
@@ -74,7 +74,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_edge_open_solver_alg)
 
 TEST_F(SSTKernelHex8Mesh, NGP_scalar_open_edge)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -98,13 +98,13 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_open_edge)
   solnOpts_.externalMeshDeformation_ = false;
   solnOpts_.relaxFactorMap_["turbulent_ke"] = 0.5;
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, 1, part);
+    *bulk_, stk::topology::QUAD_4, 1, part);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::ScalarOpenEdgeKernel<sierra::nalu::AlgTraitsQuad4>(
-      meta_, solnOpts_,tke_, tkebc_,
+      *meta_, solnOpts_,tke_, tkebc_,
       helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
   helperObjs.assembleElemSolverAlg->activeKernels_.push_back(kernel.get());
 

--- a/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
@@ -49,7 +49,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_edge_open_solver_alg)
 
   auto* part = meta_->get_part("surface_2");
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
 
   std::unique_ptr<sierra::nalu::ScalarEdgeOpenSolverAlg<sierra::nalu::AlgTraitsQuad4Hex8>>
     kernel (new sierra::nalu::ScalarEdgeOpenSolverAlg<
@@ -100,7 +100,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_open_edge)
 
   auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, 1, part);
+    bulk_, stk::topology::QUAD_4, 1, part);
 
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::ScalarOpenEdgeKernel<sierra::nalu::AlgTraitsQuad4>(

--- a/unit_tests/edge_kernels/UnitTestStreletsUpwindEdgeAlg.C
+++ b/unit_tests/edge_kernels/UnitTestStreletsUpwindEdgeAlg.C
@@ -80,7 +80,7 @@ TEST_F(SSTKernelHex8Mesh, StreletsUpwindComputation)
   YAML::Node realm_node = YAML::Load(realmInput);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0], true,
+    bulk_, stk::topology::HEX_8, 1, partVec_[0], true,
     unit_test_utils::get_default_inputs(), realm_node[0]);
 
   Realm& realm = helperObjs.realm;

--- a/unit_tests/edge_kernels/UnitTestStreletsUpwindEdgeAlg.C
+++ b/unit_tests/edge_kernels/UnitTestStreletsUpwindEdgeAlg.C
@@ -80,7 +80,7 @@ TEST_F(SSTKernelHex8Mesh, StreletsUpwindComputation)
   YAML::Node realm_node = YAML::Load(realmInput);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0], true,
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0], true,
     unit_test_utils::get_default_inputs(), realm_node[0]);
 
   Realm& realm = helperObjs.realm;
@@ -103,7 +103,7 @@ TEST_F(SSTKernelHex8Mesh, StreletsUpwindComputation)
   // we need to make a consistent velocity field to pair with
   const stk::mesh::Selector sel = stk::mesh::selectField(*velocity_);
 
-  for (const auto* ib : bulk_.get_buckets(stk::topology::NODE_RANK, sel)) {
+  for (const auto* ib : bulk_->get_buckets(stk::topology::NODE_RANK, sel)) {
     const auto& b = *ib;
     const size_t length = b.size();
     for (size_t k = 0; k < length; ++k) {
@@ -173,18 +173,18 @@ TEST_F(SSTKernelHex8Mesh, StreletsUpwindComputation)
 
   // check on host for values
   const auto rank = NaluEnv::self().parallel_rank();
-  for (const auto* ib : bulk_.get_buckets(
-         stk::topology::EDGE_RANK, meta_.locally_owned_part())) {
+  for (const auto* ib : bulk_->get_buckets(
+         stk::topology::EDGE_RANK, meta_->locally_owned_part())) {
     const auto& b = *ib;
     const size_t length = b.size();
     for (size_t k = 0; k < length; ++k) {
       stk::mesh::Entity edge = b[k];
-      const auto* nodes = bulk_.begin_nodes(edge);
-      const auto gEdge = bulk_.identifier(edge);
+      const auto* nodes = bulk_->begin_nodes(edge);
+      const auto gEdge = bulk_->identifier(edge);
       const double* x1 = stk::mesh::field_data(*coordinates_, nodes[0]);
       const double* x2 = stk::mesh::field_data(*coordinates_, nodes[1]);
-      const auto nId1 = bulk_.identifier(nodes[0]);
-      const auto nId2 = bulk_.identifier(nodes[1]);
+      const auto nId1 = bulk_->identifier(nodes[0]);
+      const auto nId2 = bulk_->identifier(nodes[1]);
       const double fieldVal = *stk::mesh::field_data(*pecletFactor_, edge);
 
       EXPECT_NEAR(tanhOne, fieldVal, 1e-12)

--- a/unit_tests/edge_kernels/UnitTestWallDistEdgeSolver.C
+++ b/unit_tests/edge_kernels/UnitTestWallDistEdgeSolver.C
@@ -31,7 +31,7 @@ static constexpr double lhs[8][8] = {
 
 TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_edge)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -39,7 +39,7 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_edge)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  unit_test_utils::EdgeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1);
+  unit_test_utils::EdgeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 1);
   helperObjs.create<sierra::nalu::WallDistEdgeSolverAlg>(partVec_[0]);
 
   helperObjs.execute();

--- a/unit_tests/edge_kernels/UnitTestWallDistEdgeSolver.C
+++ b/unit_tests/edge_kernels/UnitTestWallDistEdgeSolver.C
@@ -39,7 +39,7 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_edge)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  unit_test_utils::EdgeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 1);
+  unit_test_utils::EdgeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1);
   helperObjs.create<sierra::nalu::WallDistEdgeSolverAlg>(partVec_[0]);
 
   helperObjs.execute();

--- a/unit_tests/gcl/UnitTestMeshVelocityAlg.C
+++ b/unit_tests/gcl/UnitTestMeshVelocityAlg.C
@@ -72,41 +72,41 @@ static constexpr double face_vel_mag[12] = {0.125, 0.0,  -0.125,  0.0,
 TEST_F(TestKernelHex8Mesh, mesh_velocity_x_rot)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   // declare relevant fields
-  dnvField_ = &(meta_.declare_field<ScalarFieldType>(
+  dnvField_ = &(meta_->declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "dual_nodal_volume", 3));
-  stk::mesh::put_field_on_mesh(*dnvField_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*dnvField_, meta_->universal_part(), nullptr);
 
-  VectorFieldType* meshDisp_ = &(meta_.declare_field<VectorFieldType>(
+  VectorFieldType* meshDisp_ = &(meta_->declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "mesh_displacement", 3));
-  stk::mesh::put_field_on_mesh(*meshDisp_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*meshDisp_, meta_->universal_part(), nullptr);
 
-  VectorFieldType* cCoords_ = &(meta_.declare_field<VectorFieldType>(
+  VectorFieldType* cCoords_ = &(meta_->declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "current_coordinates"));
-  stk::mesh::put_field_on_mesh(*cCoords_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*cCoords_, meta_->universal_part(), nullptr);
 
   const auto& meSCS =
     sierra::nalu::MasterElementRepo::get_surface_master_element(
       stk::topology::HEX_8);
-  GenericFieldType* sweptVolume_ = &(meta_.declare_field<GenericFieldType>(
+  GenericFieldType* sweptVolume_ = &(meta_->declare_field<GenericFieldType>(
     stk::topology::ELEM_RANK, "swept_face_volume", 3));
   stk::mesh::put_field_on_mesh(
-    *sweptVolume_, meta_.universal_part(), meSCS->num_integration_points(),
+    *sweptVolume_, meta_->universal_part(), meSCS->num_integration_points(),
     nullptr);
 
-  GenericFieldType* faceVelMag_ = &(meta_.declare_field<GenericFieldType>(
+  GenericFieldType* faceVelMag_ = &(meta_->declare_field<GenericFieldType>(
     stk::topology::ELEM_RANK, "face_velocity_mag", 2));
   stk::mesh::put_field_on_mesh(
-    *faceVelMag_, meta_.universal_part(), meSCS->num_integration_points(),
+    *faceVelMag_, meta_->universal_part(), meSCS->num_integration_points(),
     nullptr);
 
   fill_mesh_and_init_fields();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.timeStepN_ = 0.5;   // first time step size
@@ -141,8 +141,8 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_x_rot)
     &(meshDisp_->field_of_state(stk::mesh::StateNM1));
 
   {
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
     for (const auto* b : bkts) {
       for (const auto node : *b) {
         double* dispNp1 = stk::mesh::field_data(*meshDispNp1, node);
@@ -184,8 +184,8 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_x_rot)
   const double tol = 1.0e-15;
   namespace gold_values = ::hex8_golds_x_rot::mesh_velocity;
   {
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::ELEM_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::ELEM_RANK, sel);
     int counter = 0;
     for (const auto* b : bkts) {
       const double* sv = stk::mesh::field_data(*sweptVolume_, *b, 0);
@@ -204,41 +204,41 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_x_rot)
 TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   // declare relevant fields
-  dnvField_ = &(meta_.declare_field<ScalarFieldType>(
+  dnvField_ = &(meta_->declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "dual_nodal_volume", 3));
-  stk::mesh::put_field_on_mesh(*dnvField_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*dnvField_, meta_->universal_part(), nullptr);
 
-  VectorFieldType* meshDisp_ = &(meta_.declare_field<VectorFieldType>(
+  VectorFieldType* meshDisp_ = &(meta_->declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "mesh_displacement", 3));
-  stk::mesh::put_field_on_mesh(*meshDisp_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*meshDisp_, meta_->universal_part(), nullptr);
 
-  VectorFieldType* cCoords_ = &(meta_.declare_field<VectorFieldType>(
+  VectorFieldType* cCoords_ = &(meta_->declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "current_coordinates"));
-  stk::mesh::put_field_on_mesh(*cCoords_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*cCoords_, meta_->universal_part(), nullptr);
 
   const auto& meSCS =
     sierra::nalu::MasterElementRepo::get_surface_master_element(
       stk::topology::HEX_8);
-  GenericFieldType* sweptVolume_ = &(meta_.declare_field<GenericFieldType>(
+  GenericFieldType* sweptVolume_ = &(meta_->declare_field<GenericFieldType>(
     stk::topology::ELEM_RANK, "swept_face_volume", 3));
   stk::mesh::put_field_on_mesh(
-    *sweptVolume_, meta_.universal_part(), meSCS->num_integration_points(),
+    *sweptVolume_, meta_->universal_part(), meSCS->num_integration_points(),
     nullptr);
 
-  GenericFieldType* faceVelMag_ = &(meta_.declare_field<GenericFieldType>(
+  GenericFieldType* faceVelMag_ = &(meta_->declare_field<GenericFieldType>(
     stk::topology::ELEM_RANK, "face_velocity_mag", 2));
   stk::mesh::put_field_on_mesh(
-    *faceVelMag_, meta_.universal_part(), meSCS->num_integration_points(),
+    *faceVelMag_, meta_->universal_part(), meSCS->num_integration_points(),
     nullptr);
 
   fill_mesh_and_init_fields();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.timeStepN_ = 0.5;   // first time step size
@@ -273,8 +273,8 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot)
     &(meshDisp_->field_of_state(stk::mesh::StateNM1));
 
   {
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
     for (const auto* b : bkts) {
       for (const auto node : *b) {
         double* dispNp1 = stk::mesh::field_data(*meshDispNp1, node);
@@ -316,8 +316,8 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot)
   const double tol = 1.0e-15;
   namespace gold_values = ::hex8_golds_y_rot::mesh_velocity;
   {
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::ELEM_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::ELEM_RANK, sel);
     int counter = 0;
     for (const auto* b : bkts) {
       const double* sv = stk::mesh::field_data(*sweptVolume_, *b, 0);
@@ -336,41 +336,41 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot)
 TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot_scs_center)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   // declare relevant fields
-  dnvField_ = &(meta_.declare_field<ScalarFieldType>(
+  dnvField_ = &(meta_->declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "dual_nodal_volume", 3));
-  stk::mesh::put_field_on_mesh(*dnvField_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*dnvField_, meta_->universal_part(), nullptr);
 
-  VectorFieldType* meshDisp_ = &(meta_.declare_field<VectorFieldType>(
+  VectorFieldType* meshDisp_ = &(meta_->declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "mesh_displacement", 3));
-  stk::mesh::put_field_on_mesh(*meshDisp_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*meshDisp_, meta_->universal_part(), nullptr);
 
-  VectorFieldType* cCoords_ = &(meta_.declare_field<VectorFieldType>(
+  VectorFieldType* cCoords_ = &(meta_->declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "current_coordinates"));
-  stk::mesh::put_field_on_mesh(*cCoords_, meta_.universal_part(), nullptr);
+  stk::mesh::put_field_on_mesh(*cCoords_, meta_->universal_part(), nullptr);
 
   const auto& meSCS =
     sierra::nalu::MasterElementRepo::get_surface_master_element(
       stk::topology::HEX_8);
-  GenericFieldType* sweptVolume_ = &(meta_.declare_field<GenericFieldType>(
+  GenericFieldType* sweptVolume_ = &(meta_->declare_field<GenericFieldType>(
     stk::topology::ELEM_RANK, "swept_face_volume", 3));
   stk::mesh::put_field_on_mesh(
-    *sweptVolume_, meta_.universal_part(), meSCS->num_integration_points(),
+    *sweptVolume_, meta_->universal_part(), meSCS->num_integration_points(),
     nullptr);
 
-  GenericFieldType* faceVelMag_ = &(meta_.declare_field<GenericFieldType>(
+  GenericFieldType* faceVelMag_ = &(meta_->declare_field<GenericFieldType>(
     stk::topology::ELEM_RANK, "face_velocity_mag", 2));
   stk::mesh::put_field_on_mesh(
-    *faceVelMag_, meta_.universal_part(), meSCS->num_integration_points(),
+    *faceVelMag_, meta_->universal_part(), meSCS->num_integration_points(),
     nullptr);
 
   fill_mesh_and_init_fields();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.timeStepN_ = 0.25;   // first time step size
@@ -405,8 +405,8 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot_scs_center)
     &(meshDisp_->field_of_state(stk::mesh::StateNM1));
 
   {
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
     for (const auto* b : bkts) {
       for (const auto node : *b) {
         double* dispNp1 = stk::mesh::field_data(*meshDispNp1, node);
@@ -448,8 +448,8 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot_scs_center)
   const double tol = 1.0e-15;
   namespace gold_values = ::hex8_golds_y_rot::mesh_velocity;
   {
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::ELEM_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::ELEM_RANK, sel);
     int counter = 0;
     for (const auto* b : bkts) {
       const double* sv = stk::mesh::field_data(*sweptVolume_, *b, 0);

--- a/unit_tests/gcl/UnitTestMeshVelocityAlg.C
+++ b/unit_tests/gcl/UnitTestMeshVelocityAlg.C
@@ -106,7 +106,7 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_x_rot)
   fill_mesh_and_init_fields();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.timeStepN_ = 0.5;   // first time step size
@@ -238,7 +238,7 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot)
   fill_mesh_and_init_fields();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.timeStepN_ = 0.5;   // first time step size
@@ -370,7 +370,7 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot_scs_center)
   fill_mesh_and_init_fields();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.timeStepN_ = 0.25;   // first time step size

--- a/unit_tests/kernels/UnitTestContinuityInflowElem.C
+++ b/unit_tests/kernels/UnitTestContinuityInflowElem.C
@@ -39,8 +39,8 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_inflow)
   solnOpts_.mdotInterpRhoUTogether_ = true;
   solnOpts_.activateOpenMdotCorrection_ = true;
 
-  auto* part = meta_.get_part("surface_2");
-  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::QUAD_4, 1, part);
+  auto* part = meta_->get_part("surface_2");
+  unit_test_utils::HelperObjects helperObjs(*bulk_, stk::topology::QUAD_4, 1, part);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.gamma1_ = 1.0;
@@ -50,7 +50,7 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_inflow)
 
   std::unique_ptr<sierra::nalu::Kernel> inflowKernel(
     new sierra::nalu::ContinuityInflowElemKernel<sierra::nalu::AlgTraitsQuad4>(
-      bulk_, solnOpts_, true,
+      *bulk_, solnOpts_, true,
       helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
 
   // Register the kernel for execution

--- a/unit_tests/kernels/UnitTestContinuityInflowElem.C
+++ b/unit_tests/kernels/UnitTestContinuityInflowElem.C
@@ -40,7 +40,7 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_inflow)
   solnOpts_.activateOpenMdotCorrection_ = true;
 
   auto* part = meta_->get_part("surface_2");
-  unit_test_utils::HelperObjects helperObjs(*bulk_, stk::topology::QUAD_4, 1, part);
+  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::QUAD_4, 1, part);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.gamma1_ = 1.0;

--- a/unit_tests/kernels/UnitTestEnthalpyTGradBCElem.C
+++ b/unit_tests/kernels/UnitTestEnthalpyTGradBCElem.C
@@ -16,15 +16,15 @@
 
 TEST_F(EnthalpyABLKernelHex8Mesh, NGP_tgrad_bc)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
   fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, 1, part);
+    *bulk_, stk::topology::QUAD_4, 1, part);
 
   const std::string coordsName = "coordinates";
   const bool useShifted = false;
@@ -32,7 +32,7 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_tgrad_bc)
   // Initialize the kernel
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::EnthalpyTGradBCElemKernel<sierra::nalu::AlgTraitsQuad4>(
-      bulk_, tGradBC_, viscosity_, specificHeat_, coordsName, useShifted,
+      *bulk_, tGradBC_, viscosity_, specificHeat_, coordsName, useShifted,
       helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
 
   // Register the kernel for execution

--- a/unit_tests/kernels/UnitTestEnthalpyTGradBCElem.C
+++ b/unit_tests/kernels/UnitTestEnthalpyTGradBCElem.C
@@ -24,7 +24,7 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_tgrad_bc)
 
   auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, 1, part);
+    bulk_, stk::topology::QUAD_4, 1, part);
 
   const std::string coordsName = "coordinates";
   const bool useShifted = false;

--- a/unit_tests/kernels/UnitTestFaceBasic.C
+++ b/unit_tests/kernels/UnitTestFaceBasic.C
@@ -47,14 +47,14 @@ TEST_F(Hex8Mesh, faceBasic)
     return;
   }
   fill_mesh("generated:1x1x1|sideset:xXyYzZ");
-  verify_faces_exist(bulk);
+  verify_faces_exist(*bulk);
 
   stk::topology faceTopo = stk::topology::QUAD_4;
   sierra::nalu::MasterElement* meFC = sierra::nalu::MasterElementRepo::get_surface_master_element(faceTopo);
 
-  stk::mesh::Part* surface1 = meta.get_part("surface_1");
+  stk::mesh::Part* surface1 = meta->get_part("surface_1");
   int numDof = 1;
-  unit_test_utils::HelperObjects helperObjs(bulk, faceTopo, numDof, surface1);
+  unit_test_utils::HelperObjects helperObjs(*bulk, faceTopo, numDof, surface1);
   helperObjs.assembleElemSolverAlg->dataNeededByKernels_.add_cvfem_face_me(meFC);
 
   TestFaceKernel faceKernel(faceTopo, scalarQ, helperObjs.assembleElemSolverAlg->dataNeededByKernels_);

--- a/unit_tests/kernels/UnitTestFaceBasic.C
+++ b/unit_tests/kernels/UnitTestFaceBasic.C
@@ -54,7 +54,7 @@ TEST_F(Hex8Mesh, faceBasic)
 
   stk::mesh::Part* surface1 = meta->get_part("surface_1");
   int numDof = 1;
-  unit_test_utils::HelperObjects helperObjs(*bulk, faceTopo, numDof, surface1);
+  unit_test_utils::HelperObjects helperObjs(bulk, faceTopo, numDof, surface1);
   helperObjs.assembleElemSolverAlg->dataNeededByKernels_.add_cvfem_face_me(meFC);
 
   TestFaceKernel faceKernel(faceTopo, scalarQ, helperObjs.assembleElemSolverAlg->dataNeededByKernels_);

--- a/unit_tests/kernels/UnitTestFaceElemBasic.C
+++ b/unit_tests/kernels/UnitTestFaceElemBasic.C
@@ -201,7 +201,7 @@ TEST_F(Hex8ElementWithBCFields, faceElemMomentumSymmetry)
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
 
   auto  momentumSymmetryElemKernel =
-      new sierra::nalu::MomentumSymmetryElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(*meta, solnOptions, &velocity, &viscosity,
+      new sierra::nalu::MomentumSymmetryElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(*meta, solnOptions, velocity, viscosity,
                                     faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
 
   faceElemAlg.activeKernels_.push_back(momentumSymmetryElemKernel);
@@ -227,7 +227,7 @@ TEST_F(Hex8ElementWithBCFields, faceElemMomentumOpen)
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
 
   auto  momentumOpenAdvDiffElemKernel =
-    new sierra::nalu::MomentumOpenAdvDiffElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(*meta, solnOptions, &helperObjs.eqSystem, &velocity, &Gjui, &viscosity,
+    new sierra::nalu::MomentumOpenAdvDiffElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(*meta, solnOptions, &helperObjs.eqSystem, velocity, Gjui, viscosity,
                                                                                         faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
 
   faceElemAlg.activeKernels_.push_back(momentumOpenAdvDiffElemKernel);
@@ -254,7 +254,7 @@ TEST_F(Hex8ElementWithBCFields, faceElemScalarOpen)
 
   auto  scalarOpenAdvElemKernel =
     new sierra::nalu::ScalarOpenAdvElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(*meta, solnOptions, &helperObjs.eqSystem, 
-                                                                                &scalarQ, &bcScalarQ, &Gjq, &viscosity,
+                                                                                scalarQ, bcScalarQ, Gjq, viscosity,
                                                                                 faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
 
   faceElemAlg.activeKernels_.push_back(scalarOpenAdvElemKernel);

--- a/unit_tests/kernels/UnitTestFaceElemBasic.C
+++ b/unit_tests/kernels/UnitTestFaceElemBasic.C
@@ -139,7 +139,7 @@ TEST_F(Hex8Mesh, NGP_faceElemBasic)
   stk::mesh::Part* surface1 = meta->get_part("surface_1");
   unsigned numDof = 3;
 
-  unit_test_utils::HelperObjects helperObjs(*bulk, elemTopo, numDof, surface1);
+  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, numDof, surface1);
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
@@ -195,7 +195,7 @@ TEST_F(Hex8ElementWithBCFields, faceElemMomentumSymmetry)
   stk::topology faceTopo = stk::topology::QUAD_4;
   stk::topology elemTopo = stk::topology::HEX_8;
   stk::mesh::Part* surface1 = meta->get_part("all_surfaces");
-  unit_test_utils::HelperObjects helperObjs(*bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
+  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
@@ -221,7 +221,7 @@ TEST_F(Hex8ElementWithBCFields, faceElemMomentumOpen)
   stk::topology faceTopo = stk::topology::QUAD_4;
   stk::topology elemTopo = stk::topology::HEX_8;
   stk::mesh::Part* surface1 = meta->get_part("all_surfaces");
-  unit_test_utils::HelperObjects helperObjs(*bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
+  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
@@ -247,7 +247,7 @@ TEST_F(Hex8ElementWithBCFields, faceElemScalarOpen)
   stk::topology faceTopo = stk::topology::QUAD_4;
   stk::topology elemTopo = stk::topology::HEX_8;
   stk::mesh::Part* surface1 = meta->get_part("all_surfaces");
-  unit_test_utils::HelperObjects helperObjs(*bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
+  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());

--- a/unit_tests/kernels/UnitTestFaceElemBasic.C
+++ b/unit_tests/kernels/UnitTestFaceElemBasic.C
@@ -127,8 +127,8 @@ TEST_F(Hex8Mesh, NGP_faceElemBasic)
     return;
   }
   fill_mesh("generated:1x1x1|sideset:xXyYzZ");
-  verify_faces_exist(bulk);
-  fill_with_node_ids(bulk, idField);
+  verify_faces_exist(*bulk);
+  fill_with_node_ids(*bulk, idField);
 
   stk::topology faceTopo = stk::topology::QUAD_4;
   stk::topology elemTopo = stk::topology::HEX_8;
@@ -136,10 +136,10 @@ TEST_F(Hex8Mesh, NGP_faceElemBasic)
   sierra::nalu::MasterElement* meSCS = sierra::nalu::MasterElementRepo::get_surface_master_element<sierra::nalu::AlgTraitsHex8>();
   sierra::nalu::MasterElement* meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
 
-  stk::mesh::Part* surface1 = meta.get_part("surface_1");
+  stk::mesh::Part* surface1 = meta->get_part("surface_1");
   unsigned numDof = 3;
 
-  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, numDof, surface1);
+  unit_test_utils::HelperObjects helperObjs(*bulk, elemTopo, numDof, surface1);
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
@@ -147,7 +147,7 @@ TEST_F(Hex8Mesh, NGP_faceElemBasic)
   faceElemAlg.elemDataNeeded_.add_cvfem_surface_me(meSCS);
   faceElemAlg.elemDataNeeded_.add_cvfem_volume_me(meSCV);
 
-  do_assemble_face_elem_solver_test(bulk, faceElemAlg, idField);
+  do_assemble_face_elem_solver_test(*bulk, faceElemAlg, idField);
 }
 
 #ifndef KOKKOS_ENABLE_CUDA
@@ -188,20 +188,20 @@ TEST_F(Hex8ElementWithBCFields, faceElemMomentumSymmetry)
   if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) {
     return;
   }
-  verify_faces_exist(bulk);
+  verify_faces_exist(*bulk);
 
   sierra::nalu::SolutionOptions solnOptions;
 
   stk::topology faceTopo = stk::topology::QUAD_4;
   stk::topology elemTopo = stk::topology::HEX_8;
-  stk::mesh::Part* surface1 = meta.get_part("all_surfaces");
-  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
+  stk::mesh::Part* surface1 = meta->get_part("all_surfaces");
+  unit_test_utils::HelperObjects helperObjs(*bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
 
   auto  momentumSymmetryElemKernel =
-      new sierra::nalu::MomentumSymmetryElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(meta, solnOptions, &velocity, &viscosity,
+      new sierra::nalu::MomentumSymmetryElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(*meta, solnOptions, &velocity, &viscosity,
                                     faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
 
   faceElemAlg.activeKernels_.push_back(momentumSymmetryElemKernel);
@@ -214,20 +214,20 @@ TEST_F(Hex8ElementWithBCFields, faceElemMomentumOpen)
   if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) {
     return;
   }
-  verify_faces_exist(bulk);
+  verify_faces_exist(*bulk);
 
   sierra::nalu::SolutionOptions solnOptions;
 
   stk::topology faceTopo = stk::topology::QUAD_4;
   stk::topology elemTopo = stk::topology::HEX_8;
-  stk::mesh::Part* surface1 = meta.get_part("all_surfaces");
-  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
+  stk::mesh::Part* surface1 = meta->get_part("all_surfaces");
+  unit_test_utils::HelperObjects helperObjs(*bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
 
   auto  momentumOpenAdvDiffElemKernel =
-    new sierra::nalu::MomentumOpenAdvDiffElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(meta, solnOptions, &helperObjs.eqSystem, &velocity, &Gjui, &viscosity,
+    new sierra::nalu::MomentumOpenAdvDiffElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(*meta, solnOptions, &helperObjs.eqSystem, &velocity, &Gjui, &viscosity,
                                                                                         faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
 
   faceElemAlg.activeKernels_.push_back(momentumOpenAdvDiffElemKernel);
@@ -240,20 +240,20 @@ TEST_F(Hex8ElementWithBCFields, faceElemScalarOpen)
   if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) {
     return;
   }
-  verify_faces_exist(bulk);
+  verify_faces_exist(*bulk);
 
   sierra::nalu::SolutionOptions solnOptions;
 
   stk::topology faceTopo = stk::topology::QUAD_4;
   stk::topology elemTopo = stk::topology::HEX_8;
-  stk::mesh::Part* surface1 = meta.get_part("all_surfaces");
-  unit_test_utils::HelperObjects helperObjs(bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
+  stk::mesh::Part* surface1 = meta->get_part("all_surfaces");
+  unit_test_utils::HelperObjects helperObjs(*bulk, elemTopo, sierra::nalu::AlgTraitsQuad4Hex8::nDim_, surface1);
 
   sierra::nalu::AssembleFaceElemSolverAlgorithm faceElemAlg(helperObjs.realm, surface1, &helperObjs.eqSystem,
                                                           faceTopo.num_nodes(), elemTopo.num_nodes());
 
   auto  scalarOpenAdvElemKernel =
-    new sierra::nalu::ScalarOpenAdvElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(meta, solnOptions, &helperObjs.eqSystem, 
+    new sierra::nalu::ScalarOpenAdvElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(*meta, solnOptions, &helperObjs.eqSystem, 
                                                                                 &scalarQ, &bcScalarQ, &Gjq, &viscosity,
                                                                                 faceElemAlg.faceDataNeeded_, faceElemAlg.elemDataNeeded_);
 

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -308,7 +308,7 @@ public:
   stk::ParallelMachine comm_;
   unsigned spatialDim_;
   stk::mesh::MetaData* meta_;
-  std::unique_ptr<stk::mesh::BulkData> bulk_;
+  std::shared_ptr<stk::mesh::BulkData> bulk_;
   stk::mesh::PartVector partVec_;
 
   sierra::nalu::SolutionOptions solnOpts_;

--- a/unit_tests/kernels/UnitTestScalarFluxBCElem.C
+++ b/unit_tests/kernels/UnitTestScalarFluxBCElem.C
@@ -23,8 +23,7 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_heat_flux_bc)
   fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
   auto* part = meta_->get_part("surface_5");
-  unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, 1, part);
+  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::QUAD_4, 1, part);
 
   const std::string coordsName = "coordinates";
   const bool useShifted = false;

--- a/unit_tests/kernels/UnitTestScalarFluxBCElem.C
+++ b/unit_tests/kernels/UnitTestScalarFluxBCElem.C
@@ -16,15 +16,15 @@
 
 TEST_F(EnthalpyABLKernelHex8Mesh, NGP_heat_flux_bc)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
   fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, 1, part);
+    *bulk_, stk::topology::QUAD_4, 1, part);
 
   const std::string coordsName = "coordinates";
   const bool useShifted = false;
@@ -32,7 +32,7 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_heat_flux_bc)
   // Initialize the kernel
   std::unique_ptr<sierra::nalu::Kernel> kernel(
     new sierra::nalu::ScalarFluxBCElemKernel<sierra::nalu::AlgTraitsQuad4>(
-      bulk_, heatFluxBC_, coordsName, useShifted,
+      *bulk_, heatFluxBC_, coordsName, useShifted,
       helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
 
   // Register the kernel for execution

--- a/unit_tests/kernels/UnitTestScalarOpenElem.C
+++ b/unit_tests/kernels/UnitTestScalarOpenElem.C
@@ -57,7 +57,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
 
   auto* part = meta_->get_part("surface_2");
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
+    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.gamma1_ = 1.0;

--- a/unit_tests/kernels/UnitTestScalarOpenElem.C
+++ b/unit_tests/kernels/UnitTestScalarOpenElem.C
@@ -37,7 +37,7 @@ static constexpr double lhs[8][8] = {
 
 TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
 {
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -55,9 +55,9 @@ TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
   solnOpts_.shiftedGradOpMap_["mixture_fraction"] = true;
   solnOpts_.skewSymmetricMap_["mixture_fraction"] = true;
 
-  auto* part = meta_.get_part("surface_2");
+  auto* part = meta_->get_part("surface_2");
   unit_test_utils::FaceElemHelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
+    *bulk_, stk::topology::QUAD_4, stk::topology::HEX_8, 1, part);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.gamma1_ = 1.0;
@@ -67,7 +67,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
 
   std::unique_ptr<sierra::nalu::Kernel> openKernel(
     new sierra::nalu::ScalarOpenAdvElemKernel<sierra::nalu::AlgTraitsQuad4Hex8>(
-      meta_, solnOpts_, &helperObjs.eqSystem, mixFraction_, mixFraction_, dzdx_,
+      *meta_, solnOpts_, &helperObjs.eqSystem, mixFraction_, mixFraction_, dzdx_,
       viscosity_, helperObjs.assembleFaceElemSolverAlg->faceDataNeeded_,
       helperObjs.assembleFaceElemSolverAlg->elemDataNeeded_));
 

--- a/unit_tests/kernels/UnitTestWallDistElem.C
+++ b/unit_tests/kernels/UnitTestWallDistElem.C
@@ -52,12 +52,12 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   // Initialize the kernel
   std::unique_ptr<sierra::nalu::Kernel> wallKernel(
     new sierra::nalu::WallDistElemKernel<sierra::nalu::AlgTraitsHex8>(
-      bulk_, solnOpts_, helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
+      *bulk_, solnOpts_, helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
 
   // Add to kernels to be tested
   helperObjs.assembleElemSolverAlg->activeKernels_.push_back(wallKernel.get());
@@ -83,12 +83,12 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_shifted)
   solnOpts_.externalMeshDeformation_ = false;
   solnOpts_.shiftedGradOpMap_["ndtw"] = true;
 
-  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   // Initialize the kernel
   std::unique_ptr<sierra::nalu::Kernel> wallKernel(
     new sierra::nalu::WallDistElemKernel<sierra::nalu::AlgTraitsHex8>(
-      bulk_, solnOpts_, helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
+      *bulk_, solnOpts_, helperObjs.assembleElemSolverAlg->dataNeededByKernels_));
 
   // Add to kernels to be tested
   helperObjs.assembleElemSolverAlg->activeKernels_.push_back(wallKernel.get());

--- a/unit_tests/kernels/UnitTestWallDistElem.C
+++ b/unit_tests/kernels/UnitTestWallDistElem.C
@@ -52,7 +52,7 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  unit_test_utils::HelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   // Initialize the kernel
   std::unique_ptr<sierra::nalu::Kernel> wallKernel(
@@ -83,7 +83,7 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_shifted)
   solnOpts_.externalMeshDeformation_ = false;
   solnOpts_.shiftedGradOpMap_["ndtw"] = true;
 
-  unit_test_utils::HelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   // Initialize the kernel
   std::unique_ptr<sierra::nalu::Kernel> wallKernel(

--- a/unit_tests/matrix_free/StkConductionFixture.C
+++ b/unit_tests/matrix_free/StkConductionFixture.C
@@ -12,6 +12,7 @@
 #include "matrix_free/StkToTpetraMap.h"
 #include "stk_io/StkMeshIoBroker.hpp"
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MeshBuilder.hpp"
 #include "stk_mesh/base/CoordinateSystems.hpp"
 #include "stk_mesh/base/Field.hpp"
 #include "stk_mesh/base/FieldBase.hpp"
@@ -32,8 +33,9 @@
 #include <string>
 
 ConductionFixture::ConductionFixture(int nx, double scale)
-  : meta(3u),
-    bulk(meta, MPI_COMM_WORLD, stk::mesh::BulkData::NO_AUTO_AURA),
+  : bulkPtr(stk::mesh::MeshBuilder(MPI_COMM_WORLD).set_spatial_dimension(3u).set_aura_option(stk::mesh::BulkData::NO_AUTO_AURA).create()),
+    meta(bulkPtr->mesh_meta_data()),
+    bulk(*bulkPtr),
     io(bulk.parallel()),
     q_field(meta.declare_field<stk::mesh::Field<double>>(
       stk::topology::NODE_RANK,

--- a/unit_tests/matrix_free/StkConductionFixture.h
+++ b/unit_tests/matrix_free/StkConductionFixture.h
@@ -41,7 +41,7 @@ protected:
   static constexpr int order = 1;
   ConductionFixture(int nx, double scale);
   stk::mesh::Field<double, stk::mesh::Cartesian3d>& coordinate_field();
-  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr;
   stk::mesh::BulkData& bulk;
   stk::mesh::MetaData& meta;
   stk::io::StkMeshIoBroker io;

--- a/unit_tests/matrix_free/StkConductionFixture.h
+++ b/unit_tests/matrix_free/StkConductionFixture.h
@@ -41,8 +41,9 @@ protected:
   static constexpr int order = 1;
   ConductionFixture(int nx, double scale);
   stk::mesh::Field<double, stk::mesh::Cartesian3d>& coordinate_field();
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
+  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  stk::mesh::BulkData& bulk;
+  stk::mesh::MetaData& meta;
   stk::io::StkMeshIoBroker io;
   stk::mesh::Field<double>& q_field;
   stk::mesh::Field<double>& qbc_field;

--- a/unit_tests/matrix_free/StkGradientFixture.C
+++ b/unit_tests/matrix_free/StkGradientFixture.C
@@ -18,6 +18,7 @@
 #include "mpi.h"
 #include "stk_io/StkMeshIoBroker.hpp"
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MeshBuilder.hpp"
 #include "stk_mesh/base/CoordinateSystems.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
@@ -39,8 +40,9 @@ namespace sierra {
 namespace nalu {
 namespace matrix_free {
 GradientFixture::GradientFixture(int nx, double scale)
-  : meta(3u),
-    bulk(meta, MPI_COMM_WORLD, stk::mesh::BulkData::NO_AUTO_AURA),
+  : bulkPtr(stk::mesh::MeshBuilder(MPI_COMM_WORLD).set_spatial_dimension(3u).set_aura_option(stk::mesh::BulkData::NO_AUTO_AURA).create()),
+    meta(bulkPtr->mesh_meta_data()),
+    bulk(*bulkPtr),
     io(bulk.parallel()),
     q_field(meta.declare_field<stk::mesh::Field<double>>(
       stk::topology::NODE_RANK, "q")),

--- a/unit_tests/matrix_free/StkGradientFixture.h
+++ b/unit_tests/matrix_free/StkGradientFixture.h
@@ -57,7 +57,7 @@ protected:
     return meta.get_topology_root_part(stk::topology::QUAD_4);
   }
 
-  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr;
   stk::mesh::BulkData& bulk;
   stk::mesh::MetaData& meta;
   stk::io::StkMeshIoBroker io;

--- a/unit_tests/matrix_free/StkGradientFixture.h
+++ b/unit_tests/matrix_free/StkGradientFixture.h
@@ -57,8 +57,9 @@ protected:
     return meta.get_topology_root_part(stk::topology::QUAD_4);
   }
 
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
+  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  stk::mesh::BulkData& bulk;
+  stk::mesh::MetaData& meta;
   stk::io::StkMeshIoBroker io;
   stk::mesh::Field<double>& q_field;
   stk::mesh::Field<double>& dqdx_field;

--- a/unit_tests/matrix_free/StkLowMachFixture.C
+++ b/unit_tests/matrix_free/StkLowMachFixture.C
@@ -18,6 +18,7 @@
 #include "mpi.h"
 #include "stk_io/StkMeshIoBroker.hpp"
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MeshBuilder.hpp"
 #include "stk_mesh/base/CoordinateSystems.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
@@ -39,8 +40,9 @@ namespace sierra {
 namespace nalu {
 namespace matrix_free {
 LowMachFixture::LowMachFixture(int nx, double scale)
-  : meta(3u),
-    bulk(meta, MPI_COMM_WORLD, stk::mesh::BulkData::NO_AUTO_AURA),
+  : bulkPtr(stk::mesh::MeshBuilder(MPI_COMM_WORLD).set_spatial_dimension(3u).set_aura_option(stk::mesh::BulkData::NO_AUTO_AURA).create()),
+    meta(bulkPtr->mesh_meta_data()),
+    bulk(*bulkPtr),
     io(bulk.parallel()),
     density_field(meta.declare_field<stk::mesh::Field<double>>(
       stk::topology::NODE_RANK, "density", 3)),

--- a/unit_tests/matrix_free/StkLowMachFixture.h
+++ b/unit_tests/matrix_free/StkLowMachFixture.h
@@ -57,7 +57,7 @@ protected:
     return meta.get_topology_root_part(stk::topology::QUAD_4);
   }
 
-  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr;
   stk::mesh::BulkData& bulk;
   stk::mesh::MetaData& meta;
   stk::io::StkMeshIoBroker io;

--- a/unit_tests/matrix_free/StkLowMachFixture.h
+++ b/unit_tests/matrix_free/StkLowMachFixture.h
@@ -57,8 +57,9 @@ protected:
     return meta.get_topology_root_part(stk::topology::QUAD_4);
   }
 
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
+  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  stk::mesh::BulkData& bulk;
+  stk::mesh::MetaData& meta;
   stk::io::StkMeshIoBroker io;
 
   stk::mesh::Field<double>& density_field;

--- a/unit_tests/matrix_free/UnitTestConductionFields.C
+++ b/unit_tests/matrix_free/UnitTestConductionFields.C
@@ -134,7 +134,7 @@ protected:
     mesh = stk::mesh::get_updated_ngp_mesh(*bulk);
   }
   stk::mesh::MetaData* meta;
-  std::unique_ptr<stk::mesh::BulkData> bulk;
+  std::shared_ptr<stk::mesh::BulkData> bulk;
   stk::mesh::Field<double>* q_field;
   stk::mesh::Field<double>* alpha_field;
   stk::mesh::Field<double>* lambda_field;

--- a/unit_tests/matrix_free/UnitTestConductionFields.C
+++ b/unit_tests/matrix_free/UnitTestConductionFields.C
@@ -15,6 +15,7 @@
 #include "gtest/gtest.h"
 #include "mpi.h"
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MeshBuilder.hpp"
 #include "stk_mesh/base/CoordinateSystems.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
@@ -38,78 +39,78 @@ class ConductionFieldsFixture : public ::testing::Test
 protected:
   static constexpr int order = 1;
   ConductionFieldsFixture()
-    : meta(3u),
-      bulk(meta, MPI_COMM_WORLD),
-      q_field(meta.declare_field<stk::mesh::Field<double>>(
-        stk::topology::NODE_RANK, conduction_info::q_name, 3)),
-      alpha_field(meta.declare_field<stk::mesh::Field<double>>(
-        stk::topology::NODE_RANK, conduction_info::volume_weight_name)),
-      lambda_field(meta.declare_field<stk::mesh::Field<double>>(
-        stk::topology::NODE_RANK, conduction_info::diffusion_weight_name))
   {
+    stk::mesh::MeshBuilder meshBuilder(MPI_COMM_WORLD);
+    meshBuilder.set_spatial_dimension(3u);
+    bulk = meshBuilder.create();
+    meta = &bulk->mesh_meta_data();
+
+    q_field = &meta->declare_field<stk::mesh::Field<double>>(stk::topology::NODE_RANK, conduction_info::q_name, 3);
+    alpha_field = &meta->declare_field<stk::mesh::Field<double>>(stk::topology::NODE_RANK, conduction_info::volume_weight_name);
+    lambda_field = &meta->declare_field<stk::mesh::Field<double>>(stk::topology::NODE_RANK, conduction_info::diffusion_weight_name);
+
     stk::topology topo(stk::topology::HEX_8);
 
-    stk::mesh::Part& block_1 = meta.declare_part_with_topology("block_1", topo);
+    stk::mesh::Part& block_1 = meta->declare_part_with_topology("block_1", topo);
     stk::io::put_io_part_attribute(block_1);
 
     stk::mesh::PartVector allSurfaces = {
-      &meta.declare_part("all_surfaces", meta.side_rank())};
+      &meta->declare_part("all_surfaces", meta->side_rank())};
     stk::io::put_io_part_attribute(*allSurfaces.front());
 
     stk::mesh::PartVector individualSurfaces(topo.num_sides());
     for (unsigned k = 0u; k < topo.num_sides(); ++k) {
-      individualSurfaces[k] = &meta.declare_part_with_topology(
+      individualSurfaces[k] = &meta->declare_part_with_topology(
         "surface_" + std::to_string(k), topo.side_topology(k));
     }
 
     // set a coordinate field
     using vector_field_type = stk::mesh::Field<double, stk::mesh::Cartesian3d>;
-    auto& coordField = meta.declare_field<vector_field_type>(
+    auto& coordField = meta->declare_field<vector_field_type>(
       stk::topology::NODE_RANK, "coordinates");
     stk::mesh::put_field_on_mesh(coordField, block_1, nullptr);
-    stk::mesh::put_field_on_mesh(q_field, block_1, 1, nullptr);
-    stk::mesh::put_field_on_mesh(lambda_field, block_1, 1, nullptr);
-    stk::mesh::put_field_on_mesh(alpha_field, block_1, 1, nullptr);
-    stk::mesh::put_field_on_mesh(
-      coordField, stk::mesh::selectUnion(allSurfaces), nullptr);
-    meta.set_coordinate_field(&coordField);
-    meta.commit();
+    stk::mesh::put_field_on_mesh(*q_field, block_1, 1, nullptr);
+    stk::mesh::put_field_on_mesh(*lambda_field, block_1, 1, nullptr);
+    stk::mesh::put_field_on_mesh(*alpha_field, block_1, 1, nullptr);
+    stk::mesh::put_field_on_mesh(coordField, stk::mesh::selectUnion(allSurfaces), nullptr);
+    meta->set_coordinate_field(&coordField);
+    meta->commit();
 
     stk::mesh::EntityIdVector nodeIds(topo.num_nodes());
-    std::iota(nodeIds.begin(), nodeIds.end(), 8 * bulk.parallel_rank() + 1);
+    std::iota(nodeIds.begin(), nodeIds.end(), 8 * bulk->parallel_rank() + 1);
 
-    bulk.modification_begin();
+    bulk->modification_begin();
 
     for (auto id : nodeIds) {
-      bulk.declare_entity(
+      bulk->declare_entity(
         stk::topology::NODE_RANK, id, stk::mesh::PartVector{});
     }
     auto elem = stk::mesh::declare_element(
-      bulk, block_1, bulk.parallel_rank() + 1, nodeIds);
-    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
+      *bulk, block_1, bulk->parallel_rank() + 1, nodeIds);
+    stk::mesh::create_all_sides(*bulk, block_1, allSurfaces, false);
 
-    bulk.modification_end();
+    bulk->modification_end();
 
     auto surfaceSelector = stk::mesh::selectUnion(allSurfaces);
     stk::mesh::EntityVector all_faces;
     stk::mesh::get_selected_entities(
-      surfaceSelector, bulk.get_buckets(meta.side_rank(), surfaceSelector),
+      surfaceSelector, bulk->get_buckets(meta->side_rank(), surfaceSelector),
       all_faces);
     ThrowRequire(all_faces.size() == topo.num_sides());
 
-    bulk.modification_begin();
+    bulk->modification_begin();
     for (unsigned k = 0u; k < all_faces.size(); ++k) {
-      const int ordinal = bulk.begin_element_ordinals(all_faces[k])[0];
-      bulk.change_entity_parts(
+      const int ordinal = bulk->begin_element_ordinals(all_faces[k])[0];
+      bulk->change_entity_parts(
         all_faces[k], {individualSurfaces[ordinal]}, stk::mesh::PartVector{});
     }
-    bulk.modification_end();
+    bulk->modification_end();
 
     std::vector<std::vector<double>> nodeLocations = {
       {-1, -1, -1}, {+1, -1, -1}, {+1, +1, -1}, {-1, +1, -1},
       {-1, -1, +1}, {+1, -1, +1}, {+1, +1, +1}, {-1, +1, +1}};
 
-    const auto* nodes = bulk.begin_nodes(elem);
+    const auto* nodes = bulk->begin_nodes(elem);
     for (int j = 0; j < 8; ++j) {
       for (int d = 0; d < 3; ++d) {
         stk::mesh::field_data(coordField, nodes[j])[d] =
@@ -118,32 +119,32 @@ protected:
     }
 
     for (const auto* ib :
-         bulk.get_buckets(stk::topology::NODE_RANK, meta.universal_part())) {
+         bulk->get_buckets(stk::topology::NODE_RANK, meta->universal_part())) {
       for (auto node : *ib) {
         *stk::mesh::field_data(
-          q_field.field_of_state(stk::mesh::StateNP1), node) = 1.0;
+          q_field->field_of_state(stk::mesh::StateNP1), node) = 1.0;
         *stk::mesh::field_data(
-          q_field.field_of_state(stk::mesh::StateN), node) = 1.0;
+          q_field->field_of_state(stk::mesh::StateN), node) = 1.0;
         *stk::mesh::field_data(
-          q_field.field_of_state(stk::mesh::StateNM1), node) = 1.0;
-        *stk::mesh::field_data(alpha_field, node) = 1.0;
-        *stk::mesh::field_data(lambda_field, node) = 1.0;
+          q_field->field_of_state(stk::mesh::StateNM1), node) = 1.0;
+        *stk::mesh::field_data(*alpha_field, node) = 1.0;
+        *stk::mesh::field_data(*lambda_field, node) = 1.0;
       }
     }
-    mesh = stk::mesh::get_updated_ngp_mesh(bulk);
+    mesh = stk::mesh::get_updated_ngp_mesh(*bulk);
   }
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
-  stk::mesh::Field<double>& q_field;
-  stk::mesh::Field<double>& alpha_field;
-  stk::mesh::Field<double>& lambda_field;
+  stk::mesh::MetaData* meta;
+  std::unique_ptr<stk::mesh::BulkData> bulk;
+  stk::mesh::Field<double>* q_field;
+  stk::mesh::Field<double>* alpha_field;
+  stk::mesh::Field<double>* lambda_field;
   stk::mesh::NgpMesh mesh;
 };
 
 TEST_F(ConductionFieldsFixture, gather)
 {
-  const auto conn = stk_connectivity_map<order>(mesh, meta.universal_part());
-  auto fields = gather_required_conduction_fields<order>(meta, conn);
+  const auto conn = stk_connectivity_map<order>(mesh, meta->universal_part());
+  auto fields = gather_required_conduction_fields<order>(*meta, conn);
   const auto qp1_h = Kokkos::create_mirror_view(fields.qp1);
   Kokkos::deep_copy(qp1_h, fields.qp1);
 

--- a/unit_tests/matrix_free/UnitTestStkSimdConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdConnectivityMap.C
@@ -19,6 +19,7 @@
 
 #include "stk_io/IossBridge.hpp"
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MeshBuilder.hpp"
 #include "stk_mesh/base/CoordinateSystems.hpp"
 #include "stk_mesh/base/Entity.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
@@ -46,7 +47,10 @@ namespace matrix_free {
 class SimdConnectivityFixture : public ::testing::Test
 {
 protected:
-  SimdConnectivityFixture() : meta(3u), bulk(meta, MPI_COMM_WORLD)
+  SimdConnectivityFixture() 
+    : bulkPtr(stk::mesh::MeshBuilder(MPI_COMM_WORLD).set_spatial_dimension(3u).create()), 
+      bulk(*bulkPtr), 
+      meta(bulk.mesh_meta_data())
   {
     stk::topology topo(stk::topology::HEX_8);
 
@@ -108,8 +112,9 @@ protected:
     }
     mesh = stk::mesh::NgpMesh(bulk);
   }
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
+  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  stk::mesh::BulkData& bulk;
+  stk::mesh::MetaData& meta;
   stk::mesh::NgpMesh mesh;
 };
 

--- a/unit_tests/matrix_free/UnitTestStkSimdConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdConnectivityMap.C
@@ -112,7 +112,7 @@ protected:
     }
     mesh = stk::mesh::NgpMesh(bulk);
   }
-  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr;
   stk::mesh::BulkData& bulk;
   stk::mesh::MetaData& meta;
   stk::mesh::NgpMesh mesh;

--- a/unit_tests/matrix_free/UnitTestStkSimdFaceConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdFaceConnectivityMap.C
@@ -122,7 +122,7 @@ protected:
     }
     mesh = stk::mesh::NgpMesh(bulk);
   }
-  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr;
   stk::mesh::BulkData& bulk;
   stk::mesh::MetaData& meta;
   stk::mesh::NgpMesh mesh;

--- a/unit_tests/matrix_free/UnitTestStkSimdFaceConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdFaceConnectivityMap.C
@@ -19,6 +19,7 @@
 
 #include "stk_io/IossBridge.hpp"
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MeshBuilder.hpp"
 #include "stk_mesh/base/Entity.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
@@ -56,7 +57,10 @@ namespace matrix_free {
 class SimdFaceConnectivityFixture : public ::testing::Test
 {
 protected:
-  SimdFaceConnectivityFixture() : meta(3u), bulk(meta, MPI_COMM_WORLD)
+  SimdFaceConnectivityFixture() 
+    : bulkPtr(stk::mesh::MeshBuilder(MPI_COMM_WORLD).set_spatial_dimension(3u).create()), 
+      bulk(*bulkPtr), 
+      meta(bulk.mesh_meta_data())
   {
     stk::topology topo(stk::topology::HEX_8);
 
@@ -118,8 +122,9 @@ protected:
     }
     mesh = stk::mesh::NgpMesh(bulk);
   }
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
+  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  stk::mesh::BulkData& bulk;
+  stk::mesh::MetaData& meta;
   stk::mesh::NgpMesh mesh;
 };
 

--- a/unit_tests/matrix_free/UnitTestStkSimdGatheredElementData.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdGatheredElementData.C
@@ -22,6 +22,7 @@
 #include "stk_io/IossBridge.hpp"
 #include "stk_mesh/base/Bucket.hpp"
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MeshBuilder.hpp"
 #include "stk_mesh/base/Entity.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
@@ -59,7 +60,10 @@ class SimdGatherFixture : public ::testing::Test
 protected:
   static constexpr int order = 1;
 
-  SimdGatherFixture() : meta(3u), bulk(meta, MPI_COMM_WORLD)
+  SimdGatherFixture() 
+    : bulkPtr(stk::mesh::MeshBuilder(MPI_COMM_WORLD).set_spatial_dimension(3u).create()), 
+      bulk(*bulkPtr), 
+      meta(bulk.mesh_meta_data())
   {
     stk::topology topo(stk::topology::HEX_8);
 
@@ -128,8 +132,9 @@ protected:
     q_field_ngp = stk::mesh::get_updated_ngp_field<double>(q_field);
     coord_field_ngp = stk::mesh::get_updated_ngp_field<double>(coordField);
   }
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
+  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  stk::mesh::BulkData& bulk;
+  stk::mesh::MetaData& meta;
   stk::mesh::NgpMesh mesh;
   stk::mesh::NgpField<double> q_field_ngp;
   stk::mesh::NgpField<double> coord_field_ngp;

--- a/unit_tests/matrix_free/UnitTestStkSimdGatheredElementData.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdGatheredElementData.C
@@ -132,7 +132,7 @@ protected:
     q_field_ngp = stk::mesh::get_updated_ngp_field<double>(q_field);
     coord_field_ngp = stk::mesh::get_updated_ngp_field<double>(coordField);
   }
-  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr;
   stk::mesh::BulkData& bulk;
   stk::mesh::MetaData& meta;
   stk::mesh::NgpMesh mesh;

--- a/unit_tests/matrix_free/UnitTestStkSimdNodeConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdNodeConnectivityMap.C
@@ -18,6 +18,7 @@
 
 #include "gtest/gtest.h"
 #include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/MeshBuilder.hpp"
 #include "stk_mesh/base/CoordinateSystems.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
@@ -38,7 +39,10 @@ namespace matrix_free {
 class SimdNodeConnectivityFixture : public ::testing::Test
 {
 protected:
-  SimdNodeConnectivityFixture() : meta(3u), bulk(meta, MPI_COMM_WORLD)
+  SimdNodeConnectivityFixture() 
+    : bulkPtr(stk::mesh::MeshBuilder(MPI_COMM_WORLD).set_spatial_dimension(3u).create()), 
+      bulk(*bulkPtr), 
+      meta(bulk.mesh_meta_data())
   {
     stk::topology topo(stk::topology::HEX_8);
 
@@ -99,8 +103,9 @@ protected:
     }
     mesh = stk::mesh::NgpMesh(bulk);
   }
-  stk::mesh::MetaData meta;
-  stk::mesh::BulkData bulk;
+  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  stk::mesh::BulkData& bulk;
+  stk::mesh::MetaData& meta;
   stk::mesh::NgpMesh mesh;
 };
 

--- a/unit_tests/matrix_free/UnitTestStkSimdNodeConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdNodeConnectivityMap.C
@@ -103,7 +103,7 @@ protected:
     }
     mesh = stk::mesh::NgpMesh(bulk);
   }
-  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr;
   stk::mesh::BulkData& bulk;
   stk::mesh::MetaData& meta;
   stk::mesh::NgpMesh mesh;

--- a/unit_tests/matrix_free/UnitTestStkToTpetraMap.C
+++ b/unit_tests/matrix_free/UnitTestStkToTpetraMap.C
@@ -58,7 +58,7 @@ protected:
     gid_field = stk::mesh::get_updated_ngp_field<gid_type>(gid_field_h);
   }
 
-  std::unique_ptr<stk::mesh::BulkData> bulkPtr;
+  std::shared_ptr<stk::mesh::BulkData> bulkPtr;
   stk::mesh::BulkData& bulk;
   stk::mesh::MetaData& meta;
   stk::mesh::Field<typename Tpetra::Map<>::global_ordinal_type>& gid_field_h;

--- a/unit_tests/ngp_algorithms/UnitTestCFLReAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestCFLReAlg.C
@@ -59,7 +59,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_courant_reynolds)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
   sierra::nalu::CourantReAlgDriver algDriver(helperObjs.realm);

--- a/unit_tests/ngp_algorithms/UnitTestCFLReAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestCFLReAlg.C
@@ -20,11 +20,11 @@
 TEST_F(MomentumKernelHex8Mesh, NGP_courant_reynolds)
 {
   auto& elemCourant =
-    meta_.declare_field<GenericFieldType>(stk::topology::ELEM_RANK, "element_courant");
+    meta_->declare_field<GenericFieldType>(stk::topology::ELEM_RANK, "element_courant");
   auto& elemReynolds =
-    meta_.declare_field<GenericFieldType>(stk::topology::ELEM_RANK, "element_reynolds");
-  stk::mesh::put_field_on_mesh(elemCourant, meta_.universal_part(), 1, nullptr);
-  stk::mesh::put_field_on_mesh(elemReynolds, meta_.universal_part(), 1, nullptr);
+    meta_->declare_field<GenericFieldType>(stk::topology::ELEM_RANK, "element_reynolds");
+  stk::mesh::put_field_on_mesh(elemCourant, meta_->universal_part(), 1, nullptr);
+  stk::mesh::put_field_on_mesh(elemReynolds, meta_->universal_part(), 1, nullptr);
   fill_mesh_and_init_fields();
 
   std::mt19937 rng;
@@ -59,7 +59,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_courant_reynolds)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
   sierra::nalu::CourantReAlgDriver algDriver(helperObjs.realm);

--- a/unit_tests/ngp_algorithms/UnitTestDiffFluxCoeffAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestDiffFluxCoeffAlg.C
@@ -16,7 +16,7 @@
 TEST_F(KsgsKernelHex8Mesh, NGP_eff_diff_flux_coeff)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   LowMachKernelHex8Mesh::fill_mesh_and_init_fields();
 
@@ -28,7 +28,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_eff_diff_flux_coeff)
   stk::mesh::field_fill(sigmaTurb, *tvisc_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   sierra::nalu::EffDiffFluxCoeffAlg diffFluxAlg(
     helperObjs.realm, partVec_[0], viscosity_, tvisc_, evisc_,
     sigmaLam, sigmaTurb, isTurbulent);
@@ -41,8 +41,8 @@ TEST_F(KsgsKernelHex8Mesh, NGP_eff_diff_flux_coeff)
 
   {
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     for (const auto* b: bkts)
       for (const auto node: *b) {

--- a/unit_tests/ngp_algorithms/UnitTestDiffFluxCoeffAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestDiffFluxCoeffAlg.C
@@ -28,7 +28,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_eff_diff_flux_coeff)
   stk::mesh::field_fill(sigmaTurb, *tvisc_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   sierra::nalu::EffDiffFluxCoeffAlg diffFluxAlg(
     helperObjs.realm, partVec_[0], viscosity_, tvisc_, evisc_,
     sigmaLam, sigmaTurb, isTurbulent);

--- a/unit_tests/ngp_algorithms/UnitTestEffSSTDiffFluxCoeffAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestEffSSTDiffFluxCoeffAlg.C
@@ -27,7 +27,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_eff_sst_diff_flux_coeff_alg)
   stk::mesh::field_fill(sigmaTwo, *tvisc_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   sierra::nalu::EffSSTDiffFluxCoeffAlg diffFluxAlg(
     helperObjs.realm, partVec_[0], viscosity_, tvisc_, evisc_,
     sigmaOne, sigmaTwo);

--- a/unit_tests/ngp_algorithms/UnitTestEffSSTDiffFluxCoeffAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestEffSSTDiffFluxCoeffAlg.C
@@ -16,7 +16,7 @@
 TEST_F(KsgsKernelHex8Mesh, NGP_eff_sst_diff_flux_coeff_alg)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   LowMachKernelHex8Mesh::fill_mesh_and_init_fields();
 
@@ -27,7 +27,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_eff_sst_diff_flux_coeff_alg)
   stk::mesh::field_fill(sigmaTwo, *tvisc_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   sierra::nalu::EffSSTDiffFluxCoeffAlg diffFluxAlg(
     helperObjs.realm, partVec_[0], viscosity_, tvisc_, evisc_,
     sigmaOne, sigmaTwo);
@@ -40,8 +40,8 @@ TEST_F(KsgsKernelHex8Mesh, NGP_eff_sst_diff_flux_coeff_alg)
 
   {
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     for (const auto* b: bkts)
       for (const auto node: *b) {

--- a/unit_tests/ngp_algorithms/UnitTestEnthalpyDiffFluxCoeffAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestEnthalpyDiffFluxCoeffAlg.C
@@ -16,7 +16,7 @@
 TEST_F(EnthalpyABLKernelHex8Mesh, NGP_enthalpy_eff_diff_flux_coeff)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -26,7 +26,7 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_enthalpy_eff_diff_flux_coeff)
   stk::mesh::field_fill(sigmaTurb, *tvisc_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   sierra::nalu::EnthalpyEffDiffFluxCoeffAlg enthalpyDiffFluxAlg(
     helperObjs.realm, partVec_[0], thermalCond_, specificHeat_, tvisc_, evisc_,
     sigmaTurb, isTurbulent);
@@ -40,8 +40,8 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_enthalpy_eff_diff_flux_coeff)
 
   {
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     for (const auto* b: bkts)
       for (const auto node: *b) {

--- a/unit_tests/ngp_algorithms/UnitTestEnthalpyDiffFluxCoeffAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestEnthalpyDiffFluxCoeffAlg.C
@@ -26,7 +26,7 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_enthalpy_eff_diff_flux_coeff)
   stk::mesh::field_fill(sigmaTurb, *tvisc_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   sierra::nalu::EnthalpyEffDiffFluxCoeffAlg enthalpyDiffFluxAlg(
     helperObjs.realm, partVec_[0], thermalCond_, specificHeat_, tvisc_, evisc_,
     sigmaTurb, isTurbulent);

--- a/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
@@ -21,7 +21,7 @@
 TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -31,7 +31,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
   stk::mesh::field_fill(0.0, *edgeAreaVec_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   // Force computation of edge area vector
   helperObjs.realm.realmUsesEdges_ = true;
@@ -51,11 +51,11 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
   ngpElemVol.sync_to_host();
 
   const double tol = 1.0e-16;
-  stk::mesh::Selector sel = meta_.universal_part();
+  stk::mesh::Selector sel = meta_->universal_part();
 
   // Dual volume check
   {
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int counter = 0;
     for (const auto* b: bkts)
@@ -69,7 +69,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
 
   // Element volume check
   {
-    const auto& bkts = bulk_.get_buckets(stk::topology::ELEM_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::ELEM_RANK, sel);
 
     int counter = 0;
     for (const auto* b: bkts)
@@ -83,7 +83,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
 
   // Edge area vector check
   {
-    const auto& bkts = bulk_.get_buckets(stk::topology::EDGE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::EDGE_RANK, sel);
     const double aMagSqrGold = 0.25 * 0.25;
 
     int counter = 0;
@@ -104,7 +104,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
 TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -114,13 +114,13 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
   stk::mesh::field_fill(0.0, *exposedAreaVec_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   const auto& fieldMgr = helperObjs.realm.mesh_info().ngp_field_manager();
   auto& ngpArea = fieldMgr.get_field<double>(
       exposedAreaVec_->mesh_meta_data_ordinal());
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];
   sierra::nalu::GeometryAlgDriver geomAlgDriver(helperObjs.realm);
   geomAlgDriver.register_face_algorithm<sierra::nalu::GeometryBoundaryAlg>(
@@ -134,7 +134,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
   // Exposed area vector check
   {
     stk::mesh::Selector sel(*part);
-    const auto& bkts = bulk_.get_buckets(stk::topology::FACE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::FACE_RANK, sel);
     const double aMagSqrGold = 0.25 * 0.25;
 
     const double tol = 1.0e-16;
@@ -157,7 +157,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
 TEST_F(KsgsKernelHex8Mesh, NGP_geometry_wall_func)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -168,9 +168,9 @@ TEST_F(KsgsKernelHex8Mesh, NGP_geometry_wall_func)
   stk::mesh::field_fill(0.0, *wallArea_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];
   sierra::nalu::GeometryAlgDriver geomAlgDriver(helperObjs.realm);
   geomAlgDriver.register_wall_func_algorithm<sierra::nalu::WallFuncGeometryAlg>(
@@ -188,7 +188,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_geometry_wall_func)
   // wall distance and area check
   {
     stk::mesh::Selector sel(*part);
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
     const double wdistGold = 1.0;
     const double wAreaGold = 0.25;
 

--- a/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestGeometryAlg.C
@@ -31,7 +31,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_interior)
   stk::mesh::field_fill(0.0, *edgeAreaVec_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   // Force computation of edge area vector
   helperObjs.realm.realmUsesEdges_ = true;
@@ -114,7 +114,7 @@ TEST_F(TestKernelHex8Mesh, NGP_geometry_bndry)
   stk::mesh::field_fill(0.0, *exposedAreaVec_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   const auto& fieldMgr = helperObjs.realm.mesh_info().ngp_field_manager();
   auto& ngpArea = fieldMgr.get_field<double>(
@@ -168,7 +168,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_geometry_wall_func)
   stk::mesh::field_fill(0.0, *wallArea_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];

--- a/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
@@ -21,7 +21,7 @@
 TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_calc_edge)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   fill_mesh_and_init_fields();
@@ -32,7 +32,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_calc_edge)
   solnOpts_.mdotInterpRhoUTogether_ = true;
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.interiorPartVec_.push_back(partVec_[0]);
 
   stk::mesh::field_fill(1.0, *density_);
@@ -66,8 +66,8 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_calc_edge)
 
   {
     const double tol = 1.0e-14;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::EDGE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::EDGE_RANK, sel);
 
     for (const auto* b : bkts)
       for (const auto edge : *b) {
@@ -80,7 +80,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_calc_edge)
 TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_rho_accum)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   fill_mesh_and_init_fields();
@@ -103,7 +103,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_rho_accum)
   density_->field_of_state(stk::mesh::StateN).sync_to_device();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.interiorPartVec_.push_back(partVec_[0]);
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
   helperObjs.realm.solutionOptions_->mdotInterpRhoUTogether_ = true;
@@ -128,7 +128,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_rho_accum)
 TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_correction)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   const bool doPerturb = false;
@@ -138,9 +138,9 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_correction)
   stk::mesh::field_fill(0.0, *openMassFlowRate_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.solutionOptions_->activateOpenMdotCorrection_ = true;
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];
   const bool elementContinuityEqs = true;
 
@@ -170,7 +170,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_correction)
 TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_inflow)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   const bool doPerturb = false;
@@ -186,8 +186,8 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_inflow)
   velocity_->sync_to_device();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
-  auto* part = meta_.get_part("surface_5");
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];
   const bool elementContinuityEqs = true;
   const bool useShifted = true;
@@ -204,7 +204,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_inflow)
 TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_edge)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   const bool doPerturb = false;
@@ -228,8 +228,8 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_edge)
   dpdx_->sync_to_device();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
-  auto* part = meta_.get_part("surface_6");
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  auto* part = meta_->get_part("surface_6");
   auto* surfPart = part->subsets()[0];
   const bool elementContinuityEqs = true;
   const bool needCorrection = false;

--- a/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
@@ -32,7 +32,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_calc_edge)
   solnOpts_.mdotInterpRhoUTogether_ = true;
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.interiorPartVec_.push_back(partVec_[0]);
 
   stk::mesh::field_fill(1.0, *density_);
@@ -103,7 +103,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_rho_accum)
   density_->field_of_state(stk::mesh::StateN).sync_to_device();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.interiorPartVec_.push_back(partVec_[0]);
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
   helperObjs.realm.solutionOptions_->mdotInterpRhoUTogether_ = true;
@@ -138,7 +138,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_correction)
   stk::mesh::field_fill(0.0, *openMassFlowRate_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.solutionOptions_->activateOpenMdotCorrection_ = true;
   auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];
@@ -186,7 +186,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_inflow)
   velocity_->sync_to_device();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];
   const bool elementContinuityEqs = true;
@@ -228,7 +228,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_open_edge)
   dpdx_->sync_to_device();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   auto* part = meta_->get_part("surface_6");
   auto* surfPart = part->subsets()[0];
   const bool elementContinuityEqs = true;

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradAlg.C
@@ -32,7 +32,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_edge)
   const double zCoeff = 2.0;
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
@@ -82,7 +82,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_edge_vec)
   const double zCoeff = 2.0;
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
   velocity_->sync_to_device();
@@ -136,7 +136,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem)
   const double zCoeff = 2.0;
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
@@ -187,7 +187,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem_shifted)
   const bool useShifted = true;
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
@@ -238,7 +238,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_vec)
   const bool useShifted = false;
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
   velocity_->sync_to_device();
@@ -293,7 +293,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_shifted_vec)
   const bool useShifted = true;
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
   velocity_->sync_to_device();
@@ -351,7 +351,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry)
 
   auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, 1, part);
+    bulk_, stk::topology::QUAD_4, 1, part);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
@@ -401,7 +401,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry_shifted)
 
   auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, 1, part);
+    bulk_, stk::topology::QUAD_4, 1, part);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
@@ -451,7 +451,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_bndry_elem_vec)
 
   auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::QUAD_4, 1, part);
+    bulk_, stk::topology::QUAD_4, 1, part);
   unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
   velocity_->sync_to_device();

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradAlg.C
@@ -23,7 +23,7 @@
 TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_edge)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -32,8 +32,8 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_edge)
   const double zCoeff = 2.0;
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *tke_,
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
 
@@ -56,8 +56,8 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_edge)
     };
 
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -73,7 +73,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_edge)
 TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_edge_vec)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -82,8 +82,8 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_edge_vec)
   const double zCoeff = 2.0;
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *velocity_,
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
   velocity_->sync_to_device();
 
@@ -111,8 +111,8 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_edge_vec)
     };
 
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -127,7 +127,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_edge_vec)
 TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -136,8 +136,8 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem)
   const double zCoeff = 2.0;
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *tke_,
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
 
@@ -160,8 +160,8 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem)
     };
 
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -177,7 +177,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem)
 TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem_shifted)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -187,8 +187,8 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem_shifted)
   const bool useShifted = true;
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *tke_,
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
 
@@ -211,8 +211,8 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem_shifted)
     };
 
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -228,7 +228,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_elem_shifted)
 TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_vec)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -238,8 +238,8 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_vec)
   const bool useShifted = false;
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *velocity_,
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
   velocity_->sync_to_device();
 
@@ -267,8 +267,8 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_vec)
     };
 
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -283,7 +283,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_vec)
 TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_shifted_vec)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -293,8 +293,8 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_shifted_vec)
   const bool useShifted = true;
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *velocity_,
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
   velocity_->sync_to_device();
 
@@ -322,8 +322,8 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_shifted_vec)
     };
 
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -338,7 +338,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_elem_shifted_vec)
 TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -349,10 +349,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry)
   const double zCoeff = 2.0;
   const bool useShifted = false;
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, 1, part);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *tke_,
+    *bulk_, stk::topology::QUAD_4, 1, part);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
 
@@ -372,7 +372,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry)
 
     const double tol = 1.0e-16;
     stk::mesh::Selector sel(*part);
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -388,7 +388,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry)
 TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry_shifted)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -399,10 +399,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry_shifted)
   const double zCoeff = 2.0;
   const bool useShifted = true;
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, 1, part);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *tke_,
+    *bulk_, stk::topology::QUAD_4, 1, part);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *tke_,
                                            xCoeff, yCoeff, zCoeff);
   stk::mesh::field_fill(0.0, *dkdx_);
 
@@ -422,7 +422,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry_shifted)
 
     const double tol = 1.0e-16;
     stk::mesh::Selector sel(*part);
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -438,7 +438,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_nodal_grad_bndry_shifted)
 TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_bndry_elem_vec)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -449,10 +449,10 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_bndry_elem_vec)
   const double zCoeff = 2.0;
   const bool useShifted = false;
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::QUAD_4, 1, part);
-  unit_test_alg_utils::linear_scalar_field(bulk_, *coordinates_, *velocity_,
+    *bulk_, stk::topology::QUAD_4, 1, part);
+  unit_test_alg_utils::linear_scalar_field(*bulk_, *coordinates_, *velocity_,
                                            xCoeff, yCoeff, zCoeff);
   velocity_->sync_to_device();
 
@@ -480,7 +480,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_nodal_grad_bndry_elem_vec)
 
     const double tol = 1.0e-16;
     stk::mesh::Selector sel(*part);
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
@@ -24,7 +24,7 @@
 TEST_F(LowMachKernelHex8Mesh, NGP_nodal_grad_popen)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   //const std::string meshSpec = "generated:1x1x1";
   const bool doPerturb = false;
@@ -35,10 +35,10 @@ TEST_F(LowMachKernelHex8Mesh, NGP_nodal_grad_popen)
 
   fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
-  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.solutionOptions_->activateOpenMdotCorrection_ = true;
 
-  stk::mesh::Part* surface1 = meta_.get_part("surface_1");
+  stk::mesh::Part* surface1 = meta_->get_part("surface_1");
   {
     sierra::nalu::GeometryAlgDriver geomAlgDriver(helperObjs.realm);
     geomAlgDriver.register_face_algorithm<sierra::nalu::GeometryBoundaryAlg>(
@@ -58,7 +58,7 @@ TEST_F(LowMachKernelHex8Mesh, NGP_nodal_grad_popen)
   ngpPres.sync_to_device();
   ngpDnvF.sync_to_device();
 
-  const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, meta_.universal_part());
+  const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, meta_->universal_part());
 
   std::function<void(bool,bool)> run_alg = [&](bool zeroGrad, bool useShifted) {
     stk::mesh::field_fill(0.0, *dpdx_);

--- a/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
+++ b/unit_tests/ngp_algorithms/UnitTestNodalGradPOpenBoundary.C
@@ -35,7 +35,7 @@ TEST_F(LowMachKernelHex8Mesh, NGP_nodal_grad_popen)
 
   fill_mesh_and_init_fields(doPerturb, generateSidesets);
 
-  unit_test_utils::HelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.solutionOptions_->activateOpenMdotCorrection_ = true;
 
   stk::mesh::Part* surface1 = meta_->get_part("surface_1");

--- a/unit_tests/ngp_algorithms/UnitTestSDRWallAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestSDRWallAlg.C
@@ -21,7 +21,7 @@
 TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_lowRE)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -37,10 +37,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_lowRE)
 
   const bool useShifted = false;
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.solutionOptions_->initialize_turbulence_constants();
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];
   sierra::nalu::SDRWallFuncAlgDriver algDriver(helperObjs.realm);
   algDriver.register_face_elem_algorithm<sierra::nalu::SDRLowReWallAlg>(
@@ -64,7 +64,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_lowRE)
     ngpWallArea.sync_to_host();
 
     stk::mesh::Selector sel(*part);
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
     const double wAreaGold = 0.25;
 
     auto& realm = helperObjs.realm;
@@ -87,7 +87,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_lowRE)
 TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_func)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -100,10 +100,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_func)
   stk::mesh::field_fill(utau, *wallFricVel_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.solutionOptions_->initialize_turbulence_constants();
 
-  auto* part = meta_.get_part("surface_5");
+  auto* part = meta_->get_part("surface_5");
   auto* surfPart = part->subsets()[0];
   sierra::nalu::SDRWallFuncAlgDriver algDriver(helperObjs.realm);
   algDriver.register_face_elem_algorithm<sierra::nalu::SDRWallFuncAlg>(
@@ -127,7 +127,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_func)
     ngpWallArea.sync_to_host();
 
     stk::mesh::Selector sel(*part);
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
     const double wAreaGold = 0.25;
 
     auto& realm = helperObjs.realm;

--- a/unit_tests/ngp_algorithms/UnitTestSDRWallAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestSDRWallAlg.C
@@ -37,7 +37,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_lowRE)
 
   const bool useShifted = false;
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.solutionOptions_->initialize_turbulence_constants();
 
   auto* part = meta_->get_part("surface_5");
@@ -100,7 +100,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_wall_func)
   stk::mesh::field_fill(utau, *wallFricVel_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
   helperObjs.realm.solutionOptions_->initialize_turbulence_constants();
 
   auto* part = meta_->get_part("surface_5");

--- a/unit_tests/ngp_algorithms/UnitTestSSTMaxLengthScaleAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestSSTMaxLengthScaleAlg.C
@@ -27,7 +27,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_SST_Max_Length_Scale)
   stk::mesh::field_fill(0.0, *maxLengthScale_);
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   // Force computation of edge area vector
   helperObjs.realm.realmUsesEdges_ = true;

--- a/unit_tests/ngp_algorithms/UnitTestSSTMaxLengthScaleAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestSSTMaxLengthScaleAlg.C
@@ -19,7 +19,7 @@
 TEST_F(SSTKernelHex8Mesh, NGP_SST_Max_Length_Scale)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -27,7 +27,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_SST_Max_Length_Scale)
   stk::mesh::field_fill(0.0, *maxLengthScale_);
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   // Force computation of edge area vector
   helperObjs.realm.realmUsesEdges_ = true;
@@ -47,10 +47,10 @@ TEST_F(SSTKernelHex8Mesh, NGP_SST_Max_Length_Scale)
   ngpMaxLen.sync_to_host();
 
   const double tol = 1.0e-16;
-  stk::mesh::Selector sel = meta_.universal_part();
+  stk::mesh::Selector sel = meta_->universal_part();
 
   {
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
     int counter = 0;
     for (const auto* b: bkts)
       for (const auto node: *b) {

--- a/unit_tests/ngp_algorithms/UnitTestTurbViscKsgsAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestTurbViscKsgsAlg.C
@@ -24,7 +24,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_visc_ksgs_alg)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TurbViscKsgsAlg TurbViscKsgsAlg(
     helperObjs.realm, partVec_[0], tvisc_);

--- a/unit_tests/ngp_algorithms/UnitTestTurbViscKsgsAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestTurbViscKsgsAlg.C
@@ -16,7 +16,7 @@
 TEST_F(KsgsKernelHex8Mesh, NGP_turb_visc_ksgs_alg)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   KsgsKernelHex8Mesh::fill_mesh_and_init_fields(false, false, false);
 
@@ -24,7 +24,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_visc_ksgs_alg)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TurbViscKsgsAlg TurbViscKsgsAlg(
     helperObjs.realm, partVec_[0], tvisc_);
@@ -49,8 +49,8 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_visc_ksgs_alg)
     };
 
     const double tol = 1.0e-16;
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)

--- a/unit_tests/ngp_algorithms/UnitTestTurbViscSSTAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestTurbViscSSTAlg.C
@@ -24,7 +24,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_turb_visc_sst_alg)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TurbViscSSTAlg TurbViscSSTAlg(
     helperObjs.realm, partVec_[0], tvisc_);
@@ -73,7 +73,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_turb_visc_sstams_alg)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::HelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TurbViscSSTAlg TurbViscSSTAlg(
     helperObjs.realm, partVec_[0], tvisc_, true);

--- a/unit_tests/ngp_algorithms/UnitTestTurbViscSSTAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestTurbViscSSTAlg.C
@@ -16,7 +16,7 @@
 TEST_F(SSTKernelHex8Mesh, NGP_turb_visc_sst_alg)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   SSTKernelHex8Mesh::fill_mesh_and_init_fields();
 
@@ -24,7 +24,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_turb_visc_sst_alg)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TurbViscSSTAlg TurbViscSSTAlg(
     helperObjs.realm, partVec_[0], tvisc_);
@@ -50,8 +50,8 @@ TEST_F(SSTKernelHex8Mesh, NGP_turb_visc_sst_alg)
 
     const double tol = 1.0e-15;
 
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)
@@ -65,7 +65,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_turb_visc_sst_alg)
 TEST_F(AMSKernelHex8Mesh, NGP_turb_visc_sstams_alg)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   AMSKernelHex8Mesh::fill_mesh_and_init_fields();
 
@@ -73,7 +73,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_turb_visc_sstams_alg)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::HelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   sierra::nalu::TurbViscSSTAlg TurbViscSSTAlg(
     helperObjs.realm, partVec_[0], tvisc_, true);
@@ -99,8 +99,8 @@ TEST_F(AMSKernelHex8Mesh, NGP_turb_visc_sstams_alg)
 
     const double tol = 1.0e-15;
 
-    stk::mesh::Selector sel = meta_.universal_part();
-    const auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel = meta_->universal_part();
+    const auto& bkts = bulk_->get_buckets(stk::topology::NODE_RANK, sel);
 
     int ii = 0;
     for (const auto* b: bkts)

--- a/unit_tests/ngp_kernels/UnitTestNgpKernel.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpKernel.C
@@ -31,7 +31,7 @@ TEST_F(Hex8MeshWithNSOFields, NGPKernelBasic)
 
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 
@@ -72,7 +72,7 @@ TEST_F(Hex8MeshWithNSOFields, NGPKernelRunAlg)
 
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 
@@ -95,7 +95,7 @@ TEST_F(Hex8MeshWithNSOFields, NGPKernelExecute)
 
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 

--- a/unit_tests/ngp_kernels/UnitTestNgpKernel.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpKernel.C
@@ -31,12 +31,12 @@ TEST_F(Hex8MeshWithNSOFields, NGPKernelBasic)
 
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 
   std::unique_ptr<TestContinuityKernel> testKernel(
-    new TestContinuityKernel(bulk, dataNeeded));
+    new TestContinuityKernel(*bulk, dataNeeded));
   assembleElemSolverAlg->activeKernels_.push_back(testKernel.get());
 
   EXPECT_EQ(3u, dataNeeded.get_fields().size());
@@ -72,18 +72,18 @@ TEST_F(Hex8MeshWithNSOFields, NGPKernelRunAlg)
 
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 
   std::unique_ptr<TestContinuityKernel> testKernel(
-    new TestContinuityKernel(bulk, dataNeeded));
+    new TestContinuityKernel(*bulk, dataNeeded));
   assembleElemSolverAlg->activeKernels_.push_back(testKernel.get());
 
   EXPECT_EQ(3u, dataNeeded.get_fields().size());
   EXPECT_EQ(1u, assembleElemSolverAlg->activeKernels_.size());
 
-  kernel_runalg_test(bulk, *assembleElemSolverAlg);
+  kernel_runalg_test(*bulk, *assembleElemSolverAlg);
   assembleElemSolverAlg->activeKernels_.clear();
 }
 
@@ -95,12 +95,12 @@ TEST_F(Hex8MeshWithNSOFields, NGPKernelExecute)
 
   fill_mesh_and_initialize_test_fields("generated:2x2x2");
 
-  unit_test_utils::HelperObjects helperObjs(bulk, stk::topology::HEX_8, 1, partVec[0]);
+  unit_test_utils::HelperObjects helperObjs(*bulk, stk::topology::HEX_8, 1, partVec[0]);
   auto* assembleElemSolverAlg = helperObjs.assembleElemSolverAlg;
   auto& dataNeeded = assembleElemSolverAlg->dataNeededByKernels_;
 
   std::unique_ptr<TestContinuityKernel> testKernel(
-    new TestContinuityKernel(bulk, dataNeeded));
+    new TestContinuityKernel(*bulk, dataNeeded));
   assembleElemSolverAlg->activeKernels_.push_back(testKernel.get());
 
   EXPECT_EQ(3u, dataNeeded.get_fields().size());

--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -67,7 +67,7 @@ public:
   }
 
   stk::mesh::MetaData* meta;
-  std::unique_ptr<stk::mesh::BulkData> bulk;
+  std::shared_ptr<stk::mesh::BulkData> bulk;
   stk::mesh::PartVector partVec;
   const VectorFieldType* coordField{nullptr};
   ScalarFieldType* density{nullptr};

--- a/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
@@ -76,7 +76,7 @@ static constexpr double rhs[24] = {
 TEST_F(AMSKernelHex8Mesh, NGP_tke_ams_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -86,9 +86,9 @@ TEST_F(AMSKernelHex8Mesh, NGP_tke_ams_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTAMSNodeKernel>(meta_, solnOpts_.get_coordinates_name());
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTAMSNodeKernel>(*meta_, solnOpts_.get_coordinates_name());
 
   helperObjs.execute();
 
@@ -108,7 +108,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_tke_ams_node)
 TEST_F(AMSKernelHex8Mesh, NGP_sdr_ams_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -118,9 +118,9 @@ TEST_F(AMSKernelHex8Mesh, NGP_sdr_ams_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTAMSNodeKernel>(meta_, solnOpts_.get_coordinates_name());
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTAMSNodeKernel>(*meta_, solnOpts_.get_coordinates_name());
 
   helperObjs.execute();
 
@@ -140,7 +140,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_sdr_ams_node)
 TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   fill_mesh_and_init_fields();
@@ -151,10 +151,10 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumSSTAMSForcingNodeKernel>(
-    bulk_, solnOpts_);
+    *bulk_, solnOpts_);
 
   sierra::nalu::TimeIntegrator timeIntegrator;
   timeIntegrator.currentTime_ = 0.0;

--- a/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
@@ -86,7 +86,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_tke_ams_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTAMSNodeKernel>(*meta_, solnOpts_.get_coordinates_name());
 
@@ -118,7 +118,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_sdr_ams_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTAMSNodeKernel>(*meta_, solnOpts_.get_coordinates_name());
 
@@ -151,7 +151,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumSSTAMSForcingNodeKernel>(
     *bulk_, solnOpts_);

--- a/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
@@ -17,7 +17,7 @@
 TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_gcl_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -29,11 +29,11 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_gcl_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::ContinuityGclNodeKernel>(bulk_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::ContinuityGclNodeKernel>(*bulk_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
@@ -29,7 +29,7 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_gcl_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 

--- a/unit_tests/node_kernels/UnitTestContinuityMassBDFNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestContinuityMassBDFNodeKernel.C
@@ -29,7 +29,7 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_mass_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 

--- a/unit_tests/node_kernels/UnitTestContinuityMassBDFNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestContinuityMassBDFNodeKernel.C
@@ -17,7 +17,7 @@
 TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_mass_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -29,11 +29,11 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_mass_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::ContinuityMassBDFNodeKernel>(bulk_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::ContinuityMassBDFNodeKernel>(*bulk_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestEnthalpyABLForceNode.C
+++ b/unit_tests/node_kernels/UnitTestEnthalpyABLForceNode.C
@@ -26,7 +26,7 @@ TEST_F(EnthalpyABLKernelHex8Mesh, NGP_abl_force)
   fill_mesh_and_init_fields();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.ablForcingAlg_ = new unit_test_utils::TestABLForcingAlg(helperObjs.realm);
 

--- a/unit_tests/node_kernels/UnitTestEnthalpyABLForceNode.C
+++ b/unit_tests/node_kernels/UnitTestEnthalpyABLForceNode.C
@@ -21,16 +21,16 @@
 TEST_F(EnthalpyABLKernelHex8Mesh, NGP_abl_force)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.ablForcingAlg_ = new unit_test_utils::TestABLForcingAlg(helperObjs.realm);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::EnthalpyABLForceNodeKernel>(bulk_, solnOpts_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::EnthalpyABLForceNodeKernel>(*bulk_, solnOpts_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestKsgsNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestKsgsNodeKernel.C
@@ -41,7 +41,7 @@ static constexpr double lhs[8][8] = {
 TEST_F(KsgsKernelHex8Mesh, NGP_tke_ksgs_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   const bool doPerturb = false;
   const bool generateSidesets = false;
@@ -54,9 +54,9 @@ TEST_F(KsgsKernelHex8Mesh, NGP_tke_ksgs_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::TKEKsgsNodeKernel>(meta_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::TKEKsgsNodeKernel>(*meta_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestKsgsNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestKsgsNodeKernel.C
@@ -54,7 +54,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_tke_ksgs_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::TKEKsgsNodeKernel>(*meta_);
 

--- a/unit_tests/node_kernels/UnitTestMomentumABLForceNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumABLForceNode.C
@@ -26,7 +26,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_abl_force)
   fill_mesh_and_init_fields();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.realm.ablForcingAlg_ = new unit_test_utils::TestABLForcingAlg(helperObjs.realm);
 

--- a/unit_tests/node_kernels/UnitTestMomentumABLForceNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumABLForceNode.C
@@ -21,16 +21,16 @@
 TEST_F(MomentumNodeHex8Mesh, NGP_abl_force)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.realm.ablForcingAlg_ = new unit_test_utils::TestABLForcingAlg(helperObjs.realm);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumABLForceNodeKernel>(bulk_, solnOpts_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumABLForceNodeKernel>(*bulk_, solnOpts_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestMomentumActuatorNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumActuatorNodeKernel.C
@@ -19,7 +19,7 @@
 TEST_F(ActuatorSourceKernelHex8Mesh, NGP_momentum_actuator)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   std::mt19937 rng;
   rng.seed(0); // fixed seed
@@ -30,9 +30,9 @@ TEST_F(ActuatorSourceKernelHex8Mesh, NGP_momentum_actuator)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  unit_test_utils::NodeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+  unit_test_utils::NodeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumActuatorNodeKernel>(bulk_.mesh_meta_data());
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumActuatorNodeKernel>(bulk_->mesh_meta_data());
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestMomentumActuatorNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumActuatorNodeKernel.C
@@ -30,7 +30,7 @@ TEST_F(ActuatorSourceKernelHex8Mesh, NGP_momentum_actuator)
   solnOpts_.meshMotion_ = false;
   solnOpts_.externalMeshDeformation_ = false;
 
-  unit_test_utils::NodeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+  unit_test_utils::NodeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumActuatorNodeKernel>(bulk_->mesh_meta_data());
 

--- a/unit_tests/node_kernels/UnitTestMomentumBodyForceBoxNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumBodyForceBoxNode.C
@@ -39,7 +39,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force_box_inside)
   const std::vector<double> box{0.0, 0.0, 0.0, 10.0, 10.0, 10.0};
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumBodyForceBoxNodeKernel>(
     helperObjs.realm, forces, box);
@@ -69,7 +69,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force_box_outside)
   const std::vector<double> box{0.0, 0.0, 0.0, 10.0, 0.5, 10.0};
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumBodyForceBoxNodeKernel>(
     helperObjs.realm, forces, box);

--- a/unit_tests/node_kernels/UnitTestMomentumBodyForceBoxNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumBodyForceBoxNode.C
@@ -30,7 +30,7 @@ static constexpr double rhs[24] = {1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 0.0,
 TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force_box_inside)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   fill_mesh_and_init_fields();
@@ -39,7 +39,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force_box_inside)
   const std::vector<double> box{0.0, 0.0, 0.0, 10.0, 10.0, 10.0};
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumBodyForceBoxNodeKernel>(
     helperObjs.realm, forces, box);
@@ -60,7 +60,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force_box_inside)
 TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force_box_outside)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1)
+  if (bulk_->parallel_size() > 1)
     return;
 
   fill_mesh_and_init_fields();
@@ -69,7 +69,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force_box_outside)
   const std::vector<double> box{0.0, 0.0, 0.0, 10.0, 0.5, 10.0};
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumBodyForceBoxNodeKernel>(
     helperObjs.realm, forces, box);

--- a/unit_tests/node_kernels/UnitTestMomentumBodyForceNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumBodyForceNode.C
@@ -26,7 +26,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force)
   const std::vector<double> forceVector{8.0, 8.0, 8.0};
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumBodyForceNodeKernel>(
     *bulk_, forceVector);

--- a/unit_tests/node_kernels/UnitTestMomentumBodyForceNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumBodyForceNode.C
@@ -19,17 +19,17 @@
 TEST_F(MomentumNodeHex8Mesh, NGP_momentum_body_force)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
   const std::vector<double> forceVector{8.0, 8.0, 8.0};
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumBodyForceNodeKernel>(
-    bulk_, forceVector);
+    *bulk_, forceVector);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestMomentumBoussinesqNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumBoussinesqNode.C
@@ -19,7 +19,7 @@
 TEST_F(MomentumNodeHex8Mesh, NGP_momentum_boussinesq)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   std::mt19937 rng;
   rng.seed(0); // fixed seed
@@ -36,10 +36,10 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_boussinesq)
   solnOpts_.referenceTemperature_ = 298;
   solnOpts_.thermalExpansionCoeff_ = 1.0;
 
-  unit_test_utils::NodeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+  unit_test_utils::NodeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumBoussinesqNodeKernel>(
-    bulk_, solnOpts_);
+    *bulk_, solnOpts_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestMomentumBoussinesqNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumBoussinesqNode.C
@@ -36,7 +36,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_boussinesq)
   solnOpts_.referenceTemperature_ = 298;
   solnOpts_.thermalExpansionCoeff_ = 1.0;
 
-  unit_test_utils::NodeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+  unit_test_utils::NodeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumBoussinesqNodeKernel>(
     *bulk_, solnOpts_);

--- a/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
@@ -17,7 +17,7 @@
 TEST_F(MomentumNodeHex8Mesh, NGP_momentum_coriolis)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -41,10 +41,10 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_coriolis)
   solnOpts_.northVector_ = { 0.0, 1.0, 0.0 };
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumCoriolisNodeKernel>(
-    bulk_, solnOpts_);
+    *bulk_, solnOpts_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
@@ -41,7 +41,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_coriolis)
   solnOpts_.northVector_ = { 0.0, 1.0, 0.0 };
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumCoriolisNodeKernel>(
     *bulk_, solnOpts_);

--- a/unit_tests/node_kernels/UnitTestMomentumGclSrcNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumGclSrcNodeKernel.C
@@ -45,7 +45,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_gcl_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 

--- a/unit_tests/node_kernels/UnitTestMomentumGclSrcNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumGclSrcNodeKernel.C
@@ -33,7 +33,7 @@ static constexpr double rhs[24] =
 TEST_F(MomentumNodeHex8Mesh, NGP_momentum_gcl_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -45,11 +45,11 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_gcl_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumGclSrcNodeKernel>(bulk_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumGclSrcNodeKernel>(*bulk_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestMomentumMassBDFNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumMassBDFNodeKernel.C
@@ -35,7 +35,7 @@ static constexpr double rhs[24] =
 TEST_F(MomentumKernelHex8Mesh, NGP_momentum_mass_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -49,11 +49,11 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_mass_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, nDofs, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, nDofs, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumMassBDFNodeKernel>(bulk_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::MomentumMassBDFNodeKernel>(*bulk_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestMomentumMassBDFNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumMassBDFNodeKernel.C
@@ -49,7 +49,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_momentum_mass_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, nDofs, partVec_[0]);
+    bulk_, stk::topology::HEX_8, nDofs, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 

--- a/unit_tests/node_kernels/UnitTestSSTNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestSSTNodeKernel.C
@@ -114,7 +114,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTNodeKernel>(*meta_);
 
@@ -145,7 +145,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTDESNodeKernel>(*meta_);
 
@@ -176,7 +176,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTNodeKernel>(*meta_);
 
@@ -207,7 +207,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_des_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTDESNodeKernel>(*meta_);
 

--- a/unit_tests/node_kernels/UnitTestSSTNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestSSTNodeKernel.C
@@ -104,7 +104,7 @@ static constexpr double lhs[8][8] = {
 TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -114,9 +114,9 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTNodeKernel>(meta_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTNodeKernel>(*meta_);
 
   helperObjs.execute();
 
@@ -135,7 +135,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_node)
 TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -145,9 +145,9 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTDESNodeKernel>(meta_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::TKESSTDESNodeKernel>(*meta_);
 
   helperObjs.execute();
 
@@ -166,7 +166,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_node)
 TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -176,9 +176,9 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTNodeKernel>(meta_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTNodeKernel>(*meta_);
 
   helperObjs.execute();
 
@@ -197,7 +197,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_node)
 TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_des_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -207,9 +207,9 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_des_node)
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTDESNodeKernel>(meta_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::SDRSSTDESNodeKernel>(*meta_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestScalarGclNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestScalarGclNodeKernel.C
@@ -28,7 +28,7 @@ static constexpr double rhs[8] =
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_gcl_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -40,11 +40,11 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_gcl_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::ScalarGclNodeKernel>(bulk_, mixFraction_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::ScalarGclNodeKernel>(*bulk_, mixFraction_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestScalarGclNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestScalarGclNodeKernel.C
@@ -40,7 +40,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_gcl_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 

--- a/unit_tests/node_kernels/UnitTestScalarMassBDFNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestScalarMassBDFNodeKernel.C
@@ -39,7 +39,7 @@ static constexpr double rhs[8] =
 TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_mass_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
@@ -51,11 +51,11 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_mass_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::ScalarMassBDFNodeKernel>(bulk_, mixFraction_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::ScalarMassBDFNodeKernel>(*bulk_, mixFraction_);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestScalarMassBDFNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestScalarMassBDFNodeKernel.C
@@ -51,7 +51,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_scalar_mass_node)
   timeIntegrator.gamma3_ = 0.0;
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.realm.timeIntegrator_ = &timeIntegrator;
 

--- a/unit_tests/node_kernels/UnitTestTKERodiNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestTKERodiNodeKernel.C
@@ -18,16 +18,16 @@
 TEST_F(KsgsKernelHex8Mesh, NGP_turb_kenetic_energy_Rodi)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
-  const int nprocs = bulk_.parallel_size();
+  const int nprocs = bulk_->parallel_size();
   
   std::mt19937 rng;
   rng.seed(0); // fixed seed
 
   fill_mesh_and_init_fields(false,false,true);
 
-  unit_test_utils::NodeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+  unit_test_utils::NodeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   // set solution options
   sierra::nalu::SolutionOptions *solnOpts=helperObjs.nodeAlg->realm_.solutionOptions_;
@@ -46,7 +46,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_kenetic_energy_Rodi)
   solnOpts_.thermalExpansionCoeff_ = 3.0e-3;
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::TKERodiNodeKernel>
-   (bulk_.mesh_meta_data(), *solnOpts);
+   (bulk_->mesh_meta_data(), *solnOpts);
 
   helperObjs.execute();
 

--- a/unit_tests/node_kernels/UnitTestTKERodiNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestTKERodiNodeKernel.C
@@ -27,7 +27,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_turb_kenetic_energy_Rodi)
 
   fill_mesh_and_init_fields(false,false,true);
 
-  unit_test_utils::NodeHelperObjects helperObjs(*bulk_, stk::topology::HEX_8, 3, partVec_[0]);
+  unit_test_utils::NodeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 3, partVec_[0]);
 
   // set solution options
   sierra::nalu::SolutionOptions *solnOpts=helperObjs.nodeAlg->realm_.solutionOptions_;

--- a/unit_tests/node_kernels/UnitTestWallDistNode.C
+++ b/unit_tests/node_kernels/UnitTestWallDistNode.C
@@ -22,7 +22,7 @@ TEST_F(WallDistKernelHex8Mesh, walldist_node)
   fill_mesh_and_init_fields();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
   helperObjs.nodeAlg->add_kernel<sierra::nalu::WallDistNodeKernel>(*bulk_);
 

--- a/unit_tests/node_kernels/UnitTestWallDistNode.C
+++ b/unit_tests/node_kernels/UnitTestWallDistNode.C
@@ -17,14 +17,14 @@
 TEST_F(WallDistKernelHex8Mesh, walldist_node)
 {
   // Only execute for 1 processor runs
-  if (bulk_.parallel_size() > 1) return;
+  if (bulk_->parallel_size() > 1) return;
 
   fill_mesh_and_init_fields();
 
   unit_test_utils::NodeHelperObjects helperObjs(
-    bulk_, stk::topology::HEX_8, 1, partVec_[0]);
+    *bulk_, stk::topology::HEX_8, 1, partVec_[0]);
 
-  helperObjs.nodeAlg->add_kernel<sierra::nalu::WallDistNodeKernel>(bulk_);
+  helperObjs.nodeAlg->add_kernel<sierra::nalu::WallDistNodeKernel>(*bulk_);
 
   helperObjs.execute();
 


### PR DESCRIPTION
stk::mesh::BulkData's constructor will be deprecated in favor of the stk::mesh::MeshBuilder factory object in the near future.  This change updates Nalu-Wind to use this new factory for all BulkData construction.  