### PR TITLE
FieldManager: Improve interface to various field states

### DIFF
--- a/include/FieldManager.h
+++ b/include/FieldManager.h
@@ -33,11 +33,11 @@ private:
 public:
   FieldManager(stk::mesh::MetaData& meta, int numStates);
 
-  FieldPointerTypes
-  register_field(std::string name, const stk::mesh::PartVector& parts);
+  FieldPointerTypes register_field(
+    std::string name, const stk::mesh::PartVector& parts, int numStates = 0);
 
-  FieldPointerTypes
-  register_field(std::string name, const stk::mesh::Part& part);
+  FieldPointerTypes register_field(
+    std::string name, const stk::mesh::Part& part, int numStates = 0);
 
   template <typename T>
   T get_field_ptr(
@@ -48,8 +48,8 @@ public:
     auto pointerSet = std::visit(
       [&](auto def) -> FieldPointerTypes {
         return &meta_
-          .get_field<typename decltype(def)::FieldType>(def.rank, name)
-          ->field_of_state(state);
+                  .get_field<typename decltype(def)::FieldType>(def.rank, name)
+                  ->field_of_state(state);
       },
       fieldDef);
     return std::get<T>(pointerSet);

--- a/include/FieldManager.h
+++ b/include/FieldManager.h
@@ -11,6 +11,7 @@
 #define FIELDMANAGER_H_
 
 #include "FieldRegistry.h"
+#include <stk_mesh/base/FieldState.hpp>
 #include <string>
 
 namespace stk {
@@ -39,13 +40,16 @@ public:
   register_field(std::string name, const stk::mesh::Part& part);
 
   template <typename T>
-  T get_field_ptr(std::string name)
+  T get_field_ptr(
+    std::string name,
+    stk::mesh::FieldState state = stk::mesh::FieldState::StateNone)
   {
     auto fieldDef = FieldRegistry::query(numDimensions_, numStates_, name);
     auto pointerSet = std::visit(
       [&](auto def) -> FieldPointerTypes {
-        return meta_.get_field<typename decltype(def)::FieldType>(
-          def.rank, name);
+        return &meta_
+          .get_field<typename decltype(def)::FieldType>(def.rank, name)
+          ->field_of_state(state);
       },
       fieldDef);
     return std::get<T>(pointerSet);

--- a/src/FieldManager.C
+++ b/src/FieldManager.C
@@ -51,7 +51,8 @@ FieldManager::register_field(
 }
 
 FieldPointerTypes
-FieldManager::register_field(std::string name, const stk::mesh::Part& part, int numStates)
+FieldManager::register_field(
+  std::string name, const stk::mesh::Part& part, int numStates)
 {
   auto definition = FieldRegistry::query(numDimensions_, numStates_, name);
 

--- a/src/FieldManager.C
+++ b/src/FieldManager.C
@@ -32,14 +32,14 @@ FieldManager::field_exists(std::string name)
 
 FieldPointerTypes
 FieldManager::register_field(
-  std::string name, const stk::mesh::PartVector& parts)
+  std::string name, const stk::mesh::PartVector& parts, int numStates)
 {
   auto definition = FieldRegistry::query(numDimensions_, numStates_, name);
 
   return std::visit(
     [&](auto def) -> FieldPointerTypes {
       auto* id = &(meta_.declare_field<typename decltype(def)::FieldType>(
-        def.rank, name, def.num_states));
+        def.rank, name, numStates ? numStates : def.num_states));
 
       for (auto&& part : parts) {
         stk::mesh::put_field_on_mesh(*id, *part, def.num_components, nullptr);
@@ -51,14 +51,14 @@ FieldManager::register_field(
 }
 
 FieldPointerTypes
-FieldManager::register_field(std::string name, const stk::mesh::Part& part)
+FieldManager::register_field(std::string name, const stk::mesh::Part& part, int numStates)
 {
   auto definition = FieldRegistry::query(numDimensions_, numStates_, name);
 
   return std::visit(
     [&](auto def) -> FieldPointerTypes {
       auto* id = &(meta_.declare_field<typename decltype(def)::FieldType>(
-        def.rank, name, def.num_states));
+        def.rank, name, numStates ? numStates : def.num_states));
 
       stk::mesh::put_field_on_mesh(*id, part, def.num_components, nullptr);
 

--- a/src/FieldRegistry.C
+++ b/src/FieldRegistry.C
@@ -40,7 +40,7 @@ Registry()
     {"hypre_global_id", HypreId},
     {"tpet_global_id", TpetraId},
     {"nalu_global_id", GlobalId},
-    {"dual_nodal_volume", MultiStateNodalScalar},
+    {"dual_nodal_volume", SingleStateNodalScalar},
     {"element_volume", SingleStateElemScalar},
     {"edge_area_vector", SingleStateEdgeVector},
     {"mesh_displacement", MultiStateNodalVector},

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2716,13 +2716,7 @@ Realm::register_nodal_fields(stk::mesh::Part* part)
   // register high level common fields
   // Declare volume/area_vector fields
   const int numVolStates = does_mesh_move() ? number_of_states() : 1;
-  auto& dualNodalVol = meta_data().declare_field<ScalarFieldType>(
-    stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates);
-  stk::mesh::put_field_on_mesh(dualNodalVol, *part, 1, nullptr);
-  // TODO(psakiev)           ^
-  //               Turn this | into this |
-  //                                     v
-  // fieldManager_->register_field("dual_nodal_volume", *part);
+  fieldManager_->register_field("dual_nodal_volume", *part, numVolStates);
   fieldManager_->register_field("element_volume", *part);
 
   if (realmUsesEdges_) {

--- a/unit_tests/UnitTestFieldManager.C
+++ b/unit_tests/UnitTestFieldManager.C
@@ -109,6 +109,17 @@ TEST_F(FieldManagerTest, fieldStateCanBeSelected)
   EXPECT_TRUE(np1 != n);
   EXPECT_TRUE(np1 != nm1);
 }
+
+TEST_F(FieldManagerTest, numStatesCanBeChangedAtRegistration){
+const std::string name = "dual_nodal_volume";
+const int numStates = 3;
+
+FieldManager fm(meta(), numStates);
+fm.register_field(name, meta().universal_part(), numStates);
+auto field = fm.get_field_ptr<ScalarFieldType*>(name);
+ASSERT_TRUE(field != nullptr);
+EXPECT_EQ(numStates, field->number_of_states());
+}
 } // namespace
 } // namespace nalu
 } // namespace sierra

--- a/unit_tests/UnitTestFieldManager.C
+++ b/unit_tests/UnitTestFieldManager.C
@@ -104,21 +104,22 @@ TEST_F(FieldManagerTest, fieldStateCanBeSelected)
   const auto nm1 = fm.get_field_ptr<VectorFieldType*>(name, stk::mesh::StateNM1);
   // clang-format on
   EXPECT_TRUE(np1 != nullptr);
-  EXPECT_TRUE(n!= nullptr);
+  EXPECT_TRUE(n != nullptr);
   EXPECT_TRUE(nm1 != nullptr);
   EXPECT_TRUE(np1 != n);
   EXPECT_TRUE(np1 != nm1);
 }
 
-TEST_F(FieldManagerTest, numStatesCanBeChangedAtRegistration){
-const std::string name = "dual_nodal_volume";
-const int numStates = 3;
+TEST_F(FieldManagerTest, numStatesCanBeChangedAtRegistration)
+{
+  const std::string name = "dual_nodal_volume";
+  const int numStates = 3;
 
-FieldManager fm(meta(), numStates);
-fm.register_field(name, meta().universal_part(), numStates);
-auto field = fm.get_field_ptr<ScalarFieldType*>(name);
-ASSERT_TRUE(field != nullptr);
-EXPECT_EQ(numStates, field->number_of_states());
+  FieldManager fm(meta(), numStates);
+  fm.register_field(name, meta().universal_part(), numStates);
+  auto field = fm.get_field_ptr<ScalarFieldType*>(name);
+  ASSERT_TRUE(field != nullptr);
+  EXPECT_EQ(numStates, field->number_of_states());
 }
 } // namespace
 } // namespace nalu

--- a/unit_tests/UnitTestFieldManager.C
+++ b/unit_tests/UnitTestFieldManager.C
@@ -91,6 +91,24 @@ TEST_F(FieldManagerTest, undefinedFieldCantBeRegistered)
   EXPECT_THROW(
     fm.register_field(name, meta().universal_part()), std::runtime_error);
 }
+
+TEST_F(FieldManagerTest, fieldStateCanBeSelected)
+{
+  const std::string name = "velocity";
+  const int numStates = 3;
+  FieldManager fm(meta(), numStates);
+  fm.register_field(name, meta().universal_part());
+  // clang-format off
+  const auto np1 = fm.get_field_ptr<VectorFieldType*>(name, stk::mesh::StateNP1);
+  const auto n =   fm.get_field_ptr<VectorFieldType*>(name, stk::mesh::StateN);
+  const auto nm1 = fm.get_field_ptr<VectorFieldType*>(name, stk::mesh::StateNM1);
+  // clang-format on
+  EXPECT_TRUE(np1 != nullptr);
+  EXPECT_TRUE(n!= nullptr);
+  EXPECT_TRUE(nm1 != nullptr);
+  EXPECT_TRUE(np1 != n);
+  EXPECT_TRUE(np1 != nm1);
+}
 } // namespace
 } // namespace nalu
 } // namespace sierra


### PR DESCRIPTION
This PR allows users to register a field and set the number of states at registration time. This will override what is in the registry for the field description.

An ability to get the specific field state is also added to `FieldManager::get_field_ptr`