### PR TITLE
fix floating point issue in lidar staring

### DIFF
--- a/include/wind_energy/LidarPatterns.h
+++ b/include/wind_energy/LidarPatterns.h
@@ -73,7 +73,9 @@ private:
   double determine_current_angle(double periodic_time) const;
   double determine_end_of_forward_phase() const
   {
-    return std::floor(sweep_angle_ / step_delta_angle_ + 1) * stare_time_;
+    const double small = 1e-8;
+    return std::floor(((1 + small) * sweep_angle_) / step_delta_angle_ + 1) *
+           stare_time_;
   }
 
   int periodic_count(double time) const;

--- a/unit_tests/UnitTestScanningLidarPattern.C
+++ b/unit_tests/UnitTestScanningLidarPattern.C
@@ -109,7 +109,7 @@ public:
     "  from_target_part: [unused]                           \n"
     "  type: scanning                                       \n"
     "  scanning_lidar_specifications:                       \n"
-    "    stare_time: 1 #seconds                             \n"
+    "    stare_time: 1.3 #seconds                           \n"
     "    step_delta_angle: 1 #degrees                       \n"
     "    sweep_angle: 20 #degrees                           \n"
     "    reset_time_delta: 1 #second                        \n"
@@ -215,7 +215,7 @@ TEST_F(ScanningLidarFixture, stares)
 TEST_F(ScanningLidarFixture, stares_at_end)
 {
   const auto stare = scan_spec["stare_time"].as<double>();
-  const double final_position_time = 20;
+  const double final_position_time = 20 * stare;
   const double some_time_after = 0.1 * stare + final_position_time;
   for (int d = 0; d < 3; ++d) {
     ASSERT_DOUBLE_EQ(


### PR DESCRIPTION
Could miss staring at the last point if by floating point the `floor` rounded down two perfectly divisible numbers.