### PR TITLE
Fix memory leak in UnitTestLinearSystem

### DIFF
--- a/include/LinearSolver.h
+++ b/include/LinearSolver.h
@@ -13,7 +13,7 @@
 #include <LinearSolverTypes.h>
 #include <LinearSolverConfig.h>
 
-#include <Kokkos_DefaultNode.hpp>
+#include <Kokkos_Core.hpp>
 #include <Tpetra_Details_DefaultTypes.hpp>
 #include <Tpetra_Vector.hpp>
 #include <Tpetra_CrsMatrix.hpp>

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -146,7 +146,7 @@ public:
   {
   }
 
-  virtual void free_coeff_applier(CoeffApplier*) {printf("shouldn't be here!\n");}
+  virtual void free_coeff_applier(CoeffApplier*) {}
 
   // Matrix Assembly
   virtual void zeroSystem() = 0;

--- a/include/LinearSystem.h
+++ b/include/LinearSystem.h
@@ -146,7 +146,7 @@ public:
   {
   }
 
-  virtual void free_coeff_applier(CoeffApplier*) {}
+  virtual void free_coeff_applier(CoeffApplier*) {printf("shouldn't be here!\n");}
 
   // Matrix Assembly
   virtual void zeroSystem() = 0;

--- a/include/TpetraLinearSystem.h
+++ b/include/TpetraLinearSystem.h
@@ -15,7 +15,7 @@
 #include <KokkosInterface.h>
 #include <FieldTypeDef.h>
 
-#include <Kokkos_DefaultNode.hpp>
+#include <Kokkos_Core.hpp>
 #include <Kokkos_UnorderedMap.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>

--- a/include/TpetraSegregatedLinearSystem.h
+++ b/include/TpetraSegregatedLinearSystem.h
@@ -15,7 +15,6 @@
 #include <KokkosInterface.h>
 #include <FieldTypeDef.h>
 
-#include <Kokkos_DefaultNode.hpp>
 #include <Tpetra_MultiVector.hpp>
 #include <Tpetra_CrsMatrix.hpp>
 

--- a/include/kernel/Kernel.h
+++ b/include/kernel/Kernel.h
@@ -16,9 +16,7 @@
 #include "AlgTraits.h"
 #include "NGPInstance.h"
 
-#include <Kokkos_CopyViews.hpp>
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Parallel.hpp>
+#include <Kokkos_Core.hpp>
 
 #include <stk_mesh/base/Entity.hpp>
 

--- a/include/matrix_free/ConductionSolutionUpdate.h
+++ b/include/matrix_free/ConductionSolutionUpdate.h
@@ -15,8 +15,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/MatrixFreeSolver.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Tpetra_Export.hpp"
 #include "Tpetra_Map.hpp"
 

--- a/include/matrix_free/ConductionUpdate.h
+++ b/include/matrix_free/ConductionUpdate.h
@@ -16,8 +16,7 @@
 #include "matrix_free/LinSysInfo.h"
 #include "matrix_free/StkToTpetraMap.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 
 #include "Teuchos_RCP.hpp"
 #include "Tpetra_Export.hpp"

--- a/include/matrix_free/GreenGaussGradient.h
+++ b/include/matrix_free/GreenGaussGradient.h
@@ -16,8 +16,7 @@
 #include "matrix_free/LinSysInfo.h"
 #include "matrix_free/StkToTpetraMap.h"
 
-#include "Kokkos_MemoryTraits.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Tpetra_Export.hpp"
 #include "Tpetra_Map.hpp"

--- a/include/matrix_free/LocalDualNodalVolume.h
+++ b/include/matrix_free/LocalDualNodalVolume.h
@@ -12,7 +12,7 @@
 
 #include "matrix_free/PolynomialOrders.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 
 #include "Tpetra_CrsMatrix.hpp"

--- a/include/matrix_free/SparsifiedEdgeLaplacian.h
+++ b/include/matrix_free/SparsifiedEdgeLaplacian.h
@@ -12,7 +12,7 @@
 
 #include "matrix_free/PolynomialOrders.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 
 #include "Tpetra_CrsMatrix.hpp"

--- a/include/matrix_free/StkSimdMeshTraverser.h
+++ b/include/matrix_free/StkSimdMeshTraverser.h
@@ -11,7 +11,6 @@
 #define STK_SIMD_MESH_TRAVERSER_H
 
 #include <KokkosInterface.h>
-#include <Kokkos_View.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/include/matrix_free/StkToTpetraLocalIndices.h
+++ b/include/matrix_free/StkToTpetraLocalIndices.h
@@ -12,7 +12,7 @@
 
 #include "Tpetra_Map.hpp"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 
 #include "stk_mesh/base/NgpMesh.hpp"
 #include "stk_mesh/base/Types.hpp"

--- a/include/matrix_free/StkToTpetraMap.h
+++ b/include/matrix_free/StkToTpetraMap.h
@@ -12,7 +12,7 @@
 
 #include "matrix_free/LinSysInfo.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Tpetra_Map.hpp"
 #include "Tpetra_MultiVector.hpp"

--- a/include/matrix_free/ValidSimdLength.h
+++ b/include/matrix_free/ValidSimdLength.h
@@ -12,7 +12,7 @@
 
 #include "matrix_free/KokkosViewTypes.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "stk_simd/Simd.hpp"
 #include "stk_mesh/base/Types.hpp"
 

--- a/src/LinearSolver.C
+++ b/src/LinearSolver.C
@@ -26,8 +26,7 @@
 #include <BelosTpetraAdapter.hpp>
 
 #include <Ifpack2_Factory.hpp>
-#include <Kokkos_DefaultNode.hpp>
-#include <Kokkos_Serial.hpp>
+#include <Kokkos_Core.hpp>
 #include <Teuchos_ArrayRCP.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
 #include <Teuchos_OrdinalTraits.hpp>

--- a/src/MatrixFreeLowMachEquationSystem.C
+++ b/src/MatrixFreeLowMachEquationSystem.C
@@ -36,10 +36,7 @@
 #include "user_functions/SinProfileChannelFlowVelocityAuxFunction.h"
 #include "utils/StkHelpers.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 
 #include "stk_mesh/base/Field.hpp"

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -51,7 +51,6 @@
 #include <stk_mesh/base/NgpMesh.hpp>
 
 // For Tpetra support
-#include <Kokkos_Serial.hpp>
 #include <Teuchos_ArrayRCP.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
 #include <Teuchos_OrdinalTraits.hpp>

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -47,7 +47,6 @@
 #include <stk_mesh/base/NgpMesh.hpp>
 
 // For Tpetra support
-#include <Kokkos_Serial.hpp>
 #include <Teuchos_ArrayRCP.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
 #include <Teuchos_OrdinalTraits.hpp>

--- a/src/matrix_free/ConductionDiagonal.C
+++ b/src/matrix_free/ConductionDiagonal.C
@@ -17,9 +17,7 @@
 #include "matrix_free/LocalArray.h"
 
 #include <KokkosInterface.h>
-#include <Kokkos_Macros.hpp>
 #include <Kokkos_ScatterView.hpp>
-#include <Kokkos_Parallel.hpp>
 #include <stk_simd/Simd.hpp>
 
 namespace sierra {

--- a/src/matrix_free/ConductionJacobiPreconditioner.C
+++ b/src/matrix_free/ConductionJacobiPreconditioner.C
@@ -15,12 +15,10 @@
 #include "matrix_free/StrongDirichletBC.h"
 
 #include <KokkosInterface.h>
-#include <Kokkos_Parallel.hpp>
 
 #include <Teuchos_RCP.hpp>
 #include <Tpetra_CombineMode.hpp>
 #include "Tpetra_Operator.hpp"
-#include <KokkosInterface.h>
 #include <type_traits>
 
 namespace sierra {

--- a/src/matrix_free/ConductionSolutionUpdate.C
+++ b/src/matrix_free/ConductionSolutionUpdate.C
@@ -17,8 +17,6 @@
 #include "matrix_free/StkSimdNodeConnectivityMap.h"
 
 #include <KokkosInterface.h>
-#include "Kokkos_Array.hpp"
-#include "Kokkos_View.hpp"
 
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"

--- a/src/matrix_free/ConductionUpdate.C
+++ b/src/matrix_free/ConductionUpdate.C
@@ -13,8 +13,6 @@
 #include "matrix_free/PolynomialOrders.h"
 
 #include <KokkosInterface.h>
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"
 

--- a/src/matrix_free/ContinuityInterior.C
+++ b/src/matrix_free/ContinuityInterior.C
@@ -17,8 +17,6 @@
 #include "matrix_free/ValidSimdLength.h"
 
 #include <KokkosInterface.h>
-#include "Kokkos_ExecPolicy.hpp"
-#include "Kokkos_Macros.hpp"
 #include "Kokkos_ScatterView.hpp"
 
 #include "stk_mesh/base/NgpProfilingBlock.hpp"

--- a/src/matrix_free/FilterJacobi.C
+++ b/src/matrix_free/FilterJacobi.C
@@ -20,8 +20,6 @@
 #include "Tpetra_MultiVector.hpp"
 
 #include <KokkosInterface.h>
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
 
 #include <type_traits>
 

--- a/src/matrix_free/LinearAdvectionMetric.C
+++ b/src/matrix_free/LinearAdvectionMetric.C
@@ -17,8 +17,6 @@
 #include "matrix_free/ShuffledAccess.h"
 
 #include <KokkosInterface.h>
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_View.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/matrix_free/LinearDiffusionMetric.C
+++ b/src/matrix_free/LinearDiffusionMetric.C
@@ -18,8 +18,6 @@
 #include "matrix_free/PolynomialOrders.h"
 
 #include <KokkosInterface.h>
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_View.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/src/matrix_free/MomentumDiagonal.C
+++ b/src/matrix_free/MomentumDiagonal.C
@@ -16,10 +16,8 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/LocalArray.h"
 #include <KokkosInterface.h>
-
-#include <Kokkos_Macros.hpp>
 #include <Kokkos_ScatterView.hpp>
-#include <Kokkos_Parallel.hpp>
+
 #include <stk_simd/Simd.hpp>
 
 namespace sierra {

--- a/src/matrix_free/StkSimdNodeConnectivityMap.C
+++ b/src/matrix_free/StkSimdNodeConnectivityMap.C
@@ -19,8 +19,6 @@
 #include "stk_topology/topology.hpp"
 
 #include <KokkosInterface.h>
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
 
 namespace sierra {
 namespace nalu {

--- a/unit_tests/UnitTestLinearSystem.h
+++ b/unit_tests/UnitTestLinearSystem.h
@@ -262,6 +262,8 @@ public:
     return newDeviceCoeffApplier;
   }
 
+  bool owns_coeff_applier() override { return false; }
+
   virtual void sumInto(
     unsigned numEntities,
     const stk::mesh::NgpMesh::ConnectedNodes& entities,

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -91,8 +91,6 @@ protected:
       coordField(nullptr),
       exactLaplacian(0.0)
   {
-std::cout<<"comm: "<<comm<<std::endl;
-std::cout<<"MPI_COMM_WORLD: "<<MPI_COMM_WORLD<<std::endl;
     stk::mesh::MeshBuilder meshBuilder(comm);
     meshBuilder.set_spatial_dimension(spatialDimension);
     bulk = meshBuilder.create();

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -91,6 +91,8 @@ protected:
       coordField(nullptr),
       exactLaplacian(0.0)
   {
+std::cout<<"comm: "<<comm<<std::endl;
+std::cout<<"MPI_COMM_WORLD: "<<MPI_COMM_WORLD<<std::endl;
     stk::mesh::MeshBuilder meshBuilder(comm);
     meshBuilder.set_spatial_dimension(spatialDimension);
     bulk = meshBuilder.create();

--- a/unit_tests/matrix_free/UnitTestConductionDiagonal.C
+++ b/unit_tests/matrix_free/UnitTestConductionDiagonal.C
@@ -7,12 +7,7 @@
 // for more details.
 //
 
-#include "matrix_free/KokkosViewTypes.h"
-#include <Kokkos_Array.hpp>
-#include <Kokkos_CopyViews.hpp>
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Parallel.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 #include <Teuchos_ArrayView.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
 #include <Teuchos_OrdinalTraits.hpp>

--- a/unit_tests/matrix_free/UnitTestConductionInterior.C
+++ b/unit_tests/matrix_free/UnitTestConductionInterior.C
@@ -7,12 +7,7 @@
 // for more details.
 //
 
-#include "matrix_free/KokkosViewTypes.h"
-#include <Kokkos_Array.hpp>
-#include <Kokkos_CopyViews.hpp>
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Parallel.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 #include <Teuchos_ArrayView.hpp>
 #include <Teuchos_DefaultMpiComm.hpp>
 #include <Teuchos_OrdinalTraits.hpp>

--- a/unit_tests/matrix_free/UnitTestConductionJacobiPreconditioner.C
+++ b/unit_tests/matrix_free/UnitTestConductionJacobiPreconditioner.C
@@ -19,7 +19,7 @@
 #include "matrix_free/StkToTpetraMap.h"
 
 #include "stk_mesh/base/MetaData.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Tpetra_Export.hpp"
 #include "Tpetra_Map.hpp"

--- a/unit_tests/matrix_free/UnitTestConductionSolutionUpdate.C
+++ b/unit_tests/matrix_free/UnitTestConductionSolutionUpdate.C
@@ -17,11 +17,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_DualView.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_ParameterList.hpp"
 
 #include "Tpetra_Export.hpp"

--- a/unit_tests/matrix_free/UnitTestConductionUpdate.C
+++ b/unit_tests/matrix_free/UnitTestConductionUpdate.C
@@ -16,9 +16,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_RCP.hpp"
 

--- a/unit_tests/matrix_free/UnitTestContinuityOperator.C
+++ b/unit_tests/matrix_free/UnitTestContinuityOperator.C
@@ -22,7 +22,7 @@
 #include "matrix_free/StkToTpetraLocalIndices.h"
 #include "matrix_free/StkToTpetraMap.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 
 #include "Teuchos_Array.hpp"
 #include "Teuchos_RCP.hpp"

--- a/unit_tests/matrix_free/UnitTestContinuitySolutionUpdate.C
+++ b/unit_tests/matrix_free/UnitTestContinuitySolutionUpdate.C
@@ -18,11 +18,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_DualView.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_ParameterList.hpp"
 
 #include "Tpetra_Export.hpp"

--- a/unit_tests/matrix_free/UnitTestFilterDiagonal.C
+++ b/unit_tests/matrix_free/UnitTestFilterDiagonal.C
@@ -9,11 +9,7 @@
 
 #include "matrix_free/FilterDiagonal.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_CopyViews.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_ArrayView.hpp"
 #include "Teuchos_DefaultMpiComm.hpp"
 #include "Teuchos_OrdinalTraits.hpp"

--- a/unit_tests/matrix_free/UnitTestFilterJacobi.C
+++ b/unit_tests/matrix_free/UnitTestFilterJacobi.C
@@ -16,7 +16,7 @@
 #include "matrix_free/StkToTpetraLocalIndices.h"
 #include "matrix_free/StkToTpetraMap.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Tpetra_Export.hpp"
 #include "Tpetra_Map.hpp"

--- a/unit_tests/matrix_free/UnitTestGreenGaussGradient.C
+++ b/unit_tests/matrix_free/UnitTestGreenGaussGradient.C
@@ -19,7 +19,7 @@
 #include "matrix_free/StkToTpetraMap.h"
 
 #include "gtest/gtest.h"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_Array.hpp"
 #include "Teuchos_ArrayView.hpp"
 #include "Teuchos_ParameterList.hpp"

--- a/unit_tests/matrix_free/UnitTestGreenGaussGradientBoundaryClosure.C
+++ b/unit_tests/matrix_free/UnitTestGreenGaussGradientBoundaryClosure.C
@@ -17,9 +17,7 @@
 #include "matrix_free/StkToTpetraLocalIndices.h"
 #include "matrix_free/StkToTpetraMap.h"
 
-#include "Kokkos_CopyViews.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Tpetra_CombineMode.hpp"
 #include "Tpetra_Export.hpp"

--- a/unit_tests/matrix_free/UnitTestGreenGaussGradientOperator.C
+++ b/unit_tests/matrix_free/UnitTestGreenGaussGradientOperator.C
@@ -20,7 +20,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 
 #include "Tpetra_Export.hpp"

--- a/unit_tests/matrix_free/UnitTestLinearAdvectionMetric.C
+++ b/unit_tests/matrix_free/UnitTestLinearAdvectionMetric.C
@@ -18,10 +18,7 @@
 #include "matrix_free/StkSimdComparisons.h"
 #include "matrix_free/TensorOperations.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_CopyViews.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
+#include "Kokkos_Core.hpp"
 #include "stk_simd/Simd.hpp"
 
 namespace sierra {

--- a/unit_tests/matrix_free/UnitTestLinearAreas.C
+++ b/unit_tests/matrix_free/UnitTestLinearAreas.C
@@ -16,10 +16,7 @@
 #include "StkSimdComparisons.h"
 #include "gtest/gtest.h"
 
-#include <Kokkos_Array.hpp>
-#include <Kokkos_CopyViews.hpp>
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Parallel.hpp>
+#include <Kokkos_Core.hpp>
 #include <stk_simd/Simd.hpp>
 
 #include <math.h>

--- a/unit_tests/matrix_free/UnitTestLinearDiffusionMetric.C
+++ b/unit_tests/matrix_free/UnitTestLinearDiffusionMetric.C
@@ -11,9 +11,7 @@
 #include "matrix_free/LobattoQuadratureRule.h"
 #include "StkSimdComparisons.h"
 
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Parallel.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 #include <stk_simd/Simd.hpp>
 
 #include "matrix_free/KokkosViewTypes.h"

--- a/unit_tests/matrix_free/UnitTestLinearExposedAreas.C
+++ b/unit_tests/matrix_free/UnitTestLinearExposedAreas.C
@@ -11,9 +11,7 @@
 #include "matrix_free/LobattoQuadratureRule.h"
 #include "StkSimdComparisons.h"
 
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Parallel.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 #include <stk_simd/Simd.hpp>
 
 #include "gtest/gtest.h"

--- a/unit_tests/matrix_free/UnitTestLinearVolume.C
+++ b/unit_tests/matrix_free/UnitTestLinearVolume.C
@@ -15,10 +15,7 @@
 #include "matrix_free/KokkosViewTypes.h"
 #include "matrix_free/LocalArray.h"
 
-#include <Kokkos_Array.hpp>
-#include <Kokkos_Macros.hpp>
-#include <Kokkos_Parallel.hpp>
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 #include <stk_simd/Simd.hpp>
 
 namespace sierra {

--- a/unit_tests/matrix_free/UnitTestLowMachUpdate.C
+++ b/unit_tests/matrix_free/UnitTestLowMachUpdate.C
@@ -18,9 +18,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_RCP.hpp"
 #include "matrix_free/StkToTpetraMap.h"

--- a/unit_tests/matrix_free/UnitTestMomentumJacobiOperator.C
+++ b/unit_tests/matrix_free/UnitTestMomentumJacobiOperator.C
@@ -22,7 +22,7 @@
 #include "matrix_free/StkToTpetraLocalIndices.h"
 #include "matrix_free/StkToTpetraMap.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 
 #include "Teuchos_Array.hpp"
 #include "Teuchos_RCP.hpp"

--- a/unit_tests/matrix_free/UnitTestMomentumOperator.C
+++ b/unit_tests/matrix_free/UnitTestMomentumOperator.C
@@ -22,7 +22,7 @@
 #include "matrix_free/StkToTpetraLocalIndices.h"
 #include "matrix_free/StkToTpetraMap.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 
 #include "Teuchos_Array.hpp"
 #include "Teuchos_RCP.hpp"

--- a/unit_tests/matrix_free/UnitTestMomentumSolutionUpdate.C
+++ b/unit_tests/matrix_free/UnitTestMomentumSolutionUpdate.C
@@ -18,11 +18,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_DualView.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_ParameterList.hpp"
 
 #include "Tpetra_Export.hpp"

--- a/unit_tests/matrix_free/UnitTestScalarFluxBC.C
+++ b/unit_tests/matrix_free/UnitTestScalarFluxBC.C
@@ -19,7 +19,7 @@
 
 #include "stk_mesh/base/BulkData.hpp"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Tpetra_CombineMode.hpp"
 #include "Tpetra_Export.hpp"

--- a/unit_tests/matrix_free/UnitTestSparsifiedEdgeLaplacian.C
+++ b/unit_tests/matrix_free/UnitTestSparsifiedEdgeLaplacian.C
@@ -14,11 +14,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_DualView.hpp"
-#include "Kokkos_Macros.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_ParameterList.hpp"
 
 #include "Teuchos_RCP.hpp"

--- a/unit_tests/matrix_free/UnitTestStkSimdConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdConnectivityMap.C
@@ -12,10 +12,7 @@
 #include "matrix_free/StkSimdConnectivityMap.h"
 #include "matrix_free/ValidSimdLength.h"
 
-#include "Kokkos_CopyViews.hpp"
-#include "Kokkos_HostSpace.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 
 #include "stk_io/IossBridge.hpp"
 #include "stk_mesh/base/BulkData.hpp"

--- a/unit_tests/matrix_free/UnitTestStkSimdFaceConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdFaceConnectivityMap.C
@@ -12,10 +12,7 @@
 #include "matrix_free/StkSimdFaceConnectivityMap.h"
 #include "matrix_free/ValidSimdLength.h"
 
-#include "Kokkos_CopyViews.hpp"
-#include "Kokkos_HostSpace.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 
 #include "stk_io/IossBridge.hpp"
 #include "stk_mesh/base/BulkData.hpp"

--- a/unit_tests/matrix_free/UnitTestStkSimdGatheredElementData.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdGatheredElementData.C
@@ -15,9 +15,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_Array.hpp"
-#include "Kokkos_Parallel.hpp"
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 
 #include "stk_io/IossBridge.hpp"
 #include "stk_mesh/base/Bucket.hpp"

--- a/unit_tests/matrix_free/UnitTestStkSimdNodeConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdNodeConnectivityMap.C
@@ -10,7 +10,7 @@
 #include "matrix_free/StkSimdNodeConnectivityMap.h"
 #include "matrix_free/NodeOrderMap.h"
 
-#include <Kokkos_View.hpp>
+#include <Kokkos_Core.hpp>
 #include <stk_io/IossBridge.hpp>
 #include <string>
 #include <vector>

--- a/unit_tests/matrix_free/UnitTestStrongDirichletBC.C
+++ b/unit_tests/matrix_free/UnitTestStrongDirichletBC.C
@@ -19,7 +19,7 @@
 #include "matrix_free/StkToTpetraLocalIndices.h"
 #include "matrix_free/StkToTpetraMap.h"
 
-#include "Kokkos_View.hpp"
+#include "Kokkos_Core.hpp"
 #include "Teuchos_RCP.hpp"
 #include "Tpetra_CombineMode.hpp"
 #include "Tpetra_Export.hpp"

--- a/unit_tests/ngp_kernels/UnitTestNgpKernel.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpKernel.C
@@ -112,4 +112,5 @@ TEST_F(Hex8MeshWithNSOFields, NGPKernelExecute)
   EXPECT_EQ(1u, assembleElemSolverAlg->activeKernels_.size());
 
   helperObjs.execute();
+std::cout<<"end of test comm: "<<bulk->parallel()<<std::endl;
 }

--- a/unit_tests/ngp_kernels/UnitTestNgpKernel.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpKernel.C
@@ -112,5 +112,4 @@ TEST_F(Hex8MeshWithNSOFields, NGPKernelExecute)
   EXPECT_EQ(1u, assembleElemSolverAlg->activeKernels_.size());
 
   helperObjs.execute();
-std::cout<<"end of test comm: "<<bulk->parallel()<<std::endl;
 }


### PR DESCRIPTION
Also clean up kokkos includes to stop a bunch of
warnings that were happening due to including non-public kokkos headers.