### PR TITLE
Bug fix Surface-Moment output

### DIFF
--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -142,7 +142,7 @@ SurfaceForceAndMomentAlgorithm::execute()
     return;
   }
 
-  const bool processMe = (timeStepCount % frequency_) == 0 ? true : false;
+  const bool processMe = (timeStepCount % frequency_) == 0;
 
   // do not waste time here
   if (!processMe)

--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -137,6 +137,11 @@ SurfaceForceAndMomentAlgorithm::execute()
 {
   // check to see if this is a valid step to process output file
   const int timeStepCount = realm_.get_time_step_count();
+
+  if (frequency_ < 1) {
+    return;
+  }
+
   const bool processMe = (timeStepCount % frequency_) == 0 ? true : false;
 
   // do not waste time here


### PR DESCRIPTION
Setting an output frequency of 0 will lead to a floating point exception Adding a safe way to return if no output is desired.