### PR TITLE
FSI: Remove theta ramp

### DIFF
--- a/include/aero/aero_utils/DeflectionRamping.h
+++ b/include/aero/aero_utils/DeflectionRamping.h
@@ -21,30 +21,6 @@ linear_ramp_span(const double spanLocation, const double zeroRampDistance)
                  (zeroRampDistance - spanLocation) / zeroRampDistance, 0.0);
 }
 
-double KOKKOS_FORCEINLINE_FUNCTION
-linear_ramp_theta(
-  const aero::SixDOF& hub,
-  const vs::Vector& root,
-  const vs::Vector& position,
-  const double rampSpan,
-  const double zeroRampLoc)
-{
-  auto v1 = (root - hub.position_).normalize();
-  auto v2 = (position - hub.position_).normalize();
-
-  // make sure vectors are in the plane of rotation to compute the angle between
-  // them
-  const vs::Vector rotationAxis =
-    wmp::rotate(hub.orientation_, vs::Vector::ihat(), true).normalize();
-  v1 = v1 - vs::project(v1, rotationAxis);
-  v2 = v2 - vs::project(v2, rotationAxis);
-
-  const auto angle = vs::angle(v1, v2);
-
-  return stk::math::min(
-    1.0, stk::math::max(0.0, (zeroRampLoc - angle) / rampSpan));
-}
-
 //! ramp from 0 to 1 to allow turbines to only experience rigid body blade
 //! motion until time == startRamp, then linearly ramp to full bladeDeflections
 //! over the time window startRamp to endRamp

--- a/include/aero/aero_utils/displacements.h
+++ b/include/aero/aero_utils/displacements.h
@@ -13,6 +13,7 @@
 #include "vs/vector.h"
 #include <Kokkos_Macros.hpp>
 #include <aero/aero_utils/WienerMilenkovic.h>
+#include <stk_util/util/ReportHandler.hpp>
 
 namespace aero {
 //! A struct to capture six degrees of freedom with a rotation and translation
@@ -137,6 +138,7 @@ compute_translational_displacements(
 {
   const auto fullDisp =
     compute_translational_displacements(fullDeflections, referencePos, cfdPos);
+
   return stiffDisp + ramp * (fullDisp - stiffDisp);
 }
 

--- a/include/aero/fsi/FSIturbine.h
+++ b/include/aero/fsi/FSIturbine.h
@@ -306,7 +306,6 @@ private:
               // openfast mesh element containing the projection of the tower
               // surface node on to the openfast mesh tower element
   ScalarFieldType* deflectionRamp_;
-  ScalarFieldType* distanceToRoot_;
   ScalarFieldType* dispMapInterp_; // The location of the CFD surface mesh node
                                    // projected along the OpenFAST mesh element
                                    // in non-dimensional [0,1] co-ordinates.

--- a/include/aero/fsi/FSIturbine.h
+++ b/include/aero/fsi/FSIturbine.h
@@ -308,6 +308,7 @@ private:
               // openfast mesh element containing the projection of the tower
               // surface node on to the openfast mesh tower element
   ScalarFieldType* deflectionRamp_;
+  ScalarFieldType* distanceToRoot_;
   ScalarFieldType* dispMapInterp_; // The location of the CFD surface mesh node
                                    // projected along the OpenFAST mesh element
                                    // in non-dimensional [0,1] co-ordinates.

--- a/include/aero/fsi/FSIturbine.h
+++ b/include/aero/fsi/FSIturbine.h
@@ -41,8 +41,6 @@ struct DeflectionRampingParams
 {
   // default parameters would give no ramping
   double spanRampDistance_{1e-5};
-  double zeroRampLocTheta_{180.0};
-  double thetaRampSpan_{10.0};
   double startTimeTemporalRamp_{0.0};
   double endTimeTemporalRamp_{0.0};
 };

--- a/include/edge_kernels/MomentumEdgeSolverAlg.h
+++ b/include/edge_kernels/MomentumEdgeSolverAlg.h
@@ -27,7 +27,6 @@ public:
 
 private:
   unsigned coordinates_{stk::mesh::InvalidOrdinal};
-  unsigned velocityRTM_{stk::mesh::InvalidOrdinal};
   unsigned velocity_{stk::mesh::InvalidOrdinal};
   unsigned dudx_{stk::mesh::InvalidOrdinal};
   unsigned edgeAreaVec_{stk::mesh::InvalidOrdinal};

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -2344,5 +2344,3 @@ fsiTurbine::compute_div_mesh_velocity()
 } // namespace nalu
 
 } // namespace sierra
-
-

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -47,6 +47,7 @@ fsiTurbine::fsiTurbine(int iTurb, const YAML::Node& node)
     loadMap_(NULL),
     dispMap_(NULL),
     deflectionRamp_(NULL),
+    distanceToRoot_(NULL),
     dispMapInterp_(NULL),
     tforceSCS_(NULL)
 {
@@ -188,6 +189,7 @@ fsiTurbine::populateParts(
     stk::mesh::put_field_on_mesh(*dispMap_, *part, 1, nullptr);
     stk::mesh::put_field_on_mesh(*dispMapInterp_, *part, 1, nullptr);
     stk::mesh::put_field_on_mesh(*deflectionRamp_, *part, 1, nullptr);
+    stk::mesh::put_field_on_mesh(*distanceToRoot_, *part, 1, nullptr);
   }
 }
 
@@ -239,6 +241,12 @@ fsiTurbine::setup(std::shared_ptr<stk::mesh::BulkData> bulk)
   if (deflectionRamp_ == NULL)
     deflectionRamp_ = &(meta.declare_field<ScalarFieldType>(
       stk::topology::NODE_RANK, "deflection_ramp"));
+
+  distanceToRoot_ = meta.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "distance_to_root");
+  if (distanceToRoot_ == NULL)
+    distanceToRoot_ = &(meta.declare_field<ScalarFieldType>(
+      stk::topology::NODE_RANK, "distance_to_root"));
 
   dispMap_ =
     meta.get_field<ScalarIntFieldType>(stk::topology::NODE_RANK, "disp_map");
@@ -1760,6 +1768,8 @@ fsiTurbine::mapDisplacements(double time)
           defParams.zeroRampLocTheta_);
 
         *stk::mesh::field_data(*deflectionRamp_, node) = deflectionRamp;
+        *stk::mesh::field_data(*distanceToRoot_, node) =
+          vs::mag(rootPos.position_ - nodePosition);
 
         const aero::SixDOF hubDef(brFSIdata_.hub_def.data());
         // displacements from the hub will match a fully stiff blade's

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -47,7 +47,6 @@ fsiTurbine::fsiTurbine(int iTurb, const YAML::Node& node)
     loadMap_(NULL),
     dispMap_(NULL),
     deflectionRamp_(NULL),
-    distanceToRoot_(NULL),
     dispMapInterp_(NULL),
     tforceSCS_(NULL)
 {
@@ -182,7 +181,6 @@ fsiTurbine::populateParts(
     stk::mesh::put_field_on_mesh(*dispMap_, *part, 1, nullptr);
     stk::mesh::put_field_on_mesh(*dispMapInterp_, *part, 1, nullptr);
     stk::mesh::put_field_on_mesh(*deflectionRamp_, *part, 1, nullptr);
-    stk::mesh::put_field_on_mesh(*distanceToRoot_, *part, 1, nullptr);
   }
 }
 
@@ -234,12 +232,6 @@ fsiTurbine::setup(std::shared_ptr<stk::mesh::BulkData> bulk)
   if (deflectionRamp_ == NULL)
     deflectionRamp_ = &(meta.declare_field<ScalarFieldType>(
       stk::topology::NODE_RANK, "deflection_ramp"));
-
-  distanceToRoot_ = meta.get_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "distance_to_root");
-  if (distanceToRoot_ == NULL)
-    distanceToRoot_ = &(meta.declare_field<ScalarFieldType>(
-      stk::topology::NODE_RANK, "distance_to_root"));
 
   dispMap_ =
     meta.get_field<ScalarIntFieldType>(stk::topology::NODE_RANK, "disp_map");
@@ -2352,3 +2344,5 @@ fsiTurbine::compute_div_mesh_velocity()
 } // namespace nalu
 
 } // namespace sierra
+
+

--- a/src/edge_kernels/MomentumEdgeSolverAlg.C
+++ b/src/edge_kernels/MomentumEdgeSolverAlg.C
@@ -26,9 +26,6 @@ MomentumEdgeSolverAlg::MomentumEdgeSolverAlg(
   const auto& meta = realm.meta_data();
 
   coordinates_ = get_field_ordinal(meta, realm.get_coordinates_name());
-  const std::string vrtmName =
-    realm.does_mesh_move() ? "velocity_rtm" : "velocity";
-  velocityRTM_ = get_field_ordinal(meta, vrtmName);
 
   const std::string velName = "velocity";
   velocity_ = get_field_ordinal(meta, velName, stk::mesh::StateNP1);
@@ -74,7 +71,6 @@ MomentumEdgeSolverAlg::execute()
   // STK stk::mesh::NgpField instances for capture by lambda
   const auto& fieldMgr = realm_.ngp_field_manager();
   const auto coordinates = fieldMgr.get_field<double>(coordinates_);
-  const auto vrtm = fieldMgr.get_field<double>(velocityRTM_);
   const auto vel = fieldMgr.get_field<double>(velocity_);
   const auto dudx = fieldMgr.get_field<double>(dudx_);
   const auto viscosity = fieldMgr.get_field<double>(viscosity_);

--- a/unit_tests/aero/UnitTestDeflectionRamping.C
+++ b/unit_tests/aero/UnitTestDeflectionRamping.C
@@ -34,69 +34,6 @@ TEST(DeflectionRamping, linearRampingAlongSpanOutsideRamp)
   EXPECT_DOUBLE_EQ(expectedRampFactor, calcRampFactor);
 }
 
-TEST(DeflectionRamping, linearRampingAlongThetaInsideRamp)
-{
-  const double theta = utils::radians(110.0);
-  const double rampSpan = utils::radians(20.0);
-  const double thetaZero = utils::radians(120.0);
-  const double goldRampFactor = 0.5;
-
-  const aero::SixDOF hub(vs::Vector::zero(), vs::Vector::ihat());
-  const vs::Vector root(vs::Vector::one());
-  const auto rotation = wmp::create_wm_param(vs::Vector::ihat(), theta);
-
-  const auto pClockWise = wmp::rotate(rotation, root);
-  const auto rampClockWise =
-    fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero);
-  const auto pCClockWise = wmp::rotate(rotation, root, true);
-  const auto rampCClockWise =
-    fsi::linear_ramp_theta(hub, root, pCClockWise, rampSpan, thetaZero);
-  EXPECT_NEAR(goldRampFactor, rampClockWise, 1e-10);
-  EXPECT_NEAR(rampClockWise, rampCClockWise, 1e-10);
-}
-
-TEST(DeflectionRamping, linearRampingAlongThetaPreRamp)
-{
-  const double theta = utils::radians(90.0);
-  const double rampSpan = utils::radians(20.0);
-  const double thetaZero = utils::radians(120.0);
-  const double goldRampFactor = 1.0;
-
-  const aero::SixDOF hub(vs::Vector::zero(), vs::Vector::ihat());
-  const vs::Vector root(vs::Vector::one());
-  const auto rotation = wmp::create_wm_param(vs::Vector::ihat(), theta);
-
-  const auto pClockWise = wmp::rotate(rotation, root);
-  const auto rampClockWise =
-    fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero);
-  const auto pCClockWise = wmp::rotate(rotation, root, true);
-  const auto rampCClockWise =
-    fsi::linear_ramp_theta(hub, root, pCClockWise, rampSpan, thetaZero);
-  EXPECT_DOUBLE_EQ(goldRampFactor, rampClockWise);
-  EXPECT_DOUBLE_EQ(rampClockWise, rampCClockWise);
-}
-
-TEST(DeflectionRamping, linearRampingAlongThetaPostRamp)
-{
-  const double theta = utils::radians(121.0);
-  const double rampSpan = utils::radians(20.0);
-  const double thetaZero = utils::radians(120.0);
-  const double goldRampFactor = 0.0;
-
-  const aero::SixDOF hub(vs::Vector::zero(), vs::Vector::ihat());
-  const vs::Vector root(vs::Vector::one());
-  const auto rotation = wmp::create_wm_param(vs::Vector::ihat(), theta);
-
-  const auto pClockWise = wmp::rotate(rotation, root);
-  const auto rampClockWise =
-    fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero);
-  const auto pCClockWise = wmp::rotate(rotation, root, true);
-  const auto rampCClockWise =
-    fsi::linear_ramp_theta(hub, root, pCClockWise, rampSpan, thetaZero);
-  EXPECT_DOUBLE_EQ(goldRampFactor, rampClockWise);
-  EXPECT_DOUBLE_EQ(rampClockWise, rampCClockWise);
-}
-
 TEST(DeflectionRamping, temporalRampingPhases)
 {
   const double startRamp = 1.0;


### PR DESCRIPTION
The theta ramping we implemented was ill-posed and would occasionally generate nan's when computing the angle between a point and the hub-to-blade-root vector.  Fortunately, it is not required at all anymore since we are using the hub deflections as the base deflection.

This PR removes the theta ramping all together. This allows my surrogate mesh case to run fine.