### PR TITLE
Fixes ablNeutralEdgeAMS regression test failing and exiting before completion

### DIFF
--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -1127,6 +1127,7 @@ PeriodicManager::ngp_set_slave_to_master(
   KokkosEntityPairView deviceMasterSlaves = deviceMasterSlaves_;
 
   // iterate vector of masterEntity:slaveEntity pairs
+  ngpField.sync_to_device();
   if ( bypassFieldCheck ) {
     // fields are expected to be defined on all master/slave nodes
     Kokkos::parallel_for("set_slave_to_master", masterSlaveCommunicator_.size(), KOKKOS_LAMBDA(const int i)
@@ -1165,6 +1166,7 @@ PeriodicManager::ngp_set_slave_to_master(
   }
 
   ngpField.modify_on_device();
+  ngpField.sync_to_host();
 
   if (doCommunication) {
     ngp_periodic_parallel_communicate_field(theField);

--- a/src/ngp_algorithms/SSTAMSAveragesAlg.C
+++ b/src/ngp_algorithms/SSTAMSAveragesAlg.C
@@ -64,7 +64,8 @@ SSTAMSAveragesAlg::SSTAMSAveragesAlg(Realm& realm, stk::mesh::Part* part)
     visc_(get_field_ordinal(realm.meta_data(), "viscosity")),
     beta_(get_field_ordinal(realm.meta_data(), "k_ratio")),
     Mij_(get_field_ordinal(realm.meta_data(), "metric_tensor")),
-    wallDist_(get_field_ordinal(realm.meta_data(), "minimum_distance_to_wall"))
+    wallDist_(get_field_ordinal(realm.meta_data(), "minimum_distance_to_wall")),
+    coordinates_(get_field_ordinal(realm.meta_data(), realm.get_coordinates_name()))
 {
 }
 


### PR DESCRIPTION
ablNeutralEdgeAMS regression test was failing and exiting before completion when run on ascicgpu machines.  This failure came from two causes - improper syncing in `PeriodicManager::ngp_set_slave_to_master()` causing a throw and a segfault from not initializing `coordinates_` member variable in `SSTAMSAveragesAlg`.