### PR TITLE
Resolve CPU only build errors with Trilinos develop

### DIFF
--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -266,10 +266,10 @@ Simulation::high_level_banner()
 
   if (!std::is_same<DeviceSpace, Kokkos::Serial>::value) {
     // Save output from the master proc in the log file
-    Kokkos::DefaultExecutionSpace::print_configuration(
+    Kokkos::DefaultExecutionSpace{}.print_configuration(
       NaluEnv::self().naluOutputP0());
     // But have everyone print out to standard error for debugging purposes
-    Kokkos::DefaultExecutionSpace::print_configuration(std::cerr);
+    Kokkos::DefaultExecutionSpace{}.print_configuration(std::cerr);
   }
 }
 } // namespace nalu

--- a/unit_tests/UnitTestBasicKokkos.C
+++ b/unit_tests/UnitTestBasicKokkos.C
@@ -26,7 +26,7 @@ TEST(BasicKokkos, discover_execution_space)
     std::cout << "Kokkos::Cuda is available." << std::endl;
 #endif
     std::cout << "Default execution space info: ";
-    Kokkos::DefaultExecutionSpace::print_configuration(std::cout);
+    Kokkos::DefaultExecutionSpace{}.print_configuration(std::cout);
 
     std::cout << std::endl;
   }


### PR DESCRIPTION
Resolve [build errors](https://sierra-cdash.sandia.gov/viewBuildError.php?buildid=573524) with `Trilinos@develop` 