### PR TITLE
Fix Cuda compiler warnings.

### DIFF
--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -46,12 +46,10 @@ public:
   KOKKOS_FUNCTION virtual ~MasterElement() {}
 
   template <typename SCALAR, typename SHMEM>
-  inline void
-  shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
+  inline void shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
 
   template <typename SCALAR, typename SHMEM>
-  inline void
-  shifted_shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
+  inline void shifted_shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
 
   KOKKOS_FUNCTION virtual void grad_op(
     const SharedMemView<DoubleType**, DeviceShmem>& /* coords */,

--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -46,11 +46,11 @@ public:
   KOKKOS_FUNCTION virtual ~MasterElement() {}
 
   template <typename SCALAR, typename SHMEM>
-  KOKKOS_INLINE_FUNCTION void
+  inline void
   shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
 
   template <typename SCALAR, typename SHMEM>
-  KOKKOS_INLINE_FUNCTION void
+  inline void
   shifted_shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
 
   KOKKOS_FUNCTION virtual void grad_op(
@@ -338,7 +338,7 @@ MasterElement::shape_fcn<DoubleType, DeviceShmem>(
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION void
+inline void
 MasterElement::shape_fcn<double, HostShmem>(
   SharedMemView<double**, HostShmem>& shpfc)
 {
@@ -354,7 +354,7 @@ MasterElement::shifted_shape_fcn<DoubleType, DeviceShmem>(
 }
 
 template <>
-KOKKOS_INLINE_FUNCTION void
+inline void
 MasterElement::shifted_shape_fcn<double, HostShmem>(
   SharedMemView<double**, HostShmem>& shpfc)
 {

--- a/unit_tests/UnitTestMetricTensor.C
+++ b/unit_tests/UnitTestMetricTensor.C
@@ -62,6 +62,7 @@ calculate_metric_tensor(
 
 using VectorFieldType = stk::mesh::Field<double, stk::mesh::Cartesian>;
 
+#ifndef KOKKOS_ENABLE_GPU
 void
 test_metric_for_topo_2D(stk::topology topo, double tol)
 {
@@ -194,7 +195,7 @@ test_metric_for_topo_3D(stk::topology topo, double tol)
     }
   }
 }
-
+#endif // KOKKOS_ENABLE_GPU
 } // namespace
 
 #ifndef KOKKOS_ENABLE_GPU


### PR DESCRIPTION
By removing the KOKKOS declaration from host only
functions and marking functions inline.