### PR TITLE
Refactor: boundary conditions

### DIFF
--- a/include/BoundaryConditions.h
+++ b/include/BoundaryConditions.h
@@ -24,46 +24,27 @@ namespace YAML {
 }
 
 namespace sierra{
-  namespace nalu{
-
-class Realm;
-class BoundaryConditions;
-class Simulation;
+namespace nalu {
 
 class BoundaryCondition {
  public:
- BoundaryCondition(BoundaryConditions& bcs) : boundaryConditions_(bcs) {}
-  
-  virtual ~BoundaryCondition() {}
+   BoundaryCondition() {}
+   virtual ~BoundaryCondition() {}
 
-  std::unique_ptr<BoundaryCondition> load(const YAML::Node& node);
-
-  std::string bcName_;
-  std::string targetName_;
-  BoundaryConditionType theBcType_;
-  BoundaryConditions& boundaryConditions_;
+   std::string bcName_;
+   std::string targetName_;
+   BoundaryConditionType theBcType_;
 };
 
 typedef std::vector<std::unique_ptr<BoundaryCondition>> BoundaryConditionVector;
-
-class BoundaryConditions
+struct BoundaryConditionCreator
 {
 public:
-  BoundaryConditions(Realm& realm) : realm_(realm) {}
-  ~BoundaryConditions() = default;
+  BoundaryConditionVector create_bc_vector(const YAML::Node& node);
 
-  void load(const YAML::Node& node);
-
-  // ease of access methods to particular boundary condition
-  BoundaryCondition* operator[](int i)
-  {
-    return boundaryConditionVector_[i].get();
-  }
-
-  Realm& realm_;
-  BoundaryConditionVector boundaryConditionVector_;
+  std::unique_ptr<BoundaryCondition>
+  load_single_bc_node(const YAML::Node& node);
 };
-
 } // namespace nalu
 } // namespace Sierra
 

--- a/include/BoundaryConditions.h
+++ b/include/BoundaryConditions.h
@@ -37,8 +37,6 @@ class BoundaryCondition {
   virtual ~BoundaryCondition() {}
 
   std::unique_ptr<BoundaryCondition> load(const YAML::Node& node);
-  Simulation *root();
-  BoundaryConditions *parent();
 
   std::string bcName_;
   std::string targetName_;
@@ -58,9 +56,6 @@ public:
 
   // TODO(psakiev) Delete this unused function
   void breadboard() {}
-
-  Simulation* root();
-  Realm* parent();
 
   // ease of access methods to particular boundary condition
   size_t size() { return boundaryConditionVector_.size(); }

--- a/include/BoundaryConditions.h
+++ b/include/BoundaryConditions.h
@@ -17,6 +17,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <memory>
 
 namespace YAML {
   class Node;
@@ -34,53 +35,42 @@ class BoundaryCondition {
  BoundaryCondition(BoundaryConditions& bcs) : boundaryConditions_(bcs) {}
   
   virtual ~BoundaryCondition() {}
-  
-  BoundaryCondition * load(const YAML::Node & node) ;
+
+  std::unique_ptr<BoundaryCondition> load(const YAML::Node& node);
   Simulation *root();
   BoundaryConditions *parent();
-  
-  void breadboard()
-  {
-    // nothing
-  }
-  
+
   std::string bcName_;
   std::string targetName_;
   BoundaryConditionType theBcType_;
   BoundaryConditions& boundaryConditions_;
 };
- 
- typedef std::vector<BoundaryCondition *> BoundaryConditionVector;
- 
- class BoundaryConditions {
- public:
-   
- BoundaryConditions(Realm& realm) 
-   : realm_(realm) {}
- ~BoundaryConditions() {
-   for ( size_t iboundary_condition = 0; iboundary_condition < boundaryConditionVector_.size(); ++iboundary_condition ) {
-     delete boundaryConditionVector_[iboundary_condition];
-   }
- }
 
-   BoundaryConditions* load(const YAML::Node & node);
+typedef std::vector<std::unique_ptr<BoundaryCondition>> BoundaryConditionVector;
 
- void breadboard()
- {
-   for ( size_t iboundary_condition = 0; iboundary_condition < boundaryConditionVector_.size(); ++iboundary_condition ) {
-     boundaryConditionVector_[iboundary_condition]->breadboard();
-   }
- }
- 
- Simulation *root();
- Realm *parent();
- 
- // ease of access methods to particular boundary condition
- size_t size() {return boundaryConditionVector_.size();}
- BoundaryCondition *operator[](int i) { return boundaryConditionVector_[i];}
- 
- Realm &realm_;
- BoundaryConditionVector boundaryConditionVector_;
+class BoundaryConditions
+{
+public:
+  BoundaryConditions(Realm& realm) : realm_(realm) {}
+  ~BoundaryConditions() = default;
+
+  void load(const YAML::Node& node);
+
+  // TODO(psakiev) Delete this unused function
+  void breadboard() {}
+
+  Simulation* root();
+  Realm* parent();
+
+  // ease of access methods to particular boundary condition
+  size_t size() { return boundaryConditionVector_.size(); }
+  BoundaryCondition* operator[](int i)
+  {
+    return boundaryConditionVector_[i].get();
+  }
+
+  Realm& realm_;
+  BoundaryConditionVector boundaryConditionVector_;
 };
 
 } // namespace nalu

--- a/include/BoundaryConditions.h
+++ b/include/BoundaryConditions.h
@@ -54,11 +54,7 @@ public:
 
   void load(const YAML::Node& node);
 
-  // TODO(psakiev) Delete this unused function
-  void breadboard() {}
-
   // ease of access methods to particular boundary condition
-  size_t size() { return boundaryConditionVector_.size(); }
   BoundaryCondition* operator[](int i)
   {
     return boundaryConditionVector_[i].get();

--- a/include/NaluParsing.h
+++ b/include/NaluParsing.h
@@ -238,17 +238,17 @@ struct NonConformalUserData : public UserData {
 };
 
 struct WallBoundaryConditionData : public BoundaryCondition {
-  WallBoundaryConditionData(BoundaryConditions& bcs) : BoundaryCondition(bcs){};
+  WallBoundaryConditionData(){};
   WallUserData userData_;
 };
 
 struct InflowBoundaryConditionData : public BoundaryCondition {
-  InflowBoundaryConditionData(BoundaryConditions& bcs) : BoundaryCondition(bcs){};
+  InflowBoundaryConditionData(){};
   InflowUserData userData_;
 };
 
 struct OpenBoundaryConditionData : public BoundaryCondition {
-  OpenBoundaryConditionData(BoundaryConditions& bcs) : BoundaryCondition(bcs){};
+  OpenBoundaryConditionData(){};
   OpenUserData userData_;
 };
 
@@ -258,30 +258,30 @@ struct OversetBoundaryConditionData : public BoundaryCondition {
     OVERSET_NONE  = 1  ///< Guard for error messages
   };
 
-  OversetBoundaryConditionData(BoundaryConditions& bcs) : BoundaryCondition(bcs){};
+  OversetBoundaryConditionData(){};
   OversetUserData userData_;
   OversetAPI oversetConnectivityType_;
 };
 
 struct SymmetryBoundaryConditionData : public BoundaryCondition {
-  SymmetryBoundaryConditionData(BoundaryConditions& bcs) : BoundaryCondition(bcs){};
+  SymmetryBoundaryConditionData(){};
   SymmetryUserData userData_;
 };
 
 struct ABLTopBoundaryConditionData : public BoundaryCondition {
-  ABLTopBoundaryConditionData(BoundaryConditions& bcs) : BoundaryCondition(bcs){};
+  ABLTopBoundaryConditionData(){};
   ABLTopUserData userData_;
   SymmetryUserData symmetryUserData_;
 };
 
 struct PeriodicBoundaryConditionData : public BoundaryCondition {
-  PeriodicBoundaryConditionData(BoundaryConditions& bcs) : BoundaryCondition(bcs){};
+  PeriodicBoundaryConditionData(){};
   MasterSlave masterSlave_;
   PeriodicUserData userData_;
 };
 
 struct NonConformalBoundaryConditionData : public BoundaryCondition {
-  NonConformalBoundaryConditionData(BoundaryConditions& bcs) : BoundaryCondition(bcs){};
+  NonConformalBoundaryConditionData(){};
   std::vector<std::string> currentPartNameVec_;
   std::vector<std::string> opposingPartNameVec_;
   NonConformalUserData userData_;

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -432,7 +432,7 @@ class Realm {
 
   TimeIntegrator *timeIntegrator_;
 
-  BoundaryConditions boundaryConditions_;
+  BoundaryConditionVector boundaryConditions_;
   InitialConditions initialConditions_;
   MaterialPropertys materialPropertys_;
   

--- a/src/BoundaryConditions.C
+++ b/src/BoundaryConditions.C
@@ -38,72 +38,62 @@ namespace nalu{
 //--------------------------------------------------------------------------
 
 
-/// this is an example of a load() method with polymorphism - the type of
-/// the node is determined from some information, then a particular type
-/// of object is created and returned to the parent.
+template<typename T>
+std::unique_ptr<BoundaryCondition> register_bc(const YAML::Node& node, BoundaryConditions& bcs){
+    std::unique_ptr<BoundaryCondition>this_bc = std::make_unique<T>(bcs);
+    auto* cast_bc = dynamic_cast<T*>(this_bc.get());
+    node >> *cast_bc;
+    return this_bc;
+}
 
 std::unique_ptr<BoundaryCondition> BoundaryCondition::load(const YAML::Node & node) 
 {
   std::unique_ptr<BoundaryCondition> this_bc;
   if ( node["wall_boundary_condition"] ){
-    //this_bc.reset(new WallBoundaryConditionData(boundaryConditions_));
-    this_bc = std::make_unique<WallBoundaryConditionData>(boundaryConditions_);
-    auto* wallBC = dynamic_cast<WallBoundaryConditionData*>(this_bc.get());
-
-    node >> *wallBC;
-    NaluEnv::self().naluOutputP0() << "Wall BC name:        " << wallBC->bcName_
-                    << " on " << wallBC->targetName_ << std::endl;
+    this_bc = std::move(register_bc<WallBoundaryConditionData>(node, boundaryConditions_));
+    NaluEnv::self().naluOutputP0()<<"Wall BC name:        " << this_bc->bcName_ \
+                    << " on " << this_bc->targetName_ << std::endl;
   }
   else if (node["inflow_boundary_condition"]) {
-    InflowBoundaryConditionData& inflowBC = *new InflowBoundaryConditionData(*parent());
-    node >> inflowBC;
-    NaluEnv::self().naluOutputP0() << "Inflow BC name:      " << inflowBC.bcName_
-                    << " on " << inflowBC.targetName_ << std::endl;
+    this_bc = std::move(register_bc<InflowBoundaryConditionData>(node, boundaryConditions_));
+    NaluEnv::self().naluOutputP0()<<"Inflow BC name:        " << this_bc->bcName_ \
+                    << " on " << this_bc->targetName_ << std::endl;
   }
   else if (node["open_boundary_condition"]) {
-    OpenBoundaryConditionData& openBC = *new OpenBoundaryConditionData(*parent());
-    node >> openBC;
-    NaluEnv::self().naluOutputP0() << "Open BC name:        " << openBC.bcName_
-                    << " on " << openBC.targetName_ << std::endl;
+    this_bc = std::move(register_bc<OpenBoundaryConditionData>(node, boundaryConditions_));
+    NaluEnv::self().naluOutputP0()<<"Open BC name:        " << this_bc->bcName_ \
+                    << " on " << this_bc->targetName_ << std::endl;
   }
   else if (node["symmetry_boundary_condition"]) {
-    SymmetryBoundaryConditionData& symmetryBC = *new SymmetryBoundaryConditionData(*parent());
-    node >> symmetryBC;
-    NaluEnv::self().naluOutputP0() << "Symmetry BC name:    " << symmetryBC.bcName_
-                    << " on " << symmetryBC.targetName_ << std::endl;
+    this_bc = std::move(register_bc<SymmetryBoundaryConditionData>(node, boundaryConditions_));
+    NaluEnv::self().naluOutputP0()<<"Symmetry BC name:        " << this_bc->bcName_ \
+                    << " on " << this_bc->targetName_ << std::endl;
   }
   else if (node["abltop_boundary_condition"]) {
-    ABLTopBoundaryConditionData& abltopBC = *new ABLTopBoundaryConditionData(*parent());
-    node >> abltopBC;
-    NaluEnv::self().naluOutputP0() << "ABLTop BC name:    " << abltopBC.bcName_
-                    << " on " << abltopBC.targetName_ << std::endl;
+    this_bc = std::move(register_bc<ABLTopBoundaryConditionData>(node, boundaryConditions_));
+    NaluEnv::self().naluOutputP0()<<"ABLTop BC name:        " << this_bc->bcName_ \
+                    << " on " << this_bc->targetName_ << std::endl;
   }
   else if (node["periodic_boundary_condition"]) {
-    PeriodicBoundaryConditionData& periodicBC = *new PeriodicBoundaryConditionData(*parent());
-    node >> periodicBC;
-    NaluEnv::self().naluOutputP0() << "Periodic BC name:    " << periodicBC.bcName_
-                    << " between " << periodicBC.masterSlave_.master_
-                    << " and "<< periodicBC.masterSlave_.slave_ << std::endl;
+    this_bc = std::move(register_bc<PeriodicBoundaryConditionData>(node, boundaryConditions_));
+    auto* periodicBC = dynamic_cast<PeriodicBoundaryConditionData*>(this_bc.get());
+    NaluEnv::self().naluOutputP0() << "Periodic BC name:    " << periodicBC->bcName_
+                    << " between " << periodicBC->masterSlave_.master_
+                    << " and "<< periodicBC->masterSlave_.slave_ << std::endl;
   }
   else if (node["non_conformal_boundary_condition"]) {
-    NonConformalBoundaryConditionData& nonConformalBC = *new NonConformalBoundaryConditionData(*parent());
-    node >> nonConformalBC;
-    NaluEnv::self().naluOutputP0() << "NonConformal BC name:    " << nonConformalBC.bcName_
-                    << " using " << nonConformalBC.targetName_ << std::endl;
+    this_bc = std::move(register_bc<NonConformalBoundaryConditionData>(node, boundaryConditions_));
+    NaluEnv::self().naluOutputP0() << "NonConformal BC name:    " << this_bc->bcName_
+                    << " using " << this_bc->targetName_ << std::endl;
   }
   else if (node["overset_boundary_condition"]) {
-    OversetBoundaryConditionData& oversetBC = *new OversetBoundaryConditionData(*parent());
-    node >> oversetBC;
-    NaluEnv::self().naluOutputP0() << "Overset BC name: " << oversetBC.bcName_ << std::endl;
+    this_bc = std::move(register_bc<OversetBoundaryConditionData>(node, boundaryConditions_));
+    NaluEnv::self().naluOutputP0() << "Overset BC name: " << this_bc->bcName_ << std::endl;
   } 
   else {
     throw std::runtime_error("parser error BoundaryConditions::load: no such bc type");
   }
   return this_bc;
-// Avoid nvcc unreachable statement warnings
-#ifndef __CUDACC__
-  return 0;
-#endif
 }
 
   Simulation* BoundaryCondition::root() { return parent()->root(); }

--- a/src/BoundaryConditions.C
+++ b/src/BoundaryConditions.C
@@ -7,8 +7,6 @@
 // for more details.
 //
 
-
-
 #include <Realm.h>
 #include <BoundaryConditions.h>
 #include <NaluEnv.h>
@@ -17,8 +15,8 @@
 #include <yaml-cpp/yaml.h>
 #include <NaluParsing.h>
 
-namespace sierra{
-namespace nalu{
+namespace sierra {
+namespace nalu {
 
 //==========================================================================
 // Class Definition
@@ -28,7 +26,7 @@ namespace nalu{
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-  
+
 //--------------------------------------------------------------------------
 //-------- destructor ------------------------------------------------------
 //--------------------------------------------------------------------------
@@ -37,87 +35,135 @@ namespace nalu{
 //-------- load -----------------------------------------------
 //--------------------------------------------------------------------------
 
-
-template<typename T>
-std::unique_ptr<BoundaryCondition> register_bc(const YAML::Node& node, BoundaryConditions& bcs){
-    std::unique_ptr<BoundaryCondition>this_bc = std::make_unique<T>(bcs);
-    auto* cast_bc = dynamic_cast<T*>(this_bc.get());
-    node >> *cast_bc;
-    return this_bc;
+template <typename T>
+std::unique_ptr<BoundaryCondition>
+register_bc(const YAML::Node& node, BoundaryConditions& bcs)
+{
+  std::unique_ptr<BoundaryCondition> this_bc = std::make_unique<T>(bcs);
+  auto* cast_bc = dynamic_cast<T*>(this_bc.get());
+  node >> *cast_bc;
+  return this_bc;
 }
 
-std::unique_ptr<BoundaryCondition> BoundaryCondition::load(const YAML::Node & node) 
+std::unique_ptr<BoundaryCondition>
+BoundaryCondition::load(const YAML::Node& node)
 {
   std::unique_ptr<BoundaryCondition> this_bc;
-  if ( node["wall_boundary_condition"] ){
-    this_bc = std::move(register_bc<WallBoundaryConditionData>(node, boundaryConditions_));
-    NaluEnv::self().naluOutputP0()<<"Wall BC name:        " << this_bc->bcName_ \
-                    << " on " << this_bc->targetName_ << std::endl;
-  }
-  else if (node["inflow_boundary_condition"]) {
-    this_bc = std::move(register_bc<InflowBoundaryConditionData>(node, boundaryConditions_));
-    NaluEnv::self().naluOutputP0()<<"Inflow BC name:        " << this_bc->bcName_ \
-                    << " on " << this_bc->targetName_ << std::endl;
-  }
-  else if (node["open_boundary_condition"]) {
-    this_bc = std::move(register_bc<OpenBoundaryConditionData>(node, boundaryConditions_));
-    NaluEnv::self().naluOutputP0()<<"Open BC name:        " << this_bc->bcName_ \
-                    << " on " << this_bc->targetName_ << std::endl;
-  }
-  else if (node["symmetry_boundary_condition"]) {
-    this_bc = std::move(register_bc<SymmetryBoundaryConditionData>(node, boundaryConditions_));
-    NaluEnv::self().naluOutputP0()<<"Symmetry BC name:        " << this_bc->bcName_ \
-                    << " on " << this_bc->targetName_ << std::endl;
-  }
-  else if (node["abltop_boundary_condition"]) {
-    this_bc = std::move(register_bc<ABLTopBoundaryConditionData>(node, boundaryConditions_));
-    NaluEnv::self().naluOutputP0()<<"ABLTop BC name:        " << this_bc->bcName_ \
-                    << " on " << this_bc->targetName_ << std::endl;
-  }
-  else if (node["periodic_boundary_condition"]) {
-    this_bc = std::move(register_bc<PeriodicBoundaryConditionData>(node, boundaryConditions_));
-    auto* periodicBC = dynamic_cast<PeriodicBoundaryConditionData*>(this_bc.get());
-    NaluEnv::self().naluOutputP0() << "Periodic BC name:    " << periodicBC->bcName_
-                    << " between " << periodicBC->masterSlave_.master_
-                    << " and "<< periodicBC->masterSlave_.slave_ << std::endl;
-  }
-  else if (node["non_conformal_boundary_condition"]) {
-    this_bc = std::move(register_bc<NonConformalBoundaryConditionData>(node, boundaryConditions_));
-    NaluEnv::self().naluOutputP0() << "NonConformal BC name:    " << this_bc->bcName_
-                    << " using " << this_bc->targetName_ << std::endl;
-  }
-  else if (node["overset_boundary_condition"]) {
-    this_bc = std::move(register_bc<OversetBoundaryConditionData>(node, boundaryConditions_));
-    NaluEnv::self().naluOutputP0() << "Overset BC name: " << this_bc->bcName_ << std::endl;
-  } 
-  else {
-    throw std::runtime_error("parser error BoundaryConditions::load: no such bc type");
+  if (node["wall_boundary_condition"]) {
+    this_bc = std::move(
+      register_bc<WallBoundaryConditionData>(node, boundaryConditions_));
+
+    NaluEnv::self().naluOutputP0()
+      << "Wall BC name:        " << this_bc->bcName_ << " on "
+      << this_bc->targetName_ << std::endl;
+
+  } else if (node["inflow_boundary_condition"]) {
+    this_bc = std::move(
+      register_bc<InflowBoundaryConditionData>(node, boundaryConditions_));
+
+    NaluEnv::self().naluOutputP0()
+      << "Inflow BC name:        " << this_bc->bcName_ << " on "
+      << this_bc->targetName_ << std::endl;
+
+  } else if (node["open_boundary_condition"]) {
+    this_bc = std::move(
+      register_bc<OpenBoundaryConditionData>(node, boundaryConditions_));
+
+    NaluEnv::self().naluOutputP0()
+      << "Open BC name:        " << this_bc->bcName_ << " on "
+      << this_bc->targetName_ << std::endl;
+
+  } else if (node["symmetry_boundary_condition"]) {
+    this_bc = std::move(
+      register_bc<SymmetryBoundaryConditionData>(node, boundaryConditions_));
+
+    NaluEnv::self().naluOutputP0()
+      << "Symmetry BC name:        " << this_bc->bcName_ << " on "
+      << this_bc->targetName_ << std::endl;
+
+  } else if (node["abltop_boundary_condition"]) {
+    this_bc = std::move(
+      register_bc<ABLTopBoundaryConditionData>(node, boundaryConditions_));
+
+    NaluEnv::self().naluOutputP0()
+      << "ABLTop BC name:        " << this_bc->bcName_ << " on "
+      << this_bc->targetName_ << std::endl;
+
+  } else if (node["periodic_boundary_condition"]) {
+    this_bc = std::move(
+      register_bc<PeriodicBoundaryConditionData>(node, boundaryConditions_));
+
+    auto* periodicBC =
+      dynamic_cast<PeriodicBoundaryConditionData*>(this_bc.get());
+
+    NaluEnv::self().naluOutputP0()
+      << "Periodic BC name:    " << periodicBC->bcName_ << " between "
+      << periodicBC->masterSlave_.master_ << " and "
+      << periodicBC->masterSlave_.slave_ << std::endl;
+
+  } else if (node["non_conformal_boundary_condition"]) {
+    this_bc = std::move(register_bc<NonConformalBoundaryConditionData>(
+      node, boundaryConditions_));
+
+    NaluEnv::self().naluOutputP0()
+      << "NonConformal BC name:    " << this_bc->bcName_ << " using "
+      << this_bc->targetName_ << std::endl;
+
+  } else if (node["overset_boundary_condition"]) {
+    this_bc = std::move(
+      register_bc<OversetBoundaryConditionData>(node, boundaryConditions_));
+
+    NaluEnv::self().naluOutputP0()
+      << "Overset BC name: " << this_bc->bcName_ << std::endl;
+
+  } else {
+    throw std::runtime_error(
+      "parser error BoundaryConditions::load: no such bc type");
   }
   return this_bc;
 }
 
-  Simulation* BoundaryCondition::root() { return parent()->root(); }
-  BoundaryConditions *BoundaryCondition::parent() { return &boundaryConditions_; }
+Simulation*
+BoundaryCondition::root()
+{
+  return parent()->root();
+}
+BoundaryConditions*
+BoundaryCondition::parent()
+{
+  return &boundaryConditions_;
+}
 
-  Simulation* BoundaryConditions::root() { return parent()->root(); }
-  Realm *BoundaryConditions::parent() { return &realm_; }
+Simulation*
+BoundaryConditions::root()
+{
+  return parent()->root();
+}
+Realm*
+BoundaryConditions::parent()
+{
+  return &realm_;
+}
 
-void BoundaryConditions::load(const YAML::Node &node)
+void
+BoundaryConditions::load(const YAML::Node& node)
 {
   BoundaryCondition bc_factory(*this);
 
-  if(node["boundary_conditions"]) {
+  if (node["boundary_conditions"]) {
     const YAML::Node boundary_conditions = node["boundary_conditions"];
-    for ( size_t iboundary_condition = 0; iboundary_condition < boundary_conditions.size(); ++iboundary_condition ) {
-      const YAML::Node boundary_condition_node = boundary_conditions[iboundary_condition];
-      boundaryConditionVector_.emplace_back(bc_factory.load(boundary_condition_node));
+    for (size_t iboundary_condition = 0;
+         iboundary_condition < boundary_conditions.size();
+         ++iboundary_condition) {
+      const YAML::Node boundary_condition_node =
+        boundary_conditions[iboundary_condition];
+      boundaryConditionVector_.emplace_back(
+        bc_factory.load(boundary_condition_node));
     }
-  }
-  else {
+  } else {
     throw std::runtime_error("parser error BoundaryConditions::load");
   }
 }
 
-
 } // namespace nalu
-} // namespace Sierra
+} // namespace sierra

--- a/src/BoundaryConditions.C
+++ b/src/BoundaryConditions.C
@@ -42,42 +42,41 @@ namespace nalu{
 /// the node is determined from some information, then a particular type
 /// of object is created and returned to the parent.
 
-BoundaryCondition * BoundaryCondition::load(const YAML::Node & node) 
+std::unique_ptr<BoundaryCondition> BoundaryCondition::load(const YAML::Node & node) 
 {
+  std::unique_ptr<BoundaryCondition> this_bc;
   if ( node["wall_boundary_condition"] ){
-    WallBoundaryConditionData& wallBC = *new WallBoundaryConditionData(*parent());
-    node >> wallBC;
-    NaluEnv::self().naluOutputP0() << "Wall BC name:        " << wallBC.bcName_
-                    << " on " << wallBC.targetName_ << std::endl;
-    return &wallBC;
+    //this_bc.reset(new WallBoundaryConditionData(boundaryConditions_));
+    this_bc = std::make_unique<WallBoundaryConditionData>(boundaryConditions_);
+    auto* wallBC = dynamic_cast<WallBoundaryConditionData*>(this_bc.get());
+
+    node >> *wallBC;
+    NaluEnv::self().naluOutputP0() << "Wall BC name:        " << wallBC->bcName_
+                    << " on " << wallBC->targetName_ << std::endl;
   }
   else if (node["inflow_boundary_condition"]) {
     InflowBoundaryConditionData& inflowBC = *new InflowBoundaryConditionData(*parent());
     node >> inflowBC;
     NaluEnv::self().naluOutputP0() << "Inflow BC name:      " << inflowBC.bcName_
                     << " on " << inflowBC.targetName_ << std::endl;
-    return &inflowBC;
   }
   else if (node["open_boundary_condition"]) {
     OpenBoundaryConditionData& openBC = *new OpenBoundaryConditionData(*parent());
     node >> openBC;
     NaluEnv::self().naluOutputP0() << "Open BC name:        " << openBC.bcName_
                     << " on " << openBC.targetName_ << std::endl;
-    return &openBC;
   }
   else if (node["symmetry_boundary_condition"]) {
     SymmetryBoundaryConditionData& symmetryBC = *new SymmetryBoundaryConditionData(*parent());
     node >> symmetryBC;
     NaluEnv::self().naluOutputP0() << "Symmetry BC name:    " << symmetryBC.bcName_
                     << " on " << symmetryBC.targetName_ << std::endl;
-    return &symmetryBC;
   }
   else if (node["abltop_boundary_condition"]) {
     ABLTopBoundaryConditionData& abltopBC = *new ABLTopBoundaryConditionData(*parent());
     node >> abltopBC;
     NaluEnv::self().naluOutputP0() << "ABLTop BC name:    " << abltopBC.bcName_
                     << " on " << abltopBC.targetName_ << std::endl;
-    return &abltopBC;
   }
   else if (node["periodic_boundary_condition"]) {
     PeriodicBoundaryConditionData& periodicBC = *new PeriodicBoundaryConditionData(*parent());
@@ -85,24 +84,22 @@ BoundaryCondition * BoundaryCondition::load(const YAML::Node & node)
     NaluEnv::self().naluOutputP0() << "Periodic BC name:    " << periodicBC.bcName_
                     << " between " << periodicBC.masterSlave_.master_
                     << " and "<< periodicBC.masterSlave_.slave_ << std::endl;
-    return &periodicBC;
   }
   else if (node["non_conformal_boundary_condition"]) {
     NonConformalBoundaryConditionData& nonConformalBC = *new NonConformalBoundaryConditionData(*parent());
     node >> nonConformalBC;
     NaluEnv::self().naluOutputP0() << "NonConformal BC name:    " << nonConformalBC.bcName_
                     << " using " << nonConformalBC.targetName_ << std::endl;
-    return &nonConformalBC;
   }
   else if (node["overset_boundary_condition"]) {
     OversetBoundaryConditionData& oversetBC = *new OversetBoundaryConditionData(*parent());
     node >> oversetBC;
     NaluEnv::self().naluOutputP0() << "Overset BC name: " << oversetBC.bcName_ << std::endl;
-    return &oversetBC;
   } 
   else {
     throw std::runtime_error("parser error BoundaryConditions::load: no such bc type");
   }
+  return this_bc;
 // Avoid nvcc unreachable statement warnings
 #ifndef __CUDACC__
   return 0;
@@ -115,23 +112,20 @@ BoundaryCondition * BoundaryCondition::load(const YAML::Node & node)
   Simulation* BoundaryConditions::root() { return parent()->root(); }
   Realm *BoundaryConditions::parent() { return &realm_; }
 
-BoundaryConditions* BoundaryConditions::load(const YAML::Node &node)
+void BoundaryConditions::load(const YAML::Node &node)
 {
-  BoundaryCondition tmp_boundary_condition(*this);
+  BoundaryCondition bc_factory(*this);
 
   if(node["boundary_conditions"]) {
     const YAML::Node boundary_conditions = node["boundary_conditions"];
     for ( size_t iboundary_condition = 0; iboundary_condition < boundary_conditions.size(); ++iboundary_condition ) {
       const YAML::Node boundary_condition_node = boundary_conditions[iboundary_condition];
-      BoundaryCondition* bc = tmp_boundary_condition.load(boundary_condition_node);
-      boundaryConditionVector_.push_back(bc);
+      boundaryConditionVector_.emplace_back(bc_factory.load(boundary_condition_node));
     }
   }
   else {
     throw std::runtime_error("parser error BoundaryConditions::load");
   }
-
-  return this;
 }
 
 

--- a/src/BoundaryConditions.C
+++ b/src/BoundaryConditions.C
@@ -123,28 +123,6 @@ BoundaryCondition::load(const YAML::Node& node)
   return this_bc;
 }
 
-Simulation*
-BoundaryCondition::root()
-{
-  return parent()->root();
-}
-BoundaryConditions*
-BoundaryCondition::parent()
-{
-  return &boundaryConditions_;
-}
-
-Simulation*
-BoundaryConditions::root()
-{
-  return parent()->root();
-}
-Realm*
-BoundaryConditions::parent()
-{
-  return &realm_;
-}
-
 void
 BoundaryConditions::load(const YAML::Node& node)
 {
@@ -152,14 +130,11 @@ BoundaryConditions::load(const YAML::Node& node)
 
   if (node["boundary_conditions"]) {
     const YAML::Node boundary_conditions = node["boundary_conditions"];
-    for (size_t iboundary_condition = 0;
-         iboundary_condition < boundary_conditions.size();
-         ++iboundary_condition) {
-      const YAML::Node boundary_condition_node =
-        boundary_conditions[iboundary_condition];
-      boundaryConditionVector_.emplace_back(
-        bc_factory.load(boundary_condition_node));
+
+    for (auto&& bc_node : boundary_conditions) {
+      boundaryConditionVector_.emplace_back(bc_factory.load(bc_node));
     }
+
   } else {
     throw std::runtime_error("parser error BoundaryConditions::load");
   }

--- a/src/EquationSystem.C
+++ b/src/EquationSystem.C
@@ -562,7 +562,7 @@ void EquationSystem::register_abltop_bc(
   const stk::topology &theTopo,
   const ABLTopBoundaryConditionData &abltopBCData)
 {
-  SymmetryBoundaryConditionData simData(abltopBCData.boundaryConditions_);
+  SymmetryBoundaryConditionData simData;
   register_symmetry_bc( part, theTopo, simData );
 }
 

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -2167,7 +2167,7 @@ MomentumEquationSystem::register_abltop_bc(
   auto userData = abltopBCData.userData_;
 
   if (!userData.ABLTopBC_) {
-    SymmetryBoundaryConditionData symData(abltopBCData.boundaryConditions_);
+    SymmetryBoundaryConditionData symData;
     symData.userData_ = abltopBCData.symmetryUserData_;
     register_symmetry_bc(part, partTopo, symData);
     return;
@@ -3176,7 +3176,7 @@ ContinuityEquationSystem::register_abltop_bc(
   auto userData = abltopBCData.userData_;
 
   if (!userData.ABLTopBC_) {
-    SymmetryBoundaryConditionData symData(abltopBCData.boundaryConditions_);
+    SymmetryBoundaryConditionData symData;
     register_symmetry_bc(part, partTopo, symData);
     return;
   }

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -190,7 +190,6 @@ Realm::Realm(Realms& realms, const YAML::Node& node)
     restartFileIndex_(99),
     numInitialElements_(0),
     timeIntegrator_(0),
-    boundaryConditions_(*this),
     initialConditions_(*this),
     materialPropertys_(*this),
     equationSystems_(*this),
@@ -769,7 +768,7 @@ Realm::load(const YAML::Node & node)
     NaluEnv::self().naluOutputP0() << std::endl;
     NaluEnv::self().naluOutputP0() << "Boundary Condition Review: " << std::endl;
     NaluEnv::self().naluOutputP0() << "===========================" << std::endl;
-    boundaryConditions_.load(node);
+    boundaryConditions_ = BoundaryConditionCreator().create_bc_vector(node);
     NaluEnv::self().naluOutputP0() << std::endl;
     NaluEnv::self().naluOutputP0() << "Initial Condition Review:  " << std::endl;
     NaluEnv::self().naluOutputP0() << "===========================" << std::endl;
@@ -1007,7 +1006,7 @@ void
 Realm::setup_bc()
 {
   // loop over all bcs and register
-  for (auto&& bc : boundaryConditions_.boundaryConditionVector_) {
+  for (auto&& bc : boundaryConditions_) {
     std::string name = physics_part_name(bc->targetName_);
 
     switch(bc->theBcType_) {
@@ -2313,7 +2312,7 @@ Realm::has_non_matching_boundary_face_alg() const
 bool 
 Realm::query_for_overset() 
 {
-  for (auto&& bc : boundaryConditions_.boundaryConditionVector_) {
+  for (auto&& bc : boundaryConditions_) {
     switch(bc->theBcType_) {
     case OVERSET_BC:
       hasOverset_ = true;

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1007,11 +1007,10 @@ void
 Realm::setup_bc()
 {
   // loop over all bcs and register
-  for (size_t ibc = 0; ibc < boundaryConditions_.size(); ++ibc) {
-    BoundaryCondition& bc = *boundaryConditions_[ibc];
-    std::string name = physics_part_name(bc.targetName_);
+  for (auto&& bc : boundaryConditions_.boundaryConditionVector_) {
+    std::string name = physics_part_name(bc->targetName_);
 
-    switch(bc.theBcType_) {
+    switch(bc->theBcType_) {
       case WALL_BC:
         equationSystems_.register_wall_bc(name, *reinterpret_cast<const WallBoundaryConditionData *>(&bc));
         break;
@@ -2314,9 +2313,8 @@ Realm::has_non_matching_boundary_face_alg() const
 bool 
 Realm::query_for_overset() 
 {
-  for (size_t ibc = 0; ibc < boundaryConditions_.size(); ++ibc) {
-    BoundaryCondition& bc = *boundaryConditions_[ibc];
-    switch(bc.theBcType_) {
+  for (auto&& bc : boundaryConditions_.boundaryConditionVector_) {
+    switch(bc->theBcType_) {
     case OVERSET_BC:
       hasOverset_ = true;
       break;


### PR DESCRIPTION
General refactor of the boundary conditions data structures.

- Remove the `root()` and `parent()` data structures from the boundary conditions and move to smart pointers. See #997 for why this is being pursued.
- Removing the `BoundaryConditions` class which is just a thin wrapper of `std::vector` and is required for construction in a lot of places but never really used for anything other than a `std::vector`
- Making BC object construction follow more of a factory pattern