### PR TITLE
Add a radar line sampling pattern

### DIFF
--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -1521,7 +1521,7 @@ Data probes
 
 .. inpfile:: data_probes.lidar_specifications.type
 
-   Type of LIDAR scan pattern. `scanning` or `spinner` (default).
+   Type of LIDAR scan pattern. `scanning`, `radar` or `spinner` (default).
 
 
 .. inpfile:: data_probes.lidar_specifications.scanning_lidar_specifications
@@ -1539,8 +1539,37 @@ Data probes
    step_delta_angle           Default 1 degree. Measurement interval of scan angles over the sweep
    reset_time_delta           Default 1 second. Time to reset LIDAR after sweep.
    ground_direction           Default [0,0,1]. Orthogonal orientation vector for the LIDAR
+   elevation_angles           Default none. A list of angles in degrees to change to after each sweep
    ========================== ===================================================================
 
+.. inpfile:: data_probes.lidar_specifications.radar_specifications
+
+   Block specifying parameters for the scanning lidar sampling
+
+   ========================== ===================================================================
+   Parameter                  Description
+   ========================== ===================================================================
+   axis                       Required. Zero angle vector for the angular sweep, e.g. [1,0,0].
+   center                     Required. Location of the scanning LIDAR, e.g. [0,0,0].
+   bbox                       Optional. Six values (m) describing [bottom-left, top-right] of radar clip box
+   box_1                      Optional. Along with other vertex specifications in (m) describes the radar clip box.
+   beam_length                Defaut 50000m. Only affects coordinate reporting if the line does not collide with box.
+   sweep_angle                Default 20 degrees. Extent of angular sweep between sweep_angle/2 to -sweep_angle/2.
+   angular_speed              Default 30 degrees/s. Speed of the angular sweep.
+   reset_time_delta           Default 1 second. Time to reset LIDAR after sweep.
+   ground_direction           Default [0,0,1]. Orthogonal orientation vector for the LIDAR
+   elevation_angles           Default none. A list of angles in degrees to change to after each sweep
+   ========================== ===================================================================
+
+.. inpfile:: dataprobes.lidar_specifications.radar_cone_grid
+
+   ========================== ===================================================================
+   Parameter                  Description
+   ========================== ===================================================================
+   cone_angle                 Required. cone half angle in degrees centered on radar_specifications.axis
+   num_circles                Required. Number of rays along the cone angle
+   lines_per_cone_circle      Required. Number of rays around the cone circumference
+   ========================== ===================================================================
 
 .. inpfile:: dataprobes.lidar_specifications.misc
 

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -79,7 +79,7 @@ class SolutionNormPostProcessing;
 class SideWriterContainer;
 class TurbulenceAveragingPostProcessing;
 class DataProbePostProcessing;
-class LidarLineOfSite;
+class LidarLOS;
 class AeroContainer;
 class ABLForcingAlgorithm;
 class BdyLayerStatistics;
@@ -418,7 +418,7 @@ public:
   BdyLayerStatistics* bdyLayerStats_{nullptr};
   std::unique_ptr<MeshMotionAlg> meshMotionAlg_;
   std::unique_ptr<MeshTransformationAlg> meshTransformationAlg_;
-  std::vector<LidarLineOfSite> lidarLOS_;
+  std::unique_ptr<LidarLOS> lidarLOS_;
 
   std::vector<Algorithm*> propertyAlg_;
   std::map<PropertyIdentifier, ScalarFieldType*> propertyMap_;

--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -62,7 +62,7 @@ public:
 
   inline bool does_mesh_move() const
   {
-    return has_mesh_motion() | has_mesh_deformation();
+    return has_mesh_motion() || has_mesh_deformation();
   }
 
   inline std::string get_coordinates_name() const

--- a/include/wind_energy/SyntheticLidar.h
+++ b/include/wind_energy/SyntheticLidar.h
@@ -14,6 +14,7 @@
 #include "xfer/LocalVolumeSearch.h"
 
 #include "wind_energy/LidarPatterns.h"
+#include "vs/vector.h"
 
 #include <memory>
 #include <array>
@@ -71,6 +72,29 @@ private:
 
   std::string name_{"lidar-los"};
   std::string fname_{"lidar-los.nc"};
+  bool warn_on_missing_{false};
+};
+
+namespace details {
+std::vector<vs::Vector>
+make_radar_grid(double phi, int nphi, int ntheta, vs::Vector axis);
+}
+
+class LidarLOS
+{
+public:
+  void output(
+    const stk::mesh::BulkData& bulk,
+    const stk::mesh::Selector& sel,
+    const std::string& coords_name,
+    double dt,
+    double time);
+
+  void load(const YAML::Node& node, DataProbePostProcessing* probes);
+  void set_time_for_all(double time);
+
+private:
+  std::vector<LidarLineOfSite> lidars_;
 };
 
 } // namespace nalu

--- a/nalu.C
+++ b/nalu.C
@@ -286,7 +286,7 @@ main(int argc, char** argv)
   // Hypre cleanup
   nalu_hypre::hypre_finalize();
 
-  Kokkos::finalize_all();
+  Kokkos::finalize();
 
   MPI_Finalize();
 

--- a/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
@@ -39,7 +39,7 @@ realms:
     use_edges: yes
     automatic_decomposition_type: rcb
 
-    # This defines the equations to be solved: momentum, pressure, static enthalpy, 
+    # This defines the equations to be solved: momentum, pressure, static enthalpy,
     # and subgrid-scale turbulent kinetic energy.  The equation system will be iterated
     # a maximum of 4 outer iterations.
     equation_systems:
@@ -137,7 +137,7 @@ realms:
     - periodic_boundary_condition: bc_east_west
       target_name: [east, west]
       periodic_user_data:
-        search_tolerance: 0.0001 
+        search_tolerance: 0.0001
 
     - abltop_boundary_condition: bc_upper
       target_name: upper
@@ -147,8 +147,8 @@ realms:
 
     - wall_boundary_condition: bc_lower
       target_name: lower
-      wall_user_data: 
-        no_slip: true     
+      wall_user_data:
+        no_slip: true
         velocity: [0.0,0.0,0.0]
         abl_wall_function:
           surface_heating_table:
@@ -206,7 +206,7 @@ realms:
         # the planar-averaged wind at a certain height to a certain
         # speed.
         - source_terms:
-            momentum: 
+            momentum:
               - buoyancy_boussinesq
               - EarthCoriolis
               - abl_forcing
@@ -225,7 +225,7 @@ realms:
         - limiter:
             pressure: no
             velocity: no
-            enthalpy: yes 
+            enthalpy: yes
 
         - peclet_function_form:
             velocity: classic
@@ -308,22 +308,23 @@ realms:
               reset_time_delta: 0 #s, Time to reset LIDAR after sweep.
               elevation_angles: [0]
 
-          - name: folder-to-be-created/scan-2
-            type: scanning
-            frequency: 10 #Hz
+          - name: radar/radar
+            type: radar
+            frequency: 0.2
             points_along_line: 2
             output: text
-            predictor: nearest
-            scanning_lidar_specifications:
-              center: *lidar_center
-              beam_length: 200000 # to check behavior when points aren't found
-              axis: [1,0,0] # Zero angle vector for the angular sweep
-              stare_time: 1 #s
-              sweep_angle: 30 #deg, Extent of angular sweep between sweep_angle/2 to -sweep_angle/2
-              step_delta_angle: 2 #deg
-              reset_time_delta: 1 #s, Time to reset LIDAR after sweep.
-              elevation_angles: [0]
-
+            radar_cone_grid:
+              cone_angle: 0.5 #half angle of cone, in degrees
+              num_circles: 2 # number of cones inside the half angle to sample
+              lines_per_cone_circle: 6 # number of lines around the cone circle
+            radar_specifications:
+              bbox: [0., 0., 0., 5000., 5000., 1000.] # where to cut the radar line(m)
+              center: [-10000, 2500, 100] #ideally outside of the box
+              angular_speed: 1 #degrees to sweep in a second
+              axis: [1, 0, 0] #main axis, cone grid is set around this
+              sweep_angle: 10 #angle of the sweep
+              reset_time:  0 # time to pause after a sweep
+              elevation_angles: [0,1,2,3] # elevation angles to scan after reset
 
 
     # This defines the ABL forcing to drive the winds to 8 m/s from

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -610,47 +610,11 @@ Realm::look_ahead_and_creation(const YAML::Node& node)
 void
 Realm::look_ahead_create_lidar(const YAML::Node& node)
 {
-  auto lidar_spec = node["lidar_specifications"];
-
-  auto create_lidar = [&](const YAML::Node& node) {
-    std::string output_type = "netcdf";
-    get_if_present(node, "output", output_type);
-    if (output_type == "dataprobes") {
-      LidarLineOfSite lidarLOS;
-      auto lidarDBSpec = lidarLOS.determine_line_of_site_info(node);
-      ThrowRequireMsg(
-        dataProbePostProcessing_, "Lidar processing with dataprobe output "
-                                  "requires valid data probe object");
-      dataProbePostProcessing_->add_external_data_probe_spec_info(
-        lidarDBSpec.release());
-    } else {
-      lidarLOS_.emplace_back();
-      lidarLOS_.back().load(node);
-    }
-  };
-
-  if (lidar_spec) {
-    const auto is_scalar = lidar_spec.Type() == YAML::NodeType::Map;
-    if (is_scalar) {
-      create_lidar(lidar_spec);
-    } else {
-      std::set<std::string> names;
-      for (auto spec : lidar_spec) {
-        if (!spec["name"]) {
-          throw std::runtime_error("lidar sequence requires a name");
-        }
-        names.insert(spec["name"].as<std::string>());
-        create_lidar(spec);
-      }
-      if (names.size() != lidar_spec.size()) {
-        std::string msg = "Non unique file name for lidar detected: ";
-        for (auto spec : lidar_spec) {
-          msg += spec["name"].as<std::string>() + " ";
-        }
-        throw std::runtime_error(msg);
-      }
-    }
+  if (!lidarLOS_) {
+    lidarLOS_ = std::make_unique<LidarLOS>();
   }
+  NaluEnv::self().naluOutputP0() << "LidarLineOfSite::load" << std::endl;
+  lidarLOS_->load(node, dataProbePostProcessing_);
 }
 
 //--------------------------------------------------------------------------
@@ -2447,9 +2411,7 @@ Realm::initialize_post_processing_algorithms()
   if (aeroModels_->is_active())
     aeroModels_->init(bulk_data());
 
-  for (auto& los : lidarLOS_) {
-    los.set_time(get_current_time());
-  }
+  lidarLOS_->set_time_for_all(get_current_time());
 }
 
 //--------------------------------------------------------------------------
@@ -2459,7 +2421,8 @@ std::string
 Realm::get_coordinates_name()
 {
   return (
-    (solutionOptions_->meshMotion_ | solutionOptions_->externalMeshDeformation_)
+    (solutionOptions_->meshMotion_ ||
+     solutionOptions_->externalMeshDeformation_)
       ? "current_coordinates"
       : "coordinates");
 }
@@ -2480,7 +2443,7 @@ bool
 Realm::has_mesh_deformation() const
 {
   if (meshMotionAlg_) {
-    return meshMotionAlg_->is_deforming() |
+    return meshMotionAlg_->is_deforming() ||
            solutionOptions_->externalMeshDeformation_;
   } else
     return solutionOptions_->externalMeshDeformation_;
@@ -2492,7 +2455,7 @@ Realm::has_mesh_deformation() const
 bool
 Realm::does_mesh_move() const
 {
-  return has_mesh_motion() | has_mesh_deformation();
+  return has_mesh_motion() || has_mesh_deformation();
 }
 
 //--------------------------------------------------------------------------
@@ -4520,18 +4483,9 @@ Realm::output_lidar()
   const auto sel = (stk::mesh::selectField(velocity_field) &
                     meta_data().locally_owned_part()) -
                    get_inactive_selector();
-  for (auto& los : lidarLOS_) {
-    const double small = 1e-8 * timeIntegrator_->get_time_step();
-    const double next_time =
-      timeIntegrator_->get_current_time() + timeIntegrator_->get_time_step();
-    while (los.time() < next_time - small) {
-      const double dtratio =
-        (los.time() - timeIntegrator_->get_current_time()) /
-        timeIntegrator_->get_time_step();
-      los.output(bulk_data(), sel, get_coordinates_name(), dtratio);
-      los.increment_time();
-    }
-  }
+  lidarLOS_->output(
+    bulk_data(), sel, get_coordinates_name(), timeIntegrator_->get_time_step(),
+    timeIntegrator_->get_current_time());
   NaluEnv::self().naluOutputP0() << "LidarLineOfSite::output end" << std::endl;
 }
 
@@ -4557,7 +4511,7 @@ Realm::post_converged_work()
   if (nullptr != bdyLayerStats_)
     bdyLayerStats_->execute();
 
-  if (lidarLOS_.size() > 0) {
+  if (lidarLOS_) {
     output_lidar();
   }
 }

--- a/src/wind_energy/LidarPatterns.C
+++ b/src/wind_energy/LidarPatterns.C
@@ -8,6 +8,7 @@
 //
 
 #include "wind_energy/LidarPatterns.h"
+#include "vs/vector.h"
 
 #include "NaluParsedTypes.h"
 #include "NaluParsing.h"
@@ -20,8 +21,7 @@
 
 #include <memory>
 
-namespace sierra {
-namespace nalu {
+namespace sierra::nalu {
 
 SegmentType
 segment_generator_types(std::string name)
@@ -30,7 +30,7 @@ segment_generator_types(std::string name)
   return std::map<std::string, SegmentType>{
     {"spinner", SegmentType::SPINNER},
     {"scanning", SegmentType::SCANNING},
-  }
+    {"radar", SegmentType::RADAR}}
     .at(name);
 }
 
@@ -42,6 +42,8 @@ make_segment_generator(SegmentType type)
     return std::make_unique<SpinnerLidarSegmentGenerator>();
   case SegmentType::SCANNING:
     return std::make_unique<ScanningLidarSegmentGenerator>();
+  case SegmentType::RADAR:
+    return std::make_unique<RadarSegmentGenerator>();
   default:
     throw std::runtime_error("Invalid lidar type");
     return std::make_unique<SpinnerLidarSegmentGenerator>();
@@ -58,6 +60,18 @@ namespace {
 
 std::array<double, 3>
 to_array3(Coordinates x)
+{
+  return {x.x_, x.y_, x.z_};
+}
+
+vs::Vector
+to_vec3(std::array<double, 3> x)
+{
+  return {x[0], x[1], x[2]};
+}
+
+vs::Vector
+to_vec3(Coordinates x)
 {
   return {x.x_, x.y_, x.z_};
 }
@@ -181,7 +195,7 @@ ScanningLidarSegmentGenerator::load(const YAML::Node& node)
   ThrowRequireMsg(
     reset_time_delta_ >= 0, "reset time delta must be semi-positive");
 
-  get_required(node, "beam_length", beam_length_);
+  get_if_present(node, "beam_length", beam_length_);
 
   if (node["ground_direction"]) {
     ground_normal_ = to_array3(node["ground_direction"].as<Coordinates>());
@@ -358,5 +372,340 @@ SpinnerLidarSegmentGenerator::generate(double time) const
   return Segment{tip, tail};
 }
 
-} // namespace nalu
-} // namespace sierra
+namespace {
+
+struct Triangle
+{
+  vs::Vector v0;
+  vs::Vector v1;
+  vs::Vector v2;
+};
+
+std::array<Triangle, 4>
+subdivide_face(std::array<vs::Vector, 4> face)
+{
+  std::array<Triangle, 4> tris;
+
+  auto face_mid = 0.25 * (face[0] + face[1] + face[2] + face[3]);
+  for (int itriangle = 0; itriangle < 4; ++itriangle) {
+    const int base_vertex = itriangle;
+    const int cyclic_next = (itriangle + 1) % 4;
+    tris[itriangle].v0 = face[base_vertex];
+    tris[itriangle].v1 = face[cyclic_next];
+    tris[itriangle].v2 = face_mid;
+  }
+  return tris;
+}
+
+std::array<vs::Vector, 4>
+face_coordinates(std::array<vs::Vector, 8> box, int index)
+{
+  constexpr int vertex_face_table[6][4] = {{0, 1, 2, 3}, {1, 2, 6, 5},
+                                           {4, 5, 6, 7}, {3, 2, 6, 7},
+                                           {0, 3, 7, 4}, {0, 1, 5, 4}};
+  std::array<vs::Vector, 4> face;
+  for (int n = 0; n < 4; ++n) {
+    face[n] = box[vertex_face_table[index][n]];
+  }
+  return face;
+}
+
+std::pair<bool, vs::Vector>
+triangle_line_intersection(
+  Triangle tri, vs::Vector origin, vs::Vector line, double tol)
+{
+  // trumbore-moller
+  const auto edge1 = tri.v1 - tri.v0;
+  const auto edge2 = tri.v2 - tri.v0;
+  const auto h = line ^ edge2; // cross product
+  const auto a = edge1 & h;    // dot product
+  if (a > -tol && a < tol) {
+    return {false, {}};
+  }
+  const auto f = 1.0 / a;
+  const auto s = origin - tri.v0;
+  const auto u = f * (h & s);
+  if (u < 0.0 || u > 1.0) {
+    return {false, {}};
+  }
+  const auto q = s ^ edge1;
+  const auto v = f * (line & q);
+  if (v < 0.0 || u + v > 1.0) {
+    return {false, {}};
+  }
+  const auto t = f * (edge2 & q);
+  if (t > tol) {
+    return {true, origin + line * t};
+  }
+  return {false, {}};
+}
+
+std::array<double, 3>
+to_array3(vs::Vector x)
+{
+  return {x[0], x[1], x[2]};
+}
+
+} // namespace
+
+namespace details {
+std::pair<bool, Segment>
+line_intersection_with_box(
+  std::array<vs::Vector, 8> box, vs::Vector origin, vs::Vector line)
+{
+  // do one subdivision of the box into triangular sections
+  // then do trumbore-moller on each triangle to determine intersection points
+  // core assumption here is that the box faces are almost surely planar
+  // so one subdivision is overkill to begin with.
+
+  const double tol = 100 * std::numeric_limits<double>::epsilon();
+  line.normalize();
+
+  const double large_value = std::cbrt(std::numeric_limits<double>::max());
+  constexpr int box_faces = 6;
+  constexpr int tri_per_face = 4;
+  constexpr int num_tri = box_faces * tri_per_face;
+
+  vs::Vector large = origin + vs::Vector(large_value, large_value, large_value);
+  std::array<vs::Vector, num_tri> intersection;
+  std::fill(intersection.begin(), intersection.end(), large);
+  std::array<bool, num_tri> intersected;
+  std::fill(intersected.begin(), intersected.end(), false);
+
+  for (int f = 0; f < box_faces; ++f) {
+    auto triangles = subdivide_face(face_coordinates(box, f));
+    for (int t = 0; t < tri_per_face; ++t) {
+      const int id = tri_per_face * f + t;
+      auto [found, intersect] =
+        triangle_line_intersection(triangles[t], origin, line, tol);
+      intersected[id] = found;
+      if (found) {
+        intersection[id] = intersect;
+      }
+    }
+  }
+
+  bool some_intersection = false;
+  for (int j = 0; j < num_tri; ++j) {
+    some_intersection |= intersected[j];
+    if (intersected[j]) {
+      break;
+    }
+  }
+  if (!some_intersection) {
+    return {false, {}};
+  }
+
+  // can potentially get multiple triangles intersecting the same point, if for
+  // instance the line goes through triangle's edge
+  vs::Vector i0 = large;
+  for (int j = 0; j < num_tri; ++j) {
+    if (!intersected[j]) {
+      continue;
+    }
+
+    if (vs::mag(intersection[j] - origin) < vs::mag(i0 - origin)) {
+      i0 = intersection[j];
+    }
+  }
+
+  vs::Vector i1 = large;
+  for (int j = 0; j < num_tri; ++j) {
+    if (!intersected[j]) {
+      continue;
+    }
+
+    if (
+      vs::mag(i0 - intersection[j]) > tol &&
+      vs::mag(intersection[j] - origin) < vs::mag(i1 - origin)) {
+      i1 = intersection[j];
+    }
+  }
+
+  if (vs::mag(i1 - large) < tol) {
+    // maybe only one intersection, e.g. the line is tangent to the box
+    i1 = i0;
+  }
+  return {true, {to_array3(i1), to_array3(i0)}};
+}
+} // namespace details
+
+void
+RadarSegmentGenerator::load(const YAML::Node& node)
+{
+  center_ = to_array3(node["center"].as<Coordinates>());
+
+  axis_ = to_array3(node["axis"].as<Coordinates>());
+  normalize_vec3(axis_.data());
+
+  double sweep_angle_in_degrees = 20;
+  get_if_present(node, "sweep_angle", sweep_angle_in_degrees);
+  ThrowRequireMsg(sweep_angle_in_degrees > 0, "Sweep angle must be positive");
+  sweep_angle_ = convert::degrees_to_radians(sweep_angle_in_degrees);
+
+  double angular_speed = 30; // deg/s
+  get_if_present(node, "angular_speed", angular_speed);
+  angular_speed_ = convert::degrees_to_radians(angular_speed);
+
+  beam_length_ = 50e3; // m
+  get_if_present(node, "beam_length", beam_length_);
+
+  if (node["ground_direction"]) {
+    ground_normal_ = to_array3(node["ground_direction"].as<Coordinates>());
+    normalize_vec3(ground_normal_.data());
+  }
+
+  auto box_corner_name = [](int n) { return "box_" + std::to_string(n); };
+  if (node[box_corner_name(0)]) {
+    throw std::runtime_error("box vertices are 1-indexed");
+  }
+
+  int specified_count = 0;
+  for (int n = 0; n < 8; ++n) {
+    if (node[box_corner_name(n + 1)]) {
+      ++specified_count;
+    }
+  }
+
+  get_if_present(node, "reset_time_delta", reset_time_delta_);
+  ThrowRequireMsg(
+    reset_time_delta_ >= 0, "reset time delta must be semi-positive");
+
+  if (specified_count > 0 && specified_count != 8) {
+    throw std::runtime_error("Must specify entire box with `box_n` syntax");
+  } else if (node["bbox"]) {
+    auto bbox = node["bbox"].as<std::vector<double>>();
+    if (bbox.size() != 6) {
+      throw std::runtime_error("bbox specification requires six coordinates");
+    }
+    const auto dx =
+      vs::Vector(bbox[3] - bbox[0], bbox[4] - bbox[1], bbox[5] - bbox[2]);
+    box_[0] = {bbox[0], bbox[1], bbox[2]};
+    box_[1] = box_[0] + vs::Vector(dx[0], 0, 0);
+    box_[2] = box_[0] + vs::Vector(dx[0], dx[1], 0);
+    box_[3] = box_[0] + vs::Vector(0, dx[1], 0);
+    box_[4] = box_[0] + vs::Vector(0, 0, dx[2]);
+    box_[5] = box_[0] + vs::Vector(dx[0], 0, dx[2]);
+    box_[6] = box_[0] + vs::Vector(dx[0], dx[1], dx[2]);
+    box_[7] = box_[0] + vs::Vector(0, dx[1], dx[2]);
+  } else {
+    for (int n = 0; n < 8; ++n) {
+      box_[n] = to_vec3(node[box_corner_name(n + 1)].as<Coordinates>());
+    }
+  }
+
+  // basic check to see if there's some volume to the box
+  // maybe make this a real volume calculation
+  const auto dx = (box_[6] - box_[0]);
+  const double small = 1e-15;
+  if (dx[0] < small || dx[1] < small || dx[2] < small) {
+    throw std::runtime_error("Box has no volume");
+  }
+
+  if (node["elevation_angles"]) {
+    elevation_table_ = node["elevation_angles"].as<std::vector<double>>();
+    std::transform(
+      elevation_table_.cbegin(), elevation_table_.cend(),
+      elevation_table_.begin(), convert::degrees_to_radians);
+  }
+}
+
+double
+RadarSegmentGenerator::total_sweep_time() const
+{
+  return 2 * (sweep_angle_ / angular_speed_ + reset_time_delta_);
+}
+
+double
+RadarSegmentGenerator::periodic_time(double time) const
+{
+  /* radar overshoots the sweep angle, resets, and hits the constant
+   angular speed before getting back into the sweep range.
+   we're going to model this as just going to the end and instantly reversing
+ */
+  return time - std::floor(time / total_sweep_time()) * total_sweep_time();
+}
+
+int
+RadarSegmentGenerator::periodic_count(double time) const
+{
+  return std::floor(time / total_sweep_time());
+}
+
+RadarSegmentGenerator::phase
+RadarSegmentGenerator::determine_operation_phase(double periodic_time) const
+{
+  const double phase_time = sweep_angle_ / angular_speed_;
+
+  if (periodic_time < phase_time) {
+    return phase::FORWARD;
+  } else if (periodic_time < phase_time + reset_time_delta_) {
+    return phase::FORWARD_PAUSE;
+  } else if (periodic_time < 2 * phase_time + reset_time_delta_) {
+    return phase::REVERSE;
+  } else {
+    return phase::REVERSE_PAUSE;
+  }
+}
+
+double
+RadarSegmentGenerator::determine_current_angle(double periodic_time) const
+{
+  switch (determine_operation_phase(periodic_time)) {
+  case phase::FORWARD: {
+    return angular_speed_ * periodic_time - sweep_angle_ / 2;
+  }
+  case phase::FORWARD_PAUSE: {
+    return sweep_angle_ / 2;
+  }
+  case phase::REVERSE: {
+    return 3 * sweep_angle_ / 2 -
+           angular_speed_ * (periodic_time - reset_time_delta_);
+  }
+  default: {
+    return -sweep_angle_ / 2;
+  }
+  }
+}
+
+Segment
+RadarSegmentGenerator::generate(double time) const
+{
+  /*
+   radar is taken from an assumed far away location and sweeps through a set of
+   angles at a fixed angular velocity, reversing itself at the end of its step.
+
+   model is to clip out of the segment intersected some user defined box and
+   keep a fixed number of points along a now varying length line segment.
+   presumably the full domain of the simulation.  We don't require that box have
+   planar faces but the intersection point isn't incredibly accurate for heavily
+   skewed boxes.
+  */
+
+  const auto pitch =
+    elevation_table_.at(periodic_count(time) % elevation_table_.size());
+
+  const auto tail = center_;
+  const auto yaw_angle = determine_current_angle(periodic_time(time));
+  const auto yaxis = cross(axis_, ground_normal_);
+  const auto xprime = rotate_euler_vec(yaxis, pitch, axis_);
+  const auto zprime = rotate_euler_vec(yaxis, pitch, ground_normal_);
+  const auto sight_vector = rotate_euler_vec(zprime, yaw_angle, xprime);
+  const auto tip = affine(center_, beam_length_, sight_vector);
+
+  auto [found, seg] = details::line_intersection_with_box(
+    box_, to_vec3(center_), to_vec3(sight_vector));
+  if (!found) {
+    // return the unclipped line if it doesn't intersect the domain
+    return {tip, tail};
+  }
+  const double tol = 100 * std::numeric_limits<double>::epsilon();
+  if (found && vs::mag(to_vec3(seg.tail_) - to_vec3(seg.tip_)) < tol) {
+    // found one match. consider it unmatched and return the base line
+    return {tip, tail};
+  }
+
+  return seg;
+}
+
+} // namespace sierra::nalu

--- a/src/wind_energy/SyntheticLidar.C
+++ b/src/wind_energy/SyntheticLidar.C
@@ -17,6 +17,9 @@
 #include "netcdf.h"
 #include "Ioss_FileInfo.h"
 
+#include "vs/vector.h"
+#include "vs/tensor.h"
+
 #include <memory>
 
 namespace sierra {
@@ -27,8 +30,6 @@ constexpr int dim = 3;
 void
 LidarLineOfSite::load(const YAML::Node& node)
 {
-  NaluEnv::self().naluOutputP0() << "LidarLineOfSite::load" << std::endl;
-
   if (node["type"]) {
     segGen = make_segment_generator(node["type"].as<std::string>());
   } else {
@@ -47,6 +48,7 @@ LidarLineOfSite::load(const YAML::Node& node)
   }
 
   get_required(node, "points_along_line", npoints_);
+  get_if_present(node, "warn_on_missing", warn_on_missing_);
 
   if (node["name"]) {
     name_ = node["name"].as<std::string>();
@@ -93,6 +95,8 @@ LidarLineOfSite::load(const YAML::Node& node)
 
   if (node["scanning_lidar_specifications"]) {
     segGen->load(node["scanning_lidar_specifications"]);
+  } else if (node["radar_specifications"]) {
+    segGen->load(node["radar_specifications"]);
   } else {
     segGen->load(node);
   }
@@ -243,15 +247,16 @@ LidarLineOfSite::output_txt(
 {
   if (internal_output_counter_ == 0) {
     fname_ = determine_filename(name_, ".txt");
-    std::ofstream file{fname_, std::ios_base::out};
-    file.open(fname_);
+    std::ofstream file;
+    file.exceptions(file.exceptions() | std::ios::failbit);
+    file.open(fname_, std::ios::out);
     file << "t,x,y,z,u,v,w" << std::endl;
     file.close();
   }
 
   std::ofstream file;
   file.exceptions(file.exceptions() | std::ios::failbit);
-  file.open(fname_, std::ios::out | std::ios::app);
+  file.open(fname_, std::ios::app);
   if (file.fail()) {
     throw std::ios_base::failure(std::strerror(errno));
   }
@@ -276,7 +281,9 @@ LidarLineOfSite::output(
     return;
   }
   if (internal_output_counter_ == 0) {
-    Ioss::FileInfo::create_path(name_);
+    auto dir_pos = name_.find_last_of("/");
+    auto dir_name = name_.substr(0, dir_pos);
+    std::filesystem::create_directory(dir_name);
   }
 
   if (!search_data_) {
@@ -285,6 +292,8 @@ LidarLineOfSite::output(
   }
 
   const auto seg = segGen->generate(time());
+
+  // segment length can shrink to zero, so mag(dx) isn't bounded from below
   const std::array<double, 3> dx{
     {(seg.tip_[0] - seg.tail_[0]) / (npoints_ > 1 ? (npoints_ - 1) : 1),
      (seg.tip_[1] - seg.tail_[1]) / (npoints_ > 1 ? (npoints_ - 1) : 1),
@@ -361,7 +370,7 @@ LidarLineOfSite::output(
         velocity.at(j)[d] *= inv_deg;
       }
     }
-    if (not_found_count > 0) {
+    if (not_found_count > 0 && warn_on_missing_) {
 
       auto lidar_name_start = name_.find_last_of("/");
       auto lidar_name = name_.substr(lidar_name_start + 1);
@@ -431,6 +440,192 @@ LidarLineOfSite::determine_line_of_site_info(const YAML::Node& node)
   lidarLOSInfo->dataProbeInfo_.push_back(probeInfo.release());
 
   return lidarLOSInfo;
+}
+
+void
+LidarLOS::set_time_for_all(double time)
+{
+  for (auto& los : lidars_) {
+    los.set_time(time);
+  }
+}
+
+vs::Tensor
+skew_cross(vs::Vector a, vs::Vector b)
+{
+  auto cross = b ^ a;
+  return vs::Tensor(
+    0, -cross[2], cross[1], cross[2], 0, -cross[0], -cross[1], cross[0], 0);
+}
+
+vs::Tensor
+scale(vs::Tensor v, double a)
+{
+  vs::Tensor vnew;
+  for (int j = 0; j < 9; ++j) {
+    vnew[j] = a * v[j];
+  }
+  return vnew;
+}
+
+vs::Tensor
+rotation_matrix(vs::Vector dst, vs::Vector src)
+{
+  auto vmat = skew_cross(dst, src);
+  const auto ang = dst & src;
+
+  const double small = 1e-14 * vs::mag(dst);
+  if (std::abs(1 + ang) < small) {
+    return scale(vs::Tensor::I(), -1);
+  }
+  return vs::Tensor::I() + vmat + scale((vmat & vmat), 1. / (1 + ang));
+}
+
+namespace details {
+std::vector<vs::Vector>
+make_radar_grid(double delta_phi, int nphi, int ntheta, vs::Vector axis)
+{
+  // probably a nicer way to do this but we're going to
+  // create set of rays around a circle at different cone "phi" angles
+  // by first creating the canonical case around (0,0,1) and rotating the
+  // coordinate system so that (0,0,1) matches the axis
+
+  axis.normalize();
+  const auto canon_vector = vs::Vector(0, 0, 1);
+
+  std::vector<vs::Vector> rays; // a cone grid oriented around (0,0,1)
+  const auto transform = rotation_matrix(axis, canon_vector);
+  // handle the geometric singularity to avoid putting n rays at zero
+  rays.push_back(transform & canon_vector);
+
+  for (int j = 1; j < nphi; ++j) {
+    const double phi = (delta_phi / (nphi - 1)) * j;
+    const auto zr = std::sin(phi);
+    for (int i = 0; i < ntheta; ++i) {
+      const double theta = (2 * M_PI / ntheta) * i;
+      const auto xr = zr * std::cos(theta);
+      const auto yr = zr * std::sin(theta);
+      auto ray = transform & vs::Vector(xr, yr, 1);
+      ray.normalize();
+      rays.push_back(ray);
+    }
+  }
+  return rays;
+}
+} // namespace details
+void
+LidarLOS::load(const YAML::Node& node, DataProbePostProcessing* probes)
+{
+  auto lidar_spec = node["lidar_specifications"];
+
+  auto create_lidar = [&](const YAML::Node& node) {
+    std::string output_type = "netcdf";
+    get_if_present(node, "output", output_type);
+    if (output_type == "dataprobes") {
+      LidarLineOfSite lidarLOS;
+      auto lidarDBSpec = lidarLOS.determine_line_of_site_info(node);
+      ThrowRequireMsg(
+        probes, "Lidar processing with dataprobe output "
+                "requires valid data probe object");
+      probes->add_external_data_probe_spec_info(lidarDBSpec.release());
+    } else {
+      if (node["radar_cone_grid"]) {
+        const auto cone_grid_spec = node["radar_cone_grid"];
+        if (cone_grid_spec.Type() != YAML::NodeType::Map) {
+          throw std::runtime_error("must specify map for cone grid");
+        }
+
+        double phi = 0;
+        get_required(cone_grid_spec, "cone_angle", phi);
+        phi = convert::degrees_to_radians(phi);
+        ThrowRequire(phi > 0);
+
+        int nphi = 0;
+        get_required(cone_grid_spec, "num_circles", nphi);
+        nphi += 1; // don't count the center as a circle
+
+        int ntheta = 0;
+        get_required(cone_grid_spec, "lines_per_cone_circle", ntheta);
+
+        const auto look_ahead_spec = node["radar_specifications"];
+        if (!look_ahead_spec) {
+          throw std::runtime_error(
+            "Must specifiy radar specification for cone grid");
+        }
+        const auto base_axis = look_ahead_spec["axis"].as<Coordinates>();
+
+        auto rays = details::make_radar_grid(
+          phi, nphi, ntheta,
+          vs::Vector(base_axis.x_, base_axis.y_, base_axis.z_));
+
+        int j = 0;
+        for (const auto& ray : rays) {
+          lidars_.emplace_back();
+          auto mod_node = YAML::Clone(node);
+          mod_node["name"] =
+            node["name"].as<std::string>() + "-grid-" + std::to_string(j++);
+
+          mod_node["radar_specifications"]["axis"] =
+            std::vector<double>{ray[0], ray[1], ray[2]};
+          lidars_.back().load(mod_node);
+        }
+      } else {
+        lidars_.emplace_back();
+        lidars_.back().load(node);
+      }
+    }
+  };
+
+  if (lidar_spec) {
+    const auto is_scalar = lidar_spec.Type() == YAML::NodeType::Map;
+    if (is_scalar) {
+      create_lidar(lidar_spec);
+    } else {
+      std::set<std::string> names;
+      for (auto spec : lidar_spec) {
+        if (!spec["name"]) {
+          throw std::runtime_error("lidar sequence requires a name");
+        }
+        names.insert(spec["name"].as<std::string>());
+        create_lidar(spec);
+      }
+      if (names.size() != lidar_spec.size()) {
+        std::string msg = "Non unique file name for lidar detected: ";
+        for (auto spec : lidar_spec) {
+          msg += spec["name"].as<std::string>() + " ";
+        }
+        throw std::runtime_error(msg);
+      }
+    }
+  }
+}
+
+void
+LidarLOS::output(
+  const stk::mesh::BulkData& bulk,
+  const stk::mesh::Selector& sel,
+  const std::string& coords_name,
+  double dt,
+  double time)
+{
+  constexpr int max_output_per_step = 1000;
+  for (auto& los : lidars_) {
+    const double small = 1e-8 * dt;
+    const double next_time = time + dt;
+    int step_outputs = 0;
+    while (los.time() < next_time - small &&
+           step_outputs < max_output_per_step) {
+      const double dtratio = (los.time() - time) / dt;
+      los.output(bulk, sel, coords_name, dtratio);
+      los.increment_time();
+      ++step_outputs;
+    }
+    if (step_outputs == max_output_per_step) {
+      NaluEnv::self().naluOutputP0()
+        << "Warning: max lidar outputs, " << max_output_per_step
+        << " per step reached";
+    }
+  }
 }
 
 } // namespace nalu

--- a/unit_tests.C
+++ b/unit_tests.C
@@ -53,7 +53,7 @@ main(int argc, char** argv)
     sierra::nalu::MasterElementRepo::clear();
   }
 
-  Kokkos::finalize_all();
+  Kokkos::finalize();
   MPI_Finalize();
 
   return returnVal;

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -20,6 +20,7 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestKokkosMEBC.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestKokkosViews.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestLagrangeInterpolants.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestLidarLOS.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestLocalGraphArrays.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestMasterElements.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestMetricTensor.C
@@ -28,6 +29,7 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestNGPMasterElements.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestNgpMesh1.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestPecletFunction.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestRadarPattern.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestRealm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestScanningLidarPattern.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestScratchViews.C

--- a/unit_tests/UnitTestLidarLOS.C
+++ b/unit_tests/UnitTestLidarLOS.C
@@ -1,0 +1,153 @@
+#include <gtest/gtest.h>
+
+#include "wind_energy/SyntheticLidar.h"
+#include "NaluParsing.h"
+#include "UnitTestUtils.h"
+#include "stk_mesh/base/MeshBuilder.hpp"
+#include "stk_mesh/base/FieldBLAS.hpp"
+#include "Ioss_FileInfo.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <ostream>
+#include <memory>
+#include <array>
+
+namespace sierra {
+namespace nalu {
+
+const std::string db_spec =
+  "data_probes:                                             \n"
+  "  output_frequency: 10                                   \n"
+  "  search_method: stk_kdtree                              \n"
+  "  search_tolerance: 1.0e-3                               \n"
+  "  search_expansion_factor: 2.0                           \n"
+  "  lidar_specifications:                                  \n";
+
+const std::string scan_spec =
+  "      - name: lidar/scan                                  \n"
+  "        type: scanning                                    \n"
+  "        frequency: 5                                      \n"
+  "        points_along_line: 10                             \n"
+  "        output: text                                      \n"
+  "        scanning_lidar_specifications:                    \n"
+  "          center: [500,500,100]                           \n"
+  "          beam_length: 20                                 \n"
+  "          axis: [-1,0,0]                                  \n"
+  "          stare_time: 1                                   \n"
+  "          sweep_angle: 30                                 \n"
+  "          step_delta_angle: 2                             \n"
+  "          reset_time_delta: 0                             \n"
+  "          elevation_angles: [-5,0,5]                      \n";
+
+const std::string radar_spec =
+  "      - name: lidar/radar                                 \n"
+  "        type: radar                                       \n"
+  "        frequency: 1                                      \n"
+  "        points_along_line: 2                              \n"
+  "        output: text                                      \n"
+  "        radar_cone_grid:                                  \n"
+  "          cone_angle: 0.5                                 \n"
+  "          num_circles: 2                                  \n"
+  "          lines_per_cone_circle: 6                        \n"
+  "        radar_specifications:                             \n"
+  "          bbox: [-1000,-1000,0,1000,1000,1000]            \n"
+  "          center: [-5000,0,100]                           \n"
+  "          beam_length: 10000                              \n"
+  "          angular_speed: 10                               \n"
+  "          axis: [1,0,0]                                   \n"
+  "          sweep_angle: 10                                 \n"
+  "          reset_time:  0                                  \n"
+  "          elevation_angles: [0,1,2,3]                     \n";
+
+const std::string spec_str = db_spec + scan_spec + radar_spec;
+
+class LidarLOSFixture : public ::testing::Test
+{
+public:
+  LidarLOSFixture()
+    : bulkptr(stk::mesh::MeshBuilder(MPI_COMM_WORLD)
+                .set_aura_option((stk::mesh::BulkData::NO_AUTO_AURA))
+                .set_spatial_dimension(3U)
+                .create()),
+      bulk(*bulkptr),
+      meta(bulk.mesh_meta_data())
+  {
+    stk::io::StkMeshIoBroker io(bulk.parallel());
+    io.set_bulk_data(bulk);
+
+    const int n = 16;
+    const auto nx = std::to_string(n);
+    const auto ny = std::to_string(n);
+    const auto nz = std::to_string(n / 2);
+    auto mesh_name = "generated:" + nx + "x" + ny + "x" + nz +
+                     "|bbox:-1000,-1000,0,1000,1000,1000|sideset:xXyYzZ";
+    io.add_mesh_database(mesh_name, stk::io::READ_MESH);
+    io.create_input_mesh();
+
+    using vector_field_type = stk::mesh::Field<double, stk::mesh::Cartesian3d>;
+    auto node_rank = stk::topology::NODE_RANK;
+    auto& vel_field =
+      meta.declare_field<vector_field_type>(node_rank, "velocity", 2);
+    stk::mesh::put_field_on_entire_mesh(vel_field);
+    io.populate_bulk_data();
+    stk::mesh::field_fill(1., vel_field.field_of_state(stk::mesh::StateNP1));
+    stk::mesh::field_fill(1., vel_field.field_of_state(stk::mesh::StateN));
+
+    // lidar will write new files if they exist. Delete them here
+    // to adding new files ad infinitum`
+    std::filesystem::remove("lidar/scan.txt");
+    for (int j = 0; j < 13; ++j) {
+      std::filesystem::remove("lidar/radar-grid-" + std::to_string(j) + ".txt");
+    }
+  }
+
+private:
+  std::shared_ptr<stk::mesh::BulkData> bulkptr;
+
+public:
+  stk::mesh::BulkData& bulk;
+  stk::mesh::MetaData& meta;
+  YAML::Node spec = YAML::Load(spec_str)["data_probes"];
+  LidarLOS los;
+};
+
+TEST_F(LidarLOSFixture, load) { los.load(spec, nullptr); }
+
+TEST_F(LidarLOSFixture, write)
+{
+  EXPECT_NO_THROW(los.load(spec, nullptr));
+  los.set_time_for_all(0);
+  for (int num_steps = 0; num_steps < 10; ++num_steps) {
+    los.output(
+      bulk, !stk::mesh::Selector{}, "coordinates", 0.5, num_steps * 0.5);
+  }
+}
+
+TEST(make_radar_grid, first_is_axis)
+{
+  std::mt19937 rng;
+  rng.seed(0); // fixed seed
+  std::uniform_real_distribution<double> coeff(-1.0, 1.0);
+  vs::Vector axis(coeff(rng), coeff(rng), coeff(rng));
+  axis.normalize();
+  auto rays =
+    details::make_radar_grid(convert::degrees_to_radians(45), 4, 10, axis);
+  ASSERT_DOUBLE_EQ(rays[0][0], axis[0]);
+  ASSERT_DOUBLE_EQ(rays[0][1], axis[1]);
+  ASSERT_DOUBLE_EQ(rays[0][2], axis[2]);
+}
+
+TEST(make_radar_grid, check_opposite)
+{
+  vs::Vector axis(0, 0, -1);
+  axis.normalize();
+  auto rays =
+    details::make_radar_grid(convert::degrees_to_radians(45), 4, 10, axis);
+  ASSERT_DOUBLE_EQ(rays[0][0], axis[0]);
+  ASSERT_DOUBLE_EQ(rays[0][1], axis[1]);
+  ASSERT_DOUBLE_EQ(rays[0][2], axis[2]);
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/unit_tests/UnitTestRadarPattern.C
+++ b/unit_tests/UnitTestRadarPattern.C
@@ -1,0 +1,402 @@
+#include <gtest/gtest.h>
+
+#include "wind_energy/LidarPatterns.h"
+#include "NaluParsing.h"
+#include "UnitTestUtils.h"
+#include "master_element/TensorOps.h"
+
+#include <yaml-cpp/yaml.h>
+
+#include <ostream>
+#include <memory>
+#include <array>
+
+namespace sierra {
+namespace nalu {
+
+std::array<vs::Vector, 8> box{{
+  {-1, -1, -1},
+  {+1, -1, -1},
+  {+1, +1, -1},
+  {-1, +1, -1},
+  {-1, -1, +1},
+  {+1, -1, +1},
+  {+1, +1, +1},
+  {-1, +1, +1},
+}};
+
+TEST(box_intersect, line_goes_straight_through)
+{
+  vs::Vector origin = {-10, 0, 0};
+  vs::Vector line = {1, 0, 0};
+
+  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  ASSERT_TRUE(found);
+
+  ASSERT_DOUBLE_EQ(seg.tail_[0], -1);
+  ASSERT_DOUBLE_EQ(seg.tail_[1], 0);
+  ASSERT_DOUBLE_EQ(seg.tail_[2], 0);
+
+  ASSERT_DOUBLE_EQ(seg.tip_[0], +1);
+  ASSERT_DOUBLE_EQ(seg.tip_[1], 0);
+  ASSERT_DOUBLE_EQ(seg.tip_[2], 0);
+}
+
+TEST(box_intersect, line_goes_straight_through_abl_box)
+{
+  vs::Vector origin = {-1000, 2500, 100};
+
+  vs::Vector line = {0.996195, -0.0871557, 0};
+  std::array<vs::Vector, 8> abl_box;
+  for (int n = 0; n < 8; ++n) {
+    const auto new_x = 2500 * (1 + box[n][0]);
+    const auto new_y = 2500 * (1 + box[n][1]);
+    const auto new_z = 500 * (1 + box[n][2]);
+    abl_box[n] = vs::Vector(new_x, new_y, new_z);
+  }
+
+  auto [found, seg] =
+    details::line_intersection_with_box(abl_box, origin, line);
+  ASSERT_TRUE(found);
+  ASSERT_NEAR(seg.tail_[0], 0, 1e-10);
+  ASSERT_NEAR(seg.tail_[2], 100, 1e-10);
+  ASSERT_NEAR(seg.tip_[0], 5000, 1e-10);
+  ASSERT_NEAR(seg.tip_[2], 100, 1e-10);
+}
+
+TEST(box_intersect, line_goes_through_corners)
+{
+  vs::Vector origin = {-2, -2, -2};
+  vs::Vector line = {1, 1, 1};
+
+  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  ASSERT_TRUE(found);
+
+  ASSERT_DOUBLE_EQ(seg.tail_[0], -1);
+  ASSERT_DOUBLE_EQ(seg.tail_[1], -1);
+  ASSERT_DOUBLE_EQ(seg.tail_[2], -1);
+
+  ASSERT_DOUBLE_EQ(seg.tip_[0], +1);
+  ASSERT_DOUBLE_EQ(seg.tip_[1], +1);
+  ASSERT_DOUBLE_EQ(seg.tip_[2], +1);
+}
+
+TEST(box_intersect, line_tangent_to_box)
+{
+  vs::Vector corner = box[0];
+  const double theta = -M_PI_4;
+  vs::Vector origin = {
+    box[0][0] + std::cos(theta), box[0][1] + std::sin(theta), box[0][2]};
+  vs::Vector line = {-std::cos(theta), -std::sin(theta), 0};
+
+  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  ASSERT_TRUE(found);
+
+  ASSERT_DOUBLE_EQ(seg.tail_[0], -1);
+  ASSERT_DOUBLE_EQ(seg.tail_[1], -1);
+  ASSERT_DOUBLE_EQ(seg.tail_[2], -1);
+
+  ASSERT_DOUBLE_EQ(seg.tip_[0], -1);
+  ASSERT_DOUBLE_EQ(seg.tip_[1], -1);
+  ASSERT_DOUBLE_EQ(seg.tip_[2], -1);
+}
+
+TEST(box_intersect, line_goes_along_face)
+{
+  // tolerance-y
+
+  vs::Vector origin = {-2, 0, -1};
+  vs::Vector line = {1, 0, 0};
+
+  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  ASSERT_TRUE(found);
+
+  ASSERT_DOUBLE_EQ(seg.tail_[0], -1);
+  ASSERT_DOUBLE_EQ(seg.tail_[1], 0);
+  ASSERT_DOUBLE_EQ(seg.tail_[2], -1);
+
+  ASSERT_DOUBLE_EQ(seg.tip_[0], +1);
+  ASSERT_DOUBLE_EQ(seg.tip_[1], 0);
+  ASSERT_DOUBLE_EQ(seg.tip_[2], -1);
+}
+
+TEST(box_intersect, line_goes_along_edge)
+{
+  // tolerance-y
+
+  vs::Vector edge = box[0] - box[1];
+  vs::Vector origin = vs::Vector(-2, 0, 0) + (box[1] - box[0]);
+  vs::Vector line = {1, 0, 0};
+
+  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  ASSERT_TRUE(found);
+
+  ASSERT_DOUBLE_EQ(seg.tail_[0], 1);
+  ASSERT_DOUBLE_EQ(seg.tail_[1], 0);
+  ASSERT_DOUBLE_EQ(seg.tail_[2], 0);
+
+  ASSERT_DOUBLE_EQ(seg.tip_[0], 1);
+  ASSERT_DOUBLE_EQ(seg.tip_[1], 0);
+  ASSERT_DOUBLE_EQ(seg.tip_[2], 0);
+}
+
+TEST(box_intersect, line_does_not_intersect)
+{
+  vs::Vector edge = box[0] - box[1];
+  vs::Vector origin = vs::Vector(-100, 0, 0);
+  vs::Vector line = {0, 1, 0};
+
+  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  ASSERT_FALSE(found);
+}
+
+class RadarParseFixture : public ::testing::Test
+{
+public:
+  RadarParseFixture() {}
+  RadarSegmentGenerator slgen;
+
+  std::string radar_nobox =
+    "  radar_specifications:                                \n"
+    "    angular_speed: 1 # deg/s                           \n"
+    "    sweep_angle: 20 # degrees                          \n"
+    "    center: [-10000,0,0]                               \n"
+    "    beam_length: 1e5                                   \n"
+    "    axis: [1,0,0]                                      \n";
+};
+
+TEST_F(RadarParseFixture, load_one_corner_throws)
+{
+  const std::string spec_str =
+    radar_nobox + "    box_0: [-2500,-2500,0]                             \n";
+
+  auto spec = YAML::Load(spec_str)["radar_specifications"];
+  ASSERT_THROW(slgen.load(spec), std::runtime_error);
+}
+
+TEST_F(RadarParseFixture, load_all_corners_degenerate)
+{
+  const std::string spec_str =
+    radar_nobox + "    box_1: [-2500,-2500,0]                             \n"
+                  "    box_2: [-2500,-2500,0]                             \n"
+                  "    box_3: [-2500,-2500,0]                             \n"
+                  "    box_4: [-2500,-2500,0]                             \n"
+                  "    box_5: [-2500,-2500,0]                             \n"
+                  "    box_6: [-2500,-2500,0]                             \n"
+                  "    box_7: [-2500,-2500,0]                             \n"
+                  "    box_8: [-2500,-2500,0]                             \n";
+
+  auto spec = YAML::Load(spec_str)["radar_specifications"];
+  ASSERT_THROW(slgen.load(spec), std::runtime_error);
+}
+
+TEST_F(RadarParseFixture, zero_indexed_throws)
+{
+  const std::string spec_str =
+    radar_nobox + "    box_0: [-2500,-2500,0]                             \n"
+                  "    box_1: [ 2500,-2500,0]                             \n"
+                  "    box_2: [ 2500, 2500,0]                             \n"
+                  "    box_3: [-2500, 2500,0]                             \n"
+                  "    box_4: [-2500,-2500,3000]                          \n"
+                  "    box_5: [2500,-2500,3000]                           \n"
+                  "    box_6: [2500,2500,3000]                            \n"
+                  "    box_7: [-2500,2500,3000]                           \n";
+
+  auto spec = YAML::Load(spec_str)["radar_specifications"];
+  ASSERT_THROW(slgen.load(spec), std::runtime_error);
+}
+
+TEST_F(RadarParseFixture, load_all_corners_valid)
+{
+  const std::string spec_str =
+    radar_nobox + "    box_1: [-2500,-2500,0]                             \n"
+                  "    box_2: [ 2500,-2500,0]                             \n"
+                  "    box_3: [ 2500, 2500,0]                             \n"
+                  "    box_4: [-2500, 2500,0]                             \n"
+                  "    box_5: [-2500,-2500,3000]                          \n"
+                  "    box_6: [2500,-2500,3000]                           \n"
+                  "    box_7: [2500,2500,3000]                            \n"
+                  "    box_8: [-2500,2500,3000]                           \n";
+
+  auto spec = YAML::Load(spec_str)["radar_specifications"];
+  ASSERT_NO_THROW(slgen.load(spec));
+}
+
+TEST_F(RadarParseFixture, bbox_load_valid)
+{
+  const std::string spec_str =
+    radar_nobox + "    bbox: [-2500,-2500,0,2500,2500,100]                \n";
+
+  auto spec = YAML::Load(spec_str)["radar_specifications"];
+  ASSERT_NO_THROW(slgen.load(spec));
+}
+
+TEST_F(RadarParseFixture, bbox_load_invalid)
+{
+  const std::string spec_str =
+    radar_nobox + "    bbox: [-2500,-2500,0,2500,2500,0]                \n";
+
+  auto spec = YAML::Load(spec_str)["radar_specifications"];
+  ASSERT_THROW(slgen.load(spec), std::runtime_error);
+}
+
+class RadarScanFixture : public ::testing::Test
+{
+public:
+  RadarScanFixture()
+  {
+    slgen.load(YAML::Load(radar_spec_str)["radar_specifications"]);
+  }
+  RadarSegmentGenerator slgen;
+  std::string radar_spec_str =
+    "  radar_specifications:                                \n"
+    "    angular_speed: 10 # deg/s                          \n"
+    "    sweep_angle: 20 # degrees                          \n"
+    "    center: [-10000,0,90]                              \n"
+    "    beam_length: 100000                                \n"
+    "    reset_time_delta: 1.0                              \n"
+    "    axis: [1,0,0]                                      \n"
+    "    box_1: [-2500,-2500,0]                             \n"
+    "    box_2: [ 2500,-2500,0]                             \n"
+    "    box_3: [ 2500, 2500,0]                             \n"
+    "    box_4: [-2500, 2500,0]                             \n"
+    "    box_5: [-2500,-2500,3000]                          \n"
+    "    box_6: [2500,-2500,3000]                           \n"
+    "    box_7: [2500,2500,3000]                            \n"
+    "    box_8: [-2500,2500,3000]                           \n";
+
+  double tol_ = 1e-10;
+  double reset_time_ = 1;
+  double sweep_time_ = 2; //(20/10)
+  double sweep_angle_ = convert::degrees_to_radians(20);
+
+  const double x_orig_ = -10000;
+  const double x_near_ = -2500;
+  const double x_far_ = 2500;
+  const double z_near_ = 90;
+  const double z_far_ = 90;
+};
+
+TEST_F(RadarScanFixture, correct_at_time_zero)
+{
+  const double time = 0;
+  auto seg = slgen.generate(time);
+
+  const double angle = -sweep_angle_ / 2;
+
+  const auto y_near = (x_near_ - x_orig_) * std::tan(angle);
+  const auto y_far = (x_far_ - x_orig_) * std::tan(angle);
+
+  ASSERT_NEAR(seg.tail_[0], x_near_, tol_);
+  ASSERT_NEAR(seg.tail_[1], y_near, tol_);
+  ASSERT_NEAR(seg.tail_[2], z_near_, tol_);
+
+  ASSERT_NEAR(seg.tip_[0], x_far_, tol_);
+  ASSERT_NEAR(seg.tip_[1], y_far, tol_);
+  ASSERT_NEAR(seg.tip_[2], z_far_, tol_);
+}
+
+TEST_F(RadarScanFixture, correct_at_end_of_sweep)
+{
+  const double time = sweep_time_;
+  auto seg = slgen.generate(time);
+
+  const double angle = sweep_angle_ / 2;
+
+  const auto y_near = (x_near_ - x_orig_) * std::tan(angle);
+  const auto y_far = (x_far_ - x_orig_) * std::tan(angle);
+
+  ASSERT_NEAR(seg.tail_[0], x_near_, tol_);
+  ASSERT_NEAR(seg.tail_[1], y_near, tol_);
+  ASSERT_NEAR(seg.tail_[2], z_near_, tol_);
+
+  ASSERT_NEAR(seg.tip_[0], x_far_, tol_);
+  ASSERT_NEAR(seg.tip_[1], y_far, tol_);
+  ASSERT_NEAR(seg.tip_[2], z_far_, tol_);
+}
+
+TEST_F(RadarScanFixture, pauses_at_end_of_forward_sweep)
+{
+  const double time = sweep_time_ + reset_time_;
+  auto seg = slgen.generate(time);
+
+  const double angle = sweep_angle_ / 2;
+
+  const auto y_near = (x_near_ - x_orig_) * std::tan(angle);
+  const auto y_far = (x_far_ - x_orig_) * std::tan(angle);
+
+  ASSERT_NEAR(seg.tail_[0], x_near_, tol_);
+  ASSERT_NEAR(seg.tail_[1], y_near, tol_);
+  ASSERT_NEAR(seg.tail_[2], z_near_, tol_);
+
+  ASSERT_NEAR(seg.tip_[0], x_far_, tol_);
+  ASSERT_NEAR(seg.tip_[1], y_far, tol_);
+  ASSERT_NEAR(seg.tip_[2], z_far_, tol_);
+}
+
+TEST_F(RadarScanFixture, mid_sweep_is_zero_angle)
+{
+  const double time = 3 * sweep_time_ / 2 + reset_time_;
+  auto seg = slgen.generate(time);
+
+  const double angle = 0;
+  const auto y_near = (x_near_ - x_orig_) * std::tan(angle);
+  const auto y_far = (x_far_ - x_orig_) * std::tan(angle);
+
+  ASSERT_NEAR(seg.tail_[0], x_near_, tol_);
+  ASSERT_NEAR(seg.tail_[1], y_near, tol_);
+  ASSERT_NEAR(seg.tail_[2], z_near_, tol_);
+
+  ASSERT_NEAR(seg.tip_[0], x_far_, tol_);
+  ASSERT_NEAR(seg.tip_[1], y_far, tol_);
+  ASSERT_NEAR(seg.tip_[2], z_far_, tol_);
+}
+
+TEST_F(RadarScanFixture, returns_to_start)
+{
+  const double time = 2 * sweep_time_ + reset_time_;
+  auto seg = slgen.generate(time);
+  auto seg_start = slgen.generate(0);
+
+  ASSERT_NEAR(seg.tail_[0], seg_start.tail_[0], tol_);
+  ASSERT_NEAR(seg.tail_[1], seg_start.tail_[1], tol_);
+  ASSERT_NEAR(seg.tail_[2], seg_start.tail_[2], tol_);
+  ASSERT_NEAR(seg.tip_[0], seg_start.tip_[0], tol_);
+  ASSERT_NEAR(seg.tip_[1], seg_start.tip_[1], tol_);
+  ASSERT_NEAR(seg.tip_[2], seg_start.tip_[2], tol_);
+}
+
+TEST_F(RadarScanFixture, pauses_at_end)
+{
+  const double time = 2 * sweep_time_ + 2 * reset_time_;
+  auto seg = slgen.generate(time);
+
+  const double angle = -sweep_angle_ / 2;
+  const auto y_near = (x_near_ - x_orig_) * std::tan(angle);
+  const auto y_far = (x_far_ - x_orig_) * std::tan(angle);
+
+  ASSERT_NEAR(seg.tail_[0], x_near_, tol_);
+  ASSERT_NEAR(seg.tail_[1], y_near, tol_);
+  ASSERT_NEAR(seg.tail_[2], z_near_, tol_);
+
+  ASSERT_NEAR(seg.tip_[0], x_far_, tol_);
+  ASSERT_NEAR(seg.tip_[1], y_far, tol_);
+  ASSERT_NEAR(seg.tip_[2], z_far_, tol_);
+}
+
+TEST_F(RadarScanFixture, cycles)
+{
+  const double time = 3 * sweep_time_ / 2;
+  auto seg = slgen.generate(time);
+  auto seg_periodic = slgen.generate(time + 2 * (sweep_time_ + reset_time_));
+
+  ASSERT_NEAR(seg.tail_[0], seg_periodic.tail_[0], tol_);
+  ASSERT_NEAR(seg.tail_[1], seg_periodic.tail_[1], tol_);
+  ASSERT_NEAR(seg.tail_[2], seg_periodic.tail_[2], tol_);
+  ASSERT_NEAR(seg.tip_[0], seg_periodic.tip_[0], tol_);
+  ASSERT_NEAR(seg.tip_[1], seg_periodic.tip_[1], tol_);
+  ASSERT_NEAR(seg.tip_[2], seg_periodic.tip_[2], tol_);
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/unit_tests/UnitTestScanningLidarPattern.C
+++ b/unit_tests/UnitTestScanningLidarPattern.C
@@ -125,7 +125,7 @@ public:
     "    step_delta_angle: 1 #degrees                       \n"
     "    sweep_angle: 20 #degrees                           \n"
     "    reset_time_delta: 1 #second                        \n"
-    "    center: [500,500,100]                              \n"
+    "    center: [500.,500.,100.]                           \n"
     "    beam_length: 50.                                   \n"
     "    axis: [1,1,0]                                      \n"
     "    elevation_angles: [30]                             \n"


### PR DESCRIPTION
The radar sampling scans through an azimuth sweep at a fixed angular speed, pauses, then reverses at the same speed. Also can set an array of sampling lines about a cone, generating files like `myradar-grid-{n}.txt` for each of the sampling lines associated with the `myradar` sweep.

Other notable things:
  * Always cuts the ray with a bounding box specified by the user. Doesn't need to be rectilinear but I just do one subdivision into triangles to get the intersection points
  * If it doesn't intersect the box, it returns a fixed "beam length" line, which will be populated with zeros  for the velocity but continues being reported to the text file
  * The warning about the lidar points being found is now optional (default off with the `warn_on_missing` keyword
  * Fixes up some unrelated compiler warnings