### PR TITLE
Fix some RangePolicies

### DIFF
--- a/src/aero/actuator/ActuatorBulkDiskFAST.C
+++ b/src/aero/actuator/ActuatorBulkDiskFAST.C
@@ -30,7 +30,7 @@ ActuatorBulkDiskFAST::ActuatorBulkDiskFAST(
   resize_arrays(actMeta);
   Kokkos::parallel_for(
     "ZeroArrays",
-    Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace>(
+    HostRangePolicy(
       0, actMeta.numPointsTotal_),
     [&](int index) {
       for (int j = 0; j < 3; j++) {

--- a/src/aero/actuator/ActuatorBulkDiskFAST.C
+++ b/src/aero/actuator/ActuatorBulkDiskFAST.C
@@ -29,10 +29,7 @@ ActuatorBulkDiskFAST::ActuatorBulkDiskFAST(
   compute_swept_point_count(actMeta);
   resize_arrays(actMeta);
   Kokkos::parallel_for(
-    "ZeroArrays",
-    HostRangePolicy(
-      0, actMeta.numPointsTotal_),
-    [&](int index) {
+    "ZeroArrays", HostRangePolicy(0, actMeta.numPointsTotal_), [&](int index) {
       for (int j = 0; j < 3; j++) {
         pointCentroid_.h_view(index, j) = 0;
         epsilon_.h_view(index, j) = 0;

--- a/src/aero/actuator/ActuatorBulkFAST.C
+++ b/src/aero/actuator/ActuatorBulkFAST.C
@@ -300,14 +300,14 @@ void
 ActuatorBulkFAST::output_torque_info(stk::mesh::BulkData& stkBulk)
 {
   Kokkos::parallel_for(
-    "setUpTorqueCalc", DeviceRangePolicy(0, hubLocations_.extent(0)),
+    "setUpTorqueCalc", HostRangePolicy(0, hubLocations_.extent(0)),
     ActFastSetUpThrustCalc(*this));
 
   actuator_utils::reduce_view_on_host(hubLocations_);
   actuator_utils::reduce_view_on_host(hubOrientation_);
 
   Kokkos::parallel_for(
-    "computeTorque", DeviceRangePolicy(0, coarseSearchElemIds_.extent(0)),
+    "computeTorque", HostRangePolicy(0, coarseSearchElemIds_.extent(0)),
     ActFastComputeThrust(*this, stkBulk));
   actuator_utils::reduce_view_on_host(turbineThrust_);
   actuator_utils::reduce_view_on_host(turbineTorque_);

--- a/src/aero/actuator/ActuatorExecutorsFASTNgp.C
+++ b/src/aero/actuator/ActuatorExecutorsFASTNgp.C
@@ -58,14 +58,14 @@ ActuatorLineFastNGP::operator()()
   if (actMeta_.isotropicGaussian_) {
     Kokkos::parallel_for(
       "spreadForcesActuatorNgpFAST",
-      DeviceRangePolicy(0, localSizeCoarseSearch),
+      HostRangePolicy(0, localSizeCoarseSearch),
       SpreadActuatorForce(actBulk_, stkBulk_));
   } else {
     RunActFastStashOrientVecs(actBulk_);
 
     Kokkos::parallel_for(
       "spreadForceUsingProjDistance",
-      DeviceRangePolicy(0, localSizeCoarseSearch),
+      HostRangePolicy(0, localSizeCoarseSearch),
       ActFastSpreadForceWhProjection(actBulk_, stkBulk_));
   }
 
@@ -130,7 +130,7 @@ ActuatorDiskFastNGP::operator()()
     actBulk_.coarseSearchElemIds_.view_host().extent_int(0);
 
   Kokkos::parallel_for(
-    "spreadForcesActuatorNgpFAST", DeviceRangePolicy(0, localSizeCoarseSearch),
+    "spreadForcesActuatorNgpFAST", HostRangePolicy(0, localSizeCoarseSearch),
     SpreadActuatorForce(actBulk_, stkBulk_));
 
   actBulk_.parallel_sum_source_term(stkBulk_);

--- a/src/aero/actuator/ActuatorExecutorsFASTNgp.C
+++ b/src/aero/actuator/ActuatorExecutorsFASTNgp.C
@@ -57,15 +57,13 @@ ActuatorLineFastNGP::operator()()
 
   if (actMeta_.isotropicGaussian_) {
     Kokkos::parallel_for(
-      "spreadForcesActuatorNgpFAST",
-      HostRangePolicy(0, localSizeCoarseSearch),
+      "spreadForcesActuatorNgpFAST", HostRangePolicy(0, localSizeCoarseSearch),
       SpreadActuatorForce(actBulk_, stkBulk_));
   } else {
     RunActFastStashOrientVecs(actBulk_);
 
     Kokkos::parallel_for(
-      "spreadForceUsingProjDistance",
-      HostRangePolicy(0, localSizeCoarseSearch),
+      "spreadForceUsingProjDistance", HostRangePolicy(0, localSizeCoarseSearch),
       ActFastSpreadForceWhProjection(actBulk_, stkBulk_));
   }
 


### PR DESCRIPTION
#1102 got a few RangePolicies wrong in the OpenFAST executors.  All actuator code currently executes on host.