### PR TITLE
Fix Mem leak for ADM with FLLC

### DIFF
--- a/src/actuator/ActuatorBulkDiskFAST.C
+++ b/src/actuator/ActuatorBulkDiskFAST.C
@@ -140,7 +140,16 @@ ActuatorBulkDiskFAST::resize_arrays(const ActuatorMetaFAST& actMeta)
   Kokkos::resize(pointIsLocal_, newSize);
   Kokkos::resize(localParallelRedundancy_, newSize);
   Kokkos::resize(elemContainingPoint_, newSize);
+  // resize fflc arrays as well.  This is a memory waste, but the most simple
+  // way to make things consistent
   Kokkos::resize(relativeVelocity_, newSize);
+  if (actMeta.useFLLC_) {
+    Kokkos::resize(relativeVelocityMagnitude_, newSize);
+    Kokkos::resize(liftForceDistribution_, newSize);
+    Kokkos::resize(deltaLiftForceDistribution_, newSize);
+    Kokkos::resize(epsilonOpt_, newSize);
+    Kokkos::resize(fllc_, newSize);
+  }
 }
 
 void

--- a/src/actuator/ActuatorBulkFAST.C
+++ b/src/actuator/ActuatorBulkFAST.C
@@ -231,9 +231,6 @@ ActuatorBulkFAST::init_epsilon(const ActuatorMetaFAST& actMeta)
             epsilonLocal(0), std::max(epsilonLocal(1), epsilonLocal(2))) *
           2.6282608848784661; // sqrt(log(1000))
       }
-    } else {
-      NaluEnv::self().naluOutput() << "Proc " << NaluEnv::self().parallel_rank()
-                                   << " glob iTurb " << iTurb << std::endl;
     }
   }
   actuator_utils::reduce_view_on_host(epsilon_.view_host());

--- a/src/actuator/ActuatorFLLC.C
+++ b/src/actuator/ActuatorFLLC.C
@@ -55,6 +55,8 @@ FilteredLiftingLineCorrection::compute_lift_force_distribution()
 
     const auto offset = info.offset_;
     const auto nPoints = info.nPoints_;
+    // debug size checks
+    ThrowAssert(offset + nPoints < G.size());
 
     auto range_policy =
       Kokkos::RangePolicy<exec_space>(offset, offset + nPoints);
@@ -95,6 +97,8 @@ FilteredLiftingLineCorrection::grad_lift_force_distribution()
 
     const auto offset = info.offset_;
     const auto nPoints = info.nPoints_;
+    ThrowAssert(offset + nPoints < G.size());
+    ThrowAssert(offset + nPoints < deltaG.size());
 
     auto range_policy =
       Kokkos::RangePolicy<exec_space>(offset, offset + nPoints);
@@ -128,7 +132,6 @@ FilteredLiftingLineCorrection::compute_induced_velocities()
   auto epsilon = helper.get_local_view(actBulk_.epsilon_);
   auto epsilonOpt = helper.get_local_view(actBulk_.epsilonOpt_);
   auto point = helper.get_local_view(actBulk_.pointCentroid_);
-  auto relVel = helper.get_local_view(actBulk_.relativeVelocity_);
   auto deltaU = helper.get_local_view(actBulk_.fllc_);
   auto Uinf = helper.get_local_view(actBulk_.relativeVelocityMagnitude_);
 


### PR DESCRIPTION
FLLC arrays weren't getting resized for the ADM
For a single turbine the offsets are still correct so thats why those
cases worked.

This is a quick and robust fix for the infrastructures, but it is quite
wasteful with memory.  Especially if there are a large number of ADM
points.

In general I think we are over due for a refactor of this feature to
drive memory consumption down by moving toward the implementation in
AMR-Wind.