### PR TITLE
Add an elevation angle to the scanning lidar

### DIFF
--- a/include/wind_energy/LidarPatterns.h
+++ b/include/wind_energy/LidarPatterns.h
@@ -13,6 +13,7 @@
 #include <array>
 #include <cmath>
 #include <memory>
+#include <vector>
 
 namespace YAML {
 class Node;
@@ -71,8 +72,13 @@ private:
   {
     return (sweep_angle_ / step_delta_angle_) * stare_time_;
   }
+
+  int periodic_count(double time) const;
+  double determine_elevation_angle(int sweep_count) const;
+
   double end_of_forward_phase_{determine_end_of_forward_phase()};
 
+  std::vector<double> elevation_table_{0};
   double beam_length_{1.0};
   std::array<double, 3> center_{0, 0, 0};
   std::array<double, 3> axis_{1, 0, 0};

--- a/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
@@ -291,6 +291,7 @@ realms:
           sweep_angle: 20 #deg
           step_delta_angle: 1 #deg
           reset_time_delta: 1 #s
+          elevation_angles: [-5,0,5]
 
 
     # This defines the ABL forcing to drive the winds to 8 m/s from

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -28,6 +28,7 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestNgpMesh1.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestPecletFunction.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestRealm.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestScanningLidarPattern.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestScratchViews.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestShmemAlignment.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestSideIsInElement.C

--- a/unit_tests/UnitTestSpinnerLidarPattern.C
+++ b/unit_tests/UnitTestSpinnerLidarPattern.C
@@ -74,7 +74,7 @@ TEST(SpinnerLidar, volume_interp)
 
   io.set_bulk_data(bulk);
 
-  const int n = 64;
+  const int n = 16;
   const auto nx = std::to_string(n);
   const auto ny = std::to_string(n);
   const auto nz = std::to_string(n / 2);


### PR DESCRIPTION
Add an option to adjust to a new elevation angle at the end of a scanning sweep, cycling back to the first elevation after the list has been exhausted.

