### PR TITLE
Fix bug on ambigous template function

### DIFF
--- a/unit_tests/aero/UnitTestDisplacements.C
+++ b/unit_tests/aero/UnitTestDisplacements.C
@@ -11,6 +11,13 @@
 #include <gtest/gtest.h>
 #include <aero/aero_utils/displacements.h>
 
+testing::Message&
+operator<<(testing::Message& out, const vs::Vector& vec)
+{
+  out << "(" << vec.x() << " " << vec.y() << " " << vec.z() << ")";
+  return out;
+}
+
 namespace test_displacements {
 TEST(AeroDisplacements, creation_from_pointer)
 {


### PR DESCRIPTION
We should probably just delete that operator from vectorI.h. I suspect it will always fail to compile with clang