### PR TITLE
Revert "Fix Cuda compiler warnings."

### DIFF
--- a/include/master_element/MasterElement.h
+++ b/include/master_element/MasterElement.h
@@ -46,10 +46,12 @@ public:
   KOKKOS_FUNCTION virtual ~MasterElement() {}
 
   template <typename SCALAR, typename SHMEM>
-  inline void shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
+  KOKKOS_INLINE_FUNCTION void
+  shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
 
   template <typename SCALAR, typename SHMEM>
-  inline void shifted_shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
+  KOKKOS_INLINE_FUNCTION void
+  shifted_shape_fcn(SharedMemView<SCALAR**, SHMEM>& /* shpfc */);
 
   KOKKOS_FUNCTION virtual void grad_op(
     const SharedMemView<DoubleType**, DeviceShmem>& /* coords */,
@@ -336,7 +338,7 @@ MasterElement::shape_fcn<DoubleType, DeviceShmem>(
 }
 
 template <>
-inline void
+KOKKOS_INLINE_FUNCTION void
 MasterElement::shape_fcn<double, HostShmem>(
   SharedMemView<double**, HostShmem>& shpfc)
 {
@@ -352,7 +354,7 @@ MasterElement::shifted_shape_fcn<DoubleType, DeviceShmem>(
 }
 
 template <>
-inline void
+KOKKOS_INLINE_FUNCTION void
 MasterElement::shifted_shape_fcn<double, HostShmem>(
   SharedMemView<double**, HostShmem>& shpfc)
 {

--- a/unit_tests/UnitTestMetricTensor.C
+++ b/unit_tests/UnitTestMetricTensor.C
@@ -62,7 +62,6 @@ calculate_metric_tensor(
 
 using VectorFieldType = stk::mesh::Field<double, stk::mesh::Cartesian>;
 
-#ifndef KOKKOS_ENABLE_GPU
 void
 test_metric_for_topo_2D(stk::topology topo, double tol)
 {
@@ -195,7 +194,7 @@ test_metric_for_topo_3D(stk::topology topo, double tol)
     }
   }
 }
-#endif // KOKKOS_ENABLE_GPU
+
 } // namespace
 
 #ifndef KOKKOS_ENABLE_GPU


### PR DESCRIPTION
Reverts Exawind/nalu-wind#1145

I think this broke compiling on Crusher, so I'm putting this as a draft in case anyone else can confirm, if we need to revert this.