### PR TITLE
Coordinate output of sequence of lidar specifications

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -103,6 +103,7 @@ class Realm {
 
   virtual void load(const YAML::Node & node);
   void look_ahead_and_creation(const YAML::Node & node);
+  void look_ahead_create_lidar(const YAML::Node & node);
 
   virtual void breadboard();
 
@@ -453,7 +454,7 @@ class Realm {
   BdyLayerStatistics* bdyLayerStats_{nullptr};
   std::unique_ptr<MeshMotionAlg> meshMotionAlg_;
   std::unique_ptr<MeshTransformationAlg> meshTransformationAlg_;
-  std::unique_ptr<LidarLineOfSite> lidarLOS_;
+  std::vector<LidarLineOfSite> lidarLOS_;
 
   std::vector<Algorithm *> propertyAlg_;
   std::map<PropertyIdentifier, ScalarFieldType *> propertyMap_;

--- a/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
@@ -276,22 +276,52 @@ realms:
       search_method: stk_kdtree
       search_tolerance: 1.0e-3
       search_expansion_factor: 2.0
-
       lidar_specifications:
-        from_target_part: [fluid_part]
-        type: scanning
-        frequency: 10 #Hz
-        points_along_line: 2
-        output: text
-        scanning_lidar_specifications:
-          center: [500,500,100] #m
-          beam_length: 50.0 #m
-          axis: [1,0,0] #m
-          stare_time: 1 #s
-          sweep_angle: 20 #deg
-          step_delta_angle: 1 #deg
-          reset_time_delta: 1 #s
-          elevation_angles: [-5,0,5]
+          - name: scan-1-inflow
+            type: scanning
+            frequency: 5
+            points_along_line: 10
+            output: text
+            scanning_lidar_specifications:
+              center: &lidar_center [500,500,100]  # Location of the scanning LIDAR
+              beam_length: 20
+              axis: [-1,0,0] # Zero angle vector for the angular sweep
+              stare_time: 1 #s
+              sweep_angle: 30 #deg, Extent of angular sweep between sweep_angle/2 to -sweep_angle/2
+              step_delta_angle: 2 #deg
+              reset_time_delta: 0 #s, Time to reset LIDAR after sweep.
+              elevation_angles: [-5,0,5]
+
+          - name: scan-1-outflow
+            type: scanning
+            frequency: 10
+            points_along_line: 10
+            output: netcdf
+            scanning_lidar_specifications:
+              center: *lidar_center
+              beam_length: 20
+              axis: [1,0,0] # Zero angle vector for the angular sweep
+              stare_time: 1 #s
+              sweep_angle: 30 #deg, Extent of angular sweep between sweep_angle/2 to -sweep_angle/2
+              step_delta_angle: 2 #deg
+              reset_time_delta: 0 #s, Time to reset LIDAR after sweep.
+              elevation_angles: [0]
+
+          - name: scan-2
+            type: scanning
+            frequency: 10 #Hz
+            points_along_line: 2
+            output: text
+            scanning_lidar_specifications:
+              center: *lidar_center
+              beam_length: 20 #m
+              axis: [1,0,0] # Zero angle vector for the angular sweep
+              stare_time: 1 #s
+              sweep_angle: 30 #deg, Extent of angular sweep between sweep_angle/2 to -sweep_angle/2
+              step_delta_angle: 2 #deg
+              reset_time_delta: 1 #s, Time to reset LIDAR after sweep.
+              elevation_angles: [0]
+
 
 
     # This defines the ABL forcing to drive the winds to 8 m/s from

--- a/src/wind_energy/SyntheticLidar.C
+++ b/src/wind_energy/SyntheticLidar.C
@@ -64,11 +64,13 @@ LidarLineOfSite::load(const YAML::Node& node)
   }
 
   const YAML::Node fromTargets = node["from_target_part"];
-  if (fromTargets.Type() == YAML::NodeType::Scalar) {
-    fromTargetNames_.push_back(fromTargets.as<std::string>());
-  } else {
-    for (const auto& target : fromTargets) {
-      fromTargetNames_.push_back(target.as<std::string>());
+  if (fromTargets) {
+    if (fromTargets.Type() == YAML::NodeType::Scalar) {
+      fromTargetNames_.push_back(fromTargets.as<std::string>());
+    } else {
+      for (const auto& target : fromTargets) {
+        fromTargetNames_.push_back(target.as<std::string>());
+      }
     }
   }
 


### PR DESCRIPTION
Multiple lidar wasn't working properly.  This addresses fixes the multiple lidar spec, while keeping the previous syntax of a single map for the lidar specification.

Also allows the `from_target` parameter to be dropped with the new lidar output type, since that always uses the full active domain for the search.