### PR TITLE
AMD Linker Error Fix

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -70,8 +70,13 @@ template <typename T, typename SHMEM = HostShmem>
 using SharedMemView =
   Kokkos::View<T, Kokkos::LayoutRight, SHMEM, Kokkos::MemoryUnmanaged>;
 
+#if defined(KOKKOS_ENABLE_HIP)
+template <typename T>
+using AlignedViewType = Kokkos::View<T>;
+#else
 template <typename T>
 using AlignedViewType = Kokkos::View<T, Kokkos::MemoryTraits<Kokkos::Aligned>>;
+#endif
 
 using DeviceTeamPolicy = Kokkos::TeamPolicy<DeviceSpace>;
 using HostTeamPolicy = Kokkos::TeamPolicy<HostSpace>;


### PR DESCRIPTION
Need this to resolve linker errors.

  >> 10856    lld: error: undefined symbol: operator delete(void*, std::align_val_t)
     10857    >>> referenced by Hex27CVFEM.h:234 (/gpfs/alpine/proj-shared/cfd116/mullowne/spack-manager-crusher/environments/nalu-master-trilinos-develop_rocm-5.2.0/nalu-wind/include/master_element/Hex27CVFEM.h:234)
     10858    >>>               lto.tmp:(sierra::nalu::Hex27SCV::~Hex27SCV())
     10859    >>> referenced by Hex27CVFEM.h:234 (/gpfs/alpine/proj-shared/cfd116/mullowne/spack-manager-crusher/environments/nalu-master-trilinos-develop_rocm-5.2.0/nalu-wind/include/master_element/Hex27CVFEM.h:234)
     10860    >>>               lto.tmp:(sierra::nalu::Hex27SCV::~Hex27SCV())
     10861    >>> referenced by Hex27CVFEM.h:339 (/gpfs/alpine/proj-shared/cfd116/mullowne/spack-manager-crusher/environments/nalu-master-trilinos-develop_rocm-5.2.0/nalu-wind/include/master_element/Hex27CVFEM.h:339)
     10862    >>>               lto.tmp:(sierra::nalu::Hex27SCS::~Hex27SCS())
