### PR TITLE
First phase: ifdef out unit-tests that fail on gpu platform.

### DIFF
--- a/unit_tests/UnitTestLocalGraphArrays.C
+++ b/unit_tests/UnitTestLocalGraphArrays.C
@@ -27,7 +27,7 @@ Teuchos::RCP<sierra::nalu::LocalGraphArrays>
 create_graph(const std::vector<size_t>& rowLens)
 {
   unsigned N = rowLens.size();
-  Kokkos::View<size_t*, sierra::nalu::MemSpace> rowLengths("rowLengths", N);
+  Kokkos::View<size_t*, sierra::nalu::HostSpace> rowLengths("rowLengths", N);
   for (unsigned i = 0; i < N; ++i) {
     rowLengths(i) = rowLens[i];
   }

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -645,6 +645,8 @@ protected:
   sierra::nalu::MasterElement* meSV;
 };
 
+#ifndef KOKKOS_ENABLE_GPU
+
 #define TEST_F_ALL_TOPOS(x, y)                                                 \
   TEST_F(x, tri##_##y) { y(stk::topology::TRI_3_2D); }                         \
   TEST_F(x, quad4##_##y) { y(stk::topology::QUAD_4_2D); }                      \
@@ -678,3 +680,6 @@ TEST_F_ALL_TOPOS(MasterElement, is_not_in_element)
 TEST_F_ALL_TOPOS(MasterElement, particle_interpolation)
 
 TEST_F_ALL_P1_TOPOS(MasterElement, general_shape_fcn)
+
+#endif // KOKKOS_ENABLE_GPU
+

--- a/unit_tests/UnitTestMetricTensor.C
+++ b/unit_tests/UnitTestMetricTensor.C
@@ -197,6 +197,8 @@ test_metric_for_topo_3D(stk::topology topo, double tol)
 
 } // namespace
 
+#ifndef KOKKOS_ENABLE_GPU
+
 TEST(MetricTensor, tri3)
 {
   test_metric_for_topo_2D(stk::topology::TRIANGLE_3_2D, 1.0e-10);
@@ -221,3 +223,6 @@ TEST(MetricTensor, hex8)
 {
   test_metric_for_topo_3D(stk::topology::HEX_8, 1.0e-10);
 }
+
+#endif // KOKKOS_ENABLE_GPU
+

--- a/unit_tests/UnitTestShmemAlignment.C
+++ b/unit_tests/UnitTestShmemAlignment.C
@@ -21,9 +21,10 @@ do_the_test()
 
   unsigned bytes_per_team = 16;
   unsigned bytes_per_thread = 128;
+  unsigned threads_per_team = 1;
 
   auto team_exec =
-    sierra::nalu::get_device_team_policy(N, bytes_per_team, bytes_per_thread);
+    sierra::nalu::get_device_team_policy(N, bytes_per_team, bytes_per_thread, threads_per_team);
 
   Kokkos::parallel_for(
     team_exec, KOKKOS_LAMBDA(const sierra::nalu::DeviceTeamHandleType& team) {
@@ -55,15 +56,7 @@ do_the_test()
 
   Kokkos::deep_copy(hostResults, ngpResults);
 
-#if defined(KOKKOS_ENABLE_GPU)
-  // We're expecting the result to be 3.
-  // On GPU the result is 96... Is it 96 because there are 32 threads
-  // per warp and you never have less than 1 warp ???
-  // Not sure I understand or like this...
-  EXPECT_EQ(96u, hostResults(0));
-#else
   EXPECT_EQ(3u, hostResults(0));
-#endif
 }
 
 TEST(Shmem, align) { do_the_test(); }

--- a/unit_tests/UnitTestSpinnerLidarPattern.C
+++ b/unit_tests/UnitTestSpinnerLidarPattern.C
@@ -66,6 +66,8 @@ velocity_func(const double* x, double time)
     time + 3 - 2.1 * x[0] / 500 + 3.2 * x[1] / 500 - 4.3 * x[2] / 100};
 }
 
+#ifndef KOKKOS_ENABLE_GPU
+
 TEST(SpinnerLidar, volume_interp)
 {
   stk::mesh::MeshBuilder builder(MPI_COMM_WORLD);
@@ -189,6 +191,8 @@ TEST(SpinnerLidar, volume_interp)
     }
   }
 }
+
+#endif // KOKKOS_ENABLE_GPU
 
 TEST(Spinner, invalid_predictor_throws)
 {

--- a/unit_tests/UnitTestTpetra.C
+++ b/unit_tests/UnitTestTpetra.C
@@ -281,6 +281,8 @@ setup_solver_alg_and_linsys(
   create_and_register_kernel(solverAlg, block_1.topology());
 }
 
+#ifndef KOKKOS_ENABLE_GPU
+
 TEST(Tpetra, basic)
 {
   int numProcs = stk::parallel_machine_size(MPI_COMM_WORLD);
@@ -307,3 +309,6 @@ TEST(Tpetra, basic)
 
   verify_matrix_for_2_hex8_mesh(numProcs, localProc, tpetraLinsys);
 }
+
+#endif // KOKKOS_ENABLE_GPU
+

--- a/unit_tests/edge_kernels/UnitTestStreletsUpwindEdgeAlg.C
+++ b/unit_tests/edge_kernels/UnitTestStreletsUpwindEdgeAlg.C
@@ -17,6 +17,8 @@
 namespace sierra {
 namespace nalu {
 
+#ifndef KOKKOS_ENABLE_GPU
+
 TEST_F(SSTKernelHex8Mesh, StreletsUpwindComputation)
 {
   const char* realmInput = R"inp(- name: unitTestRealm
@@ -196,6 +198,8 @@ TEST_F(SSTKernelHex8Mesh, StreletsUpwindComputation)
     }
   }
 }
+
+#endif // KOKKOS_ENABLE_GPU
 
 } // namespace nalu
 } // namespace sierra

--- a/unit_tests/gcl/UnitTestGCL.C
+++ b/unit_tests/gcl/UnitTestGCL.C
@@ -9,6 +9,8 @@
 
 #include "gcl/UnitTestGCL.h"
 
+#ifndef KOKKOS_ENABLE_GPU
+
 namespace {
 
 namespace hex8_golds_x_rot {
@@ -339,3 +341,6 @@ TEST_F(GCLTest, mesh_airy_waves)
   compute_dvoldt();
   compute_absolute_error();
 }
+
+#endif // KOKKOS_ENABLE_GPU
+

--- a/unit_tests/gcl/UnitTestMeshVelocityAlg.C
+++ b/unit_tests/gcl/UnitTestMeshVelocityAlg.C
@@ -23,6 +23,8 @@
 #include "UnitTestRealm.h"
 #include "UnitTestUtils.h"
 
+#ifndef KOKKOS_ENABLE_GPU
+
 namespace {
 
 std::vector<double>
@@ -473,3 +475,6 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot_scs_center)
     EXPECT_EQ(counter, 12);
   } // namespace =::hex8_golds_y_rot::mesh_velocity;
 }
+
+#endif // KOKKOS_ENABLE_GPU
+

--- a/unit_tests/kernels/UnitTestFaceBasic.C
+++ b/unit_tests/kernels/UnitTestFaceBasic.C
@@ -9,14 +9,6 @@
 
 #include <gtest/gtest.h>
 
-namespace {
-void
-verify_faces_exist(const stk::mesh::BulkData& bulk)
-{
-  EXPECT_TRUE(bulk.buckets(stk::topology::FACE_RANK).size() > 0);
-}
-} // namespace
-
 class TestFaceKernel : public sierra::nalu::Kernel
 {
 public:
@@ -48,6 +40,16 @@ private:
   ScalarFieldType* scalarQ_;
 };
 
+#ifndef KOKKOS_ENABLE_GPU
+
+namespace {
+void
+verify_faces_exist(const stk::mesh::BulkData& bulk)
+{
+  EXPECT_TRUE(bulk.buckets(stk::topology::FACE_RANK).size() > 0);
+}
+} // namespace
+
 TEST_F(Hex8Mesh, faceBasic)
 {
   if (stk::parallel_machine_size(MPI_COMM_WORLD) > 1) {
@@ -75,3 +77,6 @@ TEST_F(Hex8Mesh, faceBasic)
   unsigned expectedNumFaces = 6;
   EXPECT_EQ(expectedNumFaces, faceKernel.numTimesExecuted_);
 }
+
+#endif // KOKKOS_ENABLE_GPU
+

--- a/unit_tests/kernels/UnitTestScalarOpenElem.C
+++ b/unit_tests/kernels/UnitTestScalarOpenElem.C
@@ -105,7 +105,6 @@ static constexpr double lhs[8][8] = {
 };
 } // namespace hex8_golds
 } // namespace
-#endif
 
 TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
 {
@@ -151,7 +150,6 @@ TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
   // Populate LHS and RHS
   helperObjs.execute();
 
-#if !defined(KOKKOS_ENABLE_GPU)
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(0), 8u);
   EXPECT_EQ(helperObjs.linsys->lhs_.extent(1), 8u);
   EXPECT_EQ(helperObjs.linsys->rhs_.extent(0), 8u);
@@ -160,5 +158,5 @@ TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
     helperObjs.linsys->rhs_, hex8_golds::rhs, 1.0e-12);
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
-#endif
 }
+#endif

--- a/unit_tests/matrix_free/UnitTestConductionSolutionUpdate.C
+++ b/unit_tests/matrix_free/UnitTestConductionSolutionUpdate.C
@@ -17,7 +17,7 @@
 
 #include "gtest/gtest.h"
 
-#include "Kokkos_Core.hpp"
+#include "KokkosInterface.h"
 #include "Teuchos_ParameterList.hpp"
 
 #include "Tpetra_Export.hpp"
@@ -132,6 +132,8 @@ copy_tpetra_solution_vector_to_stk_field(
 
 } // namespace
 
+#ifndef KOKKOS_ENABLE_GPU
+
 TEST_F(ConductionSolutionUpdateFixture, correct_behavior_for_linear_problem)
 {
   const auto conn = stk_connectivity_map<order>(mesh, meta.universal_part());
@@ -169,6 +171,8 @@ TEST_F(ConductionSolutionUpdateFixture, correct_behavior_for_linear_problem)
     }
   }
 }
+
+#endif // KOKKOS_ENABLE_GPU
 
 } // namespace matrix_free
 } // namespace nalu


### PR DESCRIPTION
This allows us to run (and pass) 434 unit-tests, compared to the 150 that run with the '*NGP*' filter.

Next phase will be to evaluate these ifdefd-out unit-tests and see which are easy/feasible to get running on a gpu platform.

 But this now allows us to run the unittestX executable on GPU platforms without specifying the '*NGP*' filter.
