### PR TITLE
Fix fallthrough for sst-iddes source kernel / compiler warnings

### DIFF
--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -2400,7 +2400,6 @@ double
 HypreLinearSystem::copy_hypre_to_stk(stk::mesh::FieldBase* stkField)
 {
   auto& meta = realm_.meta_data();
-  auto& bulk = realm_.bulk_data();
   const auto selector =
     stk::mesh::selectField(*stkField) & meta.locally_owned_part() &
     !(stk::mesh::selectUnion(realm_.get_slave_part_vector())) &
@@ -2419,7 +2418,6 @@ HypreLinearSystem::copy_hypre_to_stk(stk::mesh::FieldBase* stkField)
   auto iLower = iLower_;
   auto iUpper = iUpper_;
   auto numDof = numDof_;
-  auto N = numRows_;
 
   /******************************/
   /* Move solution to stk field */

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -508,7 +508,6 @@ HypreUVWLinearSystem::copy_hypre_to_stk(
   stk::mesh::FieldBase* stkField, std::vector<double>& rhsNorm)
 {
   auto& meta = realm_.meta_data();
-  auto& bulk = realm_.bulk_data();
   const auto selector =
     stk::mesh::selectField(*stkField) & meta.locally_owned_part() &
     !(stk::mesh::selectUnion(realm_.get_slave_part_vector())) &
@@ -527,7 +526,6 @@ HypreUVWLinearSystem::copy_hypre_to_stk(
   auto iLower = iLower_;
   auto iUpper = iUpper_;
   auto nDim = nDim_;
-  auto N = numRows_;
 
   /******************************/
   /* Move solution to stk field */

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -304,6 +304,7 @@ TurbKineticEnergyEquationSystem::register_interior_algorithm(
           break;
         case TurbulenceModel::SST_IDDES:
           nodeAlg.add_kernel<TKESSTIDDESNodeKernel>(realm_.meta_data());
+          break;
         case TurbulenceModel::KE:
           nodeAlg.add_kernel<TKEKENodeKernel>(realm_.meta_data());
           break;

--- a/src/ngp_algorithms/TurbViscKOAlg.C
+++ b/src/ngp_algorithms/TurbViscKOAlg.C
@@ -84,10 +84,6 @@ TurbViscKOAlg::execute()
       const DblType a0Star = 0.072 / 3.0;
       const DblType aStar = (a0Star + ReTurb / rK) / (1.0 + ReTurb / rK);
 
-      const DblType omegaHat = stk::math::max(
-        sdr.get(meshIdx, 0),
-        (7.0 / 8.0) * (sijMag / stk::math::sqrt(0.09 / aStar)));
-
       tvisc.get(meshIdx, 0) = aStar * density.get(meshIdx, 0) *
                               tke.get(meshIdx, 0) /
                               stk::math::max(sdr.get(meshIdx, 0), 1.e-8);

--- a/src/node_kernels/SDRKONodeKernel.C
+++ b/src/node_kernels/SDRKONodeKernel.C
@@ -115,6 +115,9 @@ SDRKONodeKernel::execute(
     (1.0 + stk::math::pow(ReT / Rbeta, 4.0));
   DblType Dk = betaStarLowRe * density * sdr * tke;
 
+  // Clip production term and clip negative productions
+  Pk = stk::math::min(tkeProdLimitRatio_ * Dk, stk::math::max(Pk, 0.0));
+
   const DblType chi_omega = stk::math::abs(
     chi_numer / stk::math::pow(0.09 * stk::math::max(sdr, 1.e-8), 3.0));
   const DblType beta =


### PR DESCRIPTION
The SST-IDDES node kernel has an implicit fallthrough on the switch statement, activating both the sources (the KE source doesn't apply though and errors out).

Going through the compiler warnings, [`omegaHat` being unused](https://github.com/Exawind/nalu-wind/blob/master/src/ngp_algorithms/TurbViscKOAlg.C#L87) is probably unintentional and means the computed stress limiter isn't being used.  [`Dk` and the computation of `betaStarLowRe`](https://github.com/Exawind/nalu-wind/blob/master/src/node_kernels/SDRKONodeKernel.C#L116) is unused, probably also unintentionally although I know this stuff is new and being actively worked on.