### PR TITLE
radar: optionally don't save search data

### DIFF
--- a/docs/source/user/nalu_run/nalu_inp.rst
+++ b/docs/source/user/nalu_run/nalu_inp.rst
@@ -1524,6 +1524,16 @@ Data probes
    Type of LIDAR scan pattern. `scanning`, `radar` or `spinner` (default).
 
 
+.. inpfile:: data_probes.lidar_specifications.warn_on_missing
+
+   Warn if points aren't found in the simulation domain. `yes` or `no` (default).
+
+
+.. inpfile:: data_probes.lidar_specifications.reuse_search_data
+
+   Save cached search data per line. `yes` (default) or `no`.
+
+
 .. inpfile:: data_probes.lidar_specifications.scanning_lidar_specifications
 
    Block specifying parameters for the scanning lidar sampling

--- a/include/wind_energy/SyntheticLidar.h
+++ b/include/wind_energy/SyntheticLidar.h
@@ -73,6 +73,7 @@ private:
   std::string name_{"lidar-los"};
   std::string fname_{"lidar-los.nc"};
   bool warn_on_missing_{false};
+  bool reuse_search_data_{true};
 };
 
 namespace details {

--- a/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
+++ b/reg_tests/test_files/ablNeutralEdgeNoSlip/ablNeutralEdgeNoSlip.yaml
@@ -312,6 +312,7 @@ realms:
             type: radar
             frequency: 0.2
             points_along_line: 2
+	    reuse_search_data: no
             output: text
             radar_cone_grid:
               cone_angle: 0.5 #half angle of cone, in degrees

--- a/src/wind_energy/SyntheticLidar.C
+++ b/src/wind_energy/SyntheticLidar.C
@@ -50,6 +50,7 @@ LidarLineOfSite::load(const YAML::Node& node)
 
   get_required(node, "points_along_line", npoints_);
   get_if_present(node, "warn_on_missing", warn_on_missing_);
+  get_if_present(node, "reuse_search_data", reuse_search_data_);
 
   if (node["name"]) {
     name_ = node["name"].as<std::string>();
@@ -389,6 +390,9 @@ LidarLineOfSite::output(
     } else if (output_type_ == Output::NETCDF) {
       output_nc(time(), points, velocity);
     }
+  }
+  if (!reuse_search_data_) {
+    search_data_.reset();
   }
 }
 

--- a/unit_tests/UnitTestLidarLOS.C
+++ b/unit_tests/UnitTestLidarLOS.C
@@ -45,6 +45,7 @@ const std::string radar_spec =
   "        type: radar                                       \n"
   "        frequency: 1                                      \n"
   "        points_along_line: 2                              \n"
+  "        reuse_search_data: no                             \n"
   "        output: text                                      \n"
   "        radar_cone_grid:                                  \n"
   "          cone_angle: 0.5                                 \n"


### PR DESCRIPTION
Resets the cached data of the search that's saved per line.  It can add up to a lot of memory when there's hundreds of search lines. Reusing the appropriate data between lines when possible is a better solution here; in lieu of that, this allows a user to just not save the data.

