### PR TITLE
Register more fields in Realm with Manager

### DIFF
--- a/include/FieldDefinitions.h
+++ b/include/FieldDefinitions.h
@@ -9,6 +9,7 @@
 #ifndef FIELDDEFINITIONS_H_
 #define FIELDDEFINITIONS_H_
 #include "FieldTypeDef.h"
+#include <type_traits>
 #include <variant>
 
 namespace sierra {
@@ -30,26 +31,53 @@ using FieldDefTpetraId = FieldDefinition<TpetIDFieldType>;
 using FieldDefLocalId = FieldDefinition<LocalIdFieldType>;
 using FieldDefGlobalId = FieldDefinition<GlobalIdFieldType>;
 using FieldDefHypreId = FieldDefinition<HypreIDFieldType>;
+using FieldDefScalarInt = FieldDefinition<ScalarIntFieldType>;
 
-using FieldDefTypes = std::variant<
-  FieldDefScalar,
-  FieldDefVector,
-  FieldDefGeneric,
-  FieldDefGenericInt,
-  FieldDefTpetraId,
-  FieldDefLocalId,
-  FieldDefGlobalId,
-  FieldDefHypreId>;
+// Type redundancy can occur between HypreId and ScalarInt
+// which will break std::variant
+using FieldDefTypes = std::conditional<
+  std::is_same_v<ScalarIntFieldType, HypreIDFieldType>,
+  std::variant<
+    FieldDefScalar,
+    FieldDefVector,
+    FieldDefGeneric,
+    FieldDefGenericInt,
+    FieldDefTpetraId,
+    FieldDefLocalId,
+    FieldDefGlobalId,
+    FieldDefScalarInt>,
+  std::variant<
+    FieldDefScalar,
+    FieldDefVector,
+    FieldDefGeneric,
+    FieldDefGenericInt,
+    FieldDefTpetraId,
+    FieldDefLocalId,
+    FieldDefGlobalId,
+    FieldDefScalarInt,
+    FieldDefHypreId>>::type;
 
-using FieldPointerTypes = std::variant<
-  ScalarFieldType*,
-  VectorFieldType*,
-  GenericFieldType*,
-  GenericIntFieldType*,
-  TpetIDFieldType*,
-  LocalIdFieldType*,
-  GlobalIdFieldType*,
-  HypreIDFieldType*>;
+using FieldPointerTypes = std::conditional<
+  std::is_same_v<ScalarIntFieldType, HypreIDFieldType>,
+  std::variant<
+    ScalarFieldType*,
+    VectorFieldType*,
+    GenericFieldType*,
+    GenericIntFieldType*,
+    TpetIDFieldType*,
+    LocalIdFieldType*,
+    GlobalIdFieldType*,
+    ScalarIntFieldType*>,
+  std::variant<
+    ScalarFieldType*,
+    VectorFieldType*,
+    GenericFieldType*,
+    GenericIntFieldType*,
+    TpetIDFieldType*,
+    LocalIdFieldType*,
+    GlobalIdFieldType*,
+    ScalarIntFieldType*,
+    HypreIDFieldType*>>::type;
 
 } // namespace nalu
 } // namespace sierra

--- a/include/FieldDefinitions.h
+++ b/include/FieldDefinitions.h
@@ -21,6 +21,7 @@ struct FieldDefinition
   using FieldType = T;
   const stk::topology::rank_t rank;
   const int num_states{1};
+  const int num_components{1};
 };
 
 using FieldDefScalar = FieldDefinition<ScalarFieldType>;

--- a/include/FieldManager.h
+++ b/include/FieldManager.h
@@ -27,6 +27,7 @@ class FieldManager
 private:
   stk::mesh::MetaData& meta_;
   const int numStates_;
+  const int numDimensions_;
 
 public:
   FieldManager(stk::mesh::MetaData& meta, int numStates);
@@ -40,7 +41,7 @@ public:
   template <typename T>
   T get_field_ptr(std::string name)
   {
-    auto fieldDef = FieldRegistry::query(numStates_, name);
+    auto fieldDef = FieldRegistry::query(numDimensions_, numStates_, name);
     auto pointerSet = std::visit(
       [&](auto def) -> FieldPointerTypes {
         return meta_.get_field<typename decltype(def)::FieldType>(

--- a/include/FieldRegistry.h
+++ b/include/FieldRegistry.h
@@ -61,7 +61,9 @@ public:
       break;
     }
     default:
-      throw std::runtime_error("Only 2 and 3 spatial dimensions are supported. Dim Given was "+std::to_string(numDim));
+      throw std::runtime_error(
+        "Only 2 and 3 spatial dimensions are supported. Dim Given was " +
+        std::to_string(numDim));
     }
 
     auto fieldDefIter = db->find(name);

--- a/include/FieldRegistry.h
+++ b/include/FieldRegistry.h
@@ -24,22 +24,44 @@ namespace nalu {
 class FieldRegistry
 {
 public:
-  static FieldDefTypes query(int numStates, std::string name)
+  static FieldDefTypes query(int numDim, int numStates, std::string name)
   {
     static FieldRegistry instance;
     const std::map<std::string, FieldDefTypes>* db;
 
-    switch (numStates) {
+    switch (numDim) {
     case 2: {
-      db = &(instance.database_2_state_);
+      switch (numStates) {
+      case 2: {
+        db = &(instance.database_2D_2_state_);
+        break;
+      }
+      case 3: {
+        db = &(instance.database_2D_3_state_);
+        break;
+      }
+      default:
+        throw std::runtime_error("Unsupported number of reference states");
+      }
       break;
     }
     case 3: {
-      db = &(instance.database_3_state_);
+      switch (numStates) {
+      case 2: {
+        db = &(instance.database_3D_2_state_);
+        break;
+      }
+      case 3: {
+        db = &(instance.database_3D_3_state_);
+        break;
+      }
+      default:
+        throw std::runtime_error("Unsupported number of reference states");
+      }
       break;
     }
     default:
-      throw std::runtime_error("Unsupported number of reference states");
+      throw std::runtime_error("Only 2 and 3 spatial dimensions are supported. Dim Given was "+std::to_string(numDim));
     }
 
     auto fieldDefIter = db->find(name);
@@ -57,13 +79,14 @@ public:
 
 private:
   FieldRegistry();
-  // Inorder to accomodate and embed the state information we ended up creating
-  // two separate databases that are templated on the number of states required
-  // by the time integration scheme
-  // This was done to preserve the singelton/refernce lookup only behavior of
-  // the FieldRegistry
-  const std::map<std::string, FieldDefTypes>& database_2_state_;
-  const std::map<std::string, FieldDefTypes>& database_3_state_;
+  // Inorder to accomodate and embed the state and dimenstion information we
+  // ended up creating four separate databases that are templated on the number
+  // of states required by the time integration scheme This was done to preserve
+  // the singelton/refernce lookup only behavior of the FieldRegistry
+  const std::map<std::string, FieldDefTypes>& database_2D_2_state_;
+  const std::map<std::string, FieldDefTypes>& database_2D_3_state_;
+  const std::map<std::string, FieldDefTypes>& database_3D_2_state_;
+  const std::map<std::string, FieldDefTypes>& database_3D_3_state_;
 };
 
 } // namespace nalu

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -17,6 +17,7 @@
 #include <InitialConditions.h>
 #include <MaterialPropertys.h>
 #include <EquationSystems.h>
+#include <FieldManager.h>
 
 #if defined(NALU_USES_PERCEPT)
 #include <Teuchos_RCP.hpp>

--- a/src/FieldRegistry.C
+++ b/src/FieldRegistry.C
@@ -16,16 +16,16 @@ namespace nalu {
 
 // Registry object is where all the fully quantified field definitions live
 // This is the starting point for adding a new field
-template <int NUM_STATES>
+template <int NUM_DIM, int NUM_STATES>
 const std::map<std::string, FieldDefTypes>&
 Registry()
 {
-
-  FieldDefVector MultiStateNodalVector = {stk::topology::NODE_RANK, NUM_STATES};
+  // clang-format off
+  FieldDefVector MultiStateNodalVector = {stk::topology::NODE_RANK, NUM_STATES, NUM_DIM};
   FieldDefScalar MultiStateNodalScalar = {stk::topology::NODE_RANK, NUM_STATES};
 
-  FieldDefVector SingleStateNodalVector = {stk::topology::NODE_RANK};
-  FieldDefVector SingleStateEdgeVector = {stk::topology::EDGE_RANK};
+  FieldDefVector SingleStateNodalVector = {stk::topology::NODE_RANK, 1, NUM_DIM};
+  FieldDefVector SingleStateEdgeVector = {stk::topology::EDGE_RANK, 1, NUM_DIM};
   FieldDefScalar SingleStateNodalScalar = {stk::topology::NODE_RANK};
   FieldDefScalar SingleStateElemScalar = {stk::topology::ELEM_RANK};
 
@@ -34,7 +34,6 @@ Registry()
   FieldDefHypreId HypreId = {stk::topology::NODE_RANK};
   FieldDefScalarInt NodalScalarInt = {stk::topology::NODE_RANK};
 
-  // clang-format off
   static const std::map<std::string, FieldDefTypes> registry = {
     {"velocity", MultiStateNodalVector},
     {"temperature", MultiStateNodalScalar},
@@ -56,7 +55,10 @@ Registry()
 }
 
 FieldRegistry::FieldRegistry()
-  : database_2_state_(Registry<2>()), database_3_state_(Registry<3>())
+  : database_2D_2_state_(Registry<2, 2>()),
+    database_2D_3_state_(Registry<2, 3>()),
+    database_3D_2_state_(Registry<3, 2>()),
+    database_3D_3_state_(Registry<3, 3>())
 {
 }
 

--- a/src/FieldRegistry.C
+++ b/src/FieldRegistry.C
@@ -25,11 +25,14 @@ Registry()
   FieldDefScalar MultiStateNodalScalar = {stk::topology::NODE_RANK, NUM_STATES};
 
   FieldDefVector SingleStateNodalVector = {stk::topology::NODE_RANK};
+  FieldDefVector SingleStateEdgeVector = {stk::topology::EDGE_RANK};
   FieldDefScalar SingleStateNodalScalar = {stk::topology::NODE_RANK};
+  FieldDefScalar SingleStateElemScalar = {stk::topology::ELEM_RANK};
 
   FieldDefTpetraId TpetraId = {stk::topology::NODE_RANK};
   FieldDefGlobalId GlobalId = {stk::topology::NODE_RANK};
   FieldDefHypreId HypreId = {stk::topology::NODE_RANK};
+  FieldDefScalarInt NodalScalarInt = {stk::topology::NODE_RANK};
 
   // clang-format off
   static const std::map<std::string, FieldDefTypes> registry = {
@@ -38,6 +41,15 @@ Registry()
     {"hypre_global_id", HypreId},
     {"tpet_global_id", TpetraId},
     {"nalu_global_id", GlobalId},
+    {"dual_nodal_volume", MultiStateNodalScalar},
+    {"element_volume", SingleStateElemScalar},
+    {"edge_area_vector", SingleStateEdgeVector},
+    {"mesh_displacement", MultiStateNodalVector},
+    {"current_coordinates", SingleStateNodalVector},
+    {"mesh_velocity", SingleStateNodalVector},
+    {"velocity_rtm", SingleStateNodalVector},
+    {"div_mesh_velocity", SingleStateNodalScalar},
+    {"iblank", NodalScalarInt}
   };
   // clang-format on
   return registry;

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -920,6 +920,9 @@ Realm::parent() const
 void
 Realm::setup_nodal_fields()
 {
+  if (!fieldManager_) {
+    setup_field_manager();
+  }
 #ifdef NALU_USES_HYPRE
   fieldManager_->register_field("hypre_global_id", meta_data().get_parts());
   hypreGlobalId_ =
@@ -2707,12 +2710,13 @@ Realm::compute_l2_scaling()
 void
 Realm::register_nodal_fields(stk::mesh::Part* part)
 {
+  if (!fieldManager_) {
+    setup_field_manager();
+  }
   // register high level common fields
   // Declare volume/area_vector fields
   fieldManager_->register_field("dual_nodal_volume", *part);
   fieldManager_->register_field("element_volume", *part);
-  if (does_mesh_move())
-    augment_restart_variable_list("dual_nodal_volume");
 
   if (realmUsesEdges_) {
     fieldManager_->register_field("edge_area_vector", *part);
@@ -2720,6 +2724,7 @@ Realm::register_nodal_fields(stk::mesh::Part* part)
 
   // mesh motion/deformation is high level
   if (does_mesh_move()) {
+    augment_restart_variable_list("dual_nodal_volume");
     fieldManager_->register_field("mesh_displacement", *part);
     fieldManager_->register_field("current_coordinates", *part);
     fieldManager_->register_field("mesh_velocity", *part);

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2708,50 +2708,29 @@ void
 Realm::register_nodal_fields(stk::mesh::Part* part)
 {
   // register high level common fields
-  const int nDim = meta_data().spatial_dimension();
-
   // Declare volume/area_vector fields
-  const int numVolStates = does_mesh_move() ? number_of_states() : 1;
-  auto& dualNodalVol = meta_data().declare_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates);
-  stk::mesh::put_field_on_mesh(dualNodalVol, *part, 1, nullptr);
-  if (numVolStates > 1)
+  fieldManager_->register_field("dual_nodal_volume", *part);
+  fieldManager_->register_field("element_volume", *part);
+  if (does_mesh_move())
     augment_restart_variable_list("dual_nodal_volume");
-  auto& elemVol = meta_data().declare_field<ScalarFieldType>(
-    stk::topology::ELEM_RANK, "element_volume");
-  stk::mesh::put_field_on_mesh(elemVol, *part, 1, nullptr);
 
   if (realmUsesEdges_) {
-    auto& edgeAreaVec = meta_data().declare_field<VectorFieldType>(
-      stk::topology::EDGE_RANK, "edge_area_vector");
-    stk::mesh::put_field_on_mesh(
-      edgeAreaVec, *part, meta_data().spatial_dimension(), nullptr);
+    fieldManager_->register_field("edge_area_vector", *part);
   }
 
   // mesh motion/deformation is high level
-  // clang-format off
-  if ( does_mesh_move()) {
-    VectorFieldType *displacement = &(meta_data().declare_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_displacement",numVolStates));
-    stk::mesh::put_field_on_mesh(*displacement, *part, nDim, nullptr);
-    augment_restart_variable_list("mesh_displacement");
-    VectorFieldType *currentCoords = &(meta_data().declare_field<VectorFieldType>(stk::topology::NODE_RANK, "current_coordinates"));
-    stk::mesh::put_field_on_mesh(*currentCoords, *part, nDim, nullptr);
-    augment_restart_variable_list("current_coordinates");
-    VectorFieldType *meshVelocity = &(meta_data().declare_field<VectorFieldType>(stk::topology::NODE_RANK, "mesh_velocity"));
-    stk::mesh::put_field_on_mesh(*meshVelocity, *part, nDim, nullptr);
-    augment_restart_variable_list("mesh_velocity");
-    VectorFieldType *velocityRTM = &(meta_data().declare_field<VectorFieldType>(stk::topology::NODE_RANK, "velocity_rtm"));
-    stk::mesh::put_field_on_mesh(*velocityRTM, *part, nDim, nullptr);
-    if(has_mesh_deformation()){
-      ScalarFieldType *divV = &(meta_data().declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "div_mesh_velocity"));
-      stk::mesh::put_field_on_mesh(*divV, *part, nullptr);
+  if (does_mesh_move()) {
+    fieldManager_->register_field("mesh_displacement", *part);
+    fieldManager_->register_field("current_coordinates", *part);
+    fieldManager_->register_field("mesh_velocity", *part);
+    fieldManager_->register_field("velocity_rtm", *part);
+    fieldManager_->register_field("div_mesh_velocity", *part);
+    if (has_mesh_deformation()) {
+      fieldManager_->register_field("div_mesh_velocity", *part);
     }
   }
-  // clang-format on
 
-  ScalarIntFieldType& iblank = meta_data().declare_field<ScalarIntFieldType>(
-    stk::topology::NODE_RANK, "iblank");
-  stk::mesh::put_field_on_mesh(iblank, *part, nullptr);
+  fieldManager_->register_field("iblank", *part);
 }
 
 //--------------------------------------------------------------------------

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2715,7 +2715,14 @@ Realm::register_nodal_fields(stk::mesh::Part* part)
   }
   // register high level common fields
   // Declare volume/area_vector fields
-  fieldManager_->register_field("dual_nodal_volume", *part);
+  const int numVolStates = does_mesh_move() ? number_of_states() : 1;
+  auto& dualNodalVol = meta_data().declare_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates);
+  stk::mesh::put_field_on_mesh(dualNodalVol, *part, 1, nullptr);
+  // TODO(psakiev)           ^
+  //               Turn this | into this |
+  //                                     v
+  // fieldManager_->register_field("dual_nodal_volume", *part);
   fieldManager_->register_field("element_volume", *part);
 
   if (realmUsesEdges_) {

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2724,7 +2724,6 @@ Realm::register_nodal_fields(stk::mesh::Part* part)
 
   // mesh motion/deformation is high level
   if (does_mesh_move()) {
-    augment_restart_variable_list("dual_nodal_volume");
     fieldManager_->register_field("mesh_displacement", *part);
     fieldManager_->register_field("current_coordinates", *part);
     fieldManager_->register_field("mesh_velocity", *part);
@@ -2733,6 +2732,10 @@ Realm::register_nodal_fields(stk::mesh::Part* part)
     if (has_mesh_deformation()) {
       fieldManager_->register_field("div_mesh_velocity", *part);
     }
+    augment_restart_variable_list("dual_nodal_volume");
+    augment_restart_variable_list("mesh_displacement");
+    augment_restart_variable_list("current_coordinates");
+    augment_restart_variable_list("mesh_velocity");
   }
 
   fieldManager_->register_field("iblank", *part);

--- a/unit_tests/UnitTestFieldManager.C
+++ b/unit_tests/UnitTestFieldManager.C
@@ -23,6 +23,7 @@ protected:
   void SetUp()
   {
     stk::mesh::MeshBuilder builder(MPI_COMM_WORLD);
+    builder.set_spatial_dimension(3);
     meta_ = builder.create_meta_data();
     key_ = "velocity";
   }

--- a/unit_tests/UnitTestFieldRegistry.C
+++ b/unit_tests/UnitTestFieldRegistry.C
@@ -33,7 +33,8 @@ protected:
 TEST_F(FieldRegistryTest, allDataNeededToDeclareFieldIsKnownThroughQuery)
 {
   const int num_states = 2;
-  auto def = FieldRegistry::query(num_states, key_);
+  const int num_dims = 3;
+  auto def = FieldRegistry::query(num_dims, num_states, key_);
 
   ASSERT_NO_THROW(std::visit(
     [&](auto arg) {
@@ -51,7 +52,8 @@ TEST_F(FieldRegistryTest, allDataNeededToDeclareFieldIsKnownThroughQuery)
 TEST_F(FieldRegistryTest, registeredFieldPointerCanBeStored)
 {
   const int num_states = 3;
-  auto def = FieldRegistry::query(num_states, key_);
+  const int num_dims = 3;
+  auto def = FieldRegistry::query(num_dims, num_states, key_);
   std::vector<FieldPointerTypes> field_pointers;
 
   EXPECT_EQ(0, field_pointers.size());

--- a/unit_tests/mesh_motion/UnitTestCompositeFrames.C
+++ b/unit_tests/mesh_motion/UnitTestCompositeFrames.C
@@ -208,8 +208,10 @@ TEST(meshMotion, NGP_initialize)
   meshMotionAlg->initialize(currTime);
 
   // get fields to be tested
-  auto* currCoords = realm.fieldManager_->get_field_ptr<VectorFieldType*>("current_coordinates");
-  auto* meshVelocity = realm.fieldManager_->get_field_ptr<VectorFieldType*>( "mesh_velocity");
+  auto* currCoords =
+    realm.fieldManager_->get_field_ptr<VectorFieldType*>("current_coordinates");
+  auto* meshVelocity =
+    realm.fieldManager_->get_field_ptr<VectorFieldType*>("mesh_velocity");
 
   // sync coordinates to host
   currCoords->sync_to_host();

--- a/unit_tests/mesh_motion/UnitTestCompositeFrames.C
+++ b/unit_tests/mesh_motion/UnitTestCompositeFrames.C
@@ -208,10 +208,8 @@ TEST(meshMotion, NGP_initialize)
   meshMotionAlg->initialize(currTime);
 
   // get fields to be tested
-  VectorFieldType* currCoords = realm.meta_data().get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "current_coordinates");
-  VectorFieldType* meshVelocity = realm.meta_data().get_field<VectorFieldType>(
-    stk::topology::NODE_RANK, "mesh_velocity");
+  auto* currCoords = realm.fieldManager_->get_field_ptr<VectorFieldType*>("current_coordinates");
+  auto* meshVelocity = realm.fieldManager_->get_field_ptr<VectorFieldType*>( "mesh_velocity");
 
   // sync coordinates to host
   currCoords->sync_to_host();


### PR DESCRIPTION
The original intent of this PR:

Move more of the fields to use FieldManager.
Many of these can be deleted from Realm in future PR's as we start registering fields in the algorithms where they are used

One change here is that dual nodal volume always has 3 states instead of conditionally having 3 states as in the past. I can explore adding this kind of functionality into the field manager (pretty sure I can do this very quickly), but I think there is value in not having runtime dynamic states for specific fields.  I think it would be best to treat these things uniformly and find other methods to achieve the end goal. 

I'm torn about this, but we should decide what to do before merging this. @gantech this will affect how we do GCL stuff. Right now the switch is on the number of stated for the `dual_nodal_volume` field.  I think we could just switch on if we have mesh deformation enabled though.

Things that have been added since to get all the unit tests passing:
1) In adding these fields I realized I'd made a mistake and mixed the states with components in the field assignments.  So another dimension was added to our FieldRegistry database to account for variations in spatial dimensions along with temporal states.
2) Hypre_int types are equivalent to ScalarInt Types for many of our builds.  If you try to put two equivalent types inside a `std::variant` it will fail to compile. So some meta logic was added to deduce if we have equivalent types and to reduce the size of the `std::variant` we are creating to hold our different field types. 