### PR TITLE
MixtureFractionKernel test only runs on host

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -61,6 +61,7 @@ typedef Kokkos::HostSpace MemSpace;
 
 using HostSpace = Kokkos::DefaultHostExecutionSpace;
 using DeviceSpace = Kokkos::DefaultExecutionSpace;
+static constexpr bool isHostBuild = std::is_same_v<HostSpace, DeviceSpace>;
 
 using LinSysMemSpace = DeviceSpace::memory_space;
 

--- a/unit_tests/kernels/UnitTestScalarOpenElem.C
+++ b/unit_tests/kernels/UnitTestScalarOpenElem.C
@@ -13,7 +13,6 @@
 
 #include "kernel/ScalarOpenAdvElemKernel.h"
 
-#if !defined(KOKKOS_ENABLE_GPU)
 namespace {
 namespace hex8_golds {
 static constexpr double rhs[8] = {
@@ -108,8 +107,10 @@ static constexpr double lhs[8][8] = {
 
 TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
 {
+  if constexpr (!sierra::nalu::isHostBuild)
+    GTEST_SKIP();
   if (bulk_->parallel_size() > 1)
-    return;
+    GTEST_SKIP();
 
   const bool doPerturb = false;
   const bool generateSidesets = true;
@@ -159,4 +160,3 @@ TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
   unit_test_kernel_utils::expect_all_near<8>(
     helperObjs.linsys->lhs_, hex8_golds::lhs, 1.0e-12);
 }
-#endif


### PR DESCRIPTION
The kernel exercised by this test is a host-only kernel, so we do need to skip in device builds.  This change allows the test to continue to build and simply be skipped in device builds, since there's not an obvious way to force it to run on host regardless of build type.