### PR TITLE
Add unit-test fixture for cylinder mesh

### DIFF
--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -113,7 +113,8 @@ fsiTurbine::fsiTurbine(int iTurb, const YAML::Node& node)
       twrBndyPartNames_.end());
   } else
     NaluEnv::self().naluOutputP0()
-      << "Tower boundary part name(s) not specified for turbine " << iTurb_ << std::endl;
+      << "Tower boundary part name(s) not specified for turbine " << iTurb_
+      << std::endl;
 
   if (node["nacelle_boundary_parts"]) {
     const auto& nparts = node["nacelle_boundary_parts"];

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -113,7 +113,7 @@ fsiTurbine::fsiTurbine(int iTurb, const YAML::Node& node)
       twrBndyPartNames_.end());
   } else
     NaluEnv::self().naluOutputP0()
-      << "Tower part name(s) not specified for turbine " << iTurb_ << std::endl;
+      << "Tower boundary part name(s) not specified for turbine " << iTurb_ << std::endl;
 
   if (node["nacelle_boundary_parts"]) {
     const auto& nparts = node["nacelle_boundary_parts"];

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestBasicKokkos.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestCopyAndInterleave.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestCreateOnDevice.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestCylinderMesh.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestEigenDecomposition.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestElemDataRequests.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestElemSuppAlg.C

--- a/unit_tests/UnitTestCylinderMesh.C
+++ b/unit_tests/UnitTestCylinderMesh.C
@@ -95,7 +95,7 @@ TEST_F(CylinderMesh, basic_setup)
 
   test_cylinder_mesh_field_values(*bulk, coordField, testField);
 
-  const bool dumpTheMesh = true;
+  const bool dumpTheMesh = false;
   if (dumpTheMesh) {
     unit_test_utils::dump_mesh(*bulk, {});
   }

--- a/unit_tests/UnitTestCylinderMesh.C
+++ b/unit_tests/UnitTestCylinderMesh.C
@@ -28,12 +28,15 @@ test_cylinder_mesh_field_values(
     bulk.get_buckets(stk::topology::NODE_RANK, all_local);
 
   stk::mesh::NgpMesh ngpMesh(bulk);
-  stk::mesh::NgpField<double>& ngpCoordField = stk::mesh::get_updated_ngp_field<double>(*coordField);
-  stk::mesh::NgpField<double>& ngpTestField = stk::mesh::get_updated_ngp_field<double>(*testField);
+  stk::mesh::NgpField<double>& ngpCoordField =
+    stk::mesh::get_updated_ngp_field<double>(*coordField);
+  stk::mesh::NgpField<double>& ngpTestField =
+    stk::mesh::get_updated_ngp_field<double>(*testField);
 
   const int bytes_per_team = 0;
   const int bytes_per_thread = 0;
-  auto team_exec = sierra::nalu::get_device_team_policy(nodeBuckets.size(), bytes_per_team, bytes_per_thread);
+  auto team_exec = sierra::nalu::get_device_team_policy(
+    nodeBuckets.size(), bytes_per_team, bytes_per_thread);
 
   const double xDelta = 0.1;
   const double yDelta = 0.2;
@@ -49,14 +52,13 @@ test_cylinder_mesh_field_values(
       const size_t bucketLen = bkt.size();
 
       Kokkos::parallel_for(
-        Kokkos::TeamThreadRange(team, bucketLen),
-        [&](const size_t& bktIndex) {
-            stk::mesh::Entity node = bkt[bktIndex];
-            stk::mesh::FastMeshIndex nodeIndex = ngpMesh.fast_mesh_index(node);
+        Kokkos::TeamThreadRange(team, bucketLen), [&](const size_t& bktIndex) {
+          stk::mesh::Entity node = bkt[bktIndex];
+          stk::mesh::FastMeshIndex nodeIndex = ngpMesh.fast_mesh_index(node);
 
-            ngpTestField(nodeIndex,0) = ngpCoordField(nodeIndex,0) + xDelta;
-            ngpTestField(nodeIndex,1) = ngpCoordField(nodeIndex,1) + yDelta;
-            ngpTestField(nodeIndex,2) = ngpCoordField(nodeIndex,2) + zDelta;
+          ngpTestField(nodeIndex, 0) = ngpCoordField(nodeIndex, 0) + xDelta;
+          ngpTestField(nodeIndex, 1) = ngpCoordField(nodeIndex, 1) + yDelta;
+          ngpTestField(nodeIndex, 2) = ngpCoordField(nodeIndex, 2) + zDelta;
         });
     });
 
@@ -66,11 +68,13 @@ test_cylinder_mesh_field_values(
   const double tol = 1.0e-12;
   for (const stk::mesh::Bucket* bkt : nodeBuckets) {
     for (stk::mesh::Entity node : *bkt) {
-      const double* coordFieldData = reinterpret_cast<const double*>(stk::mesh::field_data(*coordField, node));
-      const double* testFieldData = reinterpret_cast<const double*>(stk::mesh::field_data(*testField, node));
-      EXPECT_NEAR(testFieldData[0], (coordFieldData[0]+xDelta), tol);
-      EXPECT_NEAR(testFieldData[1], (coordFieldData[1]+yDelta), tol);
-      EXPECT_NEAR(testFieldData[2], (coordFieldData[2]+zDelta), tol);
+      const double* coordFieldData = reinterpret_cast<const double*>(
+        stk::mesh::field_data(*coordField, node));
+      const double* testFieldData = reinterpret_cast<const double*>(
+        stk::mesh::field_data(*testField, node));
+      EXPECT_NEAR(testFieldData[0], (coordFieldData[0] + xDelta), tol);
+      EXPECT_NEAR(testFieldData[1], (coordFieldData[1] + yDelta), tol);
+      EXPECT_NEAR(testFieldData[2], (coordFieldData[2] + zDelta), tol);
     }
   }
 }
@@ -88,4 +92,3 @@ TEST_F(CylinderMesh, basic_setup)
     unit_test_utils::dump_mesh(*bulk, {});
   }
 }
-

--- a/unit_tests/UnitTestCylinderMesh.C
+++ b/unit_tests/UnitTestCylinderMesh.C
@@ -1,0 +1,91 @@
+#include "gtest/gtest.h"
+
+#include "stk_util/environment/WallTime.hpp"
+#include "stk_mesh/base/Types.hpp"
+#include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/GetEntities.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/GetNgpField.hpp"
+
+#include "UnitTestUtils.h"
+#include "UnitTestRealm.h"
+
+#include "KokkosInterface.h"
+#include "ElemDataRequests.h"
+
+void
+test_cylinder_mesh_field_values(
+  const stk::mesh::BulkData& bulk,
+  const stk::mesh::FieldBase* coordField,
+  const stk::mesh::FieldBase* testField)
+{
+  const stk::mesh::MetaData& meta = bulk.mesh_meta_data();
+  stk::mesh::Selector all_local =
+    meta.universal_part() & meta.locally_owned_part();
+  const stk::mesh::BucketVector& nodeBuckets =
+    bulk.get_buckets(stk::topology::NODE_RANK, all_local);
+
+  stk::mesh::NgpMesh ngpMesh(bulk);
+  stk::mesh::NgpField<double>& ngpCoordField = stk::mesh::get_updated_ngp_field<double>(*coordField);
+  stk::mesh::NgpField<double>& ngpTestField = stk::mesh::get_updated_ngp_field<double>(*testField);
+
+  const int bytes_per_team = 0;
+  const int bytes_per_thread = 0;
+  auto team_exec = sierra::nalu::get_device_team_policy(nodeBuckets.size(), bytes_per_team, bytes_per_thread);
+
+  const double xDelta = 0.1;
+  const double yDelta = 0.2;
+  const double zDelta = 0.3;
+
+  ngpCoordField.sync_to_device();
+
+  Kokkos::parallel_for(
+    team_exec, KOKKOS_LAMBDA(const sierra::nalu::DeviceTeamHandleType& team) {
+      const stk::mesh::NgpMesh::BucketType& bkt =
+        ngpMesh.get_bucket(stk::topology::NODE_RANK, team.league_rank());
+
+      const size_t bucketLen = bkt.size();
+
+      Kokkos::parallel_for(
+        Kokkos::TeamThreadRange(team, bucketLen),
+        [&](const size_t& bktIndex) {
+            stk::mesh::Entity node = bkt[bktIndex];
+            stk::mesh::FastMeshIndex nodeIndex = ngpMesh.fast_mesh_index(node);
+
+            ngpTestField(nodeIndex,0) = ngpCoordField(nodeIndex,0) + xDelta;
+            ngpTestField(nodeIndex,1) = ngpCoordField(nodeIndex,1) + yDelta;
+            ngpTestField(nodeIndex,2) = ngpCoordField(nodeIndex,2) + zDelta;
+        });
+    });
+
+  ngpTestField.modify_on_device();
+  ngpTestField.sync_to_host();
+
+  const double tol = 1.0e-12;
+  for (const stk::mesh::Bucket* bkt : nodeBuckets) {
+    for (stk::mesh::Entity node : *bkt) {
+      const double* coordFieldData = reinterpret_cast<const double*>(stk::mesh::field_data(*coordField, node));
+      const double* testFieldData = reinterpret_cast<const double*>(stk::mesh::field_data(*testField, node));
+      EXPECT_NEAR(testFieldData[0], (coordFieldData[0]+xDelta), tol);
+      EXPECT_NEAR(testFieldData[1], (coordFieldData[1]+yDelta), tol);
+      EXPECT_NEAR(testFieldData[2], (coordFieldData[2]+zDelta), tol);
+    }
+  }
+}
+
+TEST_F(CylinderMesh, basic_setup)
+{
+  const double innerRadius = 1.0;
+  const double outerRadius = 2.0;
+  fill_mesh_and_initialize_test_fields(20, 20, 20, innerRadius, outerRadius);
+
+  test_cylinder_mesh_field_values(*bulk, coordField, testField);
+
+  const bool dumpTheMesh = true;
+  if (dumpTheMesh) {
+    unit_test_utils::dump_mesh(*bulk, {});
+  }
+}
+

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -14,6 +14,7 @@
 #include <stk_topology/topology.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
 #include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
 #include <stk_mesh/base/CoordinateSystems.hpp>
 
 #include <Kokkos_Core.hpp>
@@ -358,6 +359,7 @@ protected:
       coordField(nullptr)
   {
     stk::mesh::MeshBuilder meshBuilder(comm);
+    meshBuilder.set_aura_option(stk::mesh::BulkData::NO_AUTO_AURA);
     meshBuilder.set_spatial_dimension(spatialDimension);
     bulk = meshBuilder.create();
     meta = &bulk->mesh_meta_data();
@@ -401,6 +403,10 @@ protected:
     transform_to_cylinder(innerRad, outerRad);
 
     stk::mesh::field_fill(0.1, *testField);
+
+    coordField->modify_on_host();
+    testField->modify_on_host();
+    stk::mesh::communicate_field_data(*bulk, {coordField, testField});
   }
 
   void transform_to_cylinder(double innerRad, double outerRad)

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -351,7 +351,9 @@ protected:
   CylinderMesh()
     : comm(MPI_COMM_WORLD),
       spatialDimension(3),
-      xMax(0), yMax(0), zMax(0),
+      xMax(0),
+      yMax(0),
+      zMax(0),
       topo(stk::topology::HEX_8),
       coordField(nullptr)
   {
@@ -360,9 +362,11 @@ protected:
     bulk = meshBuilder.create();
     meta = &bulk->mesh_meta_data();
 
-    testField = &meta->declare_field<VectorFieldType>(stk::topology::NODE_RANK, "testField");
+    testField = &meta->declare_field<VectorFieldType>(
+      stk::topology::NODE_RANK, "testField");
     const double zeroVecThree[3] = {0.0, 0.0, 0.0};
-    stk::mesh::put_field_on_mesh(*testField, meta->universal_part(), 3, zeroVecThree);
+    stk::mesh::put_field_on_mesh(
+      *testField, meta->universal_part(), 3, zeroVecThree);
   }
 
   void fill_mesh(const std::string& meshSpec = "generated:20x20x20")
@@ -370,12 +374,16 @@ protected:
     unit_test_utils::fill_hex8_mesh(meshSpec, *bulk);
   }
 
-  void fill_mesh_and_initialize_test_fields(int xDim, int yDim, int zDim,
-                                            double innerRad, double outerRad,
-                                            const bool generateSidesets = false)
+  void fill_mesh_and_initialize_test_fields(
+    int xDim,
+    int yDim,
+    int zDim,
+    double innerRad,
+    double outerRad,
+    const bool generateSidesets = false)
   {
     std::ostringstream oss;
-    oss<<"generated:"<<xDim<<"x"<<yDim<<"x"<<zDim;
+    oss << "generated:" << xDim << "x" << yDim << "x" << zDim;
     std::string meshSpec = oss.str();
 
     xMax = xDim;
@@ -397,15 +405,18 @@ protected:
 
   void transform_to_cylinder(double innerRad, double outerRad)
   {
-    stk::mesh::Selector sel = (meta->locally_owned_part() | meta->globally_shared_part());
-    const stk::mesh::BucketVector& bkts = bulk->get_buckets(stk::topology::NODE_RANK, sel);
+    stk::mesh::Selector sel =
+      (meta->locally_owned_part() | meta->globally_shared_part());
+    const stk::mesh::BucketVector& bkts =
+      bulk->get_buckets(stk::topology::NODE_RANK, sel);
 
     const double xfac = (outerRad - innerRad) / xMax;
     const double yfac = 2 * M_PI / yMax;
 
     for (const stk::mesh::Bucket* bptr : bkts) {
       for (stk::mesh::Entity node : *bptr) {
-        double* nodeCoord = reinterpret_cast<double*>(stk::mesh::field_data(*coordField, node));
+        double* nodeCoord =
+          reinterpret_cast<double*>(stk::mesh::field_data(*coordField, node));
         const double radius = innerRad + nodeCoord[0] * xfac;
         const double theta = nodeCoord[1] * yfac;
         nodeCoord[0] = radius * std::cos(theta);

--- a/unit_tests/aero/CMakeLists.txt
+++ b/unit_tests/aero/CMakeLists.txt
@@ -4,3 +4,9 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestDeflectionRamping.C
 )
 
+if(ENABLE_OPENFAST_FSI)
+target_sources(${utest_ex_name} PRIVATE
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestFSIturbine.C
+)
+endif()
+

--- a/unit_tests/aero/UnitTestFSIturbine.C
+++ b/unit_tests/aero/UnitTestFSIturbine.C
@@ -1,0 +1,58 @@
+#include "gtest/gtest.h"
+
+#include "stk_util/environment/WallTime.hpp"
+#include "stk_mesh/base/Types.hpp"
+#include "stk_mesh/base/BulkData.hpp"
+#include "stk_mesh/base/GetEntities.hpp"
+#include "stk_mesh/base/Ngp.hpp"
+#include "stk_mesh/base/NgpMesh.hpp"
+#include "stk_mesh/base/GetNgpMesh.hpp"
+#include "stk_mesh/base/NgpField.hpp"
+#include "stk_mesh/base/GetNgpField.hpp"
+
+#include "UnitTestUtils.h"
+
+#include "KokkosInterface.h"
+#include "aero/fsi/FSIturbine.h"
+
+namespace {
+
+const std::string fsiInputs =
+"tower_parts: [block_1] \n"
+"hub_parts: [block_2]\n"
+"nacelle_parts: [block_3,block_4] \n"
+"blade_parts:\n"
+"  - [block_3]\n"
+"  - [block_4]\n"
+"deflection_ramping:\n"
+"  span_ramp_distance: 10.0\n"
+"  zero_theta_ramp_angle: 180.0\n"
+"  theta_ramp_span: 15.0\n"
+"  temporal_ramp_start: 0\n"
+"  temporal_ramp_end: 10\n"
+"tower_boundary_parts: [block_1] \n"
+"hub_boundary_parts: [block_2]\n"
+"nacelle_boundary_parts: [block_3,block_4] \n"
+"blade_boundary_parts:\n"
+"  - [block_3]\n"
+"  - [block_4]\n"
+;
+
+YAML::Node create_fsi_yaml_node()
+{
+  YAML::Node yamlNode = YAML::Load(fsiInputs);
+  return yamlNode;
+}
+
+TEST_F(CylinderMesh, construct_FSIturbine)
+{
+  const double innerRadius = 1.0;
+  const double outerRadius = 2.0;
+  fill_mesh_and_initialize_test_fields(20, 20, 20, innerRadius, outerRadius);
+
+  YAML::Node yamlNode = create_fsi_yaml_node();
+  EXPECT_NO_THROW(sierra::nalu::fsiTurbine(0, yamlNode));
+}
+
+} // namespace
+

--- a/unit_tests/aero/UnitTestFSIturbine.C
+++ b/unit_tests/aero/UnitTestFSIturbine.C
@@ -17,28 +17,27 @@
 
 namespace {
 
-const std::string fsiInputs =
-"tower_parts: [block_1] \n"
-"hub_parts: [block_2]\n"
-"nacelle_parts: [block_3,block_4] \n"
-"blade_parts:\n"
-"  - [block_3]\n"
-"  - [block_4]\n"
-"deflection_ramping:\n"
-"  span_ramp_distance: 10.0\n"
-"  zero_theta_ramp_angle: 180.0\n"
-"  theta_ramp_span: 15.0\n"
-"  temporal_ramp_start: 0\n"
-"  temporal_ramp_end: 10\n"
-"tower_boundary_parts: [block_1] \n"
-"hub_boundary_parts: [block_2]\n"
-"nacelle_boundary_parts: [block_3,block_4] \n"
-"blade_boundary_parts:\n"
-"  - [block_3]\n"
-"  - [block_4]\n"
-;
+const std::string fsiInputs = "tower_parts: [block_1] \n"
+                              "hub_parts: [block_2]\n"
+                              "nacelle_parts: [block_3,block_4] \n"
+                              "blade_parts:\n"
+                              "  - [block_3]\n"
+                              "  - [block_4]\n"
+                              "deflection_ramping:\n"
+                              "  span_ramp_distance: 10.0\n"
+                              "  zero_theta_ramp_angle: 180.0\n"
+                              "  theta_ramp_span: 15.0\n"
+                              "  temporal_ramp_start: 0\n"
+                              "  temporal_ramp_end: 10\n"
+                              "tower_boundary_parts: [block_1] \n"
+                              "hub_boundary_parts: [block_2]\n"
+                              "nacelle_boundary_parts: [block_3,block_4] \n"
+                              "blade_boundary_parts:\n"
+                              "  - [block_3]\n"
+                              "  - [block_4]\n";
 
-YAML::Node create_fsi_yaml_node()
+YAML::Node
+create_fsi_yaml_node()
 {
   YAML::Node yamlNode = YAML::Load(fsiInputs);
   return yamlNode;
@@ -55,4 +54,3 @@ TEST_F(CylinderMesh, construct_FSIturbine)
 }
 
 } // namespace
-


### PR DESCRIPTION
Uses Neil Matula's code for starting with a generated mesh (which is a brick-shaped domain of hex-8 elements) and transforms the node coordinates to make the mesh into a cylinder.

The fixture is in UnitTestUtils.h for now (could be pulled out to a separate header).

A simple test that uses the fixture to demonstrate creating the fixture and doing a trivial manipulation of field-data values on device and checking their correctness on host, is located in UnitTestCylinderMesh.C

Note this is a first pass, only creates the fixture with stk-mesh support so that unit-tests can easily
be created with 'TEST_F'. Next will add integration with nalu-wind components such as Realm,
possibly kernels/algorithms, subject to Phil's needs.
