### PR TITLE
Change FSIturbine::projectPt2Line to be device-compatible

### DIFF
--- a/include/aero/aero_utils/Pt2Line.h
+++ b/include/aero/aero_utils/Pt2Line.h
@@ -22,10 +22,9 @@ namespace fsi {
    (\vec{lEnd} - \vec{lStart}) } \f]
 */
 KOKKOS_INLINE_FUNCTION
-double projectPt2Line(
-  const vs::Vector& pt,
-  const vs::Vector& lStart,
-  const vs::Vector& lEnd)
+double
+projectPt2Line(
+  const vs::Vector& pt, const vs::Vector& lStart, const vs::Vector& lEnd)
 {
   double nonDimCoord = 0.0;
 
@@ -51,10 +50,9 @@ double projectPt2Line(
    \vec{lStart}) \rvert } \f]
 */
 KOKKOS_INLINE_FUNCTION
-double perpProjectDist_Pt2Line(
-  const vs::Vector& pt,
-  const vs::Vector& lStart,
-  const vs::Vector& lEnd)
+double
+perpProjectDist_Pt2Line(
+  const vs::Vector& pt, const vs::Vector& lStart, const vs::Vector& lEnd)
 {
   double nonDimCoord = 0.0;
   double num = 0.0;

--- a/include/aero/aero_utils/Pt2Line.h
+++ b/include/aero/aero_utils/Pt2Line.h
@@ -1,0 +1,80 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef PT2LINE_H
+#define PT2LINE_H
+
+#include <KokkosInterface.h>
+#include <vs/vector.h>
+
+namespace fsi {
+
+/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
+   non-dimensional location of the projected point along the line in [0-1]
+   coordinates \f[ nonDimCoord = \frac{ (\vec{pt} - \vec{lStart}) \cdot (
+   \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
+   (\vec{lEnd} - \vec{lStart}) } \f]
+*/
+KOKKOS_INLINE_FUNCTION
+double projectPt2Line(
+  const vs::Vector& pt,
+  const vs::Vector& lStart,
+  const vs::Vector& lEnd)
+{
+  double nonDimCoord = 0.0;
+
+  double num = 0.0;
+  double denom = 0.0;
+
+  for (int i = 0; i < 3; i++) {
+    num += (pt[i] - lStart[i]) * (lEnd[i] - lStart[i]);
+    denom += (lEnd[i] - lStart[i]) * (lEnd[i] - lStart[i]);
+  }
+
+  nonDimCoord = num / denom;
+  return nonDimCoord;
+}
+
+/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
+   non-dimensional distance of 'pt' from the line w.r.t the distance from
+   'lStart' to 'lEnd' \f[
+    \vec{perp} &= (\vec{pt} - \vec{lStart}) - \frac{ (\vec{pt} - \vec{lStart})
+   \cdot ( \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
+   (\vec{lEnd} - \vec{lStart}) } ( \vec{lEnd} - \vec{lStart} ) \\
+    nonDimPerpDist = \frac{\lvert \vec{perp} \rvert}{ \lvert  (\vec{lEnd} -
+   \vec{lStart}) \rvert } \f]
+*/
+KOKKOS_INLINE_FUNCTION
+double perpProjectDist_Pt2Line(
+  const vs::Vector& pt,
+  const vs::Vector& lStart,
+  const vs::Vector& lEnd)
+{
+  double nonDimCoord = 0.0;
+  double num = 0.0;
+  double denom = 0.0;
+  for (int i = 0; i < 3; i++) {
+    num += (pt[i] - lStart[i]) * (lEnd[i] - lStart[i]);
+    denom += (lEnd[i] - lStart[i]) * (lEnd[i] - lStart[i]);
+  }
+  nonDimCoord = num / denom;
+
+  double nonDimPerpDist = 0.0;
+  for (int i = 0; i < 3; i++) {
+    double tmp = (pt[i] - lStart[i]) - nonDimCoord * (lEnd[i] - lStart[i]);
+    nonDimPerpDist += tmp * tmp;
+  }
+  nonDimPerpDist = stk::math::sqrt(nonDimPerpDist / denom);
+
+  return nonDimPerpDist;
+}
+
+} // namespace fsi
+
+#endif

--- a/include/aero/fsi/FSIturbine.h
+++ b/include/aero/fsi/FSIturbine.h
@@ -19,6 +19,7 @@
 #include "stk_mesh/base/CoordinateSystems.hpp"
 #include "stk_mesh/base/Field.hpp"
 #include "FieldTypeDef.h"
+#include <stk_search/Point.hpp>
 
 #include <vector>
 #include <string>
@@ -78,6 +79,36 @@ vector_to_field(
     ptr[i] = vec[i];
   }
 }
+
+using Point = stk::search::Point<double>;
+
+/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
+   non-dimensional location of the projected point along the line in [0-1]
+   coordinates \f[ nonDimCoord = \frac{ (\vec{pt} - \vec{lStart}) \cdot (
+   \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
+   (\vec{lEnd} - \vec{lStart}) } \f]
+*/
+KOKKOS_FUNCTION
+double projectPt2Line(
+  const Point& pt,
+  const Point& lStart,
+  const Point& lEnd);
+
+/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
+   non-dimensional distance of 'pt' from the line w.r.t the distance from
+   'lStart' to 'lEnd' \f[
+    \vec{perp} &= (\vec{pt} - \vec{lStart}) - \frac{ (\vec{pt} - \vec{lStart})
+   \cdot ( \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
+   (\vec{lEnd} - \vec{lStart}) } ( \vec{lEnd} - \vec{lStart} ) \\
+    nonDimPerpDist = \frac{\lvert \vec{perp} \rvert}{ \lvert  (\vec{lEnd} -
+   \vec{lStart}) \rvert } \f]
+*/
+KOKKOS_FUNCTION
+double perpProjectDist_Pt2Line(
+  const Point& pt,
+  const Point& lStart,
+  const Point& lEnd);
+
 // **********************************************************************
 
 class fsiTurbine
@@ -186,31 +217,6 @@ private:
     stk::mesh::PartVector& partVec,
     stk::mesh::PartVector& allPartVec,
     const std::string& turbinePart);
-
-  /** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
-     non-dimensional location of the projected point along the line in [0-1]
-     coordinates \f[ nonDimCoord = \frac{ (\vec{pt} - \vec{lStart}) \cdot (
-     \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
-     (\vec{lEnd} - \vec{lStart}) } \f]
-  */
-  double projectPt2Line(
-    std::vector<double>& pt,
-    std::vector<double>& lStart,
-    std::vector<double>& lEnd);
-
-  /** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
-     non-dimensional distance of 'pt' from the line w.r.t the distance from
-     'lStart' to 'lEnd' \f[
-      \vec{perp} &= (\vec{pt} - \vec{lStart}) - \frac{ (\vec{pt} - \vec{lStart})
-     \cdot ( \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
-     (\vec{lEnd} - \vec{lStart}) } ( \vec{lEnd} - \vec{lStart} ) \\
-      nonDimPerpDist = \frac{\lvert \vec{perp} \rvert}{ \lvert  (\vec{lEnd} -
-     \vec{lStart}) \rvert } \f]
-  */
-  double perpProjectDist_Pt2Line(
-    std::vector<double>& pt,
-    std::vector<double>& lStart,
-    std::vector<double>& lEnd);
 
   //! Compute the effective force and moment at the OpenFAST mesh node for a
   //! given force at the CFD surface mesh node

--- a/include/aero/fsi/FSIturbine.h
+++ b/include/aero/fsi/FSIturbine.h
@@ -27,6 +27,7 @@
 
 #include "yaml-cpp/yaml.h"
 #include "vs/vector_space.h"
+#include "vs/vector.h"
 
 namespace aero {
 struct SixDOF;
@@ -79,35 +80,6 @@ vector_to_field(
     ptr[i] = vec[i];
   }
 }
-
-using Point = stk::search::Point<double>;
-
-/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
-   non-dimensional location of the projected point along the line in [0-1]
-   coordinates \f[ nonDimCoord = \frac{ (\vec{pt} - \vec{lStart}) \cdot (
-   \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
-   (\vec{lEnd} - \vec{lStart}) } \f]
-*/
-KOKKOS_FUNCTION
-double projectPt2Line(
-  const Point& pt,
-  const Point& lStart,
-  const Point& lEnd);
-
-/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
-   non-dimensional distance of 'pt' from the line w.r.t the distance from
-   'lStart' to 'lEnd' \f[
-    \vec{perp} &= (\vec{pt} - \vec{lStart}) - \frac{ (\vec{pt} - \vec{lStart})
-   \cdot ( \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
-   (\vec{lEnd} - \vec{lStart}) } ( \vec{lEnd} - \vec{lStart} ) \\
-    nonDimPerpDist = \frac{\lvert \vec{perp} \rvert}{ \lvert  (\vec{lEnd} -
-   \vec{lStart}) \rvert } \f]
-*/
-KOKKOS_FUNCTION
-double perpProjectDist_Pt2Line(
-  const Point& pt,
-  const Point& lStart,
-  const Point& lEnd);
 
 // **********************************************************************
 

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -16,6 +16,7 @@
 #include "stk_util/parallel/ParallelReduce.hpp"
 #include "stk_mesh/base/FieldParallel.hpp"
 #include "stk_mesh/base/Field.hpp"
+#include "stk_math/StkMath.hpp"
 #include "master_element/MasterElement.h"
 #include "master_element/MasterElementFactory.h"
 
@@ -30,6 +31,68 @@
 namespace sierra {
 
 namespace nalu {
+
+/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
+   non-dimensional location of the projected point along the line in [0-1]
+   coordinates \f[ nonDimCoord = \frac{ (\vec{pt} - \vec{lStart}) \cdot (
+   \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot (\vec{lEnd}
+   - \vec{lStart}) } \f]
+*/
+KOKKOS_FUNCTION
+double projectPt2Line(
+  const Point& pt,
+  const Point& lStart,
+  const Point& lEnd)
+{
+
+  double nonDimCoord = 0.0;
+
+  double num = 0.0;
+  double denom = 0.0;
+
+  for (int i = 0; i < 3; i++) {
+    num += (pt[i] - lStart[i]) * (lEnd[i] - lStart[i]);
+    denom += (lEnd[i] - lStart[i]) * (lEnd[i] - lStart[i]);
+  }
+
+  nonDimCoord = num / denom;
+  return nonDimCoord;
+}
+
+/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
+   non-dimensional distance of 'pt' from the line w.r.t the distance from
+   'lStart' to 'lEnd' \f[
+    \vec{perp} &= (\vec{pt} - \vec{lStart}) - \frac{ (\vec{pt} - \vec{lStart})
+   \cdot ( \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
+   (\vec{lEnd} - \vec{lStart}) } ( \vec{lEnd} - \vec{lStart} ) \ \
+    nonDimPerpDist = \frac{\lvert \vec{perp} \rvert}{ \lvert  (\vec{lEnd} -
+   \vec{lStart}) \rvert } \f]
+*/
+KOKKOS_FUNCTION
+double perpProjectDist_Pt2Line(
+  const Point& pt,
+  const Point& lStart,
+  const Point& lEnd)
+{
+
+  double nonDimCoord = 0.0;
+  double num = 0.0;
+  double denom = 0.0;
+  for (int i = 0; i < 3; i++) {
+    num += (pt[i] - lStart[i]) * (lEnd[i] - lStart[i]);
+    denom += (lEnd[i] - lStart[i]) * (lEnd[i] - lStart[i]);
+  }
+  nonDimCoord = num / denom;
+
+  double nonDimPerpDist = 0.0;
+  for (int i = 0; i < 3; i++) {
+    double tmp = (pt[i] - lStart[i]) - nonDimCoord * (lEnd[i] - lStart[i]);
+    nonDimPerpDist += tmp * tmp;
+  }
+  nonDimPerpDist = stk::math::sqrt(nonDimPerpDist / denom);
+
+  return nonDimPerpDist;
+}
 
 inline void
 check_nc_error(int code, std::string msg)
@@ -1914,7 +1977,7 @@ fsiTurbine::computeMapping()
       double* xyz = stk::mesh::field_data(*modelCoords, node);
       int* dispMapNode = stk::mesh::field_data(*dispMap_, node);
       double* dispMapInterpNode = stk::mesh::field_data(*dispMapInterp_, node);
-      std::vector<double> ptCoords(ndim, 0.0);
+      Point ptCoords(ndim, 0.0);
       for (int i = 0; i < ndim; i++)
         ptCoords[i] = xyz[i];
       bool foundProj = false;
@@ -1922,10 +1985,10 @@ fsiTurbine::computeMapping()
       int nPtsTwr = params_.nBRfsiPtsTwr;
       if (nPtsTwr > 0) {
         for (int i = 0; i < nPtsTwr - 1; i++) {
-          std::vector<double> lStart = {
+          Point lStart = {
             brFSIdata_.twr_ref_pos[i * 6], brFSIdata_.twr_ref_pos[i * 6 + 1],
             brFSIdata_.twr_ref_pos[i * 6 + 2]};
-          std::vector<double> lEnd = {
+          Point lEnd = {
             brFSIdata_.twr_ref_pos[(i + 1) * 6],
             brFSIdata_.twr_ref_pos[(i + 1) * 6 + 1],
             brFSIdata_.twr_ref_pos[(i + 1) * 6 + 2]};
@@ -1944,10 +2007,10 @@ fsiTurbine::computeMapping()
         // check on the perpendicular distance between the surface mesh node and
         // the line joining the ends of the tower
         if (!foundProj) {
-          std::vector<double> lStart = {
+          Point lStart = {
             brFSIdata_.twr_ref_pos[0], brFSIdata_.twr_ref_pos[1],
             brFSIdata_.twr_ref_pos[2]};
-          std::vector<double> lEnd = {
+          Point lEnd = {
             brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6],
             brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6 + 1],
             brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6 + 2]};
@@ -2000,17 +2063,17 @@ fsiTurbine::computeMapping()
         int* dispMapNode = stk::mesh::field_data(*dispMap_, node);
         double* dispMapInterpNode =
           stk::mesh::field_data(*dispMapInterp_, node);
-        std::vector<double> ptCoords(ndim, 0.0);
+        Point ptCoords(ndim, 0.0);
         for (int i = 0; i < ndim; i++)
           ptCoords[i] = xyz[i];
         bool foundProj = false;
         double nDimCoord = -1.0;
         for (int i = 0; i < nPtsBlade - 1; i++) {
-          std::vector<double> lStart = {
+          Point lStart = {
             brFSIdata_.bld_ref_pos[(iStart + i) * 6],
             brFSIdata_.bld_ref_pos[(iStart + i) * 6 + 1],
             brFSIdata_.bld_ref_pos[(iStart + i) * 6 + 2]};
-          std::vector<double> lEnd = {
+          Point lEnd = {
             brFSIdata_.bld_ref_pos[(iStart + i + 1) * 6],
             brFSIdata_.bld_ref_pos[(iStart + i + 1) * 6 + 1],
             brFSIdata_.bld_ref_pos[(iStart + i + 1) * 6 + 2]};
@@ -2074,7 +2137,7 @@ fsiTurbine::computeLoadMapping()
 
   // nodal fields to gather
   std::vector<double> ws_coordinates;
-  std::vector<double> coord_bip(3, 0.0);
+  Point coord_bip(0.0, 0.0, 0.0);
   std::vector<double> ws_face_shape_function;
 
   // Do the tower first
@@ -2135,10 +2198,10 @@ fsiTurbine::computeLoadMapping()
         int nPtsTwr = params_.nBRfsiPtsTwr;
         if (nPtsTwr > 0) {
           for (int i = 0; i < nPtsTwr - 1; i++) {
-            std::vector<double> lStart = {
+            Point lStart = {
               brFSIdata_.twr_ref_pos[i * 6], brFSIdata_.twr_ref_pos[i * 6 + 1],
               brFSIdata_.twr_ref_pos[i * 6 + 2]};
-            std::vector<double> lEnd = {
+            Point lEnd = {
               brFSIdata_.twr_ref_pos[(i + 1) * 6],
               brFSIdata_.twr_ref_pos[(i + 1) * 6 + 1],
               brFSIdata_.twr_ref_pos[(i + 1) * 6 + 2]};
@@ -2157,10 +2220,10 @@ fsiTurbine::computeLoadMapping()
           // the surface mesh node and the line joining the ends of the
           // tower
           if (!foundProj) {
-            std::vector<double> lStart = {
+            Point lStart = {
               brFSIdata_.twr_ref_pos[0], brFSIdata_.twr_ref_pos[1],
               brFSIdata_.twr_ref_pos[2]};
-            std::vector<double> lEnd = {
+            Point lEnd = {
               brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6],
               brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6 + 1],
               brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6 + 2]};
@@ -2262,11 +2325,11 @@ fsiTurbine::computeLoadMapping()
           bool foundProj = false;
           double nDimCoord = -1.0;
           for (int i = 0; i < nPtsBlade - 1; i++) {
-            std::vector<double> lStart = {
+            Point lStart = {
               brFSIdata_.bld_ref_pos[(iStart + i) * 6],
               brFSIdata_.bld_ref_pos[(iStart + i) * 6 + 1],
               brFSIdata_.bld_ref_pos[(iStart + i) * 6 + 2]};
-            std::vector<double> lEnd = {
+            Point lEnd = {
               brFSIdata_.bld_ref_pos[(iStart + i + 1) * 6],
               brFSIdata_.bld_ref_pos[(iStart + i + 1) * 6 + 1],
               brFSIdata_.bld_ref_pos[(iStart + i + 1) * 6 + 2]};
@@ -2285,11 +2348,11 @@ fsiTurbine::computeLoadMapping()
           // joining the ends of the blade
           if (!foundProj) {
 
-            std::vector<double> lStart = {
+            Point lStart = {
               brFSIdata_.bld_ref_pos[iStart * 6],
               brFSIdata_.bld_ref_pos[iStart * 6 + 1],
               brFSIdata_.bld_ref_pos[iStart * 6 + 2]};
-            std::vector<double> lEnd = {
+            Point lEnd = {
               brFSIdata_.bld_ref_pos[(iStart + nPtsBlade - 1) * 6],
               brFSIdata_.bld_ref_pos[(iStart + nPtsBlade - 1) * 6 + 1],
               brFSIdata_.bld_ref_pos[(iStart + nPtsBlade - 1) * 6 + 2]};
@@ -2333,68 +2396,6 @@ fsiTurbine::computeLoadMapping()
 
     iStart += nPtsBlade;
   }
-}
-
-/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
-   non-dimensional location of the projected point along the line in [0-1]
-   coordinates \f[ nonDimCoord = \frac{ (\vec{pt} - \vec{lStart}) \cdot (
-   \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot (\vec{lEnd}
-   - \vec{lStart}) } \f]
-*/
-double
-fsiTurbine::projectPt2Line(
-  std::vector<double>& pt,
-  std::vector<double>& lStart,
-  std::vector<double>& lEnd)
-{
-
-  double nonDimCoord = 0.0;
-
-  double num = 0.0;
-  double denom = 0.0;
-
-  for (int i = 0; i < 3; i++) {
-    num += (pt[i] - lStart[i]) * (lEnd[i] - lStart[i]);
-    denom += (lEnd[i] - lStart[i]) * (lEnd[i] - lStart[i]);
-  }
-
-  nonDimCoord = num / denom;
-  return nonDimCoord;
-}
-
-/** Project a point 'pt' onto a line from 'lStart' to 'lEnd' and return the
-   non-dimensional distance of 'pt' from the line w.r.t the distance from
-   'lStart' to 'lEnd' \f[
-    \vec{perp} &= (\vec{pt} - \vec{lStart}) - \frac{ (\vec{pt} - \vec{lStart})
-   \cdot ( \vec{lEnd} - \vec{lStart} ) }{ (\vec{lEnd} - \vec{lStart}) \cdot
-   (\vec{lEnd} - \vec{lStart}) } ( \vec{lEnd} - \vec{lStart} ) \ \
-    nonDimPerpDist = \frac{\lvert \vec{perp} \rvert}{ \lvert  (\vec{lEnd} -
-   \vec{lStart}) \rvert } \f]
-*/
-double
-fsiTurbine::perpProjectDist_Pt2Line(
-  std::vector<double>& pt,
-  std::vector<double>& lStart,
-  std::vector<double>& lEnd)
-{
-
-  double nonDimCoord = 0.0;
-  double num = 0.0;
-  double denom = 0.0;
-  for (int i = 0; i < 3; i++) {
-    num += (pt[i] - lStart[i]) * (lEnd[i] - lStart[i]);
-    denom += (lEnd[i] - lStart[i]) * (lEnd[i] - lStart[i]);
-  }
-  nonDimCoord = num / denom;
-
-  double nonDimPerpDist = 0.0;
-  for (int i = 0; i < 3; i++) {
-    double tmp = (pt[i] - lStart[i]) - nonDimCoord * (lEnd[i] - lStart[i]);
-    nonDimPerpDist += tmp * tmp;
-  }
-  nonDimPerpDist = sqrt(nonDimPerpDist / denom);
-
-  return nonDimPerpDist;
 }
 
 void

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -1952,7 +1952,8 @@ fsiTurbine::computeMapping()
             brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6],
             brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6 + 1],
             brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6 + 2]};
-          double perpDist = fsi::perpProjectDist_Pt2Line(ptCoords, lStart, lEnd);
+          double perpDist =
+            fsi::perpProjectDist_Pt2Line(ptCoords, lStart, lEnd);
           if (perpDist > 1.0) { // Something's wrong if a node on the surface
                                 // mesh of the tower is more than 20% of the
                                 // tower length away from the tower axis.
@@ -2163,7 +2164,8 @@ fsiTurbine::computeLoadMapping()
               brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6],
               brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6 + 1],
               brFSIdata_.twr_ref_pos[(nPtsTwr - 1) * 6 + 2]};
-            double perpDist = fsi::perpProjectDist_Pt2Line(coord_bip, lStart, lEnd);
+            double perpDist =
+              fsi::perpProjectDist_Pt2Line(coord_bip, lStart, lEnd);
             // Something's wrong if a node on the surface mesh of
             // the tower is more than 20% of the tower length away
             // from the tower axis.
@@ -2293,7 +2295,8 @@ fsiTurbine::computeLoadMapping()
               brFSIdata_.bld_ref_pos[(iStart + nPtsBlade - 1) * 6 + 1],
               brFSIdata_.bld_ref_pos[(iStart + nPtsBlade - 1) * 6 + 2]};
 
-            double perpDist = fsi::perpProjectDist_Pt2Line(coord_bip, lStart, lEnd);
+            double perpDist =
+              fsi::perpProjectDist_Pt2Line(coord_bip, lStart, lEnd);
             // Something's wrong if a node on the surface
             // mesh of the blade is more than 20% of the
             // blade length away from the blade axis.

--- a/unit_tests/actuator/UnitTestActuatorBulkDiskFAST.C
+++ b/unit_tests/actuator/UnitTestActuatorBulkDiskFAST.C
@@ -31,6 +31,8 @@ protected:
   std::unique_ptr<ActuatorMeta> actMeta_;
 };
 
+#ifndef KOKKOS_ENABLE_GPU
+
 // TODO(psakeiv) move this to a more appropriate location
 TEST_F(ActuatorBulkDiskFastTest, NGP_fastPointIndexLocator)
 {
@@ -153,6 +155,8 @@ TEST_F(ActuatorBulkDiskFastTest, NGP_sweptPointsPopulatedVaried)
       << "Index failed at: " << i;
   }
 }
+
+#endif
 
 } // namespace
 

--- a/unit_tests/actuator/UnitTestActuatorBulkFAST.C
+++ b/unit_tests/actuator/UnitTestActuatorBulkFAST.C
@@ -42,6 +42,8 @@ protected:
   }
 };
 
+#ifndef KOKKOS_ENABLE_GPU
+
 TEST_F(ActuatorBulkFastTests, NGP_initializeActuatorBulk)
 {
   std::vector<std::string> modInputs(fastParseParams_);
@@ -120,6 +122,8 @@ TEST_F(ActuatorBulkFastTests, NGP_epsilonTowerAndAnisotropicEpsilon)
     FAIL() << err.what();
   }
 }
+
+#endif
 
 } // namespace
 

--- a/unit_tests/actuator/UnitTestActuatorFunctorsFAST.C
+++ b/unit_tests/actuator/UnitTestActuatorFunctorsFAST.C
@@ -34,6 +34,8 @@ protected:
   }
 };
 
+#ifndef KOKKOS_ENABLE_GPU
+
 TEST_F(ActuatorFunctorFastTests, NGP_runUpdatePoints)
 {
   const YAML::Node y_node = actuator_unit::create_yaml_node(fastParseParams_);
@@ -215,6 +217,8 @@ TEST_F(ActuatorFunctorFastTests, NGP_spreadForceWhProjIdentity)
     }
   }
 }
+
+#endif
 
 } // namespace
 

--- a/unit_tests/aero/CMakeLists.txt
+++ b/unit_tests/aero/CMakeLists.txt
@@ -4,3 +4,9 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestDeflectionRamping.C
 )
 
+if(ENABLE_OPENFAST_FSI)
+target_sources(${utest_ex_name} PRIVATE
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestFSIpt2line.C
+)
+endif()
+

--- a/unit_tests/aero/CMakeLists.txt
+++ b/unit_tests/aero/CMakeLists.txt
@@ -2,11 +2,6 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestWienerMilenkovic.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestDisplacements.C
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestDeflectionRamping.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestPt2Line.C
 )
-
-if(ENABLE_OPENFAST_FSI)
-target_sources(${utest_ex_name} PRIVATE
-   ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestFSIpt2line.C
-)
-endif()
 

--- a/unit_tests/aero/UnitTestFSIpt2line.C
+++ b/unit_tests/aero/UnitTestFSIpt2line.C
@@ -1,0 +1,101 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include <gtest/gtest.h>
+#include <KokkosInterface.h>
+#include <aero/fsi/FSIturbine.h>
+
+namespace {
+
+double
+call_projectPt2Line_on_device(
+  const sierra::nalu::Point& pt,
+  const sierra::nalu::Point& lStart,
+  const sierra::nalu::Point& lEnd)
+{
+  double result = 0;
+  Kokkos::parallel_reduce(
+    sierra::nalu::DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const unsigned& i, double& localResult) {
+      localResult = sierra::nalu::projectPt2Line(pt, lStart, lEnd);
+    },
+    result);
+
+  return result;
+}
+
+void
+test_projectPt2Line()
+{
+  sierra::nalu::Point pt(0.5, 0.5, 0.5);
+  sierra::nalu::Point lStart(0.0, 0.0, 0.0);
+  sierra::nalu::Point lEnd(1.0, 1.0, 1.0);
+
+  {
+    double result = call_projectPt2Line_on_device(pt, lStart, lEnd);
+
+    const double expectedResult = 0.5;
+    EXPECT_NEAR(expectedResult, result, 1.e-12);
+  }
+
+  pt = sierra::nalu::Point(0.0, 0.0, 0.5);
+  {
+    double result = call_projectPt2Line_on_device(pt, lStart, lEnd);
+
+    const double expectedResult = 0.16666667;
+    EXPECT_NEAR(expectedResult, result, 1.e-6);
+  }
+}
+
+TEST(FSI, projectPt2Line) { test_projectPt2Line(); }
+
+double
+call_perpProjectDist_Pt2Line_on_device(
+  const sierra::nalu::Point& pt,
+  const sierra::nalu::Point& lStart,
+  const sierra::nalu::Point& lEnd)
+{
+  double result = 0;
+  Kokkos::parallel_reduce(
+    sierra::nalu::DeviceRangePolicy(0, 1),
+    KOKKOS_LAMBDA(const unsigned& i, double& localResult) {
+      localResult = sierra::nalu::perpProjectDist_Pt2Line(pt, lStart, lEnd);
+    },
+    result);
+
+  return result;
+}
+
+void
+test_perpProjectDist_Pt2Line()
+{
+  sierra::nalu::Point pt(0.5, 0.5, 0.5);
+  sierra::nalu::Point lStart(0.0, 0.0, 0.0);
+  sierra::nalu::Point lEnd(1.0, 1.0, 1.0);
+
+  {
+    double result = call_perpProjectDist_Pt2Line_on_device(pt, lStart, lEnd);
+
+    const double expectedResult = 0.0;
+    EXPECT_NEAR(expectedResult, result, 1.e-12);
+  }
+
+  pt = sierra::nalu::Point(0.0, 0.0, 0.5);
+
+  {
+    double result = call_perpProjectDist_Pt2Line_on_device(pt, lStart, lEnd);
+
+    const double expectedResult = 0.23570226;
+    EXPECT_NEAR(expectedResult, result, 1.e-6);
+  }
+}
+
+TEST(FSI, perpProjectDist_Pt2Line) { test_perpProjectDist_Pt2Line(); }
+
+} // namespace

--- a/unit_tests/aero/UnitTestPt2Line.C
+++ b/unit_tests/aero/UnitTestPt2Line.C
@@ -9,21 +9,19 @@
 
 #include <gtest/gtest.h>
 #include <KokkosInterface.h>
-#include <aero/fsi/FSIturbine.h>
+#include <aero/aero_utils/Pt2Line.h>
 
 namespace {
 
 double
 call_projectPt2Line_on_device(
-  const sierra::nalu::Point& pt,
-  const sierra::nalu::Point& lStart,
-  const sierra::nalu::Point& lEnd)
+  const vs::Vector& pt, const vs::Vector& lStart, const vs::Vector& lEnd)
 {
   double result = 0;
   Kokkos::parallel_reduce(
     sierra::nalu::DeviceRangePolicy(0, 1),
     KOKKOS_LAMBDA(const unsigned& i, double& localResult) {
-      localResult = sierra::nalu::projectPt2Line(pt, lStart, lEnd);
+      localResult = fsi::projectPt2Line(pt, lStart, lEnd);
     },
     result);
 
@@ -33,9 +31,9 @@ call_projectPt2Line_on_device(
 void
 test_projectPt2Line()
 {
-  sierra::nalu::Point pt(0.5, 0.5, 0.5);
-  sierra::nalu::Point lStart(0.0, 0.0, 0.0);
-  sierra::nalu::Point lEnd(1.0, 1.0, 1.0);
+  vs::Vector pt(0.5, 0.5, 0.5);
+  vs::Vector lStart(0.0, 0.0, 0.0);
+  vs::Vector lEnd(1.0, 1.0, 1.0);
 
   {
     double result = call_projectPt2Line_on_device(pt, lStart, lEnd);
@@ -44,7 +42,7 @@ test_projectPt2Line()
     EXPECT_NEAR(expectedResult, result, 1.e-12);
   }
 
-  pt = sierra::nalu::Point(0.0, 0.0, 0.5);
+  pt = vs::Vector(0.0, 0.0, 0.5);
   {
     double result = call_projectPt2Line_on_device(pt, lStart, lEnd);
 
@@ -53,19 +51,17 @@ test_projectPt2Line()
   }
 }
 
-TEST(FSI, projectPt2Line) { test_projectPt2Line(); }
+TEST(aero_utils, projectPt2Line) { test_projectPt2Line(); }
 
 double
 call_perpProjectDist_Pt2Line_on_device(
-  const sierra::nalu::Point& pt,
-  const sierra::nalu::Point& lStart,
-  const sierra::nalu::Point& lEnd)
+  const vs::Vector& pt, const vs::Vector& lStart, const vs::Vector& lEnd)
 {
   double result = 0;
   Kokkos::parallel_reduce(
     sierra::nalu::DeviceRangePolicy(0, 1),
     KOKKOS_LAMBDA(const unsigned& i, double& localResult) {
-      localResult = sierra::nalu::perpProjectDist_Pt2Line(pt, lStart, lEnd);
+      localResult = fsi::perpProjectDist_Pt2Line(pt, lStart, lEnd);
     },
     result);
 
@@ -75,9 +71,9 @@ call_perpProjectDist_Pt2Line_on_device(
 void
 test_perpProjectDist_Pt2Line()
 {
-  sierra::nalu::Point pt(0.5, 0.5, 0.5);
-  sierra::nalu::Point lStart(0.0, 0.0, 0.0);
-  sierra::nalu::Point lEnd(1.0, 1.0, 1.0);
+  vs::Vector pt(0.5, 0.5, 0.5);
+  vs::Vector lStart(0.0, 0.0, 0.0);
+  vs::Vector lEnd(1.0, 1.0, 1.0);
 
   {
     double result = call_perpProjectDist_Pt2Line_on_device(pt, lStart, lEnd);
@@ -86,7 +82,7 @@ test_perpProjectDist_Pt2Line()
     EXPECT_NEAR(expectedResult, result, 1.e-12);
   }
 
-  pt = sierra::nalu::Point(0.0, 0.0, 0.5);
+  pt = vs::Vector(0.0, 0.0, 0.5);
 
   {
     double result = call_perpProjectDist_Pt2Line_on_device(pt, lStart, lEnd);
@@ -96,6 +92,6 @@ test_perpProjectDist_Pt2Line()
   }
 }
 
-TEST(FSI, perpProjectDist_Pt2Line) { test_perpProjectDist_Pt2Line(); }
+TEST(aero_utils, perpProjectDist_Pt2Line) { test_perpProjectDist_Pt2Line(); }
 
 } // namespace


### PR DESCRIPTION
Also convert perpProjectDist_Pt2Line.

These methods are converted into free-functions instead of class members, since they have no side-effects and don't reference class-member data. Free-functions are also trivial to unit-test.