### PR TITLE
Use Kokkos::LaunchBounds for HIP

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -40,6 +40,7 @@
 #undef KOKKOS_ENABLE_GPU
 #endif
 
+
 namespace sierra {
 namespace nalu {
 
@@ -69,8 +70,18 @@ using HostShmem = HostSpace::scratch_memory_space;
 using DynamicScheduleType = Kokkos::Schedule<Kokkos::Dynamic>;
 using TeamHandleType =
   Kokkos::TeamPolicy<HostSpace, DynamicScheduleType>::member_type;
+
+#if defined(KOKKOS_ENABLE_HIP)
 using DeviceTeamHandleType =
-  Kokkos::TeamPolicy<DeviceSpace, DynamicScheduleType>::member_type;
+  Kokkos::TeamPolicy<DeviceSpace, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, DynamicScheduleType>::member_type;
+using DeviceRangePolicy = Kokkos::RangePolicy<DeviceSpace,Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>>;
+using DeviceTeamPolicy = Kokkos::TeamPolicy<DeviceSpace,Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>>;
+#else
+using DeviceTeamHandleType = Kokkos::TeamPolicy<DeviceSpace, DynamicScheduleType>::member_type;
+using DeviceRangePolicy = Kokkos::RangePolicy<DeviceSpace>;
+using DeviceTeamPolicy = Kokkos::TeamPolicy<DeviceSpace>;
+#endif
+
 
 template <typename T, typename SHMEM = HostShmem>
 using SharedMemView =
@@ -84,8 +95,8 @@ template <typename T>
 using AlignedViewType = Kokkos::View<T, Kokkos::MemoryTraits<Kokkos::Aligned>>;
 #endif
 
-using DeviceTeamPolicy = Kokkos::TeamPolicy<DeviceSpace>;
 using HostTeamPolicy = Kokkos::TeamPolicy<HostSpace>;
+using HostRangePolicy = Kokkos::RangePolicy<HostSpace>;
 using DeviceTeam = DeviceTeamPolicy::member_type;
 using HostTeam = HostTeamPolicy::member_type;
 

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -40,7 +40,6 @@
 #undef KOKKOS_ENABLE_GPU
 #endif
 
-
 namespace sierra {
 namespace nalu {
 
@@ -72,16 +71,20 @@ using TeamHandleType =
   Kokkos::TeamPolicy<HostSpace, DynamicScheduleType>::member_type;
 
 #if defined(KOKKOS_ENABLE_HIP)
-using DeviceTeamHandleType =
-  Kokkos::TeamPolicy<DeviceSpace, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, DynamicScheduleType>::member_type;
-using DeviceRangePolicy = Kokkos::RangePolicy<DeviceSpace,Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>>;
-using DeviceTeamPolicy = Kokkos::TeamPolicy<DeviceSpace,Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>>;
+using DeviceTeamHandleType = Kokkos::TeamPolicy<
+  DeviceSpace,
+  Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+  DynamicScheduleType>::member_type;
+using DeviceRangePolicy = Kokkos::
+  RangePolicy<DeviceSpace, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>>;
+using DeviceTeamPolicy = Kokkos::
+  TeamPolicy<DeviceSpace, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>>;
 #else
-using DeviceTeamHandleType = Kokkos::TeamPolicy<DeviceSpace, DynamicScheduleType>::member_type;
+using DeviceTeamHandleType =
+  Kokkos::TeamPolicy<DeviceSpace, DynamicScheduleType>::member_type;
 using DeviceRangePolicy = Kokkos::RangePolicy<DeviceSpace>;
 using DeviceTeamPolicy = Kokkos::TeamPolicy<DeviceSpace>;
 #endif
-
 
 template <typename T, typename SHMEM = HostShmem>
 using SharedMemView =

--- a/include/NGPInstance.h
+++ b/include/NGPInstance.h
@@ -27,7 +27,7 @@ create()
   T* obj = kokkos_malloc_on_device<T>(debuggingName);
 
   Kokkos::parallel_for(
-    debuggingName, 1, KOKKOS_LAMBDA(const int) { new (obj) T(); });
+    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { new (obj) T(); });
   return obj;
 }
 
@@ -41,7 +41,7 @@ create(const T& hostObj)
   // Create local copy for capture on device
   const T hostCopy(hostObj);
   Kokkos::parallel_for(
-    debuggingName, 1, KOKKOS_LAMBDA(const int) { new (obj) T(hostCopy); });
+    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { new (obj) T(hostCopy); });
   return obj;
 }
 
@@ -55,7 +55,7 @@ create(Args&&... args)
   // CUDA lambda cannot capture packed parameter
   const T hostObj(std::forward<Args>(args)...);
   Kokkos::parallel_for(
-    debuggingName, 1, KOKKOS_LAMBDA(const int) { new (obj) T(hostObj); });
+    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { new (obj) T(hostObj); });
   return obj;
 }
 
@@ -69,7 +69,7 @@ destroy(T* obj)
 
   const std::string debuggingName(typeid(T).name());
   Kokkos::parallel_for(
-    debuggingName, 1, KOKKOS_LAMBDA(const int) { obj->~T(); });
+    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { obj->~T(); });
   kokkos_free_on_device(obj);
 }
 

--- a/include/NGPInstance.h
+++ b/include/NGPInstance.h
@@ -27,7 +27,8 @@ create()
   T* obj = kokkos_malloc_on_device<T>(debuggingName);
 
   Kokkos::parallel_for(
-    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { new (obj) T(); });
+    debuggingName, DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const int) { new (obj) T(); });
   return obj;
 }
 
@@ -41,7 +42,8 @@ create(const T& hostObj)
   // Create local copy for capture on device
   const T hostCopy(hostObj);
   Kokkos::parallel_for(
-    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { new (obj) T(hostCopy); });
+    debuggingName, DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const int) { new (obj) T(hostCopy); });
   return obj;
 }
 
@@ -55,7 +57,8 @@ create(Args&&... args)
   // CUDA lambda cannot capture packed parameter
   const T hostObj(std::forward<Args>(args)...);
   Kokkos::parallel_for(
-    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { new (obj) T(hostObj); });
+    debuggingName, DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const int) { new (obj) T(hostObj); });
   return obj;
 }
 
@@ -69,7 +72,8 @@ destroy(T* obj)
 
   const std::string debuggingName(typeid(T).name());
   Kokkos::parallel_for(
-    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { obj->~T(); });
+    debuggingName, DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const int) { obj->~T(); });
   kokkos_free_on_device(obj);
 }
 

--- a/include/aero/actuator/ActuatorFunctors.h
+++ b/include/aero/actuator/ActuatorFunctors.h
@@ -13,6 +13,7 @@
 #include <aero/actuator/ActuatorGenericSearchFunctor.h>
 #include <aero/actuator/ActuatorBulk.h>
 #include <FieldTypeDef.h>
+#include <KokkosInterface.h>
 
 namespace stk {
 namespace mesh {
@@ -43,7 +44,7 @@ RunInterpActuatorVel(ActuatorBulk& actBulk, stk::mesh::BulkData& stkBulk)
   Kokkos::deep_copy(actBulk.velocity_.view_host(), 0.0);
   actBulk.velocity_.modify_host();
   Kokkos::parallel_for(
-    "InterpActVel", actBulk.velocity_.extent(0),
+    "InterpActVel", HostRangePolicy(0,actBulk.velocity_.extent(0)),
     InterpActuatorVel(actBulk, stkBulk));
   actuator_utils::reduce_view_on_host(actBulk.velocity_.view_host());
 }

--- a/include/aero/actuator/ActuatorFunctors.h
+++ b/include/aero/actuator/ActuatorFunctors.h
@@ -44,7 +44,7 @@ RunInterpActuatorVel(ActuatorBulk& actBulk, stk::mesh::BulkData& stkBulk)
   Kokkos::deep_copy(actBulk.velocity_.view_host(), 0.0);
   actBulk.velocity_.modify_host();
   Kokkos::parallel_for(
-    "InterpActVel", HostRangePolicy(0,actBulk.velocity_.extent(0)),
+    "InterpActVel", HostRangePolicy(0, actBulk.velocity_.extent(0)),
     InterpActuatorVel(actBulk, stkBulk));
   actuator_utils::reduce_view_on_host(actBulk.velocity_.view_host());
 }

--- a/include/master_element/MasterElementFactory.h
+++ b/include/master_element/MasterElementFactory.h
@@ -71,7 +71,8 @@ MasterElementRepo::get_master_element(
     ME* MEinstance = kokkos_malloc_on_device<ME>(allocname);
     ThrowRequire(MEinstance != nullptr);
     Kokkos::parallel_for(
-      placementname, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { new (MEinstance) ME(); });
+      placementname, DeviceRangePolicy(0, 1),
+      KOKKOS_LAMBDA(const int) { new (MEinstance) ME(); });
     meMap[theTopo] = MEinstance;
   }
   return meMap.at(theTopo);

--- a/include/master_element/MasterElementFactory.h
+++ b/include/master_element/MasterElementFactory.h
@@ -71,7 +71,7 @@ MasterElementRepo::get_master_element(
     ME* MEinstance = kokkos_malloc_on_device<ME>(allocname);
     ThrowRequire(MEinstance != nullptr);
     Kokkos::parallel_for(
-      placementname, 1, KOKKOS_LAMBDA(const int) { new (MEinstance) ME(); });
+      placementname, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int) { new (MEinstance) ME(); });
     meMap[theTopo] = MEinstance;
   }
   return meMap.at(theTopo);

--- a/include/matrix_free/StkSimdMeshTraverser.h
+++ b/include/matrix_free/StkSimdMeshTraverser.h
@@ -10,6 +10,7 @@
 #ifndef STK_SIMD_MESH_TRAVERSER_H
 #define STK_SIMD_MESH_TRAVERSER_H
 
+#include <KokkosInterface.h>
 #include <Kokkos_View.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/Selector.hpp>
@@ -121,10 +122,9 @@ simd_traverse(
   auto buckets = mesh.get_bucket_ids(rank, active);
   const auto bucket_offsets = impl::simd_bucket_offsets(mesh, rank, buckets);
   Kokkos::parallel_for(
-    Kokkos::TeamPolicy<stk::mesh::NgpMesh::MeshExecSpace>(
-      buckets.size(), Kokkos::AUTO),
+    DeviceTeamPolicy(buckets.size(), Kokkos::AUTO),
     KOKKOS_LAMBDA(
-      const typename Kokkos::TeamPolicy<exec_space>::member_type& team) {
+      const typename DeviceTeamPolicy::member_type& team) {
       const auto bucket_id = buckets.device_get(team.league_rank());
       const auto& b = mesh.get_bucket(rank, bucket_id);
       const auto bucket_len = b.size();

--- a/include/matrix_free/StkSimdMeshTraverser.h
+++ b/include/matrix_free/StkSimdMeshTraverser.h
@@ -123,8 +123,7 @@ simd_traverse(
   const auto bucket_offsets = impl::simd_bucket_offsets(mesh, rank, buckets);
   Kokkos::parallel_for(
     DeviceTeamPolicy(buckets.size(), Kokkos::AUTO),
-    KOKKOS_LAMBDA(
-      const typename DeviceTeamPolicy::member_type& team) {
+    KOKKOS_LAMBDA(const typename DeviceTeamPolicy::member_type& team) {
       const auto bucket_id = buckets.device_get(team.league_rank());
       const auto& b = mesh.get_bucket(rank, bucket_id);
       const auto bucket_len = b.size();

--- a/include/ngp_utils/NgpMEUtils.h
+++ b/include/ngp_utils/NgpMEUtils.h
@@ -71,7 +71,7 @@ nodes_per_entity(const DataReqType& dataReq, const METype meType)
 
   Kokkos::View<int*, sierra::nalu::MemSpace> npe("npe", 1);
   Kokkos::parallel_for(
-    "get_nodes_per_element", DeviceRangePolicy(0,1),
+    "get_nodes_per_element", DeviceRangePolicy(0, 1),
     KOKKOS_LAMBDA(const int i) { npe(i) = me->nodesPerElement_; });
   Kokkos::View<int*, sierra::nalu::MemSpace>::HostMirror npe_host("npe", 1);
   Kokkos::deep_copy(npe_host, npe);
@@ -90,7 +90,7 @@ num_integration_points(const DataReqType& dataReq, const METype meType)
 
   Kokkos::View<int*, sierra::nalu::MemSpace> nips("nips", 1);
   Kokkos::parallel_for(
-    "get_num_integration_points", DeviceRangePolicy(0,1),
+    "get_num_integration_points", DeviceRangePolicy(0, 1),
     KOKKOS_LAMBDA(const int i) { nips(i) = me->num_integration_points(); });
   Kokkos::View<int*, sierra::nalu::MemSpace>::HostMirror nips_host("nips", 1);
   Kokkos::deep_copy(nips_host, nips);

--- a/include/ngp_utils/NgpMEUtils.h
+++ b/include/ngp_utils/NgpMEUtils.h
@@ -71,7 +71,7 @@ nodes_per_entity(const DataReqType& dataReq, const METype meType)
 
   Kokkos::View<int*, sierra::nalu::MemSpace> npe("npe", 1);
   Kokkos::parallel_for(
-    "get_nodes_per_element", 1,
+    "get_nodes_per_element", DeviceRangePolicy(0,1),
     KOKKOS_LAMBDA(const int i) { npe(i) = me->nodesPerElement_; });
   Kokkos::View<int*, sierra::nalu::MemSpace>::HostMirror npe_host("npe", 1);
   Kokkos::deep_copy(npe_host, npe);
@@ -90,7 +90,7 @@ num_integration_points(const DataReqType& dataReq, const METype meType)
 
   Kokkos::View<int*, sierra::nalu::MemSpace> nips("nips", 1);
   Kokkos::parallel_for(
-    "get_num_integration_points", 1,
+    "get_num_integration_points", DeviceRangePolicy(0,1),
     KOKKOS_LAMBDA(const int i) { nips(i) = me->num_integration_points(); });
   Kokkos::View<int*, sierra::nalu::MemSpace>::HostMirror nips_host("nips", 1);
   Kokkos::deep_copy(nips_host, nips);

--- a/include/ngp_utils/NgpTypes.h
+++ b/include/ngp_utils/NgpTypes.h
@@ -90,8 +90,10 @@ struct NGPMeshTraits
   using FieldScalarType = double;
 
 #if defined(KOKKOS_ENABLE_HIP)
-  using TeamPolicy =
-    Kokkos::TeamPolicy<typename Mesh::MeshExecSpace, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, stk::ngp::ScheduleType>;
+  using TeamPolicy = Kokkos::TeamPolicy<
+    typename Mesh::MeshExecSpace,
+    Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    stk::ngp::ScheduleType>;
 #else
   using TeamPolicy =
     Kokkos::TeamPolicy<typename Mesh::MeshExecSpace, stk::ngp::ScheduleType>;

--- a/include/ngp_utils/NgpTypes.h
+++ b/include/ngp_utils/NgpTypes.h
@@ -16,6 +16,7 @@
 
 #include "ngp_utils/NgpMeshInfo.h"
 #include "stk_mesh/base/NgpMesh.hpp"
+#include "KokkosInterface.h"
 #include "SimdInterface.h"
 
 #include <memory>
@@ -88,8 +89,13 @@ struct NGPMeshTraits
   //! Default scalar type for field data
   using FieldScalarType = double;
 
+#if defined(KOKKOS_ENABLE_HIP)
+  using TeamPolicy =
+    Kokkos::TeamPolicy<typename Mesh::MeshExecSpace, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, stk::ngp::ScheduleType>;
+#else
   using TeamPolicy =
     Kokkos::TeamPolicy<typename Mesh::MeshExecSpace, stk::ngp::ScheduleType>;
+#endif
   using TeamHandleType = typename TeamPolicy::member_type;
   using ShmemType = typename Mesh::MeshExecSpace::scratch_memory_space;
   using MeshIndex = typename Mesh::MeshIndex;

--- a/include/utils/CreateDeviceExpression.h
+++ b/include/utils/CreateDeviceExpression.h
@@ -17,7 +17,7 @@ create_device_expression(const T& rhs)
   // Bring rhs into local scope for capture to device.
   const T RHS(rhs);
   Kokkos::parallel_for(
-    debuggingName, 1, KOKKOS_LAMBDA(const int /* i */) { new (t) T(RHS); });
+    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int /* i */) { new (t) T(RHS); });
   return t;
 }
 
@@ -28,7 +28,7 @@ create_device_expression()
   const std::string debuggingName(typeid(T).name());
   T* t = kokkos_malloc_on_device<T>(debuggingName);
   Kokkos::parallel_for(
-    debuggingName, 1, KOKKOS_LAMBDA(const int /* i */) { new (t) T(); });
+    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int /* i */) { new (t) T(); });
   return t;
 }
 } // namespace nalu

--- a/include/utils/CreateDeviceExpression.h
+++ b/include/utils/CreateDeviceExpression.h
@@ -17,7 +17,8 @@ create_device_expression(const T& rhs)
   // Bring rhs into local scope for capture to device.
   const T RHS(rhs);
   Kokkos::parallel_for(
-    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int /* i */) { new (t) T(RHS); });
+    debuggingName, DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const int /* i */) { new (t) T(RHS); });
   return t;
 }
 
@@ -28,7 +29,8 @@ create_device_expression()
   const std::string debuggingName(typeid(T).name());
   T* t = kokkos_malloc_on_device<T>(debuggingName);
   Kokkos::parallel_for(
-    debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int /* i */) { new (t) T(); });
+    debuggingName, DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const int /* i */) { new (t) T(); });
   return t;
 }
 } // namespace nalu

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -1231,7 +1231,7 @@ HypreLinearSystem::buildCoeffApplierDeviceSharedDataStructures()
   auto ms = hcApplier->map_shared_;
   auto ris = row_indices_shared;
   Kokkos::parallel_for(
-    "init_shared_map", DeviceRangePolicy(0,hcApplier->num_rows_shared_),
+    "init_shared_map", DeviceRangePolicy(0, hcApplier->num_rows_shared_),
     KOKKOS_LAMBDA(const HypreIntType i) { ms.insert(ris(i), i); });
 }
 
@@ -1418,8 +1418,8 @@ HypreLinearSystem::resetCoeffApplierData()
 
     auto iLower = iLower_;
     Kokkos::parallel_for(
-      "HypreLinearSystem::resetCoeffApplierData::periodic_bcs", DeviceRangePolicy(0,N),
-      KOKKOS_LAMBDA(const unsigned& i) {
+      "HypreLinearSystem::resetCoeffApplierData::periodic_bcs",
+      DeviceRangePolicy(0, N), KOKKOS_LAMBDA(const unsigned& i) {
         HypreIntType hid = periodic_bc_rows(i);
         unsigned matIndex = mat_row_start_owned(hid - iLower);
         vals(matIndex) = 1.0;
@@ -1456,7 +1456,8 @@ HypreLinearSystem::finishCoupledOversetAssembly()
     auto vals = hcApplier->values_dev_;
     /* write to the matrix */
     Kokkos::parallel_for(
-      "fillOversetMatrixRows", DeviceRangePolicy(0,N), KOKKOS_LAMBDA(const unsigned& i) {
+      "fillOversetMatrixRows", DeviceRangePolicy(0, N),
+      KOKKOS_LAMBDA(const unsigned& i) {
         HypreIntType row = orows(i);
         HypreIntType col = ocols(i);
         /* binary search subrange rather than a map.find */
@@ -1483,7 +1484,8 @@ HypreLinearSystem::finishCoupledOversetAssembly()
     auto rhs_vals = hcApplier->rhs_dev_;
     /* write to the rhs */
     Kokkos::parallel_for(
-      "fillOversetRhsVector", DeviceRangePolicy(0,N), KOKKOS_LAMBDA(const unsigned& i) {
+      "fillOversetRhsVector", DeviceRangePolicy(0, N),
+      KOKKOS_LAMBDA(const unsigned& i) {
         HypreIntType row = orow_indices(i);
         rhs_vals(row - iLower, 0) = orvals(i);
       });
@@ -2616,7 +2618,7 @@ HypreLinearSystem::copy_hypre_to_stk(stk::mesh::FieldBase* stkField)
   double* rhs_data = hypre_VectorData(
     hypre_ParVectorLocalVector((hypre_ParVector*)hypre_IJVectorObject(rhs_)));
   Kokkos::parallel_reduce(
-    "HypreLinearSystem::Reduction", DeviceRangePolicy(0,N),
+    "HypreLinearSystem::Reduction", DeviceRangePolicy(0, N),
     KOKKOS_LAMBDA(const int i, double& update) {
       double t = rhs_data[i];
       update += t * t;

--- a/src/HypreLinearSystem.C
+++ b/src/HypreLinearSystem.C
@@ -1231,7 +1231,7 @@ HypreLinearSystem::buildCoeffApplierDeviceSharedDataStructures()
   auto ms = hcApplier->map_shared_;
   auto ris = row_indices_shared;
   Kokkos::parallel_for(
-    "init_shared_map", hcApplier->num_rows_shared_,
+    "init_shared_map", DeviceRangePolicy(0,hcApplier->num_rows_shared_),
     KOKKOS_LAMBDA(const HypreIntType i) { ms.insert(ris(i), i); });
 }
 
@@ -1418,7 +1418,7 @@ HypreLinearSystem::resetCoeffApplierData()
 
     auto iLower = iLower_;
     Kokkos::parallel_for(
-      "HypreLinearSystem::resetCoeffApplierData::periodic_bcs", N,
+      "HypreLinearSystem::resetCoeffApplierData::periodic_bcs", DeviceRangePolicy(0,N),
       KOKKOS_LAMBDA(const unsigned& i) {
         HypreIntType hid = periodic_bc_rows(i);
         unsigned matIndex = mat_row_start_owned(hid - iLower);
@@ -1456,7 +1456,7 @@ HypreLinearSystem::finishCoupledOversetAssembly()
     auto vals = hcApplier->values_dev_;
     /* write to the matrix */
     Kokkos::parallel_for(
-      "fillOversetMatrixRows", N, KOKKOS_LAMBDA(const unsigned& i) {
+      "fillOversetMatrixRows", DeviceRangePolicy(0,N), KOKKOS_LAMBDA(const unsigned& i) {
         HypreIntType row = orows(i);
         HypreIntType col = ocols(i);
         /* binary search subrange rather than a map.find */
@@ -1483,7 +1483,7 @@ HypreLinearSystem::finishCoupledOversetAssembly()
     auto rhs_vals = hcApplier->rhs_dev_;
     /* write to the rhs */
     Kokkos::parallel_for(
-      "fillOversetRhsVector", N, KOKKOS_LAMBDA(const unsigned& i) {
+      "fillOversetRhsVector", DeviceRangePolicy(0,N), KOKKOS_LAMBDA(const unsigned& i) {
         HypreIntType row = orow_indices(i);
         rhs_vals(row - iLower, 0) = orvals(i);
       });
@@ -2616,7 +2616,7 @@ HypreLinearSystem::copy_hypre_to_stk(stk::mesh::FieldBase* stkField)
   double* rhs_data = hypre_VectorData(
     hypre_ParVectorLocalVector((hypre_ParVector*)hypre_IJVectorObject(rhs_)));
   Kokkos::parallel_reduce(
-    "HypreLinearSystem::Reduction", N,
+    "HypreLinearSystem::Reduction", DeviceRangePolicy(0,N),
     KOKKOS_LAMBDA(const int i, double& update) {
       double t = rhs_data[i];
       update += t * t;

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -640,7 +640,7 @@ HypreUVWLinearSystem::copy_hypre_to_stk(
     double* rhs_data = hypre_VectorData(hypre_ParVectorLocalVector(
       (hypre_ParVector*)hypre_IJVectorObject(rhs_[d])));
     Kokkos::parallel_reduce(
-      "HypreUVWLinearSystem::Reduction", DeviceRangePolicy(0,N),
+      "HypreUVWLinearSystem::Reduction", DeviceRangePolicy(0, N),
       KOKKOS_LAMBDA(const int i, double& update) {
         double t = rhs_data[i];
         update += t * t;

--- a/src/HypreUVWLinearSystem.C
+++ b/src/HypreUVWLinearSystem.C
@@ -640,7 +640,7 @@ HypreUVWLinearSystem::copy_hypre_to_stk(
     double* rhs_data = hypre_VectorData(hypre_ParVectorLocalVector(
       (hypre_ParVector*)hypre_IJVectorObject(rhs_[d])));
     Kokkos::parallel_reduce(
-      "HypreUVWLinearSystem::Reduction", N,
+      "HypreUVWLinearSystem::Reduction", DeviceRangePolicy(0,N),
       KOKKOS_LAMBDA(const int i, double& update) {
         double t = rhs_data[i];
         update += t * t;

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -1085,7 +1085,8 @@ PeriodicManager::ngp_add_slave_to_master(
   if (bypassFieldCheck) {
     // fields are expected to be defined on all master/slave nodes
     Kokkos::parallel_for(
-      "add_slave_to_master", DeviceRangePolicy(0,masterSlaveCommunicator_.size()),
+      "add_slave_to_master",
+      DeviceRangePolicy(0, masterSlaveCommunicator_.size()),
       KOKKOS_LAMBDA(const int i) {
         // extract master node and slave node
         const KokkosEntityPair& entPair = deviceMasterSlaves(i);
@@ -1105,7 +1106,8 @@ PeriodicManager::ngp_add_slave_to_master(
   } else {
     // more costly check to see if fields are defined on master/slave nodes
     Kokkos::parallel_for(
-      "add_slave_to_master", DeviceRangePolicy(0,masterSlaveCommunicator_.size()),
+      "add_slave_to_master",
+      DeviceRangePolicy(0, masterSlaveCommunicator_.size()),
       KOKKOS_LAMBDA(const int i) {
         // extract master node and slave node
         const KokkosEntityPair& entPair = deviceMasterSlaves(i);
@@ -1215,7 +1217,8 @@ PeriodicManager::ngp_set_slave_to_master(
   if (bypassFieldCheck) {
     // fields are expected to be defined on all master/slave nodes
     Kokkos::parallel_for(
-      "set_slave_to_master", DeviceRangePolicy(0,masterSlaveCommunicator_.size()),
+      "set_slave_to_master",
+      DeviceRangePolicy(0, masterSlaveCommunicator_.size()),
       KOKKOS_LAMBDA(const int i) {
         // extract master node and slave node
         const KokkosEntityPair& entPair = deviceMasterSlaves(i);
@@ -1233,7 +1236,8 @@ PeriodicManager::ngp_set_slave_to_master(
   } else {
     // more costly check to see if fields are defined on master/slave nodes
     Kokkos::parallel_for(
-      "set_slave_to_master", DeviceRangePolicy(0,masterSlaveCommunicator_.size()),
+      "set_slave_to_master",
+      DeviceRangePolicy(0, masterSlaveCommunicator_.size()),
       KOKKOS_LAMBDA(const int i) {
         // extract master node and slave node
         const KokkosEntityPair& entPair = deviceMasterSlaves(i);

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -1085,7 +1085,7 @@ PeriodicManager::ngp_add_slave_to_master(
   if (bypassFieldCheck) {
     // fields are expected to be defined on all master/slave nodes
     Kokkos::parallel_for(
-      "add_slave_to_master", masterSlaveCommunicator_.size(),
+      "add_slave_to_master", DeviceRangePolicy(0,masterSlaveCommunicator_.size()),
       KOKKOS_LAMBDA(const int i) {
         // extract master node and slave node
         const KokkosEntityPair& entPair = deviceMasterSlaves(i);
@@ -1105,7 +1105,7 @@ PeriodicManager::ngp_add_slave_to_master(
   } else {
     // more costly check to see if fields are defined on master/slave nodes
     Kokkos::parallel_for(
-      "add_slave_to_master", masterSlaveCommunicator_.size(),
+      "add_slave_to_master", DeviceRangePolicy(0,masterSlaveCommunicator_.size()),
       KOKKOS_LAMBDA(const int i) {
         // extract master node and slave node
         const KokkosEntityPair& entPair = deviceMasterSlaves(i);
@@ -1215,7 +1215,7 @@ PeriodicManager::ngp_set_slave_to_master(
   if (bypassFieldCheck) {
     // fields are expected to be defined on all master/slave nodes
     Kokkos::parallel_for(
-      "set_slave_to_master", masterSlaveCommunicator_.size(),
+      "set_slave_to_master", DeviceRangePolicy(0,masterSlaveCommunicator_.size()),
       KOKKOS_LAMBDA(const int i) {
         // extract master node and slave node
         const KokkosEntityPair& entPair = deviceMasterSlaves(i);
@@ -1233,7 +1233,7 @@ PeriodicManager::ngp_set_slave_to_master(
   } else {
     // more costly check to see if fields are defined on master/slave nodes
     Kokkos::parallel_for(
-      "set_slave_to_master", masterSlaveCommunicator_.size(),
+      "set_slave_to_master", DeviceRangePolicy(0,masterSlaveCommunicator_.size()),
       KOKKOS_LAMBDA(const int i) {
         // extract master node and slave node
         const KokkosEntityPair& entPair = deviceMasterSlaves(i);

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1523,7 +1523,7 @@ TpetraLinearSystem::get_coeff_applier()
   auto newDeviceCoeffApplier =
     kokkos_malloc_on_device<TpetraLinSysCoeffApplier>("deviceCoeffApplier");
   Kokkos::parallel_for(
-    1, KOKKOS_LAMBDA(const int&) {
+    DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int&) {
       new (newDeviceCoeffApplier) TpetraLinSysCoeffApplier(
         ownedLocalMatrix, sharedNotOwnedLocalMatrix, ownedLocalRhs,
         sharedNotOwnedLocalRhs, entityToLID, entityToColLID, maxOwnedRowId,

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -1523,7 +1523,7 @@ TpetraLinearSystem::get_coeff_applier()
   auto newDeviceCoeffApplier =
     kokkos_malloc_on_device<TpetraLinSysCoeffApplier>("deviceCoeffApplier");
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int&) {
+    DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(const int&) {
       new (newDeviceCoeffApplier) TpetraLinSysCoeffApplier(
         ownedLocalMatrix, sharedNotOwnedLocalMatrix, ownedLocalRhs,
         sharedNotOwnedLocalRhs, entityToLID, entityToColLID, maxOwnedRowId,

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -1309,7 +1309,7 @@ TpetraSegregatedLinearSystem::get_coeff_applier()
   auto newDeviceCoeffApplier =
     kokkos_malloc_on_device<TpetraLinSysCoeffApplier>("deviceCoeffApplier");
   Kokkos::parallel_for(
-    1, KOKKOS_LAMBDA(const int&) {
+    DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int&) {
       new (newDeviceCoeffApplier) TpetraLinSysCoeffApplier(
         ownedLocalMatrix, sharedNotOwnedLocalMatrix, ownedLocalRhs,
         sharedNotOwnedLocalRhs, entityToLID, entityToColLID, maxOwnedRowId,

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -1309,7 +1309,7 @@ TpetraSegregatedLinearSystem::get_coeff_applier()
   auto newDeviceCoeffApplier =
     kokkos_malloc_on_device<TpetraLinSysCoeffApplier>("deviceCoeffApplier");
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const int&) {
+    DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(const int&) {
       new (newDeviceCoeffApplier) TpetraLinSysCoeffApplier(
         ownedLocalMatrix, sharedNotOwnedLocalMatrix, ownedLocalRhs,
         sharedNotOwnedLocalRhs, entityToLID, entityToColLID, maxOwnedRowId,

--- a/src/aero/actuator/ActuatorBulkFAST.C
+++ b/src/aero/actuator/ActuatorBulkFAST.C
@@ -300,13 +300,14 @@ void
 ActuatorBulkFAST::output_torque_info(stk::mesh::BulkData& stkBulk)
 {
   Kokkos::parallel_for(
-    "setUpTorqueCalc", DeviceRangePolicy(0,hubLocations_.extent(0)), ActFastSetUpThrustCalc(*this));
+    "setUpTorqueCalc", DeviceRangePolicy(0, hubLocations_.extent(0)),
+    ActFastSetUpThrustCalc(*this));
 
   actuator_utils::reduce_view_on_host(hubLocations_);
   actuator_utils::reduce_view_on_host(hubOrientation_);
 
   Kokkos::parallel_for(
-    "computeTorque", DeviceRangePolicy(0,coarseSearchElemIds_.extent(0)),
+    "computeTorque", DeviceRangePolicy(0, coarseSearchElemIds_.extent(0)),
     ActFastComputeThrust(*this, stkBulk));
   actuator_utils::reduce_view_on_host(turbineThrust_);
   actuator_utils::reduce_view_on_host(turbineTorque_);

--- a/src/aero/actuator/ActuatorBulkFAST.C
+++ b/src/aero/actuator/ActuatorBulkFAST.C
@@ -300,13 +300,13 @@ void
 ActuatorBulkFAST::output_torque_info(stk::mesh::BulkData& stkBulk)
 {
   Kokkos::parallel_for(
-    "setUpTorqueCalc", hubLocations_.extent(0), ActFastSetUpThrustCalc(*this));
+    "setUpTorqueCalc", DeviceRangePolicy(0,hubLocations_.extent(0)), ActFastSetUpThrustCalc(*this));
 
   actuator_utils::reduce_view_on_host(hubLocations_);
   actuator_utils::reduce_view_on_host(hubOrientation_);
 
   Kokkos::parallel_for(
-    "computeTorque", coarseSearchElemIds_.extent(0),
+    "computeTorque", DeviceRangePolicy(0,coarseSearchElemIds_.extent(0)),
     ActFastComputeThrust(*this, stkBulk));
   actuator_utils::reduce_view_on_host(turbineThrust_);
   actuator_utils::reduce_view_on_host(turbineTorque_);

--- a/src/aero/actuator/ActuatorExecutorsFASTNgp.C
+++ b/src/aero/actuator/ActuatorExecutorsFASTNgp.C
@@ -57,13 +57,13 @@ ActuatorLineFastNGP::operator()()
 
   if (actMeta_.isotropicGaussian_) {
     Kokkos::parallel_for(
-      "spreadForcesActuatorNgpFAST", localSizeCoarseSearch,
+      "spreadForcesActuatorNgpFAST", DeviceRangePolicy(0,localSizeCoarseSearch),
       SpreadActuatorForce(actBulk_, stkBulk_));
   } else {
     RunActFastStashOrientVecs(actBulk_);
 
     Kokkos::parallel_for(
-      "spreadForceUsingProjDistance", localSizeCoarseSearch,
+      "spreadForceUsingProjDistance", DeviceRangePolicy(0,localSizeCoarseSearch),
       ActFastSpreadForceWhProjection(actBulk_, stkBulk_));
   }
 
@@ -128,7 +128,7 @@ ActuatorDiskFastNGP::operator()()
     actBulk_.coarseSearchElemIds_.view_host().extent_int(0);
 
   Kokkos::parallel_for(
-    "spreadForcesActuatorNgpFAST", localSizeCoarseSearch,
+    "spreadForcesActuatorNgpFAST", DeviceRangePolicy(0,localSizeCoarseSearch),
     SpreadActuatorForce(actBulk_, stkBulk_));
 
   actBulk_.parallel_sum_source_term(stkBulk_);

--- a/src/aero/actuator/ActuatorExecutorsFASTNgp.C
+++ b/src/aero/actuator/ActuatorExecutorsFASTNgp.C
@@ -57,13 +57,15 @@ ActuatorLineFastNGP::operator()()
 
   if (actMeta_.isotropicGaussian_) {
     Kokkos::parallel_for(
-      "spreadForcesActuatorNgpFAST", DeviceRangePolicy(0,localSizeCoarseSearch),
+      "spreadForcesActuatorNgpFAST",
+      DeviceRangePolicy(0, localSizeCoarseSearch),
       SpreadActuatorForce(actBulk_, stkBulk_));
   } else {
     RunActFastStashOrientVecs(actBulk_);
 
     Kokkos::parallel_for(
-      "spreadForceUsingProjDistance", DeviceRangePolicy(0,localSizeCoarseSearch),
+      "spreadForceUsingProjDistance",
+      DeviceRangePolicy(0, localSizeCoarseSearch),
       ActFastSpreadForceWhProjection(actBulk_, stkBulk_));
   }
 
@@ -128,7 +130,7 @@ ActuatorDiskFastNGP::operator()()
     actBulk_.coarseSearchElemIds_.view_host().extent_int(0);
 
   Kokkos::parallel_for(
-    "spreadForcesActuatorNgpFAST", DeviceRangePolicy(0,localSizeCoarseSearch),
+    "spreadForcesActuatorNgpFAST", DeviceRangePolicy(0, localSizeCoarseSearch),
     SpreadActuatorForce(actBulk_, stkBulk_));
 
   actBulk_.parallel_sum_source_term(stkBulk_);

--- a/src/aero/actuator/ActuatorExecutorsSimpleNgp.C
+++ b/src/aero/actuator/ActuatorExecutorsSimpleNgp.C
@@ -57,12 +57,12 @@ ActuatorLineSimpleNGP::operator()()
   actBulk_.stk_search_act_pnts(actMeta_, stkBulk_);
 
   Kokkos::parallel_for(
-    "interpolateVelocitiesActuatorNgpSimple", HostRangePolicy(0,numActPoints_),
+    "interpolateVelocitiesActuatorNgpSimple", HostRangePolicy(0, numActPoints_),
     InterpActuatorVel(actBulk_, stkBulk_));
   actuator_utils::reduce_view_on_host(velReduce);
 
   Kokkos::parallel_for(
-    "interpolateDensityActuatorNgpSimple", HostRangePolicy(0,numActPoints_),
+    "interpolateDensityActuatorNgpSimple", HostRangePolicy(0, numActPoints_),
     InterpActuatorDensity(actBulk_, stkBulk_));
   auto rhoReduce = actBulk_.density_.view_host();
   actuator_utils::reduce_view_on_host(rhoReduce);
@@ -89,12 +89,13 @@ ActuatorLineSimpleNGP::operator()()
   // -- for both isotropic and anisotropic Guassians ---
   if (useSpreadActuatorForce_) {
     Kokkos::parallel_for(
-      "spreadForcesActuatorNgpSimple", HostRangePolicy(0,localSizeCoarseSearch),
+      "spreadForcesActuatorNgpSimple",
+      HostRangePolicy(0, localSizeCoarseSearch),
       SpreadActuatorForce(actBulk_, stkBulk_));
   } else {
     // --  use ActSimpleSpreadForceWhProjection
     Kokkos::parallel_for(
-      "spreadForceUsingProjDistance", HostRangePolicy(0,localSizeCoarseSearch),
+      "spreadForceUsingProjDistance", HostRangePolicy(0, localSizeCoarseSearch),
       ActSimpleSpreadForceWhProjection(actBulk_, stkBulk_));
   }
 

--- a/src/aero/actuator/ActuatorExecutorsSimpleNgp.C
+++ b/src/aero/actuator/ActuatorExecutorsSimpleNgp.C
@@ -57,12 +57,12 @@ ActuatorLineSimpleNGP::operator()()
   actBulk_.stk_search_act_pnts(actMeta_, stkBulk_);
 
   Kokkos::parallel_for(
-    "interpolateVelocitiesActuatorNgpSimple", numActPoints_,
+    "interpolateVelocitiesActuatorNgpSimple", HostRangePolicy(0,numActPoints_),
     InterpActuatorVel(actBulk_, stkBulk_));
   actuator_utils::reduce_view_on_host(velReduce);
 
   Kokkos::parallel_for(
-    "interpolateDensityActuatorNgpSimple", numActPoints_,
+    "interpolateDensityActuatorNgpSimple", HostRangePolicy(0,numActPoints_),
     InterpActuatorDensity(actBulk_, stkBulk_));
   auto rhoReduce = actBulk_.density_.view_host();
   actuator_utils::reduce_view_on_host(rhoReduce);
@@ -89,12 +89,12 @@ ActuatorLineSimpleNGP::operator()()
   // -- for both isotropic and anisotropic Guassians ---
   if (useSpreadActuatorForce_) {
     Kokkos::parallel_for(
-      "spreadForcesActuatorNgpSimple", localSizeCoarseSearch,
+      "spreadForcesActuatorNgpSimple", HostRangePolicy(0,localSizeCoarseSearch),
       SpreadActuatorForce(actBulk_, stkBulk_));
   } else {
     // --  use ActSimpleSpreadForceWhProjection
     Kokkos::parallel_for(
-      "spreadForceUsingProjDistance", localSizeCoarseSearch,
+      "spreadForceUsingProjDistance", HostRangePolicy(0,localSizeCoarseSearch),
       ActSimpleSpreadForceWhProjection(actBulk_, stkBulk_));
   }
 

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -45,7 +45,7 @@ get_shape_fcn_data(
   const bool skew = skewSymmetric;
   auto vf_shape = Kokkos::create_mirror_view(vf_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         vf_shape.data(), BcAlgTraits::numFaceIp_, BcAlgTraits::nodesPerFace_);
       meFC_dev->shape_fcn<>(ShmemView);
@@ -54,7 +54,7 @@ get_shape_fcn_data(
 
   auto v_shape = Kokkos::create_mirror_view(v_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         v_shape.data(), BcAlgTraits::numFaceIp_, BcAlgTraits::nodesPerFace_);
       meSCS_dev->shape_fcn<>(ShmemView);
@@ -63,7 +63,7 @@ get_shape_fcn_data(
 
   auto vf_adv_shape = Kokkos::create_mirror_view(vf_adv_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         vf_adv_shape.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);
@@ -76,7 +76,7 @@ get_shape_fcn_data(
 
   auto v_adv_shape = Kokkos::create_mirror_view(v_adv_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         v_adv_shape.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -45,7 +45,7 @@ get_shape_fcn_data(
   const bool skew = skewSymmetric;
   auto vf_shape = Kokkos::create_mirror_view(vf_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", 1, KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         vf_shape.data(), BcAlgTraits::numFaceIp_, BcAlgTraits::nodesPerFace_);
       meFC_dev->shape_fcn<>(ShmemView);
@@ -54,7 +54,7 @@ get_shape_fcn_data(
 
   auto v_shape = Kokkos::create_mirror_view(v_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", 1, KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         v_shape.data(), BcAlgTraits::numFaceIp_, BcAlgTraits::nodesPerFace_);
       meSCS_dev->shape_fcn<>(ShmemView);
@@ -63,7 +63,7 @@ get_shape_fcn_data(
 
   auto vf_adv_shape = Kokkos::create_mirror_view(vf_adv_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", 1, KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         vf_adv_shape.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);
@@ -76,7 +76,7 @@ get_shape_fcn_data(
 
   auto v_adv_shape = Kokkos::create_mirror_view(v_adv_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", 1, KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         v_adv_shape.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -31,7 +31,7 @@ get_shape_fcn(T& vf_shape_function, MasterElement* meFC_dev)
 {
   auto dev_shape_function = Kokkos::create_mirror_view(vf_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         dev_shape_function.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -31,7 +31,7 @@ get_shape_fcn(T& vf_shape_function, MasterElement* meFC_dev)
 {
   auto dev_shape_function = Kokkos::create_mirror_view(vf_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", 1, KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         dev_shape_function.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/MomentumWallFunctionElemKernel.C
+++ b/src/kernel/MomentumWallFunctionElemKernel.C
@@ -32,7 +32,7 @@ get_shape_fcn(T& vf_shape_function, MasterElement* meFC_dev)
 {
   auto dev_shape_function = Kokkos::create_mirror_view(vf_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", 1, KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         dev_shape_function.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/MomentumWallFunctionElemKernel.C
+++ b/src/kernel/MomentumWallFunctionElemKernel.C
@@ -32,7 +32,7 @@ get_shape_fcn(T& vf_shape_function, MasterElement* meFC_dev)
 {
   auto dev_shape_function = Kokkos::create_mirror_view(vf_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         dev_shape_function.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -32,7 +32,7 @@ get_shape_fcn(T& vf_shape_function, MasterElement* meFC_dev)
 {
   auto dev_shape_function = Kokkos::create_mirror_view(vf_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", 1, KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         dev_shape_function.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -32,7 +32,7 @@ get_shape_fcn(T& vf_shape_function, MasterElement* meFC_dev)
 {
   auto dev_shape_function = Kokkos::create_mirror_view(vf_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         dev_shape_function.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/ScalarOpenAdvElemKernel.C
+++ b/src/kernel/ScalarOpenAdvElemKernel.C
@@ -34,7 +34,7 @@ get_shape_fcn(
 {
   auto dev_shape_function = Kokkos::create_mirror_view(vf_adv_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0, 1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         dev_shape_function.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/kernel/ScalarOpenAdvElemKernel.C
+++ b/src/kernel/ScalarOpenAdvElemKernel.C
@@ -34,7 +34,7 @@ get_shape_fcn(
 {
   auto dev_shape_function = Kokkos::create_mirror_view(vf_adv_shape_function);
   Kokkos::parallel_for(
-    "get_shape_fcn_data", 1, KOKKOS_LAMBDA(int) {
+    "get_shape_fcn_data", DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) {
       SharedMemView<DoubleType**, DeviceShmem> ShmemView(
         dev_shape_function.data(), BcAlgTraits::numFaceIp_,
         BcAlgTraits::nodesPerFace_);

--- a/src/master_element/MasterElementFactory.C
+++ b/src/master_element/MasterElementFactory.C
@@ -235,7 +235,7 @@ MasterElementRepo::clear()
     const std::string debuggingName("MEDestroy: " + a.first.name());
     auto* meobj = a.second;
     Kokkos::parallel_for(
-      debuggingName, 1, KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
+      debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
     sierra::nalu::kokkos_free_on_device(a.second);
   }
   volumeMeMapDev().clear();
@@ -243,7 +243,7 @@ MasterElementRepo::clear()
     const std::string debuggingName("MEDestroy: " + a.first.name());
     auto* meobj = a.second;
     Kokkos::parallel_for(
-      debuggingName, 1, KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
+      debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
     sierra::nalu::kokkos_free_on_device(a.second);
   }
   surfaceMeMapDev().clear();

--- a/src/master_element/MasterElementFactory.C
+++ b/src/master_element/MasterElementFactory.C
@@ -235,7 +235,8 @@ MasterElementRepo::clear()
     const std::string debuggingName("MEDestroy: " + a.first.name());
     auto* meobj = a.second;
     Kokkos::parallel_for(
-      debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
+      debuggingName, DeviceRangePolicy(0, 1),
+      KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
     sierra::nalu::kokkos_free_on_device(a.second);
   }
   volumeMeMapDev().clear();
@@ -243,7 +244,8 @@ MasterElementRepo::clear()
     const std::string debuggingName("MEDestroy: " + a.first.name());
     auto* meobj = a.second;
     Kokkos::parallel_for(
-      debuggingName, DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
+      debuggingName, DeviceRangePolicy(0, 1),
+      KOKKOS_LAMBDA(int) { meobj->~MasterElement(); });
     sierra::nalu::kokkos_free_on_device(a.second);
   }
   surfaceMeMapDev().clear();

--- a/src/matrix_free/ConductionDiagonal.C
+++ b/src/matrix_free/ConductionDiagonal.C
@@ -16,6 +16,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/LocalArray.h"
 
+#include <KokkosInterface.h>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_ScatterView.hpp>
 #include <Kokkos_Parallel.hpp>
@@ -75,7 +76,7 @@ conduction_diagonal_t<p>::invoke(
 {
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    "diagonal", offsets.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "diagonal", DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       constexpr auto flux_point_interpolant = Coeffs<p>::Nt;
       constexpr auto flux_point_derivative = Coeffs<p>::Dt;
       constexpr auto nodal_derivative = Coeffs<p>::D;

--- a/src/matrix_free/ConductionDiagonal.C
+++ b/src/matrix_free/ConductionDiagonal.C
@@ -76,7 +76,8 @@ conduction_diagonal_t<p>::invoke(
 {
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    "diagonal", DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "diagonal", DeviceRangePolicy(0, offsets.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       constexpr auto flux_point_interpolant = Coeffs<p>::Nt;
       constexpr auto flux_point_derivative = Coeffs<p>::Dt;
       constexpr auto nodal_derivative = Coeffs<p>::D;

--- a/src/matrix_free/ConductionInterior.C
+++ b/src/matrix_free/ConductionInterior.C
@@ -16,6 +16,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/LocalArray.h"
 
+#include <KokkosInterface.h>
 #include <Kokkos_ScatterView.hpp>
 #include "stk_mesh/base/NgpProfilingBlock.hpp"
 

--- a/src/matrix_free/ConductionJacobiPreconditioner.C
+++ b/src/matrix_free/ConductionJacobiPreconditioner.C
@@ -15,7 +15,6 @@
 #include "matrix_free/StrongDirichletBC.h"
 
 #include <KokkosInterface.h>
-#include <Kokkos_Macros.hpp>
 #include <Kokkos_Parallel.hpp>
 
 #include <Teuchos_RCP.hpp>
@@ -37,7 +36,8 @@ void
 reciprocal(tpetra_view_type x)
 {
   Kokkos::parallel_for(
-    "invert", DeviceRangePolicy(0,x.extent_int(0)), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
+    "invert", DeviceRangePolicy(0, x.extent_int(0)),
+    KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
 }
 } // namespace
 template <int p>
@@ -68,7 +68,8 @@ element_multiply(
   const_tpetra_view_type inv_diag, const_tpetra_view_type b, tpetra_view_type y)
 {
   Kokkos::parallel_for(
-    "element_multiply", DeviceRangePolicy(0,b.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "element_multiply", DeviceRangePolicy(0, b.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       y(index, 0) = inv_diag(index, 0) * b(index, 0);
     });
 }
@@ -81,7 +82,8 @@ update_jacobi_sweep(
   tpetra_view_type y)
 {
   Kokkos::parallel_for(
-    "jacobi_sweep", DeviceRangePolicy(0,inv_diag.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "jacobi_sweep", DeviceRangePolicy(0, inv_diag.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       y(index, 0) += inv_diag(index, 0) * (b(index, 0) - axprev(index, 0));
     });
 }

--- a/src/matrix_free/ConductionJacobiPreconditioner.C
+++ b/src/matrix_free/ConductionJacobiPreconditioner.C
@@ -14,12 +14,14 @@
 #include "matrix_free/PolynomialOrders.h"
 #include "matrix_free/StrongDirichletBC.h"
 
+#include <KokkosInterface.h>
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Parallel.hpp>
 
 #include <Teuchos_RCP.hpp>
 #include <Tpetra_CombineMode.hpp>
 #include "Tpetra_Operator.hpp"
+#include <KokkosInterface.h>
 #include <type_traits>
 
 namespace sierra {
@@ -35,7 +37,7 @@ void
 reciprocal(tpetra_view_type x)
 {
   Kokkos::parallel_for(
-    "invert", x.extent_int(0), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
+    "invert", DeviceRangePolicy(0,x.extent_int(0)), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
 }
 } // namespace
 template <int p>
@@ -66,7 +68,7 @@ element_multiply(
   const_tpetra_view_type inv_diag, const_tpetra_view_type b, tpetra_view_type y)
 {
   Kokkos::parallel_for(
-    "element_multiply", b.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "element_multiply", DeviceRangePolicy(0,b.extent_int(0)), KOKKOS_LAMBDA(int index) {
       y(index, 0) = inv_diag(index, 0) * b(index, 0);
     });
 }
@@ -79,7 +81,7 @@ update_jacobi_sweep(
   tpetra_view_type y)
 {
   Kokkos::parallel_for(
-    "jacobi_sweep", inv_diag.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "jacobi_sweep", DeviceRangePolicy(0,inv_diag.extent_int(0)), KOKKOS_LAMBDA(int index) {
       y(index, 0) += inv_diag(index, 0) * (b(index, 0) - axprev(index, 0));
     });
 }

--- a/src/matrix_free/ConductionSolutionUpdate.C
+++ b/src/matrix_free/ConductionSolutionUpdate.C
@@ -16,6 +16,7 @@
 #include "matrix_free/StkSimdFaceConnectivityMap.h"
 #include "matrix_free/StkSimdNodeConnectivityMap.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Array.hpp"
 #include "Kokkos_View.hpp"
 

--- a/src/matrix_free/ConductionUpdate.C
+++ b/src/matrix_free/ConductionUpdate.C
@@ -12,6 +12,7 @@
 #include "matrix_free/ConductionInfo.h"
 #include "matrix_free/PolynomialOrders.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Parallel.hpp"
 #include "Teuchos_RCP.hpp"

--- a/src/matrix_free/ContinuityInterior.C
+++ b/src/matrix_free/ContinuityInterior.C
@@ -16,6 +16,7 @@
 #include "matrix_free/PolynomialOrders.h"
 #include "matrix_free/ValidSimdLength.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_ExecPolicy.hpp"
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_ScatterView.hpp"
@@ -41,7 +42,7 @@ continuity_residual_t<p>::invoke(
   const auto inv_scaling = 1.0 / scaling;
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    Kokkos::RangePolicy<exec_space, int>(0, offsets.extent_int(0)),
+    DeviceRangePolicy(0, offsets.extent_int(0)),
     KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1]> elem_rhs;
       for (int k = 0; k < p + 1; ++k) {
@@ -85,7 +86,7 @@ continuity_linearized_residual_t<p>::invoke(
 
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    offsets.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       narray delta;
       LocalArray<int[p + 1][p + 1][p + 1][simd_len]> idx;
       const auto valid_length = valid_offset<p>(index, offsets);

--- a/src/matrix_free/ContinuityInterior.C
+++ b/src/matrix_free/ContinuityInterior.C
@@ -42,8 +42,7 @@ continuity_residual_t<p>::invoke(
   const auto inv_scaling = 1.0 / scaling;
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    DeviceRangePolicy(0, offsets.extent_int(0)),
-    KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1]> elem_rhs;
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {
@@ -86,7 +85,7 @@ continuity_linearized_residual_t<p>::invoke(
 
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       narray delta;
       LocalArray<int[p + 1][p + 1][p + 1][simd_len]> idx;
       const auto valid_length = valid_offset<p>(index, offsets);

--- a/src/matrix_free/FilterDiagonal.C
+++ b/src/matrix_free/FilterDiagonal.C
@@ -15,6 +15,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/LocalArray.h"
 #include "matrix_free/LinSysInfo.h"
+#include <KokkosInterface.h>
 
 #include "Kokkos_ScatterView.hpp"
 
@@ -38,7 +39,7 @@ filter_diagonal_t<p>::invoke(
 
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    offsets.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1]> lhs;
       if (lumped) {
         for (int k = 0; k < p + 1; ++k) {

--- a/src/matrix_free/FilterDiagonal.C
+++ b/src/matrix_free/FilterDiagonal.C
@@ -39,7 +39,7 @@ filter_diagonal_t<p>::invoke(
 
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1]> lhs;
       if (lumped) {
         for (int k = 0; k < p + 1; ++k) {

--- a/src/matrix_free/FilterJacobi.C
+++ b/src/matrix_free/FilterJacobi.C
@@ -39,7 +39,8 @@ reciprocal(tpetra_view_type x)
 {
   // be brave
   Kokkos::parallel_for(
-    "invert", DeviceRangePolicy(0,x.extent_int(0)), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
+    "invert", DeviceRangePolicy(0, x.extent_int(0)),
+    KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
 }
 } // namespace
 template <int p>
@@ -71,7 +72,8 @@ element_multiply(
 {
   constexpr int dim = FilterJacobiOperator<inst::P1>::num_vectors;
   Kokkos::parallel_for(
-    "element_multiply", DeviceRangePolicy(0,b.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "element_multiply", DeviceRangePolicy(0, b.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       const auto inv_d = inv_diag(index, 0);
       for (int d = 0; d < dim; ++d) {
         y(index, d) = inv_d * b(index, d);
@@ -88,7 +90,8 @@ update_jacobi_sweep(
 {
   constexpr int dim = FilterJacobiOperator<inst::P1>::num_vectors;
   Kokkos::parallel_for(
-    "jacobi_sweep", DeviceRangePolicy(0,inv_diag.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "jacobi_sweep", DeviceRangePolicy(0, inv_diag.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       const auto inv_d = inv_diag(index, 0);
       for (int d = 0; d < dim; ++d) {
         y(index, d) += inv_d * (b(index, d) - axprev(index, d));

--- a/src/matrix_free/FilterJacobi.C
+++ b/src/matrix_free/FilterJacobi.C
@@ -19,6 +19,7 @@
 #include "Tpetra_CombineMode.hpp"
 #include "Tpetra_MultiVector.hpp"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Parallel.hpp"
 
@@ -38,7 +39,7 @@ reciprocal(tpetra_view_type x)
 {
   // be brave
   Kokkos::parallel_for(
-    "invert", x.extent_int(0), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
+    "invert", DeviceRangePolicy(0,x.extent_int(0)), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
 }
 } // namespace
 template <int p>
@@ -70,7 +71,7 @@ element_multiply(
 {
   constexpr int dim = FilterJacobiOperator<inst::P1>::num_vectors;
   Kokkos::parallel_for(
-    "element_multiply", b.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "element_multiply", DeviceRangePolicy(0,b.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto inv_d = inv_diag(index, 0);
       for (int d = 0; d < dim; ++d) {
         y(index, d) = inv_d * b(index, d);
@@ -87,7 +88,7 @@ update_jacobi_sweep(
 {
   constexpr int dim = FilterJacobiOperator<inst::P1>::num_vectors;
   Kokkos::parallel_for(
-    "jacobi_sweep", inv_diag.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "jacobi_sweep", DeviceRangePolicy(0,inv_diag.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto inv_d = inv_diag(index, 0);
       for (int d = 0; d < dim; ++d) {
         y(index, d) += inv_d * (b(index, d) - axprev(index, d));

--- a/src/matrix_free/GreenGaussBoundaryClosure.C
+++ b/src/matrix_free/GreenGaussBoundaryClosure.C
@@ -87,7 +87,7 @@ gradient_boundary_closure_t<p>::invoke(
   stk::mesh::ProfilingBlock pf("gradient_boundary_closure");
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       for (int d = 0; d < 3; ++d) {
         LocalArray<ftype[p + 1][p + 1]> rhs;
         vector_component_flux<p>(index, q, areav, rhs, d);

--- a/src/matrix_free/GreenGaussBoundaryClosure.C
+++ b/src/matrix_free/GreenGaussBoundaryClosure.C
@@ -16,6 +16,7 @@
 #include "matrix_free/PolynomialOrders.h"
 #include "matrix_free/ValidSimdLength.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_ScatterView.hpp"
 
@@ -86,7 +87,7 @@ gradient_boundary_closure_t<p>::invoke(
   stk::mesh::ProfilingBlock pf("gradient_boundary_closure");
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    offsets.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       for (int d = 0; d < 3; ++d) {
         LocalArray<ftype[p + 1][p + 1]> rhs;
         vector_component_flux<p>(index, q, areav, rhs, d);

--- a/src/matrix_free/GreenGaussGradientInterior.C
+++ b/src/matrix_free/GreenGaussGradientInterior.C
@@ -16,6 +16,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/LocalArray.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_ScatterView.hpp"
 #include "stk_mesh/base/NgpProfilingBlock.hpp"
 

--- a/src/matrix_free/LinearAdvectionMetric.C
+++ b/src/matrix_free/LinearAdvectionMetric.C
@@ -16,6 +16,7 @@
 #include "matrix_free/PolynomialOrders.h"
 #include "matrix_free/ShuffledAccess.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_View.hpp"
 
@@ -113,7 +114,7 @@ linear_advection_metric_t<p>::invoke(
 {
   enum { XH = 0, YH = 1, ZH = 2 };
   Kokkos::parallel_for(
-    areas.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,areas.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1][3]> rhou_corr;
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {

--- a/src/matrix_free/LinearAdvectionMetric.C
+++ b/src/matrix_free/LinearAdvectionMetric.C
@@ -114,7 +114,7 @@ linear_advection_metric_t<p>::invoke(
 {
   enum { XH = 0, YH = 1, ZH = 2 };
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,areas.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, areas.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1][3]> rhou_corr;
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {

--- a/src/matrix_free/LinearAreas.C
+++ b/src/matrix_free/LinearAreas.C
@@ -30,7 +30,7 @@ linear_areas_t<p>::invoke(const_vector_view<p> coordinates)
   enum { XH = 0, YH = 1, ZH = 2 };
   scs_vector_view<p> area("area", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, coordinates);
       for (int l = 0; l < p; ++l) {
         for (int s = 0; s < p + 1; ++s) {

--- a/src/matrix_free/LinearAreas.C
+++ b/src/matrix_free/LinearAreas.C
@@ -14,6 +14,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/PolynomialOrders.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 
 namespace sierra {
@@ -29,7 +30,7 @@ linear_areas_t<p>::invoke(const_vector_view<p> coordinates)
   enum { XH = 0, YH = 1, ZH = 2 };
   scs_vector_view<p> area("area", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    coordinates.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, coordinates);
       for (int l = 0; l < p; ++l) {
         for (int s = 0; s < p + 1; ++s) {

--- a/src/matrix_free/LinearDiffusionMetric.C
+++ b/src/matrix_free/LinearDiffusionMetric.C
@@ -36,7 +36,8 @@ diffusion_metric_t<p>::invoke(
 
   scs_vector_view<p> metric("diffusion", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "diffusion_metric", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "diffusion_metric", DeviceRangePolicy(0, coordinates.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       static constexpr auto ntilde = Coeffs<p>::Nt;
 
       LocalArray<ftype[3][p + 1][p + 1][p + 1]> interp;
@@ -78,7 +79,8 @@ diffusion_metric_t<p>::invoke(const_vector_view<p> coordinates)
   enum { XH = 0, YH = 1, ZH = 2 };
   scs_vector_view<p> metric("diffusion", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "diffusion_metric", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "diffusion_metric", DeviceRangePolicy(0, coordinates.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, coordinates);
       for (int l = 0; l < p; ++l) {
         for (int s = 0; s < p + 1; ++s) {

--- a/src/matrix_free/LinearDiffusionMetric.C
+++ b/src/matrix_free/LinearDiffusionMetric.C
@@ -17,6 +17,7 @@
 #include "matrix_free/LocalArray.h"
 #include "matrix_free/PolynomialOrders.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_View.hpp"
 
@@ -35,7 +36,7 @@ diffusion_metric_t<p>::invoke(
 
   scs_vector_view<p> metric("diffusion", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "diffusion_metric", coordinates.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "diffusion_metric", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
       static constexpr auto ntilde = Coeffs<p>::Nt;
 
       LocalArray<ftype[3][p + 1][p + 1][p + 1]> interp;
@@ -77,7 +78,7 @@ diffusion_metric_t<p>::invoke(const_vector_view<p> coordinates)
   enum { XH = 0, YH = 1, ZH = 2 };
   scs_vector_view<p> metric("diffusion", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "diffusion_metric", coordinates.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "diffusion_metric", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, coordinates);
       for (int l = 0; l < p; ++l) {
         for (int s = 0; s < p + 1; ++s) {

--- a/src/matrix_free/LinearExposedAreas.C
+++ b/src/matrix_free/LinearExposedAreas.C
@@ -68,7 +68,8 @@ exposed_areas_t<p>::invoke(const const_face_vector_view<p> coordinates)
   constexpr auto nlin = Coeffs<p>::Nlin;
   face_vector_view<p> areas("exposed_area_vectors", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "volume", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "volume", DeviceRangePolicy(0, coordinates.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       const auto base_box = face_vertex_coordinates<p>(index, coordinates);
       for (int j = 0; j < p + 1; ++j) {
         for (int i = 0; i < p + 1; ++i) {

--- a/src/matrix_free/LinearExposedAreas.C
+++ b/src/matrix_free/LinearExposedAreas.C
@@ -9,6 +9,7 @@
 
 #include "matrix_free/LinearExposedAreas.h"
 
+#include <KokkosInterface.h>
 #include <Kokkos_Macros.hpp>
 
 #include "matrix_free/HexVertexCoordinates.h"
@@ -67,7 +68,7 @@ exposed_areas_t<p>::invoke(const const_face_vector_view<p> coordinates)
   constexpr auto nlin = Coeffs<p>::Nlin;
   face_vector_view<p> areas("exposed_area_vectors", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "volume", coordinates.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "volume", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto base_box = face_vertex_coordinates<p>(index, coordinates);
       for (int j = 0; j < p + 1; ++j) {
         for (int i = 0; i < p + 1; ++i) {

--- a/src/matrix_free/LinearVolume.C
+++ b/src/matrix_free/LinearVolume.C
@@ -33,7 +33,8 @@ volume_metric_t<p>::invoke(
 {
   scalar_view<p> volume("volumes", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "volume", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "volume", DeviceRangePolicy(0, coordinates.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, coordinates);
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {
@@ -54,7 +55,8 @@ volume_metric_t<p>::invoke(const_vector_view<p> coordinates)
 {
   scalar_view<p> volume("volumes", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "volume", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "volume", DeviceRangePolicy(0, coordinates.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, coordinates);
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {

--- a/src/matrix_free/LinearVolume.C
+++ b/src/matrix_free/LinearVolume.C
@@ -17,6 +17,7 @@
 #include "matrix_free/PolynomialOrders.h"
 #include "matrix_free/TensorOperations.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 
 namespace sierra {
@@ -32,7 +33,7 @@ volume_metric_t<p>::invoke(
 {
   scalar_view<p> volume("volumes", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "volume", coordinates.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "volume", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, coordinates);
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {
@@ -53,7 +54,7 @@ volume_metric_t<p>::invoke(const_vector_view<p> coordinates)
 {
   scalar_view<p> volume("volumes", coordinates.extent_int(0));
   Kokkos::parallel_for(
-    "volume", coordinates.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "volume", DeviceRangePolicy(0,coordinates.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, coordinates);
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {

--- a/src/matrix_free/LocalDualNodalVolume.C
+++ b/src/matrix_free/LocalDualNodalVolume.C
@@ -18,6 +18,7 @@
 
 #include "matrix_free/StkSimdConnectivityMap.h"
 #include "matrix_free/StkSimdGatheredElementData.h"
+#include <KokkosInterface.h>
 
 namespace sierra {
 namespace nalu {
@@ -86,7 +87,7 @@ local_dual_nodal_volume_t<p>::invoke(
 
   dnv.set_all(mesh, 0.);
   Kokkos::parallel_for(
-    xc.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,xc.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, xc);
       const auto valid_length = valid_offset<p>(index, conn);
 

--- a/src/matrix_free/LocalDualNodalVolume.C
+++ b/src/matrix_free/LocalDualNodalVolume.C
@@ -87,7 +87,7 @@ local_dual_nodal_volume_t<p>::invoke(
 
   dnv.set_all(mesh, 0.);
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,xc.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, xc.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto box = hex_vertex_coordinates<p>(index, xc);
       const auto valid_length = valid_offset<p>(index, conn);
 

--- a/src/matrix_free/LowMachGatheredFieldManager.C
+++ b/src/matrix_free/LowMachGatheredFieldManager.C
@@ -24,6 +24,7 @@
 #include "matrix_free/ValidSimdLength.h"
 #include "matrix_free/ElementSCSInterpolate.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 
 #include "stk_mesh/base/FieldState.hpp"

--- a/src/matrix_free/MaxCourantReynolds.C
+++ b/src/matrix_free/MaxCourantReynolds.C
@@ -15,6 +15,7 @@
 #include "matrix_free/ElementVolumeIntegral.h"
 #include "matrix_free/ElementSCSInterpolate.h"
 #include "matrix_free/LocalArray.h"
+#include <KokkosInterface.h>
 #include <Kokkos_NumericTraits.hpp>
 #include <stk_simd/Simd.hpp>
 
@@ -140,7 +141,7 @@ max_local_courant_reynolds_t<p>::invoke(
   Kokkos::pair<double, double> max_cflre;
   PairReduce<Kokkos::Max<double>> reducer(max_cflre);
   Kokkos::parallel_reduce(
-    xc.extent_int(0),
+    DeviceRangePolicy(0,xc.extent_int(0)),
     KOKKOS_LAMBDA(int index, Kokkos::pair<double, double>& val) {
       const auto elem_xc = Kokkos::subview(
         xc, index, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());

--- a/src/matrix_free/MaxCourantReynolds.C
+++ b/src/matrix_free/MaxCourantReynolds.C
@@ -141,7 +141,7 @@ max_local_courant_reynolds_t<p>::invoke(
   Kokkos::pair<double, double> max_cflre;
   PairReduce<Kokkos::Max<double>> reducer(max_cflre);
   Kokkos::parallel_reduce(
-    DeviceRangePolicy(0,xc.extent_int(0)),
+    DeviceRangePolicy(0, xc.extent_int(0)),
     KOKKOS_LAMBDA(int index, Kokkos::pair<double, double>& val) {
       const auto elem_xc = Kokkos::subview(
         xc, index, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());

--- a/src/matrix_free/MomentumDiagonal.C
+++ b/src/matrix_free/MomentumDiagonal.C
@@ -82,7 +82,7 @@ advdiff_diagonal_t<p>::invoke(
 {
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1]> lhs;
       // generally works better to lump the mass term to the diagonal here
       for (int k = 0; k < p + 1; ++k) {

--- a/src/matrix_free/MomentumDiagonal.C
+++ b/src/matrix_free/MomentumDiagonal.C
@@ -15,6 +15,7 @@
 #include "matrix_free/ShuffledAccess.h"
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/LocalArray.h"
+#include <KokkosInterface.h>
 
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_ScatterView.hpp>
@@ -81,7 +82,7 @@ advdiff_diagonal_t<p>::invoke(
 {
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    offsets.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1]> lhs;
       // generally works better to lump the mass term to the diagonal here
       for (int k = 0; k < p + 1; ++k) {

--- a/src/matrix_free/MomentumInterior.C
+++ b/src/matrix_free/MomentumInterior.C
@@ -22,6 +22,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/LocalArray.h"
 #include "matrix_free/ElementSCSInterpolate.h"
+#include <KokkosInterface.h>
 
 #include "Kokkos_ScatterView.hpp"
 #include "stk_mesh/base/NgpProfilingBlock.hpp"
@@ -244,7 +245,7 @@ momentum_residual_t<p>::invoke(
   stk::mesh::ProfilingBlock pf("momentum_residual");
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    offsets.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1][3]> elem_rhs;
       if (p == 1) {
         static constexpr auto lumped = Coeffs<p>::Wl;
@@ -323,7 +324,11 @@ momentum_linearized_residual_t<p>::invoke(
 
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
 
+#if defined(KOKKOS_ENABLE_HIP)
+  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<2>, int>;
+#else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<2>, int>;
+#endif
   const auto range = policy_type({0, 0}, {offsets.extent_int(0), 3});
   Kokkos::parallel_for(
     range, KOKKOS_LAMBDA(int index, int d) {

--- a/src/matrix_free/MomentumInterior.C
+++ b/src/matrix_free/MomentumInterior.C
@@ -245,7 +245,7 @@ momentum_residual_t<p>::invoke(
   stk::mesh::ProfilingBlock pf("momentum_residual");
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1][p + 1][3]> elem_rhs;
       if (p == 1) {
         static constexpr auto lumped = Coeffs<p>::Wl;
@@ -325,7 +325,9 @@ momentum_linearized_residual_t<p>::invoke(
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
 
 #if defined(KOKKOS_ENABLE_HIP)
-  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<2>, int>;
+  using policy_type = Kokkos::MDRangePolicy<
+    exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    Kokkos::Rank<2>, int>;
 #else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<2>, int>;
 #endif

--- a/src/matrix_free/MomentumJacobi.C
+++ b/src/matrix_free/MomentumJacobi.C
@@ -8,6 +8,7 @@
 
 #include "matrix_free/PolynomialOrders.h"
 #include "matrix_free/KokkosViewTypes.h"
+#include <KokkosInterface.h>
 
 namespace sierra {
 namespace nalu {
@@ -23,7 +24,7 @@ reciprocal(tpetra_view_type x)
 {
   // be brave
   Kokkos::parallel_for(
-    "invert", x.extent_int(0), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
+    "invert", DeviceRangePolicy(0,x.extent_int(0)), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
 }
 } // namespace
 template <int p>
@@ -56,7 +57,7 @@ element_multiply(
   constexpr int dim = MomentumJacobiOperator<inst::P1>::num_vectors;
 
   Kokkos::parallel_for(
-    "element_multiply", b.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "element_multiply", DeviceRangePolicy(0,b.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto inv_d = inv_diag(index, 0);
       for (int d = 0; d < dim; ++d) {
         y(index, d) = inv_d * b(index, d);
@@ -73,7 +74,7 @@ update_jacobi_sweep(
 {
   constexpr int dim = MomentumJacobiOperator<inst::P1>::num_vectors;
   Kokkos::parallel_for(
-    "jacobi_sweep", inv_diag.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "jacobi_sweep", DeviceRangePolicy(0,inv_diag.extent_int(0)), KOKKOS_LAMBDA(int index) {
       const auto inv_d = inv_diag(index, 0);
       for (int d = 0; d < dim; ++d) {
         y(index, d) += inv_d * (b(index, d) - axprev(index, d));

--- a/src/matrix_free/MomentumJacobi.C
+++ b/src/matrix_free/MomentumJacobi.C
@@ -24,7 +24,8 @@ reciprocal(tpetra_view_type x)
 {
   // be brave
   Kokkos::parallel_for(
-    "invert", DeviceRangePolicy(0,x.extent_int(0)), KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
+    "invert", DeviceRangePolicy(0, x.extent_int(0)),
+    KOKKOS_LAMBDA(int k) { x(k, 0) = 1 / x(k, 0); });
 }
 } // namespace
 template <int p>
@@ -57,7 +58,8 @@ element_multiply(
   constexpr int dim = MomentumJacobiOperator<inst::P1>::num_vectors;
 
   Kokkos::parallel_for(
-    "element_multiply", DeviceRangePolicy(0,b.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "element_multiply", DeviceRangePolicy(0, b.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       const auto inv_d = inv_diag(index, 0);
       for (int d = 0; d < dim; ++d) {
         y(index, d) = inv_d * b(index, d);
@@ -74,7 +76,8 @@ update_jacobi_sweep(
 {
   constexpr int dim = MomentumJacobiOperator<inst::P1>::num_vectors;
   Kokkos::parallel_for(
-    "jacobi_sweep", DeviceRangePolicy(0,inv_diag.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "jacobi_sweep", DeviceRangePolicy(0, inv_diag.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       const auto inv_d = inv_diag(index, 0);
       for (int d = 0; d < dim; ++d) {
         y(index, d) += inv_d * (b(index, d) - axprev(index, d));

--- a/src/matrix_free/ScalarFluxBC.C
+++ b/src/matrix_free/ScalarFluxBC.C
@@ -89,7 +89,8 @@ scalar_neumann_residual_t<p>::invoke(
   stk::mesh::ProfilingBlock pf("scalar_neumann_residual");
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    "flux_residual", DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    "flux_residual", DeviceRangePolicy(0, offsets.extent_int(0)),
+    KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1]> element_rhs;
       {
         LocalArray<ftype[p + 1][p + 1]> scratch;

--- a/src/matrix_free/ScalarFluxBC.C
+++ b/src/matrix_free/ScalarFluxBC.C
@@ -14,6 +14,7 @@
 #include "matrix_free/ValidSimdLength.h"
 #include "matrix_free/KokkosViewTypes.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_ScatterView.hpp"
 #include "Kokkos_Macros.hpp"
 #include "Teuchos_RCP.hpp"
@@ -88,7 +89,7 @@ scalar_neumann_residual_t<p>::invoke(
   stk::mesh::ProfilingBlock pf("scalar_neumann_residual");
   auto yout_scatter = Kokkos::Experimental::create_scatter_view(yout);
   Kokkos::parallel_for(
-    "flux_residual", offsets.extent_int(0), KOKKOS_LAMBDA(int index) {
+    "flux_residual", DeviceRangePolicy(0,offsets.extent_int(0)), KOKKOS_LAMBDA(int index) {
       LocalArray<ftype[p + 1][p + 1]> element_rhs;
       {
         LocalArray<ftype[p + 1][p + 1]> scratch;

--- a/src/matrix_free/SparsifiedEdgeLaplacian.C
+++ b/src/matrix_free/SparsifiedEdgeLaplacian.C
@@ -157,7 +157,7 @@ assemble_sparsified_edge_laplacian_t<p>::invoke(
   field_gather<p>(conn, coords, xc);
 
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,conn.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, conn.extent_int(0)), KOKKOS_LAMBDA(int index) {
       auto elem_coords = Kokkos::subview(
         xc, index, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
       const auto length = valid_offset<p>(index, conn);

--- a/src/matrix_free/SparsifiedEdgeLaplacian.C
+++ b/src/matrix_free/SparsifiedEdgeLaplacian.C
@@ -18,6 +18,7 @@
 
 #include "matrix_free/StkSimdConnectivityMap.h"
 #include "matrix_free/StkSimdGatheredElementData.h"
+#include <KokkosInterface.h>
 #include <Kokkos_ExecPolicy.hpp>
 #include <Kokkos_UniqueToken.hpp>
 
@@ -156,7 +157,7 @@ assemble_sparsified_edge_laplacian_t<p>::invoke(
   field_gather<p>(conn, coords, xc);
 
   Kokkos::parallel_for(
-    conn.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,conn.extent_int(0)), KOKKOS_LAMBDA(int index) {
       auto elem_coords = Kokkos::subview(
         xc, index, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
       const auto length = valid_offset<p>(index, conn);

--- a/src/matrix_free/StkSimdConnectivityMap.C
+++ b/src/matrix_free/StkSimdConnectivityMap.C
@@ -19,6 +19,7 @@
 #include "stk_mesh/base/Selector.hpp"
 #include "stk_topology/topology.hpp"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 
 namespace sierra {

--- a/src/matrix_free/StkSimdFaceConnectivityMap.C
+++ b/src/matrix_free/StkSimdFaceConnectivityMap.C
@@ -17,6 +17,7 @@
 #include "stk_mesh/base/Selector.hpp"
 #include "stk_topology/topology.hpp"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 
 namespace sierra {

--- a/src/matrix_free/StkSimdGatheredElementData.C
+++ b/src/matrix_free/StkSimdGatheredElementData.C
@@ -36,7 +36,9 @@ field_gather_t<p>::invoke(
   scalar_view<p> simd_element_field)
 {
 #if defined(KOKKOS_ENABLE_HIP)
-  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<4>, int>;
+  using policy_type = Kokkos::MDRangePolicy<
+    exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    Kokkos::Rank<4>, int>;
 #else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<4>, int>;
 #endif
@@ -61,7 +63,9 @@ field_gather_t<p>::invoke(
   vector_view<p> simd_element_field)
 {
 #if defined(KOKKOS_ENABLE_HIP)
-  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<4>, int>;
+  using policy_type = Kokkos::MDRangePolicy<
+    exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    Kokkos::Rank<4>, int>;
 #else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<4>, int>;
 #endif
@@ -89,7 +93,9 @@ field_gather_t<p>::invoke(
   face_scalar_view<p> simd_element_field)
 {
 #if defined(KOKKOS_ENABLE_HIP)
-  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<3>, int>;
+  using policy_type = Kokkos::MDRangePolicy<
+    exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    Kokkos::Rank<3>, int>;
 #else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<3>, int>;
 #endif
@@ -114,7 +120,9 @@ field_gather_t<p>::invoke(
   face_vector_view<p> simd_element_field)
 {
 #if defined(KOKKOS_ENABLE_HIP)
-  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<3>, int>;
+  using policy_type = Kokkos::MDRangePolicy<
+    exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    Kokkos::Rank<3>, int>;
 #else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<3>, int>;
 #endif
@@ -143,8 +151,7 @@ field_gather(
   node_scalar_view simd_node_field)
 {
   Kokkos::parallel_for(
-    DeviceRangePolicy(0, conn.extent_int(0)),
-    KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, conn.extent_int(0)), KOKKOS_LAMBDA(int index) {
       for (int n = 0; n < simd_len; ++n) {
         const auto simd_mesh_index = conn(index, n);
         const auto mesh_index =
@@ -162,8 +169,7 @@ field_gather(
   node_vector_view simd_node_field)
 {
   Kokkos::parallel_for(
-    DeviceRangePolicy(0, conn.extent_int(0)),
-    KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, conn.extent_int(0)), KOKKOS_LAMBDA(int index) {
       for (int n = 0; n < simd_len; ++n) {
         const auto simd_mesh_index = conn(index, n);
         const auto mesh_index =

--- a/src/matrix_free/StkSimdGatheredElementData.C
+++ b/src/matrix_free/StkSimdGatheredElementData.C
@@ -13,6 +13,7 @@
 #include "matrix_free/StkSimdConnectivityMap.h"
 #include "matrix_free/ValidSimdLength.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_ExecPolicy.hpp"
 #include "Kokkos_Macros.hpp"
 
@@ -34,7 +35,11 @@ field_gather_t<p>::invoke(
   const stk::mesh::NgpField<double>& field,
   scalar_view<p> simd_element_field)
 {
+#if defined(KOKKOS_ENABLE_HIP)
+  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<4>, int>;
+#else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<4>, int>;
+#endif
   const auto range =
     policy_type({0, 0, 0, 0}, {conn.extent_int(0), p + 1, p + 1, p + 1});
   Kokkos::parallel_for(
@@ -55,7 +60,11 @@ field_gather_t<p>::invoke(
   const stk::mesh::NgpField<double>& field,
   vector_view<p> simd_element_field)
 {
+#if defined(KOKKOS_ENABLE_HIP)
+  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<4>, int>;
+#else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<4>, int>;
+#endif
   const auto range =
     policy_type({0, 0, 0, 0}, {conn.extent_int(0), p + 1, p + 1, p + 1});
   Kokkos::parallel_for(
@@ -79,7 +88,11 @@ field_gather_t<p>::invoke(
   const stk::mesh::NgpField<double>& field,
   face_scalar_view<p> simd_element_field)
 {
+#if defined(KOKKOS_ENABLE_HIP)
+  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<3>, int>;
+#else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<3>, int>;
+#endif
   const auto range = policy_type({0, 0, 0}, {conn.extent_int(0), p + 1, p + 1});
   Kokkos::parallel_for(
     range, KOKKOS_LAMBDA(int index, int j, int i) {
@@ -100,7 +113,11 @@ field_gather_t<p>::invoke(
   const stk::mesh::NgpField<double>& field,
   face_vector_view<p> simd_element_field)
 {
+#if defined(KOKKOS_ENABLE_HIP)
+  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<3>, int>;
+#else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<3>, int>;
+#endif
   const auto range = policy_type({0, 0, 0}, {conn.extent_int(0), p + 1, p + 1});
   Kokkos::parallel_for(
     range, KOKKOS_LAMBDA(int index, int j, int i) {
@@ -126,7 +143,7 @@ field_gather(
   node_scalar_view simd_node_field)
 {
   Kokkos::parallel_for(
-    Kokkos::RangePolicy<exec_space, int>(0, conn.extent_int(0)),
+    DeviceRangePolicy(0, conn.extent_int(0)),
     KOKKOS_LAMBDA(int index) {
       for (int n = 0; n < simd_len; ++n) {
         const auto simd_mesh_index = conn(index, n);
@@ -145,7 +162,7 @@ field_gather(
   node_vector_view simd_node_field)
 {
   Kokkos::parallel_for(
-    Kokkos::RangePolicy<exec_space, int>(0, conn.extent_int(0)),
+    DeviceRangePolicy(0, conn.extent_int(0)),
     KOKKOS_LAMBDA(int index) {
       for (int n = 0; n < simd_len; ++n) {
         const auto simd_mesh_index = conn(index, n);

--- a/src/matrix_free/StkSimdNodeConnectivityMap.C
+++ b/src/matrix_free/StkSimdNodeConnectivityMap.C
@@ -18,6 +18,7 @@
 #include "stk_mesh/base/Types.hpp"
 #include "stk_topology/topology.hpp"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Parallel.hpp"
 

--- a/src/matrix_free/StkToTpetraMap.C
+++ b/src/matrix_free/StkToTpetraMap.C
@@ -248,7 +248,7 @@ make_owned_shared_constrained_row_map(
       row_ids(num_owned + index) = gids.get(mi, 0);
     });
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,rgids.extent_int(0)),
+    DeviceRangePolicy(0, rgids.extent_int(0)),
     KOKKOS_LAMBDA(int k) { row_ids(num_owned + num_shared + k) = rgids(k); });
   Kokkos::sort(row_ids, num_owned, row_ids.extent_int(0));
 

--- a/src/matrix_free/StkToTpetraMap.C
+++ b/src/matrix_free/StkToTpetraMap.C
@@ -12,6 +12,7 @@
 #include "matrix_free/StkToTpetraComm.h"
 #include "matrix_free/StkToTpetraLocalIndices.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Sort.hpp"
 
@@ -101,8 +102,8 @@ enumerated_for_each_entity(
   auto buckets = mesh.get_bucket_ids(stk::topology::NODE_RANK, active);
   auto offsets = bucket_offsets(mesh, buckets);
   Kokkos::parallel_for(
-    Kokkos::TeamPolicy<>(buckets.size(), Kokkos::AUTO),
-    KOKKOS_LAMBDA(const typename Kokkos::TeamPolicy<>::member_type& team) {
+    DeviceTeamPolicy(buckets.size(), Kokkos::AUTO),
+    KOKKOS_LAMBDA(const typename DeviceTeamPolicy::member_type& team) {
       const auto league_index = team.league_rank();
       const auto bucket_id = buckets.device_get(league_index);
       const auto& b = mesh.get_bucket(stk::topology::NODE_RANK, bucket_id);
@@ -247,7 +248,7 @@ make_owned_shared_constrained_row_map(
       row_ids(num_owned + index) = gids.get(mi, 0);
     });
   Kokkos::parallel_for(
-    rgids.extent_int(0),
+    DeviceRangePolicy(0,rgids.extent_int(0)),
     KOKKOS_LAMBDA(int k) { row_ids(num_owned + num_shared + k) = rgids(k); });
   Kokkos::sort(row_ids, num_owned, row_ids.extent_int(0));
 

--- a/src/matrix_free/StrongDirichletBC.C
+++ b/src/matrix_free/StrongDirichletBC.C
@@ -33,7 +33,8 @@ dirichlet_residual(
 {
   stk::mesh::ProfilingBlock pf("scalar_dirichlet_residual");
   Kokkos::parallel_for(
-    "scalar_dirichlet_residual", DeviceRangePolicy(0,dirichlet_bc_offsets.extent_int(0)),
+    "scalar_dirichlet_residual",
+    DeviceRangePolicy(0, dirichlet_bc_offsets.extent_int(0)),
     KOKKOS_LAMBDA(int index) {
       const auto residual = qbc(index) - qp1(index);
       const int valid_length = valid_offset(index, dirichlet_bc_offsets);
@@ -57,7 +58,9 @@ dirichlet_residual(
   ThrowRequireMsg(yout.extent_int(1) == 3, "length is " << yout.extent_int(1));
 
 #if defined(KOKKOS_ENABLE_HIP)
-  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<2>, int>;
+  using policy_type = Kokkos::MDRangePolicy<
+    exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    Kokkos::Rank<2>, int>;
 #else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<2>, int>;
 #endif
@@ -86,7 +89,9 @@ dirichlet_linearized(
   ThrowRequire(yout.extent_int(1) == xin.extent_int(1));
 
 #if defined(KOKKOS_ENABLE_HIP)
-  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<2>, int>;
+  using policy_type = Kokkos::MDRangePolicy<
+    exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    Kokkos::Rank<2>, int>;
 #else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<2>, int>;
 #endif
@@ -108,7 +113,9 @@ dirichlet_diagonal(
 {
   stk::mesh::ProfilingBlock pf("dirichlet_diagonal");
 #if defined(KOKKOS_ENABLE_HIP)
-  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<2>, int>;
+  using policy_type = Kokkos::MDRangePolicy<
+    exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM, 1>,
+    Kokkos::Rank<2>, int>;
 #else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<2>, int>;
 #endif

--- a/src/matrix_free/StrongDirichletBC.C
+++ b/src/matrix_free/StrongDirichletBC.C
@@ -13,6 +13,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 
 #include <Teuchos_RCP.hpp>
+#include <KokkosInterface.h>
 #include <stk_simd/Simd.hpp>
 
 #include "stk_mesh/base/NgpProfilingBlock.hpp"
@@ -32,7 +33,7 @@ dirichlet_residual(
 {
   stk::mesh::ProfilingBlock pf("scalar_dirichlet_residual");
   Kokkos::parallel_for(
-    "scalar_dirichlet_residual", dirichlet_bc_offsets.extent_int(0),
+    "scalar_dirichlet_residual", DeviceRangePolicy(0,dirichlet_bc_offsets.extent_int(0)),
     KOKKOS_LAMBDA(int index) {
       const auto residual = qbc(index) - qp1(index);
       const int valid_length = valid_offset(index, dirichlet_bc_offsets);
@@ -55,7 +56,11 @@ dirichlet_residual(
   stk::mesh::ProfilingBlock pf("vector_dirichlet_residual");
   ThrowRequireMsg(yout.extent_int(1) == 3, "length is " << yout.extent_int(1));
 
+#if defined(KOKKOS_ENABLE_HIP)
+  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<2>, int>;
+#else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<2>, int>;
+#endif
   auto range = policy_type({0, 0}, {dirichlet_bc_offsets.extent_int(0), 3});
   Kokkos::parallel_for(
     range, KOKKOS_LAMBDA(int index, int d) {
@@ -80,7 +85,11 @@ dirichlet_linearized(
   ThrowRequire(yout.extent_int(0) == xin.extent_int(0));
   ThrowRequire(yout.extent_int(1) == xin.extent_int(1));
 
+#if defined(KOKKOS_ENABLE_HIP)
+  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<2>, int>;
+#else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<2>, int>;
+#endif
   auto range = policy_type(
     {0, 0}, {dirichlet_bc_offsets.extent_int(0), xin.extent_int(1)});
   Kokkos::parallel_for(
@@ -98,7 +107,11 @@ dirichlet_diagonal(
   const_node_offset_view offsets, int max_owned_lid, tpetra_view_type yout)
 {
   stk::mesh::ProfilingBlock pf("dirichlet_diagonal");
+#if defined(KOKKOS_ENABLE_HIP)
+  using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::LaunchBounds<NTHREADS_PER_DEVICE_TEAM,1>, Kokkos::Rank<2>, int>;
+#else
   using policy_type = Kokkos::MDRangePolicy<exec_space, Kokkos::Rank<2>, int>;
+#endif
   auto range = policy_type({0, 0}, {offsets.extent_int(0), yout.extent_int(1)});
   Kokkos::parallel_for(
     range, KOKKOS_LAMBDA(int index, int d) {

--- a/src/matrix_free/TransportCoefficients.C
+++ b/src/matrix_free/TransportCoefficients.C
@@ -126,7 +126,7 @@ transport_coefficients_t<p>::invoke(
   scs_vector_view<p> diff)
 {
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,conn.extent_int(0)), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0, conn.extent_int(0)), KOKKOS_LAMBDA(int index) {
       {
         const auto box = hex_vertex_coordinates<p>(index, xc);
         auto uvec = Kokkos::subview(

--- a/src/matrix_free/TransportCoefficients.C
+++ b/src/matrix_free/TransportCoefficients.C
@@ -22,6 +22,7 @@
 #include "matrix_free/ValidSimdLength.h"
 #include "matrix_free/GeometricFunctions.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 
 #include "stk_mesh/base/FieldState.hpp"
@@ -125,7 +126,7 @@ transport_coefficients_t<p>::invoke(
   scs_vector_view<p> diff)
 {
   Kokkos::parallel_for(
-    conn.extent_int(0), KOKKOS_LAMBDA(int index) {
+    DeviceRangePolicy(0,conn.extent_int(0)), KOKKOS_LAMBDA(int index) {
       {
         const auto box = hex_vertex_coordinates<p>(index, xc);
         auto uvec = Kokkos::subview(

--- a/src/overset/AssembleOversetDecoupledAlgorithm.C
+++ b/src/overset/AssembleOversetDecoupledAlgorithm.C
@@ -39,7 +39,7 @@ AssembleOversetDecoupledAlgorithm::execute()
   const auto& fringeNodes = realm_.oversetManager_->ngpFringeNodes_;
   auto* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
   Kokkos::parallel_for(
-    fringeNodes.size(), KOKKOS_LAMBDA(const size_t& i) {
+    DeviceRangePolicy(0,fringeNodes.size()), KOKKOS_LAMBDA(const size_t& i) {
       coeffApplier->resetRows(1, &fringeNodes(i), 0, numDof, 1.0, 0.0);
     });
 

--- a/src/overset/AssembleOversetDecoupledAlgorithm.C
+++ b/src/overset/AssembleOversetDecoupledAlgorithm.C
@@ -39,7 +39,7 @@ AssembleOversetDecoupledAlgorithm::execute()
   const auto& fringeNodes = realm_.oversetManager_->ngpFringeNodes_;
   auto* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,fringeNodes.size()), KOKKOS_LAMBDA(const size_t& i) {
+    DeviceRangePolicy(0, fringeNodes.size()), KOKKOS_LAMBDA(const size_t& i) {
       coeffApplier->resetRows(1, &fringeNodes(i), 0, numDof, 1.0, 0.0);
     });
 

--- a/src/overset/OversetConstraintBase.C
+++ b/src/overset/OversetConstraintBase.C
@@ -45,7 +45,7 @@ OversetConstraintBase::prepare_constraints()
 
   auto* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
   Kokkos::parallel_for(
-    DeviceRangePolicy(0,holeRows.size()), KOKKOS_LAMBDA(const size_t& i) {
+    DeviceRangePolicy(0, holeRows.size()), KOKKOS_LAMBDA(const size_t& i) {
       coeffApplier->resetRows(1, &holeRows(i), 0, numDof, 1.0, 0.0);
     });
 

--- a/src/overset/OversetConstraintBase.C
+++ b/src/overset/OversetConstraintBase.C
@@ -45,7 +45,7 @@ OversetConstraintBase::prepare_constraints()
 
   auto* coeffApplier = eqSystem_->linsys_->get_coeff_applier();
   Kokkos::parallel_for(
-    holeRows.size(), KOKKOS_LAMBDA(const size_t& i) {
+    DeviceRangePolicy(0,holeRows.size()), KOKKOS_LAMBDA(const size_t& i) {
       coeffApplier->resetRows(1, &holeRows(i), 0, numDof, 1.0, 0.0);
     });
 

--- a/unit_tests/UnitTestCreateOnDevice.C
+++ b/unit_tests/UnitTestCreateOnDevice.C
@@ -56,7 +56,7 @@ do_shape_test(Shape* s)
     sierra::nalu::create_device_expression<T>(*dynamic_cast<T*>(s));
   double area = 0.0;
   Kokkos::parallel_reduce(
-    1, KOKKOS_LAMBDA(int, double& a) { a = s_dev->area(); }, area);
+    sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int, double& a) { a = s_dev->area(); }, area);
 
   sierra::nalu::kokkos_free_on_device(s_dev);
   return area;

--- a/unit_tests/UnitTestCreateOnDevice.C
+++ b/unit_tests/UnitTestCreateOnDevice.C
@@ -56,7 +56,8 @@ do_shape_test(Shape* s)
     sierra::nalu::create_device_expression<T>(*dynamic_cast<T*>(s));
   double area = 0.0;
   Kokkos::parallel_reduce(
-    sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int, double& a) { a = s_dev->area(); }, area);
+    sierra::nalu::DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(int, double& a) { a = s_dev->area(); }, area);
 
   sierra::nalu::kokkos_free_on_device(s_dev);
   return area;

--- a/unit_tests/UnitTestNgpMesh1.C
+++ b/unit_tests/UnitTestNgpMesh1.C
@@ -10,6 +10,7 @@
 #include "UnitTestUtils.h"
 #include "UnitTestRealm.h"
 
+#include "KokkosInterface.h"
 #include "SimdInterface.h"
 #include "ElemDataRequests.h"
 
@@ -181,3 +182,177 @@ TEST_F(Hex8MeshWithNSOFields, NGPMeshField)
 
   test_ngp_mesh_field_values(*bulk, velocity, massFlowRate);
 }
+
+//struct MyBaseClass
+//{
+//  KOKKOS_DEFAULTED_FUNCTION MyBaseClass() = default;
+//  KOKKOS_DEFAULTED_FUNCTION MyBaseClass(const MyBaseClass&) = default;
+//  KOKKOS_DEFAULTED_FUNCTION virtual ~MyBaseClass() = default;
+//
+//  KOKKOS_FUNCTION virtual unsigned get_num() const { return 0; }
+//};
+
+struct MyDeviceClass //: public MyBaseClass
+{
+  KOKKOS_FUNCTION MyDeviceClass()
+  : ngpField(), num(0)
+  {
+    printf("MyDeviceClass def ctor\n");
+  }
+
+  KOKKOS_FUNCTION MyDeviceClass(const MyDeviceClass& src)
+  : ngpField(src.ngpField), num(src.num)
+  {
+    printf("MyDeviceClass copy ctor\n");
+  }
+
+  KOKKOS_FUNCTION ~MyDeviceClass()
+  {
+    printf("MyDeviceClass dtor\n");
+  }
+
+  KOKKOS_FUNCTION unsigned get_num() const /*override*/ { return num; }
+
+  stk::mesh::NgpField<double> ngpField;
+  unsigned num = 0;
+};
+
+void test_ngp_field_placement_new()
+{
+  MyDeviceClass hostObj;
+  hostObj.num = 42;
+
+  printf("sizeof(MyDeviceClass): %lu, sizeof(NgpField): %lu\n", sizeof(MyDeviceClass), sizeof(stk::mesh::NgpField<double>));
+  std::string debugName("MyDeviceClass");
+  MyDeviceClass* devicePtr = static_cast<MyDeviceClass*>(Kokkos::kokkos_malloc<stk::ngp::MemSpace>(debugName, 2*sizeof(MyDeviceClass)));
+
+  int constructionFinished = 0;
+  printf("about to call parallel_reduce for placement new\n");
+  Kokkos::parallel_reduce(sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const unsigned& i, int& localFinished) {
+    printf("before placement-new\n");
+    new (devicePtr) MyDeviceClass(hostObj);
+    printf("after placement-new\n");
+    localFinished = 1;
+  }, constructionFinished);
+  EXPECT_EQ(1, constructionFinished);
+
+  int numFromDevice = 0;
+  printf("about to call parallel_reduce for access check\n");
+  Kokkos::parallel_reduce(sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const unsigned& i, int& localNum) {
+    localNum = devicePtr->get_num();
+  }, numFromDevice);
+  EXPECT_EQ(42, numFromDevice);
+}
+
+TEST(DevicePlacementNew, structWithNgpField)
+{
+  test_ngp_field_placement_new();
+}
+
+enum {MaxLen = 6};
+typedef Kokkos::View<unsigned*, stk::ngp::MemSpace> UnsignedViewType;
+
+class FakeFieldBase
+{
+public:
+  KOKKOS_DEFAULTED_FUNCTION FakeFieldBase() = default;
+  KOKKOS_DEFAULTED_FUNCTION FakeFieldBase(const FakeFieldBase&) = default;
+  KOKKOS_DEFAULTED_FUNCTION FakeFieldBase(FakeFieldBase&&) = default;
+  KOKKOS_FUNCTION FakeFieldBase& operator=(const FakeFieldBase&) { return *this; }
+  KOKKOS_FUNCTION FakeFieldBase& operator=(FakeFieldBase&&) { return *this; }
+  KOKKOS_FUNCTION virtual ~FakeFieldBase() {}
+};
+
+template<typename T>
+struct FakeField : public FakeFieldBase
+{
+public:
+  KOKKOS_FUNCTION FakeField()
+  {
+    printf("FakeField default ctor\n");
+    for(int i=0; i<MaxLen; ++i) {
+      val[i] = 1.1;
+    }
+  }
+  KOKKOS_FUNCTION FakeField(const FakeField<T>& src)
+  {
+    printf("FakeField copy ctor\n");
+    for(int i=0; i<MaxLen; ++i) {
+      val[i] = src.val[i];
+    }
+  }
+  KOKKOS_FUNCTION ~FakeField()
+  {
+    printf("FakeField dtor\n");
+  }
+
+  KOKKOS_FUNCTION double get_val() const /*override*/ { return val; }
+
+private:
+  UnsignedViewType unsignedDeviceView1;
+  typename UnsignedViewType::HostMirror unsignedHostView1;
+  UnsignedViewType unsignedDeviceView2;
+  typename UnsignedViewType::HostMirror unsignedHostView2;
+  UnsignedViewType unsignedDeviceView3;
+  typename UnsignedViewType::HostMirror unsignedHostView3;
+  UnsignedViewType unsignedDeviceView4;
+  typename UnsignedViewType::HostMirror unsignedHostView4;
+  UnsignedViewType unsignedDeviceView5;
+  typename UnsignedViewType::HostMirror unsignedHostView5;
+  UnsignedViewType unsignedDeviceView6;
+  typename UnsignedViewType::HostMirror unsignedHostView6;
+  UnsignedViewType unsignedDeviceView7;
+  typename UnsignedViewType::HostMirror unsignedHostView7;
+  UnsignedViewType unsignedDeviceView8;
+  typename UnsignedViewType::HostMirror unsignedHostView8;
+  UnsignedViewType unsignedDeviceView9;
+  typename UnsignedViewType::HostMirror unsignedHostView9;
+  T val[MaxLen];
+};
+
+struct MyFakeDeviceClass
+{
+  KOKKOS_DEFAULTED_FUNCTION MyFakeDeviceClass() = default;
+  KOKKOS_FUNCTION MyFakeDeviceClass(const MyFakeDeviceClass& src)
+  : ngpField(src.ngpField), num(src.num)
+  {}
+  KOKKOS_DEFAULTED_FUNCTION ~MyFakeDeviceClass() = default;
+
+  KOKKOS_FUNCTION unsigned get_num() const /*override*/ { return num; }
+
+  FakeField<double> ngpField;
+  unsigned num = 0;
+};
+
+void test_fake_field_placement_new()
+{
+  MyFakeDeviceClass hostObj;
+  hostObj.num = 42;
+
+  printf("sizeof(MyFakeDeviceClass): %lu, sizeof(FakeField): %lu\n", sizeof(MyFakeDeviceClass), sizeof(FakeField<double>));
+  std::string debugName("MyFakeDeviceClass");
+  MyFakeDeviceClass* devicePtr = static_cast<MyFakeDeviceClass*>(Kokkos::kokkos_malloc<stk::ngp::MemSpace>(debugName, sizeof(MyFakeDeviceClass)));
+
+  int constructionFinished = 0;
+  printf("about to call parallel_reduce for placement new\n");
+  Kokkos::parallel_reduce(sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const unsigned& i, int& localFinished) {
+    printf("before placement-new\n");
+    new (devicePtr) MyFakeDeviceClass(hostObj);
+    printf("after placement-new\n");
+    localFinished = 1;
+  }, constructionFinished);
+  EXPECT_EQ(1, constructionFinished);
+
+  int numFromDevice = 0;
+  printf("about to call parallel_reduce for access check\n");
+  Kokkos::parallel_reduce(sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const unsigned& i, int& localNum) {
+    localNum = devicePtr->get_num();
+  }, numFromDevice);
+  EXPECT_EQ(42, numFromDevice);
+}
+
+TEST(DevicePlacementNew, structWithFakeField)
+{
+  test_fake_field_placement_new();
+}
+

--- a/unit_tests/UnitTestNgpMesh1.C
+++ b/unit_tests/UnitTestNgpMesh1.C
@@ -183,32 +183,22 @@ TEST_F(Hex8MeshWithNSOFields, NGPMeshField)
   test_ngp_mesh_field_values(*bulk, velocity, massFlowRate);
 }
 
-//struct MyBaseClass
-//{
-//  KOKKOS_DEFAULTED_FUNCTION MyBaseClass() = default;
-//  KOKKOS_DEFAULTED_FUNCTION MyBaseClass(const MyBaseClass&) = default;
-//  KOKKOS_DEFAULTED_FUNCTION virtual ~MyBaseClass() = default;
-//
-//  KOKKOS_FUNCTION virtual unsigned get_num() const { return 0; }
-//};
-
-struct MyDeviceClass //: public MyBaseClass
+struct TestKernelWithNgpField
 {
-  KOKKOS_FUNCTION MyDeviceClass()
-  : ngpField(), num(0)
+  KOKKOS_FUNCTION TestKernelWithNgpField() : ngpField(), num(0)
   {
-    printf("MyDeviceClass def ctor\n");
+    printf("TestKernelWithNgpField def ctor\n");
   }
 
-  KOKKOS_FUNCTION MyDeviceClass(const MyDeviceClass& src)
-  : ngpField(src.ngpField), num(src.num)
+  KOKKOS_FUNCTION TestKernelWithNgpField(const TestKernelWithNgpField& src)
+    : ngpField(src.ngpField), num(src.num)
   {
-    printf("MyDeviceClass copy ctor\n");
+    printf("TestKernelWithNgpField copy ctor\n");
   }
 
-  KOKKOS_FUNCTION ~MyDeviceClass()
+  KOKKOS_FUNCTION ~TestKernelWithNgpField()
   {
-    printf("MyDeviceClass dtor\n");
+    printf("TestKernelWithNgpField dtor\n");
   }
 
   KOKKOS_FUNCTION unsigned get_num() const /*override*/ { return num; }
@@ -217,142 +207,41 @@ struct MyDeviceClass //: public MyBaseClass
   unsigned num = 0;
 };
 
-void test_ngp_field_placement_new()
+void
+test_ngp_field_placement_new()
 {
-  MyDeviceClass hostObj;
+  TestKernelWithNgpField hostObj;
   hostObj.num = 42;
 
-  printf("sizeof(MyDeviceClass): %lu, sizeof(NgpField): %lu\n", sizeof(MyDeviceClass), sizeof(stk::mesh::NgpField<double>));
-  std::string debugName("MyDeviceClass");
-  MyDeviceClass* devicePtr = static_cast<MyDeviceClass*>(Kokkos::kokkos_malloc<stk::ngp::MemSpace>(debugName, 2*sizeof(MyDeviceClass)));
+  printf(
+    "sizeof(TestKernelWithNgpField): %lu, sizeof(NgpField): %lu\n",
+    sizeof(TestKernelWithNgpField), sizeof(stk::mesh::NgpField<double>));
+  std::string debugName("TestKernelWithNgpField");
+  TestKernelWithNgpField* devicePtr = static_cast<TestKernelWithNgpField*>(
+    Kokkos::kokkos_malloc<stk::ngp::MemSpace>(
+      debugName, sizeof(TestKernelWithNgpField)));
 
   int constructionFinished = 0;
-  printf("about to call parallel_reduce for placement new\n");
-  Kokkos::parallel_reduce(sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const unsigned& i, int& localFinished) {
-    printf("before placement-new\n");
-    new (devicePtr) MyDeviceClass(hostObj);
-    printf("after placement-new\n");
-    localFinished = 1;
-  }, constructionFinished);
+  Kokkos::parallel_reduce(
+    sierra::nalu::DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const unsigned& i, int& localFinished) {
+      new (devicePtr) TestKernelWithNgpField(hostObj);
+      localFinished = 1;
+    },
+    constructionFinished);
   EXPECT_EQ(1, constructionFinished);
 
   int numFromDevice = 0;
-  printf("about to call parallel_reduce for access check\n");
-  Kokkos::parallel_reduce(sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const unsigned& i, int& localNum) {
-    localNum = devicePtr->get_num();
-  }, numFromDevice);
+  Kokkos::parallel_reduce(
+    sierra::nalu::DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const unsigned& i, int& localNum) {
+      localNum = devicePtr->get_num();
+    },
+    numFromDevice);
   EXPECT_EQ(42, numFromDevice);
 }
 
-TEST(DevicePlacementNew, structWithNgpField)
+TEST(DevicePlacementNew, NGP_structWithNgpField)
 {
   test_ngp_field_placement_new();
 }
-
-enum {MaxLen = 6};
-typedef Kokkos::View<unsigned*, stk::ngp::MemSpace> UnsignedViewType;
-
-class FakeFieldBase
-{
-public:
-  KOKKOS_DEFAULTED_FUNCTION FakeFieldBase() = default;
-  KOKKOS_DEFAULTED_FUNCTION FakeFieldBase(const FakeFieldBase&) = default;
-  KOKKOS_DEFAULTED_FUNCTION FakeFieldBase(FakeFieldBase&&) = default;
-  KOKKOS_FUNCTION FakeFieldBase& operator=(const FakeFieldBase&) { return *this; }
-  KOKKOS_FUNCTION FakeFieldBase& operator=(FakeFieldBase&&) { return *this; }
-  KOKKOS_FUNCTION virtual ~FakeFieldBase() {}
-};
-
-template<typename T>
-struct FakeField : public FakeFieldBase
-{
-public:
-  KOKKOS_FUNCTION FakeField()
-  {
-    printf("FakeField default ctor\n");
-    for(int i=0; i<MaxLen; ++i) {
-      val[i] = 1.1;
-    }
-  }
-  KOKKOS_FUNCTION FakeField(const FakeField<T>& src)
-  {
-    printf("FakeField copy ctor\n");
-    for(int i=0; i<MaxLen; ++i) {
-      val[i] = src.val[i];
-    }
-  }
-  KOKKOS_FUNCTION ~FakeField()
-  {
-    printf("FakeField dtor\n");
-  }
-
-  KOKKOS_FUNCTION double get_val() const /*override*/ { return val; }
-
-private:
-  UnsignedViewType unsignedDeviceView1;
-  typename UnsignedViewType::HostMirror unsignedHostView1;
-  UnsignedViewType unsignedDeviceView2;
-  typename UnsignedViewType::HostMirror unsignedHostView2;
-  UnsignedViewType unsignedDeviceView3;
-  typename UnsignedViewType::HostMirror unsignedHostView3;
-  UnsignedViewType unsignedDeviceView4;
-  typename UnsignedViewType::HostMirror unsignedHostView4;
-  UnsignedViewType unsignedDeviceView5;
-  typename UnsignedViewType::HostMirror unsignedHostView5;
-  UnsignedViewType unsignedDeviceView6;
-  typename UnsignedViewType::HostMirror unsignedHostView6;
-  UnsignedViewType unsignedDeviceView7;
-  typename UnsignedViewType::HostMirror unsignedHostView7;
-  UnsignedViewType unsignedDeviceView8;
-  typename UnsignedViewType::HostMirror unsignedHostView8;
-  UnsignedViewType unsignedDeviceView9;
-  typename UnsignedViewType::HostMirror unsignedHostView9;
-  T val[MaxLen];
-};
-
-struct MyFakeDeviceClass
-{
-  KOKKOS_DEFAULTED_FUNCTION MyFakeDeviceClass() = default;
-  KOKKOS_FUNCTION MyFakeDeviceClass(const MyFakeDeviceClass& src)
-  : ngpField(src.ngpField), num(src.num)
-  {}
-  KOKKOS_DEFAULTED_FUNCTION ~MyFakeDeviceClass() = default;
-
-  KOKKOS_FUNCTION unsigned get_num() const /*override*/ { return num; }
-
-  FakeField<double> ngpField;
-  unsigned num = 0;
-};
-
-void test_fake_field_placement_new()
-{
-  MyFakeDeviceClass hostObj;
-  hostObj.num = 42;
-
-  printf("sizeof(MyFakeDeviceClass): %lu, sizeof(FakeField): %lu\n", sizeof(MyFakeDeviceClass), sizeof(FakeField<double>));
-  std::string debugName("MyFakeDeviceClass");
-  MyFakeDeviceClass* devicePtr = static_cast<MyFakeDeviceClass*>(Kokkos::kokkos_malloc<stk::ngp::MemSpace>(debugName, sizeof(MyFakeDeviceClass)));
-
-  int constructionFinished = 0;
-  printf("about to call parallel_reduce for placement new\n");
-  Kokkos::parallel_reduce(sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const unsigned& i, int& localFinished) {
-    printf("before placement-new\n");
-    new (devicePtr) MyFakeDeviceClass(hostObj);
-    printf("after placement-new\n");
-    localFinished = 1;
-  }, constructionFinished);
-  EXPECT_EQ(1, constructionFinished);
-
-  int numFromDevice = 0;
-  printf("about to call parallel_reduce for access check\n");
-  Kokkos::parallel_reduce(sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(const unsigned& i, int& localNum) {
-    localNum = devicePtr->get_num();
-  }, numFromDevice);
-  EXPECT_EQ(42, numFromDevice);
-}
-
-TEST(DevicePlacementNew, structWithFakeField)
-{
-  test_fake_field_placement_new();
-}
-

--- a/unit_tests/UnitTestPecletFunction.C
+++ b/unit_tests/UnitTestPecletFunction.C
@@ -25,7 +25,7 @@ exec_on_device(PecFuncType* devptr, ValueType pecNum)
 {
   ValueType pecFac = 0.0;
   Kokkos::parallel_reduce(
-    1, KOKKOS_LAMBDA(int, ValueType& pf) { pf = devptr->execute(pecNum); },
+    sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int, ValueType& pf) { pf = devptr->execute(pecNum); },
     pecFac);
   return pecFac;
 }

--- a/unit_tests/UnitTestPecletFunction.C
+++ b/unit_tests/UnitTestPecletFunction.C
@@ -25,7 +25,8 @@ exec_on_device(PecFuncType* devptr, ValueType pecNum)
 {
   ValueType pecFac = 0.0;
   Kokkos::parallel_reduce(
-    sierra::nalu::DeviceRangePolicy(0,1), KOKKOS_LAMBDA(int, ValueType& pf) { pf = devptr->execute(pecNum); },
+    sierra::nalu::DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(int, ValueType& pf) { pf = devptr->execute(pecNum); },
     pecFac);
   return pecFac;
 }

--- a/unit_tests/matrix_free/UnitTestConductionGatheredFieldManager.C
+++ b/unit_tests/matrix_free/UnitTestConductionGatheredFieldManager.C
@@ -92,7 +92,7 @@ sum_field(scalar_view<p> qp1)
 {
   double sum_prev = 0;
   Kokkos::parallel_reduce(
-    sierra::nalu::DeviceRangePolicy(0,qp1.extent_int(0)),
+    sierra::nalu::DeviceRangePolicy(0, qp1.extent_int(0)),
     KOKKOS_LAMBDA(int index, double& sumval) {
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {

--- a/unit_tests/matrix_free/UnitTestConductionGatheredFieldManager.C
+++ b/unit_tests/matrix_free/UnitTestConductionGatheredFieldManager.C
@@ -13,6 +13,7 @@
 #include "matrix_free/ConductionInfo.h"
 #include "StkConductionFixture.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Parallel_Reduce.hpp"
 
@@ -91,7 +92,7 @@ sum_field(scalar_view<p> qp1)
 {
   double sum_prev = 0;
   Kokkos::parallel_reduce(
-    qp1.extent_int(0),
+    sierra::nalu::DeviceRangePolicy(0,qp1.extent_int(0)),
     KOKKOS_LAMBDA(int index, double& sumval) {
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {

--- a/unit_tests/matrix_free/UnitTestLowMachGatheredFieldManager.C
+++ b/unit_tests/matrix_free/UnitTestLowMachGatheredFieldManager.C
@@ -13,6 +13,7 @@
 #include "matrix_free/LowMachInfo.h"
 #include "StkLowMachFixture.h"
 
+#include <KokkosInterface.h>
 #include "Kokkos_Macros.hpp"
 #include "Kokkos_Parallel_Reduce.hpp"
 
@@ -91,7 +92,7 @@ sum_field(vector_view<p> qp1)
 {
   double sum_prev = 0;
   Kokkos::parallel_reduce(
-    qp1.extent_int(0),
+    sierra::nalu::DeviceRangePolicy(0,qp1.extent_int(0)),
     KOKKOS_LAMBDA(int index, double& sumval) {
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {

--- a/unit_tests/matrix_free/UnitTestLowMachGatheredFieldManager.C
+++ b/unit_tests/matrix_free/UnitTestLowMachGatheredFieldManager.C
@@ -92,7 +92,7 @@ sum_field(vector_view<p> qp1)
 {
   double sum_prev = 0;
   Kokkos::parallel_reduce(
-    sierra::nalu::DeviceRangePolicy(0,qp1.extent_int(0)),
+    sierra::nalu::DeviceRangePolicy(0, qp1.extent_int(0)),
     KOKKOS_LAMBDA(int index, double& sumval) {
       for (int k = 0; k < p + 1; ++k) {
         for (int j = 0; j < p + 1; ++j) {

--- a/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
@@ -56,18 +56,19 @@ my_create(const T& hostObj)
 
   // Create local copy for capture on device
   const T hostCopy(hostObj);
-  Kokkos::parallel_for(debuggingName, 1,
-    KOKKOS_LAMBDA(const int) {
-    printf("before placement new\n");
+  Kokkos::parallel_for(
+    debuggingName, 1, KOKKOS_LAMBDA(const int) {
+      printf("before placement new\n");
       new (obj) T();
-    printf("after placement new\n");
+      printf("after placement new\n");
       *obj = hostCopy;
-    printf("after assignment\n");
+      printf("after assignment\n");
     });
   return obj;
 }
 
-void test_kernel_on_device(const sierra::nalu::ContinuityGclNodeKernel& kernel)
+void
+test_kernel_on_device(const sierra::nalu::ContinuityGclNodeKernel& kernel)
 {
   sierra::nalu::ContinuityGclNodeKernel* deviceKernel = my_create(kernel);
 }
@@ -84,4 +85,3 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_gcl_node_kernel)
 
   test_kernel_on_device(kernel);
 }
-

--- a/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestContinuityGclNodeKernel.C
@@ -11,6 +11,8 @@
 #include "UnitTestUtils.h"
 #include "UnitTestHelperObjects.h"
 
+#include "KokkosInterface.h"
+#include "NGPInstance.h"
 #include "node_kernels/ContinuityGclNodeKernel.h"
 
 TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_gcl_node)
@@ -44,3 +46,42 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_gcl_node)
   unit_test_kernel_utils::expect_all_near(helperObjs.linsys->rhs_, 9.375);
   unit_test_kernel_utils::expect_all_near<8>(helperObjs.linsys->lhs_, 0.0);
 }
+
+template <class T>
+inline T*
+my_create(const T& hostObj)
+{
+  const std::string debuggingName(typeid(T).name());
+  T* obj = sierra::nalu::kokkos_malloc_on_device<T>(debuggingName);
+
+  // Create local copy for capture on device
+  const T hostCopy(hostObj);
+  Kokkos::parallel_for(debuggingName, 1,
+    KOKKOS_LAMBDA(const int) {
+    printf("before placement new\n");
+      new (obj) T();
+    printf("after placement new\n");
+      *obj = hostCopy;
+    printf("after assignment\n");
+    });
+  return obj;
+}
+
+void test_kernel_on_device(const sierra::nalu::ContinuityGclNodeKernel& kernel)
+{
+  sierra::nalu::ContinuityGclNodeKernel* deviceKernel = my_create(kernel);
+}
+
+TEST_F(ContinuityKernelHex8Mesh, NGP_continuity_gcl_node_kernel)
+{
+  // Only execute for 1 processor runs
+  if (bulk_->parallel_size() > 1)
+    return;
+
+  fill_mesh_and_init_fields();
+
+  sierra::nalu::ContinuityGclNodeKernel kernel(*bulk_);
+
+  test_kernel_on_device(kernel);
+}
+


### PR DESCRIPTION
We don't use LaunchBounds with Cuda. So ifdefs only add LaunchBounds to the Range/TeamPolicy objects if HIP is enabled.

nalu-wind is now able to build on crusher without the gpu-max-threads-per-block flag, and all NGP unit tests pass.
