### PR TITLE
radar: always clip to beam length irrespective of whether it intersects bounding box + fix up documentation

### DIFF
--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -1544,20 +1544,20 @@ Data probes
 
 .. inpfile:: data_probes.lidar_specifications.radar_specifications
 
-   Block specifying parameters for the scanning lidar sampling
+   Block specifying parameters for the radar sampling
 
    ========================== ===================================================================
    Parameter                  Description
    ========================== ===================================================================
    axis                       Required. Zero angle vector for the angular sweep, e.g. [1,0,0].
-   center                     Required. Location of the scanning LIDAR, e.g. [0,0,0].
+   center                     Required. Location of the radar, e.g. [0,0,0]. Ideally outside of the bounding box.
    bbox                       Optional. Six values (m) describing [bottom-left, top-right] of radar clip box
    box_1                      Optional. Along with other vertex specifications in (m) describes the radar clip box.
-   beam_length                Defaut 50000m. Only affects coordinate reporting if the line does not collide with box.
-   sweep_angle                Default 20 degrees. Extent of angular sweep between sweep_angle/2 to -sweep_angle/2.
+   beam_length                Required. Sets the maximum length of the line sampled. Also used if line does not intersect box. 
+   sweep_angle                Default 20 degrees. Extent of angular sweep between -sweep_angle/2 to sweep_angle/2.
    angular_speed              Default 30 degrees/s. Speed of the angular sweep.
    reset_time_delta           Default 1 second. Time to reset LIDAR after sweep.
-   ground_direction           Default [0,0,1]. Orthogonal orientation vector for the LIDAR
+   ground_direction           Default [0,0,1]. Orthogonal orientation vector for the radar
    elevation_angles           Default none. A list of angles in degrees to change to after each sweep
    ========================== ===================================================================
 

--- a/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
@@ -324,6 +324,26 @@ realms:
               axis: [1, 0, 0] #main axis, cone grid is set around this
               sweep_angle: 10 #angle of the sweep
               reset_time:  0 # time to pause after a sweep
+              beam_length: 20000 # in m, maximum possible length of beam from the center
+              elevation_angles: [0,1,2,3] # elevation angles to scan after reset
+
+          - name: radar/radar-beam-clip
+            type: radar
+            frequency: 4
+            points_along_line: 5
+            output: text
+            radar_cone_grid:
+              cone_angle: 0.5 #half angle of cone, in degrees
+              num_circles: 2 # number of cones inside the half angle to sample
+              lines_per_cone_circle: 6 # number of lines around the cone circle
+            radar_specifications:
+              bbox: [0., 0., 0., 5000., 5000., 1000.] # where to cut the radar line(m)
+              center: [-10000, 2500, 100] #ideally outside of the box
+              angular_speed: 1 #degrees to sweep in a second
+              axis: [1, 0, 0] #main axis, cone grid is set around this
+              sweep_angle: 10 #angle of the sweep
+              reset_time:  0 # time to pause after a sweep
+              beam_length: 12500 # in m, maximum possible length of beam from the center
               elevation_angles: [0,1,2,3] # elevation angles to scan after reset
 
 

--- a/src/wind_energy/LidarPatterns.C
+++ b/src/wind_energy/LidarPatterns.C
@@ -195,7 +195,7 @@ ScanningLidarSegmentGenerator::load(const YAML::Node& node)
   ThrowRequireMsg(
     reset_time_delta_ >= 0, "reset time delta must be semi-positive");
 
-  get_if_present(node, "beam_length", beam_length_);
+  get_required(node, "beam_length", beam_length_);
 
   if (node["ground_direction"]) {
     ground_normal_ = to_array3(node["ground_direction"].as<Coordinates>());
@@ -548,7 +548,7 @@ RadarSegmentGenerator::load(const YAML::Node& node)
   angular_speed_ = convert::degrees_to_radians(angular_speed);
 
   beam_length_ = 50e3; // m
-  get_if_present(node, "beam_length", beam_length_);
+  get_required(node, "beam_length", beam_length_);
 
   if (node["ground_direction"]) {
     ground_normal_ = to_array3(node["ground_direction"].as<Coordinates>());
@@ -705,6 +705,13 @@ RadarSegmentGenerator::generate(double time) const
     return {tip, tail};
   }
 
+  if (vs::mag(to_vec3(seg.tip_) - to_vec3(center_)) > beam_length_) {
+    seg.tip_ = tip;
+  }
+
+  if (vs::mag(to_vec3(seg.tail_) - to_vec3(center_)) > beam_length_) {
+    seg.tail_ = tail;
+  }
   return seg;
 }
 


### PR DESCRIPTION
Feedback was that users wanted to line to be able to be clipped a maximum length inside the bounding box.  This is a QOL improvement---this could be handled in postprocessing before this.

`beam_length` moves to a `required` parameter with this.

Also fixes up the documentation. 