### PR TITLE
Add a scanning lidar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ def runDoxygen(doxyfileIn, doxyfileOut):
     doxname = os.path.join(sourcedir, doxyfileOut)
     with open(doxname, 'w') as fh:
         fh.write(c2)
-    print 'Running Doxygen on %s' % doxyfileOut
+    print('Running Doxygen on %s' % doxyfileOut)
     try:
         subprocess.call(('doxygen', doxname))
     except:

--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -1514,6 +1514,34 @@ Data probes
    The orientation vector for the LIDAR measurements.
 
 
+.. inpfile:: data_probes.lidar_specifications.output
+
+   Output type for subsampling LIDAR. Either `text` or `netcdf` (default).
+
+
+.. inpfile:: data_probes.lidar_specifications.type
+
+   Type of LIDAR scan pattern. `scanning` or `spinner` (default).
+
+
+.. inpfile:: data_probes.lidar_specifications.scanning_lidar_specifications
+
+   Block specifying parameters for the scanning lidar sampling
+
+   ========================== ===================================================================
+   Parameter                  Description
+   ========================== ===================================================================
+   beam_length                Required. Length over which to measure, e.g. 50.
+   axis                       Required. Zero angle vector for the angular sweep, e.g. [1,0,0].
+   center                     Required. Location of the scanning LIDAR, e.g. [0,0,0].
+   stare_time                 Default 1 second. Time line spends at a particular scan angle.
+   sweep_angle                Default 20 degrees. Extent of angular sweep between sweep_angle/2 to -sweep_angle/2.
+   step_delta_angle           Default 1 degree. Measurement interval of scan angles over the sweep
+   reset_time_delta           Default 1 second. Time to reset LIDAR after sweep.
+   ground_direction           Default [0,0,1]. Orthogonal orientation vector for the LIDAR
+   ========================== ===================================================================
+
+
 .. inpfile:: dataprobes.lidar_specifications.misc
 
    The user may also set a number of parameters corresponding to the hardware

--- a/include/wind_energy/SyntheticLidar.h
+++ b/include/wind_energy/SyntheticLidar.h
@@ -6,7 +6,6 @@
 // This software is released under the BSD 3-clause license. See LICENSE file
 // for more details.
 //
-
 #ifndef SyntheticLidar_H
 #define SyntheticLidar_H
 
@@ -14,85 +13,18 @@
 
 #include "xfer/LocalVolumeSearch.h"
 
+#include "wind_energy/LidarPatterns.h"
+
 #include <memory>
 #include <array>
 
 namespace sierra {
 namespace nalu {
 
-struct Segment
-{
-  Segment() = default;
-  Segment(std::array<double, 3> tip, std::array<double, 3> tail)
-    : tip_(tip), tail_(tail){};
-
-  std::array<double, 3> tip_{{}};
-  std::array<double, 3> tail_{{}};
-};
-
-struct PrismParameters
-{
-  PrismParameters() = default;
-  PrismParameters(double theta0, double rot, double azimuth)
-    : theta0_{theta0}, rot_{rot}, azimuth_{azimuth} {};
-
-  double theta0_{0};  // rad
-  double rot_{0};     // rad / s
-  double azimuth_{0}; // rad
-};
-
-class SpinnerLidarSegmentGenerator
-{
-public:
-  SpinnerLidarSegmentGenerator() = default;
-
-  SpinnerLidarSegmentGenerator(
-    PrismParameters inner, PrismParameters outer, double in_beamLength);
-
-  void load(const YAML::Node& node);
-
-  Segment generate_path_segment(double time) const;
-
-  void set_inner_prism(PrismParameters innerPrism) { innerPrism_ = innerPrism; }
-  void set_inner_prism(double theta0, double rot, double azi)
-  {
-    innerPrism_ = {theta0, rot, azi};
-  }
-  void set_outer_prism(PrismParameters outerPrism) { outerPrism_ = outerPrism; }
-  void set_outer_prism(double theta0, double rot, double azi)
-  {
-    outerPrism_ = {theta0, rot, azi};
-  }
-  void set_lidar_center(Coordinates lidarCenter)
-  {
-    lidarCenter_ = {{lidarCenter.x_, lidarCenter.y_, lidarCenter.z_}};
-  }
-  void set_laser_axis(Coordinates laserAxis)
-  {
-    laserAxis_ = {{laserAxis.x_, laserAxis.y_, laserAxis.z_}};
-  }
-  void set_ground_normal(Coordinates gNormal)
-  {
-    groundNormal_ = {{gNormal.x_, gNormal.y_, gNormal.z_}};
-  }
-  void set_beam_length(double beamLength) { beamLength_ = beamLength; }
-
-private:
-  PrismParameters innerPrism_;
-  PrismParameters outerPrism_;
-  double beamLength_{1.0};
-
-  std::array<double, 3> lidarCenter_{{0, 0, 0}};
-  std::array<double, 3> laserAxis_{{1, 0, 0}};
-  std::array<double, 3> groundNormal_{{0, 0, 1}};
-};
-
 class LidarLineOfSite
 {
 public:
-  LidarLineOfSite() = default;
   void load(const YAML::Node& node);
-
   std::unique_ptr<DataProbeSpecInfo>
   determine_line_of_site_info(const YAML::Node& node);
 
@@ -108,7 +40,7 @@ public:
 
 private:
   enum class Output { NETCDF, TEXT, DATAPROBE } output_type_{Output::NETCDF};
-  SpinnerLidarSegmentGenerator segGen;
+  std::unique_ptr<SegmentGenerator> segGen;
 
   void prepare_nc_file();
   void output_nc(

--- a/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
@@ -271,6 +271,28 @@ realms:
       output_frequency: 10
       time_hist_output_frequency: 2
 
+    data_probes:
+      output_frequency: 10
+      search_method: stk_kdtree
+      search_tolerance: 1.0e-3
+      search_expansion_factor: 2.0
+
+      lidar_specifications:
+        from_target_part: [fluid_part]
+        type: scanning
+        frequency: 10 #Hz
+        points_along_line: 2
+        output: text
+        scanning_lidar_specifications:
+          center: [500,500,100] #m
+          beam_length: 50.0 #m
+          axis: [1,0,0] #m
+          stare_time: 1 #s
+          sweep_angle: 20 #deg
+          step_delta_angle: 1 #deg
+          reset_time_delta: 1 #s
+
+
     # This defines the ABL forcing to drive the winds to 8 m/s from
     # 245 degrees (southwest) at 90 m above the surface in a planar
     # averaged sense.

--- a/src/wind_energy/CMakeLists.txt
+++ b/src/wind_energy/CMakeLists.txt
@@ -2,5 +2,6 @@ target_sources(nalu PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/ABLForcingAlgorithm.C
   ${CMAKE_CURRENT_SOURCE_DIR}/BdyHeightAlgorithm.C
   ${CMAKE_CURRENT_SOURCE_DIR}/BdyLayerStatistics.C
+  ${CMAKE_CURRENT_SOURCE_DIR}/LidarPatterns.C
   ${CMAKE_CURRENT_SOURCE_DIR}/SyntheticLidar.C
   )

--- a/src/wind_energy/LidarPatterns.C
+++ b/src/wind_energy/LidarPatterns.C
@@ -1,0 +1,323 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include "wind_energy/LidarPatterns.h"
+
+#include "NaluParsedTypes.h"
+#include "NaluParsing.h"
+#include "master_element/TensorOps.h"
+
+#include "xfer/Transfer.h"
+#include "xfer/LocalVolumeSearch.h"
+#include "netcdf.h"
+#include "Ioss_FileInfo.h"
+
+#include <memory>
+
+namespace sierra {
+namespace nalu {
+
+constexpr int dim = 3;
+
+SegmentType
+segment_generator_types(std::string name)
+{
+  std::transform(name.cbegin(), name.cend(), name.begin(), ::tolower);
+  return std::map<std::string, SegmentType>{
+    {"spinner", SegmentType::SPINNER},
+    {"scanning", SegmentType::SCANNING},
+  }.at(name);
+}
+
+std::unique_ptr<SegmentGenerator>
+make_segment_generator(SegmentType type)
+{
+  switch (type) {
+  case SegmentType::SPINNER:
+    return std::make_unique<SpinnerLidarSegmentGenerator>();
+  case SegmentType::SCANNING:
+    return std::make_unique<ScanningLidarSegmentGenerator>();
+  default:
+    throw std::runtime_error("Invalid lidar type");
+    return std::make_unique<SpinnerLidarSegmentGenerator>();
+  }
+}
+
+std::unique_ptr<SegmentGenerator>
+make_segment_generator(const std::string& name)
+{
+  return make_segment_generator(segment_generator_types(name));
+}
+
+namespace {
+
+std::array<double, 3>
+to_array3(Coordinates x)
+{
+  return {x.x_, x.y_, x.z_};
+}
+
+std::array<double, 3>
+rotate_euler_vec(
+  const std::array<double, 3>& axis, double angle, std::array<double, 3> vec)
+{
+  enum { XH = 0, YH = 1, ZH = 2 };
+
+  normalize_vec3(vec.data());
+
+  std::array<double, 9> nX = {
+    {0, -axis[ZH], +axis[YH], +axis[ZH], 0, -axis[XH], -axis[YH], +axis[XH],
+     0}};
+  const double cosTheta = std::cos(angle);
+  std::array<double, 9> rot = {
+    {cosTheta, 0, 0, 0, cosTheta, 0, 0, 0, cosTheta}};
+
+  const double sinTheta = std::sin(angle);
+  for (int j = 0; j < 3; ++j) {
+    for (int i = 0; i < 3; ++i) {
+      rot[j * 3 + i] +=
+        (1 - cosTheta) * axis[i] * axis[j] + sinTheta * nX[j * 3 + i];
+    }
+  }
+  std::array<double, 3> vecprime;
+  matvec33(rot.data(), vec.data(), vecprime.data());
+  return vecprime;
+}
+
+std::array<double, 3>
+reflect(const std::array<double, 3>& line, const std::array<double, 3>& vec)
+{
+  enum { XH = 0, YH = 1, ZH = 2 };
+
+  std::array<double, 9> ref = {
+    {1 - 2 * line[XH] * line[XH], -2 * line[XH] * line[YH],
+     -2 * line[XH] * line[ZH], -2 * line[YH] * line[XH],
+     1 - 2 * line[YH] * line[YH], -2 * line[YH] * line[ZH],
+     -2 * line[ZH] * line[XH], -2 * line[ZH] * line[YH],
+     1 - 2 * line[ZH] * line[ZH]}};
+
+  std::array<double, 3> result;
+  matvec33(ref.data(), vec.data(), result.data());
+  return result;
+}
+
+auto
+affine(
+  const std::array<double, 3>& trans,
+  const std::array<double, 9>& lin,
+  const std::array<double, 3>& x)
+{
+  enum {
+    XX = 0,
+    XY = 1,
+    XZ = 2,
+    YX = 3,
+    YY = 4,
+    YZ = 5,
+    ZX = 6,
+    ZY = 7,
+    ZZ = 8
+  };
+  enum { XH = 0, YH = 1, ZH = 2 };
+  return std::array<double, 3>{
+    trans[XH] + (lin[XX] * x[XH] + lin[XY] * x[YH] + lin[XZ] * x[ZH]),
+    trans[YH] + (lin[YX] * x[XH] + lin[YY] * x[YH] + lin[YZ] * x[ZH]),
+    trans[ZH] + (lin[ZX] * x[XH] + lin[ZY] * x[YH] + lin[ZZ] * x[ZH])};
+}
+
+auto
+affine(
+  const std::array<double, 3>& trans,
+  double lin,
+  const std::array<double, 3>& x)
+{
+  return affine(
+    trans,
+    {
+      lin, 0, 0,
+      0, lin, 0,
+      0, 0, lin,
+    },
+    x);
+}
+
+} // namespace
+
+void
+ScanningLidarSegmentGenerator::load(const YAML::Node& node)
+{
+  center_ = to_array3(node["center"].as<Coordinates>());
+
+  axis_ = to_array3(node["axis"].as<Coordinates>());
+  normalize_vec3(axis_.data());
+
+  double sweep_angle_in_degrees = 20;
+  get_if_present(node, "sweep_angle", sweep_angle_in_degrees);
+  ThrowRequireMsg(sweep_angle_in_degrees > 0, "Sweep angle must be positive");
+  sweep_angle_ = convert::degrees_to_radians(sweep_angle_in_degrees);
+
+  double step_delta_angle_in_degrees = 1;
+  get_if_present(node, "step_delta_angle", step_delta_angle_in_degrees);
+  step_delta_angle_ = convert::degrees_to_radians(step_delta_angle_in_degrees);
+
+  ThrowRequireMsg(step_delta_angle_ > 0, "step delta angle must be positive");
+  ThrowRequireMsg(
+    step_delta_angle_ <= sweep_angle_,
+    "step delta angle must be less than full sweep");
+
+  get_if_present(node, "stare_time", stare_time_);
+  ThrowRequireMsg(stare_time_ > 0, "stare time must be positive");
+
+  get_if_present(node, "reset_time_delta", reset_time_delta_);
+  ThrowRequireMsg(
+    reset_time_delta_ >= 0, "reset time delta must be semi-positive");
+
+  get_required(node, "beam_length", beam_length_);
+
+  if (node["ground_direction"]) {
+    ground_normal_ = to_array3(node["ground_direction"].as<Coordinates>());
+    normalize_vec3(ground_normal_.data());
+  }
+  end_of_forward_phase_ = determine_end_of_forward_phase();
+}
+
+double
+ScanningLidarSegmentGenerator::periodic_time(double time) const
+{
+  const double total_sweep_time = end_of_forward_phase_ + reset_time_delta_;
+  return time - std::floor(time / total_sweep_time) * total_sweep_time;
+}
+
+ScanningLidarSegmentGenerator::phase
+ScanningLidarSegmentGenerator::determine_operation_phase(
+  double periodic_time) const
+{
+  return (periodic_time <= end_of_forward_phase_) ? phase::FORWARD
+                                                  : phase::RESET;
+}
+
+double
+ScanningLidarSegmentGenerator::angle_if_during_reset(double periodic_time) const
+{
+  const double reset_time = periodic_time - end_of_forward_phase_;
+  const int orientation = (dir_ == direction::CLOCKWISE) ? -1 : 1;
+  return orientation *
+         (sweep_angle_ / 2 - (sweep_angle_ / reset_time_delta_) * reset_time);
+}
+
+double
+ScanningLidarSegmentGenerator::angle_if_during_forward_phase(
+  double periodic_time) const
+{
+  const int orientation = (dir_ == direction::CLOCKWISE) ? -1 : 1;
+  return orientation *
+         (-sweep_angle_ / 2 +
+          std::floor(periodic_time / stare_time_) * step_delta_angle_);
+}
+
+double
+ScanningLidarSegmentGenerator::determine_current_angle(
+  double periodic_time) const
+{
+  return (determine_operation_phase(periodic_time) == phase::FORWARD)
+           ? angle_if_during_forward_phase(periodic_time)
+           : angle_if_during_reset(periodic_time);
+}
+
+Segment
+ScanningLidarSegmentGenerator::generate(double time) const
+{
+  /*
+   scanning lidar steps to a particular angle in a sweep, stares, then moves
+   quickly to the next angle. At the max sweep angle, it resets itself to the
+   starting angle (-sweep angle/2) over some finite period of time.
+  */
+  const auto tail = center_;
+  const auto sight_vector = rotate_euler_vec(
+    ground_normal_, determine_current_angle(periodic_time(time)), axis_);
+  const auto tip = affine(center_, beam_length_, sight_vector);
+  return Segment{tip, tail};
+}
+
+void
+SpinnerLidarSegmentGenerator::load(const YAML::Node& node)
+{
+  NaluEnv::self().naluOutputP0()
+    << "LidarLineOfSite::SpinnerLidarSegmentGenerator::load" << std::endl;
+
+  ThrowRequireMsg(node["center"], "Lidar center must be provided");
+  ThrowRequireMsg(node["axis"], "Lidar axis must be provided");
+
+  lidarCenter_ = to_array3(node["center"].as<Coordinates>());
+
+  laserAxis_ = to_array3(node["axis"].as<Coordinates>());
+  normalize_vec3(laserAxis_.data());
+
+  double innerPrismTheta0 = 90;
+  get_if_present(node, "inner_prism_initial_theta", innerPrismTheta0);
+
+  double innerPrismRot = 3.5;
+  get_if_present(node, "inner_prism_rotation_rate", innerPrismRot);
+
+  double innerPrismAzi = 15.2;
+  get_if_present(node, "inner_prism_azimuth", innerPrismAzi);
+
+  double outerPrismTheta0 = 90;
+  get_if_present(node, "outer_prism_initial_theta", outerPrismTheta0);
+
+  double outerPrismRot = 6.5;
+  get_if_present(node, "outer_prism_rotation_rate", outerPrismRot);
+
+  double outerPrismAzi = 15.2;
+  get_if_present(node, "outer_prism_azimuth", outerPrismAzi);
+
+  innerPrism_ = {
+    convert::degrees_to_radians(innerPrismTheta0),
+    convert::rotations_to_radians(innerPrismRot),
+    convert::degrees_to_radians(innerPrismAzi)};
+  outerPrism_ = {
+    convert::degrees_to_radians(outerPrismTheta0),
+    convert::rotations_to_radians(outerPrismRot),
+    convert::degrees_to_radians(outerPrismAzi)};
+  get_required(node, "beam_length", beamLength_);
+
+  if (node["ground_direction"]) {
+    groundNormal_ = to_array3(node["ground_direction"].as<Coordinates>());
+    normalize_vec3(groundNormal_.data());
+  }
+
+  ThrowRequireMsg(
+    std::abs(ddot(groundNormal_.data(), laserAxis_.data(), 3)) <
+      small_positive_value(),
+    "Ground and laser axes must be orthogonal");
+}
+
+Segment
+SpinnerLidarSegmentGenerator::generate(double time) const
+{
+  const auto inner_angle = -(innerPrism_.azimuth_ / 2 + M_PI_2);
+  const auto outer_angle = outerPrism_.azimuth_ / 2;
+
+  const auto reflection_1 = rotate_euler_vec(
+    laserAxis_, innerPrism_.theta(time),
+    rotate_euler_vec(groundNormal_, inner_angle, laserAxis_));
+
+  const auto reflection_2 = rotate_euler_vec(
+    laserAxis_, outerPrism_.theta(time),
+    rotate_euler_vec(groundNormal_, outer_angle, laserAxis_));
+
+  const auto tail = lidarCenter_;
+  const auto tip = affine(
+    tail, -beamLength_,
+    reflect(reflection_2, reflect(reflection_1, laserAxis_)));
+  return Segment{tip, tail};
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/src/wind_energy/SyntheticLidar.C
+++ b/src/wind_energy/SyntheticLidar.C
@@ -24,151 +24,17 @@ namespace nalu {
 
 constexpr int dim = 3;
 
-SpinnerLidarSegmentGenerator::SpinnerLidarSegmentGenerator(
-  PrismParameters inner, PrismParameters outer, double in_beamLength)
-  : innerPrism_(inner), outerPrism_(outer), beamLength_(in_beamLength)
-{
-}
-
-void
-SpinnerLidarSegmentGenerator::load(const YAML::Node& node)
-{
-  NaluEnv::self().naluOutputP0()
-    << "LidarLineOfSite::SpinnerLidarSegmentGenerator::load" << std::endl;
-
-  ThrowRequireMsg(node["center"], "Lidar center must be provided");
-  set_lidar_center(node["center"].as<Coordinates>());
-
-  ThrowRequireMsg(node["axis"], "Lidar axis must be provided");
-  set_laser_axis(node["axis"].as<Coordinates>());
-
-  double innerPrismTheta0 = 90;
-  get_if_present(
-    node, "inner_prism_initial_theta", innerPrismTheta0, innerPrismTheta0);
-  innerPrismTheta0 *= M_PI / 180;
-
-  double innerPrismRot = 3.5;
-  get_if_present(node, "inner_prism_rotation_rate", innerPrismRot);
-  innerPrismRot *= 2 * M_PI;
-
-  double innerPrismAzi = 15.2;
-  get_if_present(node, "inner_prism_azimuth", innerPrismAzi);
-  innerPrismAzi *= M_PI / 180;
-
-  set_inner_prism(innerPrismTheta0, innerPrismRot, innerPrismAzi);
-
-  double outerPrismTheta0 = 90;
-  get_if_present(node, "outer_prism_initial_theta", outerPrismTheta0);
-  outerPrismTheta0 *= M_PI / 180;
-
-  double outerPrismRot = 6.5;
-  get_if_present(node, "outer_prism_rotation_rate", outerPrismRot);
-  outerPrismRot *= 2 * M_PI;
-
-  double outerPrismAzi = 15.2;
-  get_if_present(node, "outer_prism_azimuth", outerPrismAzi);
-  outerPrismAzi *= M_PI / 180;
-
-  set_outer_prism(outerPrismTheta0, outerPrismRot, outerPrismAzi);
-
-  double beamLength = 1;
-  get_required(node, "beam_length", beamLength);
-  set_beam_length(beamLength);
-
-  if (node["ground_direction"]) {
-    set_ground_normal(node["ground_direction"].as<Coordinates>());
-  }
-
-  ThrowRequireMsg(
-    std::abs(ddot(groundNormal_.data(), laserAxis_.data(), 3)) <
-      small_positive_value(),
-    "Ground and laser axes must be orthogonal");
-}
-
-namespace {
-std::array<double, 3>
-rotate_euler_vec(
-  const std::array<double, 3>& axis, double angle, std::array<double, 3> vec)
-{
-  enum { XH = 0, YH = 1, ZH = 2 };
-
-  normalize_vec3(vec.data());
-
-  std::array<double, 9> nX = {
-    {0, -axis[ZH], +axis[YH], +axis[ZH], 0, -axis[XH], -axis[YH], +axis[XH],
-     0}};
-  const double cosTheta = std::cos(angle);
-
-  std::array<double, 9> rot = {
-    {cosTheta, 0, 0, 0, cosTheta, 0, 0, 0, cosTheta}};
-
-  const double sinTheta = std::sin(angle);
-  for (int j = 0; j < 3; ++j) {
-    for (int i = 0; i < 3; ++i) {
-      rot[j * 3 + i] +=
-        (1 - cosTheta) * axis[i] * axis[j] + sinTheta * nX[j * 3 + i];
-    }
-  }
-
-  std::array<double, 3> vecprime;
-  matvec33(rot.data(), vec.data(), vecprime.data());
-  return vecprime;
-}
-
-std::array<double, 3>
-reflect(const std::array<double, 3>& line, const std::array<double, 3>& vec)
-{
-  enum { XH = 0, YH = 1, ZH = 2 };
-
-  std::array<double, 9> ref = {
-    {1 - 2 * line[XH] * line[XH], -2 * line[XH] * line[YH],
-     -2 * line[XH] * line[ZH], -2 * line[YH] * line[XH],
-     1 - 2 * line[YH] * line[YH], -2 * line[YH] * line[ZH],
-     -2 * line[ZH] * line[XH], -2 * line[ZH] * line[YH],
-     1 - 2 * line[ZH] * line[ZH]}};
-
-  std::array<double, 3> result;
-  matvec33(ref.data(), vec.data(), result.data());
-  return result;
-}
-
-} // namespace
-
-Segment
-SpinnerLidarSegmentGenerator::generate_path_segment(double time) const
-{
-  auto axis = laserAxis_;
-  normalize_vec3(axis.data());
-
-  const double innerTheta = innerPrism_.theta0_ + innerPrism_.rot_ * time;
-  const double outerTheta = outerPrism_.theta0_ + outerPrism_.rot_ * time;
-
-  const auto reflection_1 = rotate_euler_vec(
-    axis, innerTheta,
-    rotate_euler_vec(
-      groundNormal_, -(innerPrism_.azimuth_ / 2 + M_PI / 2), axis));
-
-  const auto reflection_2 = rotate_euler_vec(
-    axis, outerTheta,
-    rotate_euler_vec(groundNormal_, outerPrism_.azimuth_ / 2, axis));
-
-  Segment current;
-  current.tail_ = lidarCenter_;
-
-  std::array<double, 3> reversedAxis = {{-axis[0], -axis[1], -axis[2]}};
-  current.tip_ = reflect(reflection_2, reflect(reflection_1, reversedAxis));
-
-  for (int d = 0; d < 3; ++d) {
-    current.tip_[d] = current.tail_[d] + current.tip_[d] * beamLength_;
-  }
-
-  return current;
-}
-
 void
 LidarLineOfSite::load(const YAML::Node& node)
 {
   NaluEnv::self().naluOutputP0() << "LidarLineOfSite::load" << std::endl;
+
+  if (node["type"]) {
+    segGen = make_segment_generator(node["type"].as<std::string>());
+  }
+  else {
+    segGen = make_segment_generator(SegmentType::SPINNER);
+  }
 
   if (node["output"]) {
     const auto type = node["output"].as<std::string>();
@@ -188,7 +54,10 @@ LidarLineOfSite::load(const YAML::Node& node)
 
   if (node["time_step"] && output_type_ != Output::DATAPROBE) {
     lidar_dt_ = node["time_step"].as<double>();
-  } else {
+  } else if (node["frequency"] && output_type_ != Output::DATAPROBE){
+    lidar_dt_ = 1.0/node["frequency"].as<double>();
+  }
+  else {
     get_required(node, "scan_time", scanTime_);
     get_required(node, "number_of_samples", nsamples_);
     lidar_dt_ = scanTime_ / nsamples_;
@@ -203,7 +72,12 @@ LidarLineOfSite::load(const YAML::Node& node)
     }
   }
 
-  segGen.load(node);
+  if (node["scanning_lidar_specifications"]) {
+    segGen->load(node["scanning_lidar_specifications"]);
+  }
+  else {
+    segGen->load(node);
+  }
 }
 
 bool
@@ -364,7 +238,7 @@ LidarLineOfSite::output(
       std::make_unique<LocalVolumeSearchData>(bulk, active, npoints_);
   }
 
-  const auto seg = segGen.generate_path_segment(time());
+  const auto seg = segGen->generate(time());
   const std::array<double, 3> dx{
     {(seg.tip_[0] - seg.tail_[0]) / (npoints_ > 1 ? (npoints_ - 1) : 1),
      (seg.tip_[1] - seg.tail_[1]) / (npoints_ > 1 ? (npoints_ - 1) : 1),
@@ -459,7 +333,7 @@ LidarLineOfSite::determine_line_of_site_info(const YAML::Node& node)
 
   for (int ilos = 0; ilos < nsamples_; ilos++) {
     const double lidarTime = scanTime_ / (double)nsamples_ * ilos;
-    Segment seg = segGen.generate_path_segment(lidarTime);
+    Segment seg = segGen->generate(lidarTime);
 
     probeInfo->processorId_[ilos] = divProcProbe > 0 ? ilos % divProcProbe : 0;
     probeInfo->partName_[ilos] = name_ + "_" + std::to_string(ilos);

--- a/unit_tests/UnitTestScanningLidarPattern.C
+++ b/unit_tests/UnitTestScanningLidarPattern.C
@@ -1,0 +1,129 @@
+#include <gtest/gtest.h>
+
+#include "wind_energy/LidarPatterns.h"
+#include "NaluParsing.h"
+#include "UnitTestUtils.h"
+#include "master_element/TensorOps.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <ostream>
+#include <memory>
+#include <array>
+
+namespace sierra {
+namespace nalu {
+
+class ScanningLidarFixture : public ::testing::Test
+{
+public:
+  ScanningLidarFixture()
+  {
+    lidar_spec = YAML::Load(lidar_spec_str)["lidar_specifications"];
+    scan_spec = lidar_spec["scanning_lidar_specifications"];
+    freq = lidar_spec["frequency"].as<double>();
+    slgen.load(scan_spec);
+  }
+
+  double angle(double time)
+  {
+    const auto axis_coord = scan_spec["axis"].as<Coordinates>();
+    const auto center_coord = scan_spec["center"].as<Coordinates>();
+
+    std::array<double, 3> axis{axis_coord.x_, axis_coord.y_, axis_coord.z_};
+    normalize_vec3(axis.data());
+
+    std::array<double, 3> center{
+      center_coord.x_, center_coord.y_, center_coord.z_};
+    const auto length = scan_spec["beam_length"].as<double>();
+    std::array<double, 3> normalized_tip_loc;
+
+    const std::array<double, 3> normal{0, 0, 1};
+    for (int d = 0; d < 3; ++d) {
+      normalized_tip_loc[d] =
+        (slgen.generate(time).tip_[d] - center[d]) / length;
+    }
+    std::array<double, 3> cross;
+    cross3(normalized_tip_loc.data(), axis.data(), cross.data());
+    return -180 / M_PI *
+           std::atan2(
+             ddot(cross.data(), normal.data(), 3),
+             ddot(normalized_tip_loc.data(), axis.data(), 3));
+  }
+
+  YAML::Node scan_spec;
+  YAML::Node lidar_spec;
+  ScanningLidarSegmentGenerator slgen;
+  double freq{1};
+
+  const std::string lidar_spec_str =
+    "lidar_specifications:                                  \n"
+    "  from_target_part: [unused]                           \n"
+    "  type: scanning                                       \n"
+    "  scanning_lidar_specifications:                       \n"
+    "    stare_time: 1 #seconds                             \n"
+    "    step_delta_angle: 1 #degrees                       \n"
+    "    sweep_angle: 20 #degrees                           \n"
+    "    reset_time_delta: 1 #second                        \n"
+    "    center: [500,500,100]                              \n"
+    "    beam_length: 50.                                   \n"
+    "    axis: [1,1,0]                                      \n"
+    "  frequency: 2  #Hz                                    \n"
+    "  points_along_line: 2                                 \n"
+    "  output: text                                         \n"
+    "  name: lidar-los                                      \n";
+};
+
+TEST_F(ScanningLidarFixture, print_tip_location)
+{
+  const double dt = 1.0 / freq;
+  const double time = 21;
+  const int samples = 1 + std::round(time / dt);
+  auto center = scan_spec["center"].as<Coordinates>();
+
+  std::ofstream outputFile("ScanningLidar.pattern.txt");
+  outputFile << "x,y,z" << std::endl;
+  for (int j = 0; j < samples; ++j) {
+    const double time = dt * j;
+    auto seg = slgen.generate(time);
+    ASSERT_DOUBLE_EQ(seg.tail_.at(0), center.x_);
+    ASSERT_DOUBLE_EQ(seg.tail_.at(1), center.y_);
+    ASSERT_DOUBLE_EQ(seg.tail_.at(2), center.z_);
+    ASSERT_DOUBLE_EQ(seg.tip_.at(2), seg.tail_.at(2));
+    outputFile << std::setprecision(15) << seg.tip_.at(0) << ", "
+               << seg.tip_.at(1) << ", " << seg.tip_.at(2) << std::endl;
+  }
+}
+
+TEST_F(ScanningLidarFixture, check_angles)
+{
+  const auto sweep = scan_spec["sweep_angle"].as<double>();
+  const auto stare = scan_spec["stare_time"].as<double>();
+  const auto reset = scan_spec["reset_time_delta"].as<double>();
+
+  const double start_time = 0;
+  ASSERT_NEAR(angle(start_time), sweep / 2, 1e-12);
+
+  const double forward_phase_end = start_time + sweep / stare;
+  ASSERT_NEAR(angle(forward_phase_end), -sweep / 2, 1e-12);
+
+  const double mid_reset_time = forward_phase_end + reset / 2;
+  ASSERT_NEAR(angle(mid_reset_time), 0, 1e-12);
+
+  const double end_time = forward_phase_end + reset;
+  ASSERT_NEAR(angle(end_time), sweep / 2, 1e-12);
+}
+
+TEST_F(ScanningLidarFixture, stares)
+{
+  const auto stare = scan_spec["stare_time"].as<double>();
+  const double some_time = std::floor(11 / stare) * stare;
+  const double some_time_frac = 0.1 * stare + some_time;
+  for (int d = 0; d < 3; ++d) {
+    ASSERT_DOUBLE_EQ(
+      slgen.generate(some_time).tip_.at(d), slgen.generate(some_time_frac).tip_.at(d));
+  }
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/unit_tests/UnitTestSpinnerLidarPattern.C
+++ b/unit_tests/UnitTestSpinnerLidarPattern.C
@@ -46,7 +46,7 @@ TEST(SpinnerLidar, print_tip_location)
 
   for (int j = 0; j < nsamp; ++j) {
     const double time = dt * j;
-    auto seg = slgen.generate_path_segment(time);
+    auto seg = slgen.generate(time);
     ASSERT_TRUE(seg.tip_.at(0) > seg.tail_.at(0));
     ASSERT_TRUE(seg.tip_.at(1) > seg.tail_.at(1));
     ASSERT_DOUBLE_EQ(seg.tail_.at(0), 500);


### PR DESCRIPTION
Adds a scanning lidar pattern for making synthetic lidar measurements. I switched to specifying the lidar configuration specific parameters as a yaml block for this, which is inconsistent with the spinner lidar specification. But I think I'll deprecate the non-block style specification for the spinner soon.

Should hopefully be more straightforward as to how to add additional scan patterns now as well.