### PR TITLE
cleaning unit-tests

### DIFF
--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -997,9 +997,10 @@ get_num_bytes_pre_req_data(
          get_num_scalars_pre_req_data(dataNeededBySuppAlgs, nDim, reqType);
 }
 
-template <typename ELEMDATAREQUESTSTYPE,
-          typename TEAMTYPE = sierra::nalu::DeviceTeamHandleType,
-          typename SHMEM = sierra::nalu::DeviceShmem>
+template <
+  typename ELEMDATAREQUESTSTYPE,
+  typename TEAMTYPE = sierra::nalu::DeviceTeamHandleType,
+  typename SHMEM = sierra::nalu::DeviceShmem>
 inline int
 calculate_shared_mem_bytes_per_thread(
   int lhsSize,
@@ -1012,7 +1013,7 @@ calculate_shared_mem_bytes_per_thread(
   int bytes_per_thread =
     (rhsSize + lhsSize) * sizeof(double) + (2 * scratchIdsSize) * sizeof(int) +
     get_num_bytes_pre_req_data<double>(dataNeededByKernels, nDim, reqType) +
-    MultiDimViews<double,TEAMTYPE,SHMEM>::bytes_needed(
+    MultiDimViews<double, TEAMTYPE, SHMEM>::bytes_needed(
       dataNeededByKernels.get_total_num_fields(),
       count_needed_field_views(dataNeededByKernels.get_host_fields()));
 
@@ -1031,9 +1032,10 @@ calc_shmem_bytes_per_thread_edge(int rhsSize)
   return (matSize + idSize);
 }
 
-template <typename ELEMDATAREQUESTSTYPE,
-          typename TEAMTYPE = sierra::nalu::DeviceTeamHandleType,
-          typename SHMEM = sierra::nalu::DeviceShmem>
+template <
+  typename ELEMDATAREQUESTSTYPE,
+  typename TEAMTYPE = sierra::nalu::DeviceTeamHandleType,
+  typename SHMEM = sierra::nalu::DeviceShmem>
 inline int
 calculate_shared_mem_bytes_per_thread(
   int lhsSize,
@@ -1049,10 +1051,10 @@ calculate_shared_mem_bytes_per_thread(
       faceDataNeeded, nDim, ElemReqType::FACE) +
     sierra::nalu::get_num_bytes_pre_req_data<double>(
       elemDataNeeded, nDim, ElemReqType::FACE_ELEM) +
-    MultiDimViews<double,TEAMTYPE,SHMEM>::bytes_needed(
+    MultiDimViews<double, TEAMTYPE, SHMEM>::bytes_needed(
       faceDataNeeded.get_total_num_fields(),
       count_needed_field_views(faceDataNeeded.get_host_fields())) +
-    MultiDimViews<double,TEAMTYPE,SHMEM>::bytes_needed(
+    MultiDimViews<double, TEAMTYPE, SHMEM>::bytes_needed(
       elemDataNeeded.get_total_num_fields(),
       count_needed_field_views(elemDataNeeded.get_host_fields()));
 

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -997,7 +997,9 @@ get_num_bytes_pre_req_data(
          get_num_scalars_pre_req_data(dataNeededBySuppAlgs, nDim, reqType);
 }
 
-template <typename ELEMDATAREQUESTSTYPE>
+template <typename ELEMDATAREQUESTSTYPE,
+          typename TEAMTYPE = sierra::nalu::DeviceTeamHandleType,
+          typename SHMEM = sierra::nalu::DeviceShmem>
 inline int
 calculate_shared_mem_bytes_per_thread(
   int lhsSize,
@@ -1010,7 +1012,7 @@ calculate_shared_mem_bytes_per_thread(
   int bytes_per_thread =
     (rhsSize + lhsSize) * sizeof(double) + (2 * scratchIdsSize) * sizeof(int) +
     get_num_bytes_pre_req_data<double>(dataNeededByKernels, nDim, reqType) +
-    MultiDimViews<double>::bytes_needed(
+    MultiDimViews<double,TEAMTYPE,SHMEM>::bytes_needed(
       dataNeededByKernels.get_total_num_fields(),
       count_needed_field_views(dataNeededByKernels.get_host_fields()));
 
@@ -1029,7 +1031,9 @@ calc_shmem_bytes_per_thread_edge(int rhsSize)
   return (matSize + idSize);
 }
 
-template <typename ELEMDATAREQUESTSTYPE>
+template <typename ELEMDATAREQUESTSTYPE,
+          typename TEAMTYPE = sierra::nalu::DeviceTeamHandleType,
+          typename SHMEM = sierra::nalu::DeviceShmem>
 inline int
 calculate_shared_mem_bytes_per_thread(
   int lhsSize,
@@ -1045,10 +1049,10 @@ calculate_shared_mem_bytes_per_thread(
       faceDataNeeded, nDim, ElemReqType::FACE) +
     sierra::nalu::get_num_bytes_pre_req_data<double>(
       elemDataNeeded, nDim, ElemReqType::FACE_ELEM) +
-    MultiDimViews<double>::bytes_needed(
+    MultiDimViews<double,TEAMTYPE,SHMEM>::bytes_needed(
       faceDataNeeded.get_total_num_fields(),
       count_needed_field_views(faceDataNeeded.get_host_fields())) +
-    MultiDimViews<double>::bytes_needed(
+    MultiDimViews<double,TEAMTYPE,SHMEM>::bytes_needed(
       elemDataNeeded.get_total_num_fields(),
       count_needed_field_views(elemDataNeeded.get_host_fields()));
 

--- a/unit_tests/UnitTestCopyAndInterleave.C
+++ b/unit_tests/UnitTestCopyAndInterleave.C
@@ -111,7 +111,7 @@ do_the_multidimviews_test()
   std::cout << "simdLen = " << sierra::nalu::simdLen << std::endl;
 
   Kokkos::parallel_for(
-    team_exec, KOKKOS_LAMBDA(const TeamType& team) {
+    team_exec, [=](const TeamType& team) {
       unsigned maxOrdinal = totalNumFields - 1;
       sierra::nalu::MultiDimViews<DoubleType,TeamType,ShmemType> simdMultiDimViews(
         team, maxOrdinal, numNeededViews);

--- a/unit_tests/UnitTestGetDofStatus.C
+++ b/unit_tests/UnitTestGetDofStatus.C
@@ -55,4 +55,3 @@ TEST_F(DofStatusHex8Mesh, getDofStatus_shared)
     }
   }
 }
-

--- a/unit_tests/UnitTestGetDofStatus.C
+++ b/unit_tests/UnitTestGetDofStatus.C
@@ -8,8 +8,6 @@
 #include <TpetraLinearSystem.h>
 #include <TpetraLinearSystemHelpers.h>
 
-#if !defined(KOKKOS_ENABLE_GPU)
-
 class DofStatusHex8Mesh : public Hex8Mesh
 {
 };
@@ -58,4 +56,3 @@ TEST_F(DofStatusHex8Mesh, getDofStatus_shared)
   }
 }
 
-#endif

--- a/unit_tests/UnitTestKokkosUtils.h
+++ b/unit_tests/UnitTestKokkosUtils.h
@@ -46,27 +46,12 @@ kokkos_bucket_loop(
 
 template <class LOOP_BODY>
 void
-kokkos_thread_team_bucket_loop(
-  const stk::mesh::BucketVector& buckets, LOOP_BODY inner_loop_body)
-{
-  Kokkos::parallel_for(
-    sierra::nalu::DeviceTeamPolicy(buckets.size(), NTHREADS_PER_DEVICE_TEAM),
-    KOKKOS_LAMBDA(const sierra::nalu::TeamHandleType& team) {
-      const stk::mesh::Bucket& bkt = *buckets[team.league_rank()];
-      Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, bkt.size()),
-        [&](const size_t& j) { inner_loop_body(bkt[j]); });
-    });
-}
-
-template <class LOOP_BODY>
-void
 kokkos_thread_team_bucket_loop_with_topo(
   const stk::mesh::BucketVector& buckets, const LOOP_BODY& inner_loop_body)
 {
   Kokkos::parallel_for(
     sierra::nalu::DeviceTeamPolicy(buckets.size(), NTHREADS_PER_DEVICE_TEAM),
-    KOKKOS_LAMBDA(const sierra::nalu::TeamHandleType& team) {
+    KOKKOS_LAMBDA(const sierra::nalu::DeviceTeamHandleType& team) {
       const stk::mesh::Bucket& bkt = *buckets[team.league_rank()];
       stk::topology topo = bkt.topology();
       sierra::nalu::MasterElement* meSCS =

--- a/unit_tests/UnitTestLidarLOS.C
+++ b/unit_tests/UnitTestLidarLOS.C
@@ -120,10 +120,7 @@ public:
     remove_files();
   }
 
-  ~LidarLOSFixture()
-  {
-    remove_files();
-  }
+  ~LidarLOSFixture() { remove_files(); }
 
 private:
   std::shared_ptr<stk::mesh::BulkData> bulkptr;

--- a/unit_tests/UnitTestLidarLOS.C
+++ b/unit_tests/UnitTestLidarLOS.C
@@ -24,7 +24,7 @@ const std::string db_spec =
   "  lidar_specifications:                                  \n";
 
 const std::string scan_spec =
-  "      - name: lidar/scan                                  \n"
+  "      - name: lidar_scan                                  \n"
   "        type: scanning                                    \n"
   "        frequency: 5                                      \n"
   "        points_along_line: 10                             \n"
@@ -40,7 +40,7 @@ const std::string scan_spec =
   "          elevation_angles: [-5,0,5]                      \n";
 
 const std::string radar_spec =
-  "      - name: lidar/radar                                 \n"
+  "      - name: lidar_radar                                 \n"
   "        type: radar                                       \n"
   "        frequency: 1                                      \n"
   "        points_along_line: 2                              \n"
@@ -61,7 +61,7 @@ const std::string radar_spec =
   "          elevation_angles: [0,1,2,3]                     \n";
 
 const std::string radar_cone_spec =
-  "      - name: lidar/radar-filtered                        \n"
+  "      - name: lidar_radar-filtered                        \n"
   "        type: radar                                       \n"
   "        frequency: 4                                      \n"
   "        points_along_line: 10                              \n"
@@ -117,16 +117,26 @@ public:
 
     // lidar will write new files if they exist. Delete them here
     // to adding new files ad infinitum`
-    Ioss::FileInfo("lidar/scan.txt").remove_file();
-    Ioss::FileInfo("lidar/radar-filtered.txt").remove_file();
-    for (int j = 0; j < 13; ++j) {
-      Ioss::FileInfo("lidar/radar-grid-" + std::to_string(j) + ".txt")
-        .remove_file();
-    }
+    remove_files();
+  }
+
+  ~LidarLOSFixture()
+  {
+    remove_files();
   }
 
 private:
   std::shared_ptr<stk::mesh::BulkData> bulkptr;
+
+  void remove_files()
+  {
+    Ioss::FileInfo("lidar_scan.txt").remove_file();
+    Ioss::FileInfo("lidar_radar-filtered.txt").remove_file();
+    for (int j = 0; j < 13; ++j) {
+      Ioss::FileInfo("lidar_radar-grid-" + std::to_string(j) + ".txt")
+        .remove_file();
+    }
+  }
 
 public:
   stk::mesh::BulkData& bulk;

--- a/unit_tests/UnitTestMovingAverage.C
+++ b/unit_tests/UnitTestMovingAverage.C
@@ -124,7 +124,8 @@ TEST_F(PostProcessor, moving_average_ou)
   avgPP.add_fields({"temperature"});
   avgPP.set_time_scale(timeScale);
 
-  std::ofstream outputFile("PostProcessor.moving_average_ou.txt");
+  std::string outputFileName("PostProcessor.moving_average_ou.txt");
+  std::ofstream outputFile(outputFileName);
   outputFile << "t, temperature, temperature_avg" << std::endl;
   for (int j = 0; j < numSteps; ++j) {
     *stk::mesh::field_data(*temperature_, node) = realization[j];
@@ -134,4 +135,5 @@ TEST_F(PostProcessor, moving_average_ou)
                << ", " << *stk::mesh::field_data(*raTemperature_, node)
                << std::endl;
   }
+  unlink(outputFileName.c_str());
 }

--- a/unit_tests/UnitTestRealm.C
+++ b/unit_tests/UnitTestRealm.C
@@ -142,17 +142,17 @@ get_realm_default_node()
 }
 
 NaluTest::NaluTest(const YAML::Node& doc)
-  : comm_(MPI_COMM_WORLD), spatialDim_(3), sim_(doc)
+  : comm_(MPI_COMM_WORLD), spatialDim_(3), sim_(doc),
+    logFileName_("unittestX_naluwrapper.log")
 {
   // NaluEnv log file
-  std::string logFileName = "unittestX_naluwrapper.log";
   auto testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
   if (testInfo) {
     std::string caseName = testInfo->test_case_name();
     std::string caseInstance = testInfo->name();
-    logFileName = caseName + "." + caseInstance + ".log";
+    logFileName_ = caseName + "." + caseInstance + ".log";
   }
-  sierra::nalu::NaluEnv::self().set_log_file_stream(logFileName, false);
+  sierra::nalu::NaluEnv::self().set_log_file_stream(logFileName_, false);
 
   sim_.linearSolvers_ = new sierra::nalu::LinearSolvers(sim_);
   sim_.realms_ = new sierra::nalu::Realms(sim_);
@@ -160,6 +160,11 @@ NaluTest::NaluTest(const YAML::Node& doc)
 
   sim_.linearSolvers_->load(doc);
   sim_.timeIntegrator_->load(doc);
+}
+
+NaluTest::~NaluTest()
+{
+  unlink(logFileName_.c_str());
 }
 
 sierra::nalu::Realm&

--- a/unit_tests/UnitTestRealm.C
+++ b/unit_tests/UnitTestRealm.C
@@ -142,7 +142,9 @@ get_realm_default_node()
 }
 
 NaluTest::NaluTest(const YAML::Node& doc)
-  : comm_(MPI_COMM_WORLD), spatialDim_(3), sim_(doc),
+  : comm_(MPI_COMM_WORLD),
+    spatialDim_(3),
+    sim_(doc),
     logFileName_("unittestX_naluwrapper.log")
 {
   // NaluEnv log file
@@ -162,10 +164,7 @@ NaluTest::NaluTest(const YAML::Node& doc)
   sim_.timeIntegrator_->load(doc);
 }
 
-NaluTest::~NaluTest()
-{
-  unlink(logFileName_.c_str());
-}
+NaluTest::~NaluTest() { unlink(logFileName_.c_str()); }
 
 sierra::nalu::Realm&
 NaluTest::create_realm(

--- a/unit_tests/UnitTestRealm.h
+++ b/unit_tests/UnitTestRealm.h
@@ -29,6 +29,8 @@ class NaluTest
 public:
   NaluTest(const YAML::Node& doc = get_default_inputs());
 
+  ~NaluTest();
+
   sierra::nalu::Realm& create_realm(
     const YAML::Node& realm_node = get_realm_default_node(),
     const std::string realm_type = "multi_physics",
@@ -43,6 +45,7 @@ public:
 
 private:
   NaluTest(const NaluTest&) = delete;
+  std::string logFileName_;
 };
 
 } // namespace unit_test_utils

--- a/unit_tests/UnitTestScanningLidarPattern.C
+++ b/unit_tests/UnitTestScanningLidarPattern.C
@@ -130,7 +130,8 @@ TEST_F(ScanningLidarFixture, print_tip_location)
   const int samples = std::round(time / dt);
   auto center = scan_spec["center"].as<Coordinates>();
 
-  std::ofstream outputFile("ScanningLidar.pattern.txt");
+  std::string outputFileName("ScanningLidar.pattern.txt");
+  std::ofstream outputFile(outputFileName);
   outputFile << "x,y,z" << std::endl;
 
   const auto start_height = slgen.generate(0).tip_[2];
@@ -145,6 +146,7 @@ TEST_F(ScanningLidarFixture, print_tip_location)
     outputFile << std::setprecision(15) << seg.tip_.at(0) << ", "
                << seg.tip_.at(1) << ", " << seg.tip_.at(2) << "\n";
   }
+  unlink(outputFileName.c_str());
 }
 
 TEST_F(ScanningLidarFixture, check_angles)

--- a/unit_tests/UnitTestSpinnerLidarPattern.C
+++ b/unit_tests/UnitTestSpinnerLidarPattern.C
@@ -42,7 +42,8 @@ TEST(SpinnerLidar, print_tip_location)
   SpinnerLidarSegmentGenerator slgen;
   slgen.load(lidarSpecNode);
 
-  std::ofstream outputFile("SpinnerLidar.pattern.txt");
+  std::string outputFileName("SpinnerLidar.pattern.txt");
+  std::ofstream outputFile(outputFileName);
   outputFile << "x,y,z" << std::endl;
 
   for (int j = 0; j < nsamp; ++j) {
@@ -55,6 +56,7 @@ TEST(SpinnerLidar, print_tip_location)
     outputFile << seg.tip_.at(0) << ", " << seg.tip_.at(1) << ", "
                << seg.tip_.at(2) << std::endl;
   }
+  unlink(outputFileName.c_str());
 }
 
 std::array<double, 3>

--- a/unit_tests/UnitTestTpetra.C
+++ b/unit_tests/UnitTestTpetra.C
@@ -14,6 +14,7 @@
 #include "UnitTestUtils.h"
 
 #include "LinearSolvers.h"
+#include "kernel/Kernel.h"
 #include "kernel/KernelBuilder.h"
 #include "SolverAlgorithmDriver.h"
 #include "AssembleElemSolverAlgorithm.h"
@@ -129,38 +130,58 @@ static const double lhsVals[12][12] = {
   {0.0, 0.0, 0.0, 0.0, -0.2, -0.3, -0.5, -0.4, -0.6, -0.7, 2.0, -0.8},
   {0.0, 0.0, 0.0, 0.0, -0.3, -0.4, -0.6, -0.5, -0.7, -0.8, -0.8, 2.0}};
 
-class TestKernel : public sierra::nalu::Kernel
+class TestKernel : public sierra::nalu::NGPKernel<TestKernel>
 {
 public:
   TestKernel(stk::topology elemTopo)
-    : numCallsToExecute(0), numNodesPerElem(elemTopo.num_nodes())
+    : numNodesPerElem(elemTopo.num_nodes()),
+      d_elemVals("device-elem-vals", 8, 8)
+  {
+    Kokkos::View<double**,sierra::nalu::MemSpace>::HostMirror h_elemVals = Kokkos::create_mirror_view(d_elemVals);
+    for(int i=0; i<8; ++i) {
+      for(int j=0; j<8; ++j) {
+        h_elemVals(i,j) = elemVals[i][j];
+      }
+    }
+    Kokkos::deep_copy(d_elemVals, h_elemVals);
+  }
+
+  KOKKOS_FUNCTION
+  TestKernel()
+   : numNodesPerElem(0),
+     d_elemVals()
+  {
+  }
+
+  KOKKOS_FUNCTION
+  TestKernel(const TestKernel& src)
+   : numNodesPerElem(src.numNodesPerElem),
+     d_elemVals(src.d_elemVals)
   {
   }
 
   using sierra::nalu::Kernel::execute;
+  KOKKOS_FUNCTION
   virtual void execute(
-    sierra::nalu::SharedMemView<DoubleType**>& lhs,
-    sierra::nalu::SharedMemView<DoubleType*>& rhs,
-    sierra::nalu::ScratchViews<DoubleType>& /* scratchViews */)
+    sierra::nalu::SharedMemView<DoubleType**,sierra::nalu::DeviceShmem>& lhs,
+    sierra::nalu::SharedMemView<DoubleType*,sierra::nalu::DeviceShmem>& rhs,
+    sierra::nalu::ScratchViews<DoubleType,sierra::nalu::DeviceTeamHandleType,sierra::nalu::DeviceShmem>& /* scratchViews */)
   {
-    EXPECT_EQ(numNodesPerElem * numNodesPerElem, lhs.size());
-    EXPECT_EQ(numNodesPerElem, rhs.size());
-    ThrowRequireMsg(
-      numNodesPerElem == 8, "For now, this is hard-wired for hex-8.");
-
-    for (unsigned i = 0; i < numNodesPerElem; ++i) {
-      for (unsigned j = 0; j < numNodesPerElem; ++j) {
-        lhs(i, j) = elemVals[i][j];
+    const bool check0 = numNodesPerElem * numNodesPerElem == lhs.size();
+    const bool check1 = numNodesPerElem == rhs.size();
+    const bool check2 = numNodesPerElem == 8;
+    if (check0 && check1 && check2) {
+      for (unsigned i = 0; i < numNodesPerElem; ++i) {
+        for (unsigned j = 0; j < numNodesPerElem; ++j) {
+          lhs(i, j) = d_elemVals(i,j);
+        }
       }
     }
-
-    ++numCallsToExecute;
   }
-
-  unsigned numCallsToExecute;
 
 private:
   unsigned numNodesPerElem;
+  Kokkos::View<double**,sierra::nalu::MemSpace> d_elemVals;
 };
 
 std::vector<unsigned>
@@ -270,7 +291,7 @@ setup_realm(unit_test_utils::NaluTest& naluObj, const std::string& meshSpec)
   return realm;
 }
 
-void
+sierra::nalu::Realm&
 setup_solver_alg_and_linsys(
   unit_test_utils::NaluTest& naluObj, const std::string& meshSpec)
 {
@@ -279,20 +300,18 @@ setup_solver_alg_and_linsys(
   sierra::nalu::AssembleElemSolverAlgorithm* solverAlg =
     create_algorithm(realm, block_1);
   create_and_register_kernel(solverAlg, block_1.topology());
+  return realm;
 }
-
-#ifndef KOKKOS_ENABLE_GPU
 
 TEST(Tpetra, basic)
 {
-  int numProcs = stk::parallel_machine_size(MPI_COMM_WORLD);
-  if (numProcs > 2) {
-    return;
-  }
+  const int numProcs = stk::parallel_machine_size(MPI_COMM_WORLD);
+  if (numProcs > 2) { GTEST_SKIP(); }
   int localProc = stk::parallel_machine_rank(MPI_COMM_WORLD);
 
   unit_test_utils::NaluTest naluObj;
-  setup_solver_alg_and_linsys(naluObj, "generated:1x1x2");
+  sierra::nalu::Realm& realm =
+     setup_solver_alg_and_linsys(naluObj, "generated:1x1x2");
 
   sierra::nalu::TpetraLinearSystem* tpetraLinsys =
     get_TpetraLinearSystem(naluObj);
@@ -304,10 +323,15 @@ TEST(Tpetra, basic)
 
   verify_graph_for_2_hex8_mesh(numProcs, localProc, tpetraLinsys);
 
+  auto meSCV = sierra::nalu::MasterElementRepo::get_volume_master_element<sierra::nalu::AlgTraitsHex8>();
+  auto& dataNeeded = solverAlg->dataNeededByKernels_;
+  dataNeeded.add_cvfem_volume_me(meSCV);
+  auto* coordsField = realm.meta_data().coordinate_field();
+  dataNeeded.add_coordinates_field(*coordsField, 3, sierra::nalu::CURRENT_COORDINATES);
+  dataNeeded.add_master_element_call(sierra::nalu::SCV_VOLUME, sierra::nalu::CURRENT_COORDINATES);
+
   solverAlg->execute();
   tpetraLinsys->loadComplete();
-
   verify_matrix_for_2_hex8_mesh(numProcs, localProc, tpetraLinsys);
 }
 
-#endif // KOKKOS_ENABLE_GPU

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -545,14 +545,15 @@ Hex8Mesh::check_discrete_laplacian(double exactLaplacian)
     meta->locally_owned_part() & !meta->globally_shared_part();
   const stk::mesh::BucketVector& nodeBuckets =
     bulk->get_buckets(stk::topology::NODE_RANK, selector);
-  bucket_loop_serial_only(nodeBuckets,
-  [](stk::topology topo, sierra::nalu::MasterElement& meSCS) {},
-  [&](stk::mesh::Entity node, stk::topology topo, sierra::nalu::MasterElement& meSCS) {
-    if (bulk->num_elements(node) == 8) {
-      EXPECT_NEAR(
-        *stk::mesh::field_data(*discreteLaplacianOfPressure, node),
-        exactLaplacian, tol);
-    }
-  });
+  bucket_loop_serial_only(
+    nodeBuckets, [](stk::topology topo, sierra::nalu::MasterElement& meSCS) {},
+    [&](
+      stk::mesh::Entity node, stk::topology topo,
+      sierra::nalu::MasterElement& meSCS) {
+      if (bulk->num_elements(node) == 8) {
+        EXPECT_NEAR(
+          *stk::mesh::field_data(*discreteLaplacianOfPressure, node),
+          exactLaplacian, tol);
+      }
+    });
 }
-

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -538,8 +538,6 @@ random_linear_transformation(int dim, double scale, std::mt19937& rng)
 
 } // namespace unit_test_utils
 
-#if !defined(KOKKOS_ENABLE_GPU)
-
 void
 Hex8Mesh::check_discrete_laplacian(double exactLaplacian)
 {
@@ -547,7 +545,9 @@ Hex8Mesh::check_discrete_laplacian(double exactLaplacian)
     meta->locally_owned_part() & !meta->globally_shared_part();
   const stk::mesh::BucketVector& nodeBuckets =
     bulk->get_buckets(stk::topology::NODE_RANK, selector);
-  kokkos_thread_team_bucket_loop(nodeBuckets, [&](stk::mesh::Entity node) {
+  bucket_loop_serial_only(nodeBuckets,
+  [](stk::topology topo, sierra::nalu::MasterElement& meSCS) {},
+  [&](stk::mesh::Entity node, stk::topology topo, sierra::nalu::MasterElement& meSCS) {
     if (bulk->num_elements(node) == 8) {
       EXPECT_NEAR(
         *stk::mesh::field_data(*discreteLaplacianOfPressure, node),
@@ -556,4 +556,3 @@ Hex8Mesh::check_discrete_laplacian(double exactLaplacian)
   });
 }
 
-#endif

--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -545,15 +545,14 @@ Hex8Mesh::check_discrete_laplacian(double exactLaplacian)
     meta->locally_owned_part() & !meta->globally_shared_part();
   const stk::mesh::BucketVector& nodeBuckets =
     bulk->get_buckets(stk::topology::NODE_RANK, selector);
-  bucket_loop_serial_only(
-    nodeBuckets, [](stk::topology topo, sierra::nalu::MasterElement& meSCS) {},
-    [&](
-      stk::mesh::Entity node, stk::topology topo,
-      sierra::nalu::MasterElement& meSCS) {
+
+  for (const stk::mesh::Bucket* bptr : nodeBuckets) {
+    for (stk::mesh::Entity node : *bptr) {
       if (bulk->num_elements(node) == 8) {
         EXPECT_NEAR(
           *stk::mesh::field_data(*discreteLaplacianOfPressure, node),
           exactLaplacian, tol);
       }
-    });
+    }
+  }
 }

--- a/unit_tests/algorithms/UnitTestAlgorithmUtils.h
+++ b/unit_tests/algorithms/UnitTestAlgorithmUtils.h
@@ -45,21 +45,23 @@ public:
     rhs_norm_ = 0.0;
     N_ = 0;
 
-    bucket_loop_serial_only(buckets,
-    [](stk::topology topo, sierra::nalu::MasterElement& meSCS) {},
-    [&](stk::mesh::Entity node, stk::topology topo, sierra::nalu::MasterElement& meSCS) {
-      for (size_t i = 0; i < activeSuppAlgs_.size(); ++i) {
-        double lhs_value = 0.0;
-        double rhs_value = 0.0;
+    bucket_loop_serial_only(
+      buckets, [](stk::topology topo, sierra::nalu::MasterElement& meSCS) {},
+      [&](
+        stk::mesh::Entity node, stk::topology topo,
+        sierra::nalu::MasterElement& meSCS) {
+        for (size_t i = 0; i < activeSuppAlgs_.size(); ++i) {
+          double lhs_value = 0.0;
+          double rhs_value = 0.0;
 
-        activeSuppAlgs_[i]->node_execute(&lhs_value, &rhs_value, node);
+          activeSuppAlgs_[i]->node_execute(&lhs_value, &rhs_value, node);
 
-        Kokkos::atomic_add(&lhs_norm_, (lhs_value * lhs_value));
-        Kokkos::atomic_add(&rhs_norm_, (rhs_value * rhs_value));
-      }
+          Kokkos::atomic_add(&lhs_norm_, (lhs_value * lhs_value));
+          Kokkos::atomic_add(&rhs_norm_, (rhs_value * rhs_value));
+        }
 
-      Kokkos::atomic_add(&N_, (size_t)1);
-    });
+        Kokkos::atomic_add(&N_, (size_t)1);
+      });
   }
 
   inline double get_lhs_norm()

--- a/unit_tests/algorithms/UnitTestAlgorithmUtils.h
+++ b/unit_tests/algorithms/UnitTestAlgorithmUtils.h
@@ -17,8 +17,6 @@
 #include "SupplementalAlgorithm.h"
 #include "UnitTestKokkosUtils.h"
 
-#if !defined(KOKKOS_ENABLE_GPU)
-
 namespace unit_test_algorithm_utils {
 
 /** Driver class that mimics Assemble*SolverAlgorithm
@@ -47,7 +45,9 @@ public:
     rhs_norm_ = 0.0;
     N_ = 0;
 
-    kokkos_thread_team_bucket_loop(buckets, [&](stk::mesh::Entity node) {
+    bucket_loop_serial_only(buckets,
+    [](stk::topology topo, sierra::nalu::MasterElement& meSCS) {},
+    [&](stk::mesh::Entity node, stk::topology topo, sierra::nalu::MasterElement& meSCS) {
       for (size_t i = 0; i < activeSuppAlgs_.size(); ++i) {
         double lhs_value = 0.0;
         double rhs_value = 0.0;
@@ -81,7 +81,5 @@ private:
 };
 
 } // namespace unit_test_algorithm_utils
-
-#endif /* KOKKOS_ENABLE_CUDA */
 
 #endif /* UNITTESTALGORITHMUTILS_H */

--- a/unit_tests/algorithms/UnitTestRodiAlgorithm.C
+++ b/unit_tests/algorithms/UnitTestRodiAlgorithm.C
@@ -15,8 +15,6 @@
 #include "SolutionOptions.h"
 #include "TurbKineticEnergyRodiNodeSourceSuppAlg.h"
 
-#if !defined(KOKKOS_ENABLE_GPU)
-
 TEST_F(TestTurbulenceAlgorithm, turbkineticenergyrodinodesourcesuppalg)
 {
   sierra::nalu::Realm& realm = this->create_realm();
@@ -53,4 +51,3 @@ TEST_F(TestTurbulenceAlgorithm, turbkineticenergyrodinodesourcesuppalg)
   EXPECT_NEAR(rhs_norm, rhs_gold_norm, tol);
 }
 
-#endif

--- a/unit_tests/algorithms/UnitTestRodiAlgorithm.C
+++ b/unit_tests/algorithms/UnitTestRodiAlgorithm.C
@@ -50,4 +50,3 @@ TEST_F(TestTurbulenceAlgorithm, turbkineticenergyrodinodesourcesuppalg)
   EXPECT_NEAR(lhs_norm, lhs_gold_norm, tol);
   EXPECT_NEAR(rhs_norm, rhs_gold_norm, tol);
 }
-

--- a/unit_tests/matrix_free/UnitTestGreenGaussGradient.C
+++ b/unit_tests/matrix_free/UnitTestGreenGaussGradient.C
@@ -282,8 +282,10 @@ TEST_F(ComputeGradientFixture, error_in_gradient_is_smallish_for_harmonic_field)
   auto& gq = stk::mesh::get_updated_ngp_field<double>(dqdx_field);
   g_grad.gradient(q, gq);
   gq.sync_to_host();
-  dump_mesh(bulk, {&q_field, &dqdx_field, &dqdx_exact_field}, "test/data.e");
+  std::string fileName("test_data.e");
+  dump_mesh(bulk, {&q_field, &dqdx_field, &dqdx_exact_field}, fileName);
   ASSERT_LT(error(), 5e-3);
+  unlink(fileName.c_str());
 }
 
 } // namespace matrix_free

--- a/unit_tests/matrix_free/UnitTestLowMachUpdate.C
+++ b/unit_tests/matrix_free/UnitTestLowMachUpdate.C
@@ -127,7 +127,10 @@ TEST_F(LowMachSimulationFixture, reduce_peak_velocity)
 
   vel.sync_to_host();
 
-  unit_test_utils::dump_mesh(bulk, {&velocity_field});
+  const bool doOutput = false;
+  if (doOutput) {
+    unit_test_utils::dump_mesh(bulk, {&velocity_field});
+  }
   auto max_val_post = max_value();
   ASSERT_GT(max_val_pre, max_val_post);
 }


### PR DESCRIPTION
These commits enable a few unit-tests to run in a gpu build when they were previously
excluded by 'ifndef KOKKOS_ENABLE_GPU'.
In some cases I made them successfully run on the host.
In a couple of cases (most notably the Tpetra.basic test) I made them actually use the gpu.

The second commit cleans up some unit-tests that were creating files and leaving them.
Those tests now remove the files before finishing.
