### PR TITLE
fix integer division bug in new LIDAR + tweaks

### DIFF
--- a/include/Realm.h
+++ b/include/Realm.h
@@ -362,6 +362,8 @@ public:
   const std::vector<std::string>& get_physics_target_names();
   double get_tanh_blending(const std::string dofName);
 
+  void output_lidar();
+
   Realms& realms_;
 
   std::string name_;

--- a/include/wind_energy/SyntheticLidar.h
+++ b/include/wind_energy/SyntheticLidar.h
@@ -28,7 +28,8 @@ public:
   std::unique_ptr<DataProbeSpecInfo>
   determine_line_of_site_info(const YAML::Node& node);
 
-  double time() { return lidar_time_; }
+  double time() const { return lidar_time_; }
+
   void set_time(double t) { lidar_time_ = t; }
   void increment_time() { lidar_time_ += lidar_dt_; }
 
@@ -40,6 +41,11 @@ public:
 
 private:
   enum class Output { NETCDF, TEXT, DATAPROBE } output_type_{Output::NETCDF};
+  enum class Predictor {
+    NEAREST,
+    FORWARD_EULER
+  } predictor_{Predictor::FORWARD_EULER};
+
   std::unique_ptr<SegmentGenerator> segGen;
 
   void prepare_nc_file();
@@ -64,6 +70,7 @@ private:
   std::vector<std::string> fromTargetNames_;
 
   std::string name_{"lidar-los"};
+  std::string fname_{"lidar-los.nc"};
 };
 
 } // namespace nalu

--- a/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
@@ -297,6 +297,7 @@ realms:
             frequency: 10
             points_along_line: 10
             output: netcdf
+            predictor: forward_euler
             scanning_lidar_specifications:
               center: *lidar_center
               beam_length: 20
@@ -307,14 +308,15 @@ realms:
               reset_time_delta: 0 #s, Time to reset LIDAR after sweep.
               elevation_angles: [0]
 
-          - name: scan-2
+          - name: folder-to-be-created/scan-2
             type: scanning
             frequency: 10 #Hz
             points_along_line: 2
             output: text
+            predictor: nearest
             scanning_lidar_specifications:
               center: *lidar_center
-              beam_length: 20 #m
+              beam_length: 200000 # to check behavior when points aren't found
               axis: [1,0,0] # Zero angle vector for the angular sweep
               stare_time: 1 #s
               sweep_angle: 30 #deg, Extent of angular sweep between sweep_angle/2 to -sweep_angle/2

--- a/src/xfer/LocalVolumeSearch.C
+++ b/src/xfer/LocalVolumeSearch.C
@@ -335,9 +335,7 @@ local_field_interpolation(
     auto point = points[point_id];
     auto elem = bulk.get_entity(stk::topology::ELEM_RANK, match.second.id());
     const auto& x_dist = compute_local_coordinates(bulk, x_field, elem, point);
-    if (
-      x_dist.second < 1 + std::numeric_limits<double>::epsilon() &&
-      x_dist.second < data.dist[point_id]) {
+    if (x_dist.second < data.dist[point_id]) {
       data.dist.at(point_id) = x_dist.second;
       data.interpolated_values.at(point_id) =
         interpolate_field(bulk, elem, field_prev, field, x_dist.first, dtratio);

--- a/unit_tests/UnitTestSpinnerLidarPattern.C
+++ b/unit_tests/UnitTestSpinnerLidarPattern.C
@@ -3,6 +3,7 @@
 #include <wind_energy/SyntheticLidar.h>
 #include "UnitTestUtils.h"
 
+#include <stk_mesh/base/MeshBuilder.hpp>
 #include <yaml-cpp/yaml.h>
 
 #include <ostream>
@@ -67,12 +68,13 @@ velocity_func(const double* x, double time)
 
 TEST(SpinnerLidar, volume_interp)
 {
-  stk::mesh::MetaData meta(3u);
-  stk::mesh::BulkData bulk(
-    meta, MPI_COMM_WORLD, stk::mesh::BulkData::NO_AUTO_AURA);
-  stk::io::StkMeshIoBroker io(bulk.parallel());
-
-  io.set_bulk_data(bulk);
+  stk::mesh::MeshBuilder builder(MPI_COMM_WORLD);
+  builder.set_aura_option(stk::mesh::BulkData::NO_AUTO_AURA);
+  builder.set_spatial_dimension(3U);
+   auto bulk = builder.create();
+  auto& meta = bulk->mesh_meta_data();
+  stk::io::StkMeshIoBroker io(bulk->parallel());
+  io.set_bulk_data(*bulk);
 
   const int n = 16;
   const auto nx = std::to_string(n);
@@ -96,12 +98,11 @@ TEST(SpinnerLidar, volume_interp)
     *dynamic_cast<const vector_field_type*>(meta.coordinate_field());
 
   const auto& node_buckets =
-    bulk.get_buckets(stk::topology::NODE_RANK, meta.universal_part());
+    bulk->get_buckets(stk::topology::NODE_RANK, meta.universal_part());
   for (const auto* ib : node_buckets) {
     for (const auto& node : *ib) {
       auto* uptr = stk::mesh::field_data(vel_field, node);
       auto* uptr_old = stk::mesh::field_data(vel_field_old, node);
-
       const auto* xptr = stk::mesh::field_data(coord_field, node);
       const auto vel_at_x = velocity_func(xptr, 0);
       for (int d = 0; d < 3; ++d) {
@@ -115,9 +116,9 @@ TEST(SpinnerLidar, volume_interp)
     LidarLineOfSite los;
     los.load(YAML::Load(lidarSpec)["lidar_specifications"]);
     los.set_time(0);
-    los.output(bulk, meta.universal_part(), "coordinates", 0);
+    los.output(*bulk, meta.universal_part(), "coordinates", 0);
 
-    if (bulk.parallel_rank() == 0) {
+    if (bulk->parallel_rank() == 0) {
       std::string line;
       std::ifstream myfile("lidar-los.txt");
       if (myfile.is_open()) {
@@ -160,7 +161,7 @@ TEST(SpinnerLidar, volume_interp)
       "  number_of_samples: 984                               \n"
       "  points_along_line: 4                                 \n"
       "  center: [500,500,100]                                \n"
-      "  beam_length: 500.                                    \n"
+      "  beam_length: 50.                                     \n"
       "  axis: [1,1,0]                                        \n"
       "  ground_direction: [0,0,1]                            \n"
       "  output: netcdf                                       \n"
@@ -183,10 +184,51 @@ TEST(SpinnerLidar, volume_interp)
           }
         }
       }
-      los.output(bulk, !stk::mesh::Selector{}, "coordinates", 0);
+      los.output(*bulk, !stk::mesh::Selector{}, "coordinates", 0);
       los.increment_time();
     }
   }
 }
+
+TEST(Spinner, invalid_predictor_throws)
+{
+  const std::string lidar_nc =
+    "lidar_specifications:                                  \n"
+    "  from_target_part: [unused]                           \n"
+    "  inner_prism_initial_theta: 90                        \n"
+    "  inner_prism_rotation_rate: 3.5                       \n"
+    "  inner_prism_azimuth: 15.2                            \n"
+    "  outer_prism_initial_theta: 90                        \n"
+    "  outer_prism_rotation_rate: 6.5                       \n"
+    "  outer_prism_azimuth: 15.2                            \n"
+    "  scan_time: 2 #seconds                                \n"
+    "  number_of_samples: 984                               \n"
+    "  points_along_line: 4                                 \n"
+    "  center: [500,500,100]                                \n"
+    "  beam_length: 500.                                    \n"
+    "  axis: [1,1,0]                                        \n"
+    "  ground_direction: [0,0,1]                            \n"
+    "  output: netcdf                                       \n"
+    "  time_step: 0.01                                      \n"
+    "  name: lidar/lidar-1                                  \n";
+
+  const std::string bad_predictor = "  predictor: foo";
+  const std::string good_predictor = "  predictor: nearest";
+
+  const auto bad_spec =
+    YAML::Load(lidar_nc + bad_predictor)["lidar_specifications"];
+  const auto good_spec =
+    YAML::Load(lidar_nc + good_predictor)["lidar_specifications"];
+
+  {
+    LidarLineOfSite los;
+    EXPECT_NO_THROW(los.load(good_spec));
+  }
+  {
+    LidarLineOfSite los;
+    EXPECT_THROW(los.load(bad_spec), std::runtime_error);
+  }
+}
+
 } // namespace nalu
 } // namespace sierra

--- a/unit_tests/UnitTestSpinnerLidarPattern.C
+++ b/unit_tests/UnitTestSpinnerLidarPattern.C
@@ -71,7 +71,7 @@ TEST(SpinnerLidar, volume_interp)
   stk::mesh::MeshBuilder builder(MPI_COMM_WORLD);
   builder.set_aura_option(stk::mesh::BulkData::NO_AUTO_AURA);
   builder.set_spatial_dimension(3U);
-   auto bulk = builder.create();
+  auto bulk = builder.create();
   auto& meta = bulk->mesh_meta_data();
   stk::io::StkMeshIoBroker io(bulk->parallel());
   io.set_bulk_data(*bulk);


### PR DESCRIPTION
The issue was the `1 / degree` calculation was using integer division instead of floating point like it should have. Tweaks:
   * Just accept the best match in the fine search, like the xfer code does. Poor pyramid / hex / wedge elements could fail to match a point if it's near a side.
   * Automatically append `-rst-n` to a filename if it already exists on the run. Might be better to overwrite or append.
   * Allow the user to turn of the time extrapolation for the velocity at the lidar time, in line with amr-wind
