### PR TITLE
add modify_on_device to fix ConductionSolution unit test

### DIFF
--- a/unit_tests/matrix_free/UnitTestConductionSolutionUpdate.C
+++ b/unit_tests/matrix_free/UnitTestConductionSolutionUpdate.C
@@ -128,11 +128,10 @@ copy_tpetra_solution_vector_to_stk_field(
         field(mi, d) = delta_view(tpetra_lid, d);
       }
     });
+  field.modify_on_device();
 }
 
 } // namespace
-
-#ifndef KOKKOS_ENABLE_GPU
 
 TEST_F(ConductionSolutionUpdateFixture, correct_behavior_for_linear_problem)
 {
@@ -171,8 +170,6 @@ TEST_F(ConductionSolutionUpdateFixture, correct_behavior_for_linear_problem)
     }
   }
 }
-
-#endif // KOKKOS_ENABLE_GPU
 
 } // namespace matrix_free
 } // namespace nalu


### PR DESCRIPTION
Test was failing with bad values in device builds -- turns out missing modify meant the data wasn't being synced back to host for the final check.