### PR TITLE
update for trilinos deprecations

### DIFF
--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -87,6 +87,8 @@ struct LinSys {
   using Matrix            = Tpetra::CrsMatrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
   using LocalMatrix       = Matrix::local_matrix_device_type;
   using LocalMatrixHost   = Matrix::local_matrix_host_type;
+  using LocalIndicesHost  = Matrix::local_inds_host_view_type;
+  using LocalValuesHost   = Matrix::values_host_view_type;
   using Operator          = Tpetra::Operator<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
   using MultiVectorTraits = Belos::MultiVecTraits<Scalar, MultiVector>;
   using OperatorTraits    = Belos::OperatorTraits<Scalar,MultiVector, Operator>;

--- a/include/matrix_free/SparsifiedEdgeLaplacian.h
+++ b/include/matrix_free/SparsifiedEdgeLaplacian.h
@@ -28,7 +28,7 @@ namespace matrix_free {
 class NoAuraDeviceMatrix
 {
 public:
-  using local_matrix_type = typename Tpetra::CrsMatrix<>::local_matrix_type;
+  using local_matrix_type = typename Tpetra::CrsMatrix<>::local_matrix_device_type;
   using lid_type = typename Tpetra::CrsMatrix<>::local_ordinal_type;
   using entity_lid_view_type = Kokkos::View<const lid_type*>;
 

--- a/src/matrix_free/ConductionJacobiPreconditioner.C
+++ b/src/matrix_free/ConductionJacobiPreconditioner.C
@@ -98,7 +98,6 @@ JacobiOperator<p>::apply(
       owned_diagonal_.getLocalViewDevice(Tpetra::Access::ReadOnly), cached_mv_.getLocalViewDevice(Tpetra::Access::ReadOnly),
       x.getLocalViewDevice(Tpetra::Access::ReadOnly), y.getLocalViewDevice(Tpetra::Access::ReadWrite));
   }
-  y.modify_device();
 }
 
 template <int p>
@@ -115,7 +114,6 @@ JacobiOperator<p>::compute_diagonal()
       dirichlet_bc_offsets_, owned_diagonal_.getLocalLength(),
       owned_and_shared_diagonal_.getLocalViewDevice(Tpetra::Access::ReadWrite));
   }
-  owned_and_shared_diagonal_.modify_device();
   owned_diagonal_.putScalar(0.);
   owned_diagonal_.doExport(owned_and_shared_diagonal_, exporter_, Tpetra::ADD);
   reciprocal(owned_diagonal_.getLocalViewDevice(Tpetra::Access::ReadWrite));

--- a/src/matrix_free/ConductionOperator.C
+++ b/src/matrix_free/ConductionOperator.C
@@ -57,9 +57,7 @@ ConductionResidualOperator<p>::compute(mv_type& owned_rhs)
         cached_shared_rhs_.getLocalViewDevice(Tpetra::Access::ReadWrite));
     }
 
-    cached_shared_rhs_.modify_device();
     owned_rhs.putScalar(0.);
-    owned_rhs.modify_device();
     owned_rhs.doExport(cached_shared_rhs_, exporter_, Tpetra::ADD);
   } else {
     owned_rhs.putScalar(0.);
@@ -80,7 +78,6 @@ ConductionResidualOperator<p>::compute(mv_type& owned_rhs)
         bc_nodal_specified_field_, owned_rhs.getLocalLength(),
         owned_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
     }
-    owned_rhs.modify_device();
   }
 }
 INSTANTIATE_POLYCLASS(ConductionResidualOperator);
@@ -122,10 +119,7 @@ ConductionLinearizedResidualOperator<p>::apply(
         cached_sln_.getLocalViewDevice(Tpetra::Access::ReadWrite), cached_rhs_.getLocalViewDevice(Tpetra::Access::ReadWrite));
     }
 
-    cached_rhs_.modify_device();
     owned_rhs.putScalar(0.);
-    owned_rhs.modify_device();
-    exec_space().fence();
     owned_rhs.doExport(cached_rhs_, exporter_, Tpetra::ADD);
   } else {
     owned_rhs.putScalar(0.);
@@ -138,7 +132,6 @@ ConductionLinearizedResidualOperator<p>::apply(
         dirichlet_bc_offsets_, owned_rhs.getLocalLength(),
         owned_sln.getLocalViewDevice(Tpetra::Access::ReadOnly), owned_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
     }
-    owned_rhs.modify_device();
   }
 }
 INSTANTIATE_POLYCLASS(ConductionLinearizedResidualOperator);

--- a/src/matrix_free/ContinuityOperator.C
+++ b/src/matrix_free/ContinuityOperator.C
@@ -44,9 +44,7 @@ ContinuityResidualOperator<p>::compute(mv_type& owned_rhs)
     continuity_residual<p>(
       time_scale_, elem_offsets_, mdot_, cached_rhs_.getLocalViewDevice(Tpetra::Access::ReadWrite));
 
-    cached_rhs_.modify_device();
     owned_rhs.putScalar(0.);
-    owned_rhs.modify_device();
     {
       stk::mesh::ProfilingBlock pfinner("export from owned-shared to owned");
       owned_rhs.doExport(cached_rhs_, exporter_, Tpetra::ADD);
@@ -55,7 +53,6 @@ ContinuityResidualOperator<p>::compute(mv_type& owned_rhs)
     owned_rhs.putScalar(0.);
     continuity_residual<p>(
       time_scale_, elem_offsets_, mdot_, owned_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
-    owned_rhs.modify_device();
   }
 }
 INSTANTIATE_POLYCLASS(ContinuityResidualOperator);
@@ -93,9 +90,6 @@ ContinuityLinearizedResidualOperator<p>::apply(
     continuity_linearized_residual<p>(
       elem_offsets_, metric_, cached_sln_.getLocalViewDevice(Tpetra::Access::ReadWrite),
       cached_rhs_.getLocalViewDevice(Tpetra::Access::ReadWrite));
-
-    cached_rhs_.modify_device();
-    exec_space().fence();
     {
       stk::mesh::ProfilingBlock pfinner("export from owned-shared to owned");
       owned_rhs.doExport(cached_rhs_, exporter_, Tpetra::ADD);
@@ -105,7 +99,6 @@ ContinuityLinearizedResidualOperator<p>::apply(
     continuity_linearized_residual<p>(
       elem_offsets_, metric_, owned_sln.getLocalViewDevice(Tpetra::Access::ReadOnly),
       owned_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
-    owned_rhs.modify_device();
   }
 }
 INSTANTIATE_POLYCLASS(ContinuityLinearizedResidualOperator);

--- a/src/matrix_free/FilterJacobi.C
+++ b/src/matrix_free/FilterJacobi.C
@@ -109,7 +109,6 @@ FilterJacobiOperator<p>::apply(
       owned_diagonal.getLocalViewDevice(Tpetra::Access::ReadOnly), cached_mv.getLocalViewDevice(Tpetra::Access::ReadOnly),
       x.getLocalViewDevice(Tpetra::Access::ReadOnly), y.getLocalViewDevice(Tpetra::Access::ReadWrite));
   }
-  y.modify_device();
 }
 
 template <int p>
@@ -118,7 +117,6 @@ FilterJacobiOperator<p>::compute_diagonal(const_scalar_view<p> vols)
 {
   shared_diagonal.putScalar(0.);
   filter_diagonal<p>(elem_offsets, vols, shared_diagonal.getLocalViewDevice(Tpetra::Access::ReadWrite));
-  shared_diagonal.modify_device();
   owned_diagonal.putScalar(0.);
   owned_diagonal.doExport(shared_diagonal, exporter, Tpetra::ADD);
   reciprocal(owned_diagonal.getLocalViewDevice(Tpetra::Access::ReadWrite));

--- a/src/matrix_free/GreenGaussGradientOperator.C
+++ b/src/matrix_free/GreenGaussGradientOperator.C
@@ -48,8 +48,6 @@ GradientResidualOperator<p>::compute(mv_type& owned_rhs)
         face_bc_offsets_, face_q_, exposed_areas_,
         cached_rhs_.getLocalViewDevice(Tpetra::Access::ReadWrite));
     }
-
-    cached_rhs_.modify_device();
     {
       stk::mesh::ProfilingBlock pfinner("export from owned-shared to owned");
       owned_rhs.doExport(cached_rhs_, exporter_, Tpetra::ADD);
@@ -66,7 +64,6 @@ GradientResidualOperator<p>::compute(mv_type& owned_rhs)
         face_bc_offsets_, face_q_, exposed_areas_,
         owned_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
     }
-    owned_rhs.modify_device();
   }
 }
 
@@ -106,10 +103,7 @@ GradientLinearizedResidualOperator<p>::apply(
       elem_offsets_, volumes_, cached_sln_.getLocalViewDevice(Tpetra::Access::ReadWrite),
       cached_rhs_.getLocalViewDevice(Tpetra::Access::ReadWrite));
 
-    cached_rhs_.modify_device();
     owned_rhs.putScalar(0.);
-    owned_rhs.modify_device();
-    exec_space().fence();
     {
       stk::mesh::ProfilingBlock pfinner("export from owned-shared to owned");
       owned_rhs.doExport(cached_rhs_, exporter_, Tpetra::ADD);

--- a/src/matrix_free/LowMachUpdate.C
+++ b/src/matrix_free/LowMachUpdate.C
@@ -404,7 +404,6 @@ LowMachUpdate<p>::create_continuity_preconditioner(
   copy_stk_field_to_owned_tpetra_vector(
     stk::mesh::get_updated_ngp_mesh(bulk_), active_, linsys_.stk_lid_to_tpetra_lid,
     coords, coord_mv->getLocalViewDevice(Tpetra::Access::ReadWrite));
-  coord_mv->modify_device();
 
   muelu_params.set("xml parameter file", xmlname);
   muelu_params.sublist("user data").set("Coordinates", coord_mv);

--- a/src/matrix_free/MomentumJacobi.C
+++ b/src/matrix_free/MomentumJacobi.C
@@ -95,7 +95,6 @@ MomentumJacobiOperator<p>::apply(
       owned_diagonal.getLocalViewDevice(Tpetra::Access::ReadOnly), cached_mv.getLocalViewDevice(Tpetra::Access::ReadOnly),
       x.getLocalViewDevice(Tpetra::Access::ReadOnly), y.getLocalViewDevice(Tpetra::Access::ReadWrite));
   }
-  y.modify_device();
 }
 
 template <int p>
@@ -116,7 +115,6 @@ MomentumJacobiOperator<p>::compute_diagonal(
       dirichlet_bc_offsets_, owned_diagonal.getLocalLength(),
       owned_and_shared_diagonal.getLocalViewDevice(Tpetra::Access::ReadWrite));
   }
-  owned_and_shared_diagonal.modify_device();
   owned_diagonal.putScalar(0.);
   owned_diagonal.doExport(owned_and_shared_diagonal, exporter, Tpetra::ADD);
   reciprocal(owned_diagonal.getLocalViewDevice(Tpetra::Access::ReadWrite));

--- a/src/matrix_free/MomentumOperator.C
+++ b/src/matrix_free/MomentumOperator.C
@@ -25,7 +25,7 @@ MomentumResidualOperator<p>::MomentumResidualOperator(
   const_elem_offset_view<p> elem_offsets_in, const export_type& exporter_in)
   : elem_offsets_(elem_offsets_in),
     exporter_(exporter_in),
-    max_owned_row_id_(exporter_in.getTargetMap()->getNodeNumElements()),
+    max_owned_row_id_(exporter_in.getTargetMap()->getLocalNumElements()),
     cached_rhs_(exporter_in.getSourceMap(), num_vectors)
 {
 }
@@ -61,7 +61,6 @@ MomentumResidualOperator<p>::compute(mv_type& owned_rhs)
   if (exporter_.getTargetMap()->isDistributed()) {
     ThrowRequire(owned_rhs.getLocalLength() == size_t(max_owned_row_id_));
     local_compute(cached_rhs_.getLocalViewDevice(Tpetra::Access::ReadWrite));
-    cached_rhs_.modify_device();
     {
       stk::mesh::ProfilingBlock pfinner("export from owned-shared to owned");
       owned_rhs.putScalar(0.);
@@ -69,7 +68,6 @@ MomentumResidualOperator<p>::compute(mv_type& owned_rhs)
     }
   } else {
     local_compute(owned_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
-    owned_rhs.modify_device();
   }
 }
 INSTANTIATE_POLYCLASS(MomentumResidualOperator);
@@ -79,7 +77,7 @@ MomentumLinearizedResidualOperator<p>::MomentumLinearizedResidualOperator(
   const_elem_offset_view<p> elem_offsets_in, const export_type& exporter_in)
   : elem_offsets_(elem_offsets_in),
     exporter_(exporter_in),
-    max_owned_row_id_(exporter_in.getTargetMap()->getNodeNumElements()),
+    max_owned_row_id_(exporter_in.getTargetMap()->getLocalNumElements()),
     cached_sln_(exporter_in.getSourceMap(), num_vectors),
     cached_rhs_(exporter_in.getSourceMap(), num_vectors)
 {
@@ -131,7 +129,6 @@ MomentumLinearizedResidualOperator<p>::apply(
     ThrowRequire(owned_rhs.getLocalLength() == size_t(max_owned_row_id_));
     local_apply(
       cached_sln_.getLocalViewDevice(Tpetra::Access::ReadWrite), cached_rhs_.getLocalViewDevice(Tpetra::Access::ReadWrite));
-    cached_rhs_.modify_device();
 
     {
       stk::mesh::ProfilingBlock pfinner("export from owned-shared to owned");

--- a/unit_tests/UnitTestTpetra.C
+++ b/unit_tests/UnitTestTpetra.C
@@ -171,7 +171,7 @@ void verify_graph_for_2_hex8_mesh(int numProcs, int localProc, sierra::nalu::Tpe
     expectedNumOwnedRows = localProc==0 ? 8 : 4;
   }
   EXPECT_EQ(expectedNumGlobalRows, tpetraLinsys->getOwnedGraph()->getGlobalNumRows());
-  EXPECT_EQ(expectedNumOwnedRows, tpetraLinsys->getOwnedGraph()->getNodeNumRows());
+  EXPECT_EQ(expectedNumOwnedRows, tpetraLinsys->getOwnedGraph()->getLocalNumRows());
 
   std::vector<unsigned> goldRowLengths = get_gold_row_lengths(numProcs, localProc);
 
@@ -190,7 +190,7 @@ void verify_matrix_for_2_hex8_mesh(int numProcs, int localProc, sierra::nalu::Tp
     expectedLocalNumRows = localProc==0 ? 8 : 4;
   }
   EXPECT_EQ(expectedGlobalNumRows, ownedMatrix->getGlobalNumRows());
-  EXPECT_EQ((unsigned)expectedLocalNumRows, ownedMatrix->getNodeNumRows());
+  EXPECT_EQ((unsigned)expectedLocalNumRows, ownedMatrix->getLocalNumRows());
 
   Teuchos::RCP<const sierra::nalu::LinSys::Map> rowMap = ownedMatrix->getRowMap();
   Teuchos::RCP<const sierra::nalu::LinSys::Map> colMap = ownedMatrix->getColMap();
@@ -198,8 +198,8 @@ void verify_matrix_for_2_hex8_mesh(int numProcs, int localProc, sierra::nalu::Tp
   for(sierra::nalu::LinSys::LocalOrdinal rowlid=0; rowlid<expectedLocalNumRows; ++rowlid) {
     sierra::nalu::LinSys::GlobalOrdinal rowgid = rowMap->getGlobalElement(rowlid);
     unsigned rowLength = ownedMatrix->getNumEntriesInGlobalRow(rowgid);
-    Teuchos::ArrayView<const sierra::nalu::LinSys::LocalOrdinal> inds;
-    Teuchos::ArrayView<const double> vals;
+    sierra::nalu::LinSys::LocalIndicesHost inds;
+    sierra::nalu::LinSys::LocalValuesHost vals;
     ownedMatrix->getLocalRowView(rowlid, inds, vals);
     for(unsigned j=0; j<rowLength; ++j) {
       sierra::nalu::LinSys::GlobalOrdinal colgid = colMap->getGlobalElement(inds[j]);

--- a/unit_tests/matrix_free/UnitTestConductionJacobiPreconditioner.C
+++ b/unit_tests/matrix_free/UnitTestConductionJacobiPreconditioner.C
@@ -85,7 +85,6 @@ TEST_F(JacobiFixture, jacobi_operator_is_stricly_positive_for_laplacian)
   jac_op.set_coefficients(0.0, coefficient_fields);
   jac_op.compute_diagonal();
   auto& result = jac_op.get_inverse_diagonal();
-  result.sync_host();
   auto view_h = result.getLocalViewHost(Tpetra::Access::ReadWrite);
   for (size_t k = 0u; k < result.getLocalLength(); ++k) {
     ASSERT_GT(view_h(k, 0), 1.0e-2);

--- a/unit_tests/matrix_free/UnitTestConductionOperator.C
+++ b/unit_tests/matrix_free/UnitTestConductionOperator.C
@@ -102,7 +102,7 @@ TEST_F(ConductionOperatorFixture, residual_operator_zero_for_constant_data)
   resid_op.set_fields({{+1, -1, 0}}, fields);
   resid_op.compute(rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   for (size_t k = 0u; k < rhs.getLocalLength(); ++k) {
@@ -137,7 +137,7 @@ TEST_F(
   resid_op.set_fields({{+1, -1, 0}}, fields);
   resid_op.compute(rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
   double max_error = -1;
   for (size_t k = 0u; k < rhs.getLocalLength(); ++k) {
@@ -161,7 +161,7 @@ TEST_F(
   lhs.putScalar(0.);
   cond_op.apply(lhs, rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
   for (size_t k = 0u; k < rhs.getLocalLength(); ++k) {
     ASSERT_NEAR(view_h(k, 0), 0, 1.e-14);
@@ -194,10 +194,10 @@ TEST_F(
   cond_op.set_coefficients(gammas[0], coefficient_fields);
 
   lhs.randomize(-1, +1);
-  lhs.sync_device();
+  
   cond_op.apply(lhs, rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   double max_error = -1;

--- a/unit_tests/matrix_free/UnitTestContinuityOperator.C
+++ b/unit_tests/matrix_free/UnitTestContinuityOperator.C
@@ -101,7 +101,10 @@ protected:
   Tpetra::MultiVector<> lhs;
   Tpetra::MultiVector<> rhs;
   const const_entity_row_view_type elid;
-  const typename decltype(elid)::HostMirror elid_h;
+
+  using host_space = Kokkos::DefaultHostExecutionSpace;
+  using host_type = decltype(Kokkos::create_mirror_view_and_copy(host_space{}, elid));
+  const host_type elid_h;
 
   elem_mesh_index_view<order> conn;
   elem_offset_view<order> offsets;

--- a/unit_tests/matrix_free/UnitTestFilterJacobi.C
+++ b/unit_tests/matrix_free/UnitTestFilterJacobi.C
@@ -89,7 +89,6 @@ TEST_F(FilterJacobiFixture, jacobi_operator_is_stricly_positive_for_mass)
   prec_op.compute_diagonal(vols);
 
   auto& result = prec_op.get_inverse_diagonal();
-  result.sync_host();
   auto view_h = result.getLocalViewHost(Tpetra::Access::ReadWrite);
   for (size_t k = 0u; k < result.getLocalLength(); ++k) {
     ASSERT_TRUE(std::isfinite(stk::simd::get_data(view_h(k, 0), 0)));

--- a/unit_tests/matrix_free/UnitTestGreenGaussGradientBoundaryClosure.C
+++ b/unit_tests/matrix_free/UnitTestGreenGaussGradientBoundaryClosure.C
@@ -103,11 +103,10 @@ TEST_F(GradientBoundaryFixture, bc_residual)
   gradient_boundary_closure<order>(
     grad_bc_offsets, q_face, exposed_areas,
     owned_and_shared_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
-  owned_and_shared_rhs.modify_device();
   owned_rhs.putScalar(0.);
   owned_rhs.doExport(owned_and_shared_rhs, exporter, Tpetra::ADD);
 
-  owned_rhs.sync_host();
+  
   auto view_h = owned_rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   double maxval = -1;

--- a/unit_tests/matrix_free/UnitTestGreenGaussGradientOperator.C
+++ b/unit_tests/matrix_free/UnitTestGreenGaussGradientOperator.C
@@ -146,7 +146,7 @@ TEST_F(GradientOperatorFixture, residual_operator_zero_for_zero_data)
   resid_op.set_fields(gather_required_fields());
   resid_op.compute(rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   for (size_t k = 0u; k < rhs.getLocalLength(); ++k) {
@@ -161,7 +161,7 @@ TEST_F(GradientOperatorFixture, residual_operator_not_zero_for_nonconstant_data)
   resid_op.set_fields(gather_required_fields());
   resid_op.compute(rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
   double max_error = -1;
   for (size_t k = 0u; k < rhs.getLocalLength(); ++k) {
@@ -181,7 +181,7 @@ TEST_F(
   lhs.putScalar(0.);
   lin_op.apply(lhs, rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
   for (size_t k = 0u; k < rhs.getLocalLength(); ++k) {
     ASSERT_NEAR(view_h(k, 0), 0, 1.e-14);
@@ -198,10 +198,10 @@ TEST_F(
   lin_op.set_volumes(fields.vols);
 
   lhs.randomize(-1, +1);
-  lhs.sync_device();
+  
   lin_op.apply(lhs, rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   double max_error = -1;

--- a/unit_tests/matrix_free/UnitTestMomentumJacobiOperator.C
+++ b/unit_tests/matrix_free/UnitTestMomentumJacobiOperator.C
@@ -98,7 +98,6 @@ TEST_F(MomentumJacobiOperatorFixture, diagonal_positive)
     1., fields.volume_metric, fields.advection_metric, fields.diffusion_metric);
 
   auto& result = prec_op.get_inverse_diagonal();
-  result.sync_host();
   auto view_h = result.getLocalViewHost(Tpetra::Access::ReadWrite);
   for (size_t k = 0u; k < result.getLocalLength(); ++k) {
     ASSERT_TRUE(std::isfinite(stk::simd::get_data(view_h(k, 0), 0)));

--- a/unit_tests/matrix_free/UnitTestMomentumOperator.C
+++ b/unit_tests/matrix_free/UnitTestMomentumOperator.C
@@ -82,8 +82,10 @@ protected:
   Tpetra::MultiVector<> lhs;
   Tpetra::MultiVector<> rhs;
   const const_entity_row_view_type elid;
-  const typename decltype(elid)::HostMirror elid_h;
 
+  using host_space = Kokkos::DefaultHostExecutionSpace;
+  using host_type = decltype(Kokkos::create_mirror_view_and_copy(host_space{}, elid));
+  const host_type elid_h;
 
   elem_mesh_index_view<order> conn;
   elem_offset_view<order> offsets;

--- a/unit_tests/matrix_free/UnitTestMomentumOperator.C
+++ b/unit_tests/matrix_free/UnitTestMomentumOperator.C
@@ -68,6 +68,7 @@ protected:
       rhs(Teuchos::rcpFromRef(owned_map), 3),
       elid(make_stk_lid_to_tpetra_lid_map(
         mesh(), active(), gid_field_ngp, owned_and_shared_map.getLocalMap())),
+      elid_h(Kokkos::create_mirror_view_and_copy(Kokkos::DefaultHostExecutionSpace{}, elid)),
       conn(stk_connectivity_map<order>(mesh(), active())),
       offsets(create_offset_map<order>(mesh(), active(), elid))
   {
@@ -81,6 +82,8 @@ protected:
   Tpetra::MultiVector<> lhs;
   Tpetra::MultiVector<> rhs;
   const const_entity_row_view_type elid;
+  const typename decltype(elid)::HostMirror elid_h;
+
 
   elem_mesh_index_view<order> conn;
   elem_offset_view<order> offsets;
@@ -121,7 +124,7 @@ TEST_F(
   resid_op.set_fields({{+1, -1, 0}}, fields);
   resid_op.compute(rhs);
 
-  rhs.sync_host();
+
   auto view_h = rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   //  side should be #(faces connectded to node) * (scale/nx)^2
@@ -129,7 +132,7 @@ TEST_F(
   for (const auto* ib :
        bulk.get_buckets(stk::topology::NODE_RANK, interior_selector)) {
     for (auto node : *ib) {
-      auto lid = elid(node.local_offset());
+      auto lid = elid_h(node.local_offset());
       if (lid < view_h.extent_int(0)) {
         for (int d = 0; d < 3; ++d) {
           ASSERT_NEAR(view_h(lid, d), 0, 1.0e-14);
@@ -143,24 +146,24 @@ TEST_F(
   MomentumOperatorFixture,
   linearized_residual_operator_nonzero_for_nonconstant_velocity)
 {
-  auto host_lhs = lhs.getLocalViewHost(Tpetra::Access::ReadWrite);
-  ThrowRequire(host_lhs.extent(1) == 3u);
-  for (const auto* ib : bulk.get_buckets(stk::topology::NODE_RANK, active())) {
-    for (auto node : *ib) {
-      const auto x = stk::mesh::field_data(coordinate_field(), node)[0];
-      const auto y = stk::mesh::field_data(coordinate_field(), node)[1];
-      const auto z = stk::mesh::field_data(coordinate_field(), node)[2];
+  {
+    auto host_lhs = lhs.getLocalViewHost(Tpetra::Access::ReadWrite);
+    ThrowRequire(host_lhs.extent(1) == 3u);
+    for (const auto* ib : bulk.get_buckets(stk::topology::NODE_RANK, active())) {
+      for (auto node : *ib) {
+        const auto x = stk::mesh::field_data(coordinate_field(), node)[0];
+        const auto y = stk::mesh::field_data(coordinate_field(), node)[1];
+        const auto z = stk::mesh::field_data(coordinate_field(), node)[2];
 
-      const auto lid = elid(node.local_offset());
-      if (lid < host_lhs.extent_int(0)) {
-        host_lhs(lid, 0) = y * z;
-        host_lhs(lid, 1) = x * z;
-        host_lhs(lid, 2) = x * y;
+        const auto lid = elid_h(node.local_offset());
+        if (lid < host_lhs.extent_int(0)) {
+          host_lhs(lid, 0) = y * z;
+          host_lhs(lid, 1) = x * z;
+          host_lhs(lid, 2) = x * y;
+        }
       }
     }
   }
-  lhs.modify_host();
-  lhs.sync_device();
 
   auto fields = gather_required_lowmach_fields<order>(meta, conn);
   LowMachLinearizedResidualFields<order> coefficient_fields;
@@ -173,6 +176,7 @@ TEST_F(
   MomentumLinearizedResidualOperator<order> resid_op(offsets, exporter);
   resid_op.set_fields(1., coefficient_fields);
   resid_op.apply(lhs, rhs);
+  
 
   Teuchos::Array<double> mv_norm(3);
   rhs.norm2(mv_norm());

--- a/unit_tests/matrix_free/UnitTestScalarFluxBC.C
+++ b/unit_tests/matrix_free/UnitTestScalarFluxBC.C
@@ -114,11 +114,10 @@ TEST_F(FluxFixture, bc_residual)
   scalar_neumann_residual<order>(
     flux_bc_offsets, flux, exposed_areas,
     owned_and_shared_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
-  owned_and_shared_rhs.modify_device();
   owned_rhs.putScalar(0.);
   owned_rhs.doExport(owned_and_shared_rhs, exporter, Tpetra::ADD);
 
-  owned_rhs.sync_host();
+  
   auto view_h = owned_rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   double maxval = -1;

--- a/unit_tests/matrix_free/UnitTestSparsifiedEdgeLaplacian.C
+++ b/unit_tests/matrix_free/UnitTestSparsifiedEdgeLaplacian.C
@@ -128,23 +128,21 @@ protected:
 TEST_F(SparsifiedEdgeLaplacianFixture, laplacian_is_an_l_matrix)
 {
   if (bulk.parallel_size() > 1) {
-    return;
+    GTEST_SKIP();
   }
-  auto local_mat = mat->getLocalMatrix();
-  decltype(local_mat) shared_mat{};
-  NoAuraDeviceMatrix devmat(
-    mat->getNodeNumRows(), local_mat, shared_mat, linsys.stk_lid_to_tpetra_lid,
-    linsys.stk_lid_to_tpetra_lid);
 
   auto& coords = coordinate_field();
   auto coords_ngp = stk::mesh::get_updated_ngp_field<double>(coords);
 
   Tpetra::beginAssembly(*mat);
   assemble_sparsified_edge_laplacian(
-    order, mesh, meta.universal_part(), coords_ngp, devmat);
+    order, mesh, meta.universal_part(), coords_ngp, NoAuraDeviceMatrix(
+    mat->getLocalNumRows(), mat->getLocalMatrixDevice(), {}, linsys.stk_lid_to_tpetra_lid,
+    linsys.stk_lid_to_tpetra_lid));
   Tpetra::endAssembly(*mat);
 
-  for (unsigned i = 0; i < mat->getNodeNumRows(); ++i) {
+  for (unsigned i = 0; i < mat->getLocalNumRows(); ++i) {
+    auto local_mat = mat->getLocalMatrixHost();
     auto row = local_mat.row(i);
     for (int j = 0; j < row.length; ++j) {
       if (static_cast<unsigned>(row.colidx(j)) == i) {
@@ -159,20 +157,17 @@ TEST_F(SparsifiedEdgeLaplacianFixture, laplacian_is_an_l_matrix)
 TEST_F(SparsifiedEdgeLaplacianFixture, row_and_column_sums_are_zero)
 {
   if (bulk.parallel_size() > 1) {
-    return;
+    GTEST_SKIP();
   }
-  auto local_mat = mat->getLocalMatrix();
-  decltype(local_mat) shared_mat{};
-  NoAuraDeviceMatrix devmat(
-    mat->getNodeNumRows(), local_mat, shared_mat, linsys.stk_lid_to_tpetra_lid,
-    linsys.stk_lid_to_tpetra_lid);
 
   auto& coords = coordinate_field();
   auto coords_ngp = stk::mesh::get_updated_ngp_field<double>(coords);
 
   Tpetra::beginAssembly(*mat);
   assemble_sparsified_edge_laplacian(
-    order, mesh, meta.universal_part(), coords_ngp, devmat);
+    order, mesh, meta.universal_part(), coords_ngp, NoAuraDeviceMatrix(
+    mat->getLocalNumRows(), mat->getLocalMatrixDevice(), {}, linsys.stk_lid_to_tpetra_lid,
+    linsys.stk_lid_to_tpetra_lid));
   Tpetra::endAssembly(*mat);
 
   Tpetra::Vector<> ones(Teuchos::rcpFromRef(linsys.owned));
@@ -191,18 +186,15 @@ TEST_F(SparsifiedEdgeLaplacianFixture, sample_for_positive_definiteness)
   if (bulk.parallel_size() > 1) {
     return;
   }
-  auto local_mat = mat->getLocalMatrix();
-  decltype(local_mat) shared_mat{};
-  NoAuraDeviceMatrix devmat(
-    mat->getNodeNumRows(), local_mat, shared_mat, linsys.stk_lid_to_tpetra_lid,
-    linsys.stk_lid_to_tpetra_lid);
 
   auto& coords = coordinate_field();
   auto coords_ngp = stk::mesh::get_updated_ngp_field<double>(coords);
 
   Tpetra::beginAssembly(*mat);
   assemble_sparsified_edge_laplacian(
-    order, mesh, meta.universal_part(), coords_ngp, devmat);
+    order, mesh, meta.universal_part(), coords_ngp, NoAuraDeviceMatrix(
+    mat->getLocalNumRows(), mat->getLocalMatrixDevice(), {}, linsys.stk_lid_to_tpetra_lid,
+    linsys.stk_lid_to_tpetra_lid));
   Tpetra::endAssembly(*mat);
 
   Tpetra::Vector<> ones(Teuchos::rcpFromRef(linsys.owned));

--- a/unit_tests/matrix_free/UnitTestStkToTpetraMap.C
+++ b/unit_tests/matrix_free/UnitTestStkToTpetraMap.C
@@ -155,7 +155,7 @@ TEST_F(MapFixture, owned_map_has_correct_local_size)
   // that ever changes, this will fail
   const auto asserted_local_size = (bulk.parallel_rank() == 0) ? 8u : 4u;
   ASSERT_EQ(
-    make_owned_row_map(mesh, active).getNodeNumElements(), asserted_local_size);
+    make_owned_row_map(mesh, active).getLocalNumElements(), asserted_local_size);
 }
 
 TEST_F(MapFixture, owned_and_shared_is_just_owned_in_serial)

--- a/unit_tests/matrix_free/UnitTestStrongDirichletBC.C
+++ b/unit_tests/matrix_free/UnitTestStrongDirichletBC.C
@@ -111,11 +111,10 @@ TEST_F(DirichletFixture, bc_residual_scalar)
   dirichlet_residual(
     dirichlet_offsets, qp1, qbc, owned_rhs.getLocalLength(),
     owned_and_shared_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
-  owned_and_shared_rhs.modify_device();
   owned_rhs.putScalar(0.);
   owned_rhs.doExport(owned_and_shared_rhs, exporter, Tpetra::ADD);
 
-  owned_rhs.sync_host();
+  
   auto view_h = owned_rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   double maxval = -1;
@@ -137,11 +136,10 @@ TEST_F(DirichletFixture, bc_residual_vector)
   dirichlet_residual(
     dirichlet_offsets, qp1, qbc, owned_rhs.getLocalLength(),
     owned_and_shared_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
-  owned_and_shared_rhs.modify_device();
   owned_rhs.putScalar(0.);
   owned_rhs.doExport(owned_and_shared_rhs, exporter, Tpetra::ADD);
 
-  owned_rhs.sync_host();
+  
   auto view_h = owned_rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   double maxval = -1;
@@ -164,12 +162,10 @@ TEST_F(DirichletFixture, linearized_bc_residual)
     dirichlet_offsets, owned_lhs.getLocalLength(),
     owned_and_shared_lhs.getLocalViewDevice(Tpetra::Access::ReadWrite),
     owned_and_shared_rhs.getLocalViewDevice(Tpetra::Access::ReadWrite));
-
-  owned_and_shared_rhs.modify_device();
   owned_rhs.putScalar(0.);
   owned_rhs.doExport(owned_and_shared_rhs, exporter, Tpetra::ADD);
 
-  owned_rhs.sync_host();
+  
   auto view_h = owned_rhs.getLocalViewHost(Tpetra::Access::ReadWrite);
 
   constexpr double tol = 1.0e-14;


### PR DESCRIPTION
Update some function calls and data synchronizations for some changes made in tpetra/trilinos.  Fixes some device accesses on host in the operator unittests for the post-uvm world.