### PR TITLE
Specify namespace for matrix_free make_rcp after addition to Teuchos

### DIFF
--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -150,18 +150,20 @@ public:
   double latitude_;
   double raBoussinesqTimeScale_;
   double symmetryBcPenaltyFactor_;
-  double roughnessHeight_;
-  bool lengthScaleLimiter_;
-  double referenceVelocity_;
-  bool RANSBelowKs_;
   bool useStreletsUpwinding_;
-  bool transition_model_;
-  bool gammaEqActive_;
 
   // global mdot correction alg
   bool activateOpenMdotCorrection_;
   double mdotAlgOpenCorrection_;
   bool explicitlyZeroOpenPressureGradient_;
+
+  bool resetAMSAverages_;
+  bool transition_model_;
+  bool gammaEqActive_;
+  bool lengthScaleLimiter_;
+  double referenceVelocity_;
+  double roughnessHeight_;
+  bool RANSBelowKs_;
 
   // turbulence model coeffs
   std::map<TurbulenceModelConstant, double> turbModelConstantMap_;
@@ -229,8 +231,6 @@ public:
   std::string name_;
 
   bool newHO_;
-
-  bool resetAMSAverages_;
 };
 
 } // namespace nalu

--- a/include/kernel/KernelBuilder.h
+++ b/include/kernel/KernelBuilder.h
@@ -181,6 +181,7 @@ namespace nalu{
           default:
             ThrowRequireMsg(false,
               "Quad4 exposed face is not attached to either a hex8, pyr5, or wedge6.");
+              return nullptr;
         }
       case stk::topology::QUAD_9:
         return new T<AlgTraitsQuad9Hex27>(std::forward<Args>(args)...);
@@ -195,6 +196,7 @@ namespace nalu{
           default :
             ThrowRequireMsg(false,
               "Tri3 exposed face is not attached to either a tet4, pyr5, or wedge6.");
+              return nullptr;
         }
       case stk::topology::LINE_2:
         switch(elemTopo) {

--- a/include/node_kernels/BLTGammaM2015NodeKernel.h
+++ b/include/node_kernels/BLTGammaM2015NodeKernel.h
@@ -70,8 +70,6 @@ private:
   unsigned dudxID_            {stk::mesh::InvalidOrdinal};
   unsigned minDID_            {stk::mesh::InvalidOrdinal};
   unsigned dualNodalVolumeID_ {stk::mesh::InvalidOrdinal};
-  unsigned coordinatesID_     {stk::mesh::InvalidOrdinal};
-  unsigned velocityNp1ID_     {stk::mesh::InvalidOrdinal};
   unsigned gamintID_          {stk::mesh::InvalidOrdinal};
 
   NodeKernelTraits::DblType caOne_;

--- a/src/GammaEquationSystem.C
+++ b/src/GammaEquationSystem.C
@@ -239,11 +239,14 @@ GammaEquationSystem::register_interior_algorithm(
       "gamma_transition_time_derivative",
       "lumped_gamma_transition_time_derivative"};
     bool elementMassAlg = supp_alg_is_requested(checkAlgNames);
+    if (elementMassAlg) {
+      throw std::runtime_error("consistent mass integration of gamma time-derivative unavailable");
+    }
+
     auto& solverAlgMap = solverAlgDriver_->solverAlgMap_;
     process_ngp_node_kernels(
       solverAlgMap, realm_, part, this,
       [&](AssembleNGPNodeSolverAlgorithm& nodeAlg) {
-        if (!elementMassAlg)
           nodeAlg.add_kernel<ScalarMassBDFNodeKernel>(realm_.bulk_data(), gamma_);
           
           NaluEnv::self().naluOutputP0() << "call BLTGammaM2015NodeKernel: " <<std::endl;
@@ -352,8 +355,8 @@ GammaEquationSystem::register_inflow_bc(
 void
 GammaEquationSystem::register_open_bc(
   stk::mesh::Part *part,
-  const stk::topology & partTopo,
-  const OpenBoundaryConditionData &openBCData)
+  const stk::topology & /* partTopo */,
+  const OpenBoundaryConditionData & /* openBCData */)
 {
 
   // algorithm type
@@ -375,7 +378,7 @@ void
 GammaEquationSystem::register_wall_bc(
   stk::mesh::Part *part,
   const stk::topology &/*theTopo*/,
-  const WallBoundaryConditionData &wallBCData)
+  const WallBoundaryConditionData &/* wallBCData */)
 {
 
   // algorithm type

--- a/src/ngp_algorithms/SSTAMSAveragesAlg.C
+++ b/src/ngp_algorithms/SSTAMSAveragesAlg.C
@@ -30,6 +30,11 @@ SSTAMSAveragesAlg::SSTAMSAveragesAlg(Realm& realm, stk::mesh::Part* part)
     aspectRatioSwitch_(realm.get_turb_model_constant(TM_aspRatSwitch)),
     avgTimeCoeff_(realm.get_turb_model_constant(TM_avgTimeCoeff)),
     meshMotion_(realm.does_mesh_move()),
+    RANSBelowKs_(realm_.solutionOptions_->RANSBelowKs_),
+    z0_(realm_.solutionOptions_->roughnessHeight_),
+    lengthScaleLimiter_(realm_.solutionOptions_->lengthScaleLimiter_),
+    eastVector_(realm_.solutionOptions_->eastVector_),
+    northVector_(realm_.solutionOptions_->northVector_),
     velocity_(get_field_ordinal(realm.meta_data(), "velocity")),
     density_(get_field_ordinal(realm.meta_data(), "density")),
     dudx_(get_field_ordinal(realm.meta_data(), "dudx")),
@@ -59,13 +64,7 @@ SSTAMSAveragesAlg::SSTAMSAveragesAlg(Realm& realm, stk::mesh::Part* part)
     visc_(get_field_ordinal(realm.meta_data(), "viscosity")),
     beta_(get_field_ordinal(realm.meta_data(), "k_ratio")),
     Mij_(get_field_ordinal(realm.meta_data(), "metric_tensor")),
-    wallDist_(get_field_ordinal(realm.meta_data(), "minimum_distance_to_wall")),
-    coordinates_(get_field_ordinal(realm.meta_data(), realm.get_coordinates_name())),
-    RANSBelowKs_(realm_.solutionOptions_->RANSBelowKs_),
-    z0_(realm_.solutionOptions_->roughnessHeight_),
-    lengthScaleLimiter_(realm_.solutionOptions_->lengthScaleLimiter_),
-    eastVector_(realm_.solutionOptions_->eastVector_),
-    northVector_(realm_.solutionOptions_->northVector_)
+    wallDist_(get_field_ordinal(realm.meta_data(), "minimum_distance_to_wall"))
 {
 }
 

--- a/src/node_kernels/BLTGammaM2015NodeKernel.C
+++ b/src/node_kernels/BLTGammaM2015NodeKernel.C
@@ -28,8 +28,6 @@ BLTGammaM2015NodeKernel::BLTGammaM2015NodeKernel(
     dudxID_(get_field_ordinal(meta, "dudx")),
     minDID_(get_field_ordinal(meta, "minimum_distance_to_wall")),
     dualNodalVolumeID_(get_field_ordinal(meta, "dual_nodal_volume")),
-    coordinatesID_(get_field_ordinal(meta, "coordinates")),
-    velocityNp1ID_(get_field_ordinal(meta, "velocity")),
     gamintID_(get_field_ordinal(meta, "gamma_transition")),
     nDim_(meta.spatial_dimension())
 {}
@@ -46,8 +44,6 @@ BLTGammaM2015NodeKernel::setup(Realm& realm)
   dudx_            = fieldMgr.get_field<double>(dudxID_);
   minD_            = fieldMgr.get_field<double>(minDID_);
   dualNodalVolume_ = fieldMgr.get_field<double>(dualNodalVolumeID_);
-  coordinates_     = fieldMgr.get_field<double>(coordinatesID_);
-  velocityNp1_     = fieldMgr.get_field<double>(velocityNp1ID_);
   gamint_          = fieldMgr.get_field<double>(gamintID_);
 
   // Update transition model constants
@@ -92,11 +88,6 @@ BLTGammaM2015NodeKernel::execute(
 {
   using DblType = NodeKernelTraits::DblType;
 
-  NALU_ALIGNED NodeKernelTraits::DblType coords[NodeKernelTraits::NDimMax]; // coordinates
-  NALU_ALIGNED NodeKernelTraits::DblType vel[NodeKernelTraits::NDimMax];
-  NALU_ALIGNED NodeKernelTraits::DblType dwalldistdx[NodeKernelTraits::NDimMax];
-  NALU_ALIGNED NodeKernelTraits::DblType dndotvdx[NodeKernelTraits::NDimMax];
-
   const DblType tke       = tke_.get(node, 0);
   const DblType sdr       = sdr_.get(node, 0);
   const DblType gamint    = gamint_.get(node, 0);
@@ -128,10 +119,6 @@ BLTGammaM2015NodeKernel::execute(
   DblType Ctu2=1000.;
   DblType Ctu3=1.0;
 
-  for (int d = 0; d < nDim_; d++) {
-    coords[d] = coordinates_.get(node, d);
-    vel[d] = velocityNp1_.get(node, d);
-  }
 
   for (int i=0; i < nDim_; ++i) {
     for (int j=0; j < nDim_; ++j) {

--- a/unit_tests/matrix_free/UnitTestConductionDiagonal.C
+++ b/unit_tests/matrix_free/UnitTestConductionDiagonal.C
@@ -46,10 +46,10 @@ static constexpr int num_elems = 1;
 Teuchos::RCP<const Tpetra::Map<>>
 make_map()
 {
-  return make_rcp<Tpetra::Map<>>(
+  return matrix_free::make_rcp<Tpetra::Map<>>(
     Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
     num_elems * nodes_per_elem, 1,
-    make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
+    matrix_free::make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
 }
 
 template <int p>

--- a/unit_tests/matrix_free/UnitTestConductionInterior.C
+++ b/unit_tests/matrix_free/UnitTestConductionInterior.C
@@ -47,10 +47,10 @@ static constexpr int num_elems = 1;
 Teuchos::RCP<const Tpetra::Map<>>
 make_map()
 {
-  return make_rcp<Tpetra::Map<>>(
+  return matrix_free::make_rcp<Tpetra::Map<>>(
     Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
     num_elems * nodes_per_elem, 1,
-    make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
+    matrix_free::make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
 }
 
 template <int p>

--- a/unit_tests/matrix_free/UnitTestContinuityInterior.C
+++ b/unit_tests/matrix_free/UnitTestContinuityInterior.C
@@ -44,10 +44,10 @@ static constexpr int num_elems = 1;
 Teuchos::RCP<const Tpetra::Map<>>
 make_map()
 {
-  return make_rcp<Tpetra::Map<>>(
+  return matrix_free::make_rcp<Tpetra::Map<>>(
     Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
     num_elems * nodes_per_elem, 1,
-    make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
+    matrix_free::make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
 }
 
 template <int p>

--- a/unit_tests/matrix_free/UnitTestFilterDiagonal.C
+++ b/unit_tests/matrix_free/UnitTestFilterDiagonal.C
@@ -52,10 +52,10 @@ static constexpr int num_elems = 1;
 Teuchos::RCP<const Tpetra::Map<>>
 make_map()
 {
-  return make_rcp<Tpetra::Map<>>(
+  return matrix_free::make_rcp<Tpetra::Map<>>(
     Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
     num_elems * nodes_per_elem, 1,
-    make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
+    matrix_free::make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
 }
 
 template <int p>

--- a/unit_tests/matrix_free/UnitTestGradientInterior.C
+++ b/unit_tests/matrix_free/UnitTestGradientInterior.C
@@ -28,10 +28,10 @@ static constexpr int num_elems = 1;
 Teuchos::RCP<const Tpetra::Map<>>
 make_map()
 {
-  return make_rcp<Tpetra::Map<>>(
+  return matrix_free::make_rcp<Tpetra::Map<>>(
     Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
     num_elems * nodes_per_elem, 1,
-    make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
+    matrix_free::make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
 }
 
 template <int p>

--- a/unit_tests/matrix_free/UnitTestGreenGaussGradientInterior.C
+++ b/unit_tests/matrix_free/UnitTestGreenGaussGradientInterior.C
@@ -28,10 +28,10 @@ static constexpr int num_elems = 1;
 Teuchos::RCP<const Tpetra::Map<>>
 make_map()
 {
-  return make_rcp<Tpetra::Map<>>(
+  return matrix_free::make_rcp<Tpetra::Map<>>(
     Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
     num_elems * nodes_per_elem, 1,
-    make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
+    matrix_free::make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
 }
 
 template <int p>

--- a/unit_tests/matrix_free/UnitTestMomentumDiagonal.C
+++ b/unit_tests/matrix_free/UnitTestMomentumDiagonal.C
@@ -39,10 +39,10 @@ static constexpr int num_elems = 1;
 Teuchos::RCP<const Tpetra::Map<>>
 make_map()
 {
-  return make_rcp<Tpetra::Map<>>(
+  return matrix_free::make_rcp<Tpetra::Map<>>(
     Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
     num_elems * nodes_per_elem, 1,
-    make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
+    matrix_free::make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
 }
 
 template <int p>

--- a/unit_tests/matrix_free/UnitTestMomentumInterior.C
+++ b/unit_tests/matrix_free/UnitTestMomentumInterior.C
@@ -39,10 +39,10 @@ static constexpr int num_elems = 1;
 Teuchos::RCP<const Tpetra::Map<>>
 make_map()
 {
-  return make_rcp<Tpetra::Map<>>(
+  return matrix_free::make_rcp<Tpetra::Map<>>(
     Teuchos::OrdinalTraits<Tpetra::global_size_t>::invalid(),
     num_elems * nodes_per_elem, 1,
-    make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
+    matrix_free::make_rcp<Teuchos::MpiComm<int>>(MPI_COMM_WORLD));
 }
 
 template <int p>


### PR DESCRIPTION
https://github.com/trilinos/Trilinos/pull/10647 added `Teuchos::make_rcp`.  I'd like to switch to that once `stable` is there, see https://github.com/Exawind/nalu-wind/issues/991 . 

Also fix a smattering of compiler warnings to compile cleanly with gcc 9.3. 

