### PR TITLE
FSI: Solve for MeshDeformation

### DIFF
--- a/include/AssembleNodalGradUAlgorithmDriver.h
+++ b/include/AssembleNodalGradUAlgorithmDriver.h
@@ -1,0 +1,35 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef AssembleNodalGradUAlgorithmDriver_h
+#define AssembleNodalGradUAlgorithmDriver_h
+
+#include <AlgorithmDriver.h>
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+class AssembleNodalGradUAlgorithmDriver : public AlgorithmDriver
+{
+public:
+  AssembleNodalGradUAlgorithmDriver(Realm& realm, const std::string dudxName);
+  virtual ~AssembleNodalGradUAlgorithmDriver() {}
+
+  virtual void pre_work();
+  virtual void post_work();
+
+  const std::string dudxName_;
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif

--- a/include/AssembleNodalGradUBoundaryAlgorithm.h
+++ b/include/AssembleNodalGradUBoundaryAlgorithm.h
@@ -1,0 +1,45 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+/*------------------------------------------------------------------------*/
+
+#ifndef AssembleNodalGradUBoundaryAlgorithm_h
+#define AssembleNodalGradUBoundaryAlgorithm_h
+
+#include <Algorithm.h>
+#include <FieldTypeDef.h>
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+class AssembleNodalGradUBoundaryAlgorithm : public Algorithm
+{
+public:
+  AssembleNodalGradUBoundaryAlgorithm(
+    Realm& realm,
+    stk::mesh::Part* part,
+    VectorFieldType* vectorQ,
+    GenericFieldType* dqdx,
+    const bool useShifted);
+  virtual ~AssembleNodalGradUBoundaryAlgorithm() {}
+
+  virtual void execute();
+
+  VectorFieldType* vectorQ_;
+  GenericFieldType* dqdx_;
+
+  const bool useShifted_;
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif

--- a/include/AssembleNodalGradUElemAlgorithm.h
+++ b/include/AssembleNodalGradUElemAlgorithm.h
@@ -1,0 +1,41 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef AssembleNodalGradUElemAlgorithm_h
+#define AssembleNodalGradUElemAlgorithm_h
+
+#include <Algorithm.h>
+#include <FieldTypeDef.h>
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+class AssembleNodalGradUElemAlgorithm : public Algorithm
+{
+public:
+  AssembleNodalGradUElemAlgorithm(
+    Realm& realm,
+    stk::mesh::Part* part,
+    VectorFieldType* velocity,
+    GenericFieldType* dudx,
+    const bool useShifted = false);
+  virtual ~AssembleNodalGradUElemAlgorithm() {}
+
+  virtual void execute();
+
+  VectorFieldType* vectorQ_;
+  GenericFieldType* dqdx_;
+  const bool useShifted_;
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif

--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -58,10 +58,7 @@ public:
 
   inline bool has_mesh_motion() const { return meshMotion_; }
 
-  inline bool has_mesh_deformation() const
-  {
-    return (externalMeshDeformation_ || openfastFSI_);
-  }
+  inline bool has_mesh_deformation() const { return meshDeformation_; }
 
   inline bool does_mesh_move() const
   {
@@ -127,8 +124,7 @@ public:
   TurbulenceModel turbulenceModel_;
   bool meshMotion_;
   bool meshTransformation_;
-  bool externalMeshDeformation_;
-  bool openfastFSI_;
+  bool meshDeformation_;
   bool ncAlgGaussLabatto_;
   bool ncAlgUpwindAdvection_;
   bool ncAlgIncludePstab_;

--- a/include/mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.h
+++ b/include/mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.h
@@ -1,0 +1,50 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef AssembleMeshDisplacementElemSolverAlgorithm_h
+#define AssembleMeshDisplacementElemSolverAlgorithm_h
+
+#include <SolverAlgorithm.h>
+#include <FieldTypeDef.h>
+
+namespace stk {
+namespace mesh {
+class Part;
+}
+} // namespace stk
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+class AssembleMeshDisplacementElemSolverAlgorithm : public SolverAlgorithm
+{
+public:
+  AssembleMeshDisplacementElemSolverAlgorithm(
+    Realm& realm,
+    stk::mesh::Part* part,
+    EquationSystem* eqSystem,
+    const bool deformWrtModelCoords);
+  virtual ~AssembleMeshDisplacementElemSolverAlgorithm() {}
+  virtual void initialize_connectivity();
+  virtual void execute();
+
+  const bool deformWrtModelCoords_;
+  VectorFieldType* meshDisplacement_;
+  VectorFieldType* coordinates_;
+  VectorFieldType* modelCoordinates_;
+  ScalarFieldType* mu_;
+  ScalarFieldType* lambda_;
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif

--- a/include/mesh_motion/MeshDisplacementEquationSystem.h
+++ b/include/mesh_motion/MeshDisplacementEquationSystem.h
@@ -1,0 +1,84 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef MeshDisplacementEquationSystem_h
+#define MeshDisplacementEquationSystem_h
+
+#include <EquationSystem.h>
+#include <FieldTypeDef.h>
+#include <NaluParsedTypes.h>
+
+namespace stk {
+struct topology;
+}
+
+namespace sierra {
+namespace nalu {
+
+class AlgorithmDriver;
+class AssembleNodalGradUAlgorithmDriver;
+class Realm;
+class LinearSystem;
+
+class MeshDisplacementEquationSystem : public EquationSystem
+{
+
+public:
+  MeshDisplacementEquationSystem(
+    EquationSystems& equationSystems,
+    const bool activateMass,
+    const bool deformWrtModelCoords);
+  virtual ~MeshDisplacementEquationSystem();
+
+  void initial_work();
+
+  void register_nodal_fields(stk::mesh::Part* part);
+
+  void
+  register_element_fields(stk::mesh::Part* part, const stk::topology& theTopo);
+
+  void register_interior_algorithm(stk::mesh::Part* part);
+
+  void register_wall_bc(
+    stk::mesh::Part* part,
+    const stk::topology& theTopo,
+    const WallBoundaryConditionData& wallBCData);
+
+  void register_overset_bc();
+
+  void initialize();
+  void reinitialize_linear_system();
+
+  void predict_state();
+  void solve_and_update();
+  void compute_current_coordinates();
+  void compute_div_mesh_velocity();
+
+  const bool activateMass_;
+  const bool deformWrtModelCoords_;
+  bool isInit_;
+  VectorFieldType* meshDisplacement_;
+  VectorFieldType* meshVelocity_;
+  GenericFieldType* dvdx_;
+  ScalarFieldType* divV_;
+  VectorFieldType* coordinates_;
+  VectorFieldType* currentCoordinates_;
+  ScalarFieldType* dualNodalVolume_;
+  ScalarFieldType* density_;
+  ScalarFieldType* lameMu_;
+  ScalarFieldType* lameLambda_;
+  VectorFieldType* dxTmp_;
+
+  AssembleNodalGradUAlgorithmDriver* assembleNodalGradAlgDriver_;
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif

--- a/include/mesh_motion/MeshDisplacementMassBackwardEulerNodeSuppAlg.h
+++ b/include/mesh_motion/MeshDisplacementMassBackwardEulerNodeSuppAlg.h
@@ -1,0 +1,47 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef MeshDisplacementMassBackwardEulerNodeSuppAlg_h
+#define MeshDisplacementMassBackwardEulerNodeSuppAlg_h
+
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+
+#include <stk_mesh/base/Entity.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+class MeshDisplacementMassBackwardEulerNodeSuppAlg
+  : public SupplementalAlgorithm
+{
+public:
+  MeshDisplacementMassBackwardEulerNodeSuppAlg(Realm& realm);
+
+  virtual ~MeshDisplacementMassBackwardEulerNodeSuppAlg() {}
+
+  virtual void setup();
+
+  virtual void node_execute(double* lhs, double* rhs, stk::mesh::Entity node);
+
+  VectorFieldType* displacementN_;
+  VectorFieldType* displacementNp1_;
+  ScalarFieldType* density_;
+  ScalarFieldType* dualNodalVolume_;
+
+  double dt_;
+  int nDim_;
+};
+
+} // namespace nalu
+} // namespace sierra
+
+#endif

--- a/src/AMSAlgDriver.C
+++ b/src/AMSAlgDriver.C
@@ -81,7 +81,7 @@ AMSAlgDriver::register_nodal_fields(stk::mesh::Part* part)
 
   if (
     realm_.solutionOptions_->meshMotion_ ||
-    realm_.solutionOptions_->externalMeshDeformation_) {
+    realm_.solutionOptions_->meshDeformation_) {
     avgVelocityRTM_ = &(meta.declare_field<VectorFieldType>(
       stk::topology::NODE_RANK, "average_velocity_rtm"));
     stk::mesh::put_field_on_mesh(*avgVelocityRTM_, *part, nDim, nullptr);
@@ -297,7 +297,7 @@ AMSAlgDriver::execute()
 
   if (
     realm_.solutionOptions_->meshMotion_ ||
-    realm_.solutionOptions_->externalMeshDeformation_) {
+    realm_.solutionOptions_->meshDeformation_) {
     realm_.compute_vrtm("average_velocity");
   }
   avgMdotAlg_.execute();

--- a/src/AssembleNodalGradUAlgorithmDriver.C
+++ b/src/AssembleNodalGradUAlgorithmDriver.C
@@ -1,0 +1,116 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include <AssembleNodalGradUAlgorithmDriver.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra {
+namespace nalu {
+
+class Realm;
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// AssembleNodalGradUAlgorithmDriver - Drives nodal grad algorithms
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+AssembleNodalGradUAlgorithmDriver::AssembleNodalGradUAlgorithmDriver(
+  Realm& realm, const std::string dudxName)
+  : AlgorithmDriver(realm), dudxName_(dudxName)
+{
+  // does nothing
+}
+
+//--------------------------------------------------------------------------
+//-------- pre_work --------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleNodalGradUAlgorithmDriver::pre_work()
+{
+
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  // extract fields
+  GenericFieldType* dudx =
+    meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, dudxName_);
+
+  // define some common selectors; select all nodes (locally and shared)
+  // where dudx is defined
+  stk::mesh::Selector s_all_nodes =
+    (meta_data.locally_owned_part() | meta_data.globally_shared_part()) &
+    stk::mesh::selectField(*dudx);
+
+  //===========================================================
+  // zero out nodal gradient
+  //===========================================================
+
+  stk::mesh::BucketVector const& node_buckets =
+    realm_.get_buckets(stk::topology::NODE_RANK, s_all_nodes);
+  for (stk::mesh::BucketVector::const_iterator ib = node_buckets.begin();
+       ib != node_buckets.end(); ++ib) {
+    stk::mesh::Bucket& b = **ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+    double* du = stk::mesh::field_data(*dudx, b);
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+      const int offSet = k * nDim * nDim;
+      int counter = 0;
+      for (int i = 0; i < nDim; ++i) {
+        for (int j = 0; j < nDim; ++j) {
+          du[offSet + counter++] = 0.0;
+        }
+      }
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- post_work -------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleNodalGradUAlgorithmDriver::post_work()
+{
+
+  stk::mesh::BulkData& bulk_data = realm_.bulk_data();
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+
+  // extract fields
+  GenericFieldType* dudx =
+    meta_data.get_field<GenericFieldType>(stk::topology::NODE_RANK, dudxName_);
+  stk::mesh::parallel_sum(bulk_data, {dudx});
+
+  if (realm_.hasPeriodic_) {
+    const unsigned nDim = meta_data.spatial_dimension();
+    const unsigned sizeOfField = nDim * nDim;
+    realm_.periodic_field_update(dudx, sizeOfField);
+  }
+
+  if (realm_.hasOverset_) {
+    // this is a tensor
+    const unsigned nDim = meta_data.spatial_dimension();
+    realm_.overset_field_update(dudx, nDim, nDim);
+  }
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/src/AssembleNodalGradUBoundaryAlgorithm.C
+++ b/src/AssembleNodalGradUBoundaryAlgorithm.C
@@ -1,0 +1,184 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+// nalu
+#include <AssembleNodalGradUBoundaryAlgorithm.h>
+#include <Algorithm.h>
+
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <TimeIntegrator.h>
+#include <master_element/MasterElement.h>
+#include "master_element/MasterElementRepo.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra {
+namespace nalu {
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// AssembleNodalGradUBoundaryAlgorithm - adds in boundary contribution
+//                                       for elem/edge proj nodal gradient
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+AssembleNodalGradUBoundaryAlgorithm::AssembleNodalGradUBoundaryAlgorithm(
+  Realm& realm,
+  stk::mesh::Part* part,
+  VectorFieldType* vectorQ,
+  GenericFieldType* dqdx,
+  const bool useShifted)
+  : Algorithm(realm, part),
+    vectorQ_(vectorQ),
+    dqdx_(dqdx),
+    useShifted_(useShifted)
+{
+  // nothing to do
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleNodalGradUBoundaryAlgorithm::execute()
+{
+
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  // extract fields
+  GenericFieldType* exposedAreaVec = meta_data.get_field<GenericFieldType>(
+    meta_data.side_rank(), "exposed_area_vector");
+  ScalarFieldType* dualNodalVolume = meta_data.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "dual_nodal_volume");
+
+  // nodal fields to gather; gather everything other than what we are assembling
+  std::vector<double> ws_vectorQ;
+
+  // geometry related to populate
+  std::vector<double> ws_shape_function;
+
+  // ip data
+  std::vector<double> qIp(nDim);
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union =
+    meta_data.locally_owned_part() & stk::mesh::selectUnion(partVec_);
+
+  stk::mesh::BucketVector const& face_buckets =
+    realm_.get_buckets(meta_data.side_rank(), s_locally_owned_union);
+  for (stk::mesh::BucketVector::const_iterator ib = face_buckets.begin();
+       ib != face_buckets.end(); ++ib) {
+    stk::mesh::Bucket& b = **ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+
+    // extract master element
+    MasterElement* meFC =
+      sierra::nalu::MasterElementRepo::get_surface_master_element_on_host(
+        b.topology());
+
+    // extract master element specifics
+    const int nodesPerFace = meFC->nodesPerElement_;
+    const int numScsIp = meFC->num_integration_points();
+    const int* ipNodeMap = meFC->ipNodeMap();
+
+    // algorithm related
+    ws_vectorQ.resize(nodesPerFace * nDim);
+    ws_shape_function.resize(numScsIp * nodesPerFace);
+
+    // pointers
+    double* p_vectorQ = &ws_vectorQ[0];
+    SharedMemView<double**, HostShmem> p_shape_function(
+      ws_shape_function.data(), numScsIp, nodesPerFace);
+
+    if (useShifted_)
+      meFC->shifted_shape_fcn<>(p_shape_function);
+    else
+      meFC->shape_fcn<>(p_shape_function);
+
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+
+      // face data
+      double* areaVec = stk::mesh::field_data(*exposedAreaVec, b, k);
+
+      //===============================================
+      // gather nodal data; this is how we do it now..
+      //===============================================
+      stk::mesh::Entity const* face_node_rels = b.begin_nodes(k);
+      int num_nodes = b.num_nodes(k);
+
+      // sanity check on num nodes
+      ThrowAssert(num_nodes == nodesPerFace);
+
+      for (int ni = 0; ni < num_nodes; ++ni) {
+        stk::mesh::Entity node = face_node_rels[ni];
+
+        // pointers to real data
+        double* vectorQ = stk::mesh::field_data(*vectorQ_, node);
+
+        // gather vectors
+        const int offSet = ni * nDim;
+        for (int j = 0; j < nDim; ++j) {
+          p_vectorQ[offSet + j] = vectorQ[j];
+        }
+      }
+
+      // start assembly
+      for (int ip = 0; ip < numScsIp; ++ip) {
+
+        // nearest node
+        const int nn = ipNodeMap[ip];
+
+        stk::mesh::Entity nodeNN = face_node_rels[nn];
+
+        // pointer to fields to assemble
+        double* gradQNN = stk::mesh::field_data(*dqdx_, nodeNN);
+
+        // suplemental
+        double volNN = *stk::mesh::field_data(*dualNodalVolume, nodeNN);
+
+        // interpolate to scs point; operate on saved off ws_field
+        for (int j = 0; j < nDim; ++j)
+          qIp[j] = 0.0;
+
+        for (int ic = 0; ic < nodesPerFace; ++ic) {
+          const double r = p_shape_function(ip, ic);
+          for (int j = 0; j < nDim; ++j) {
+            qIp[j] += r * p_vectorQ[ic * nDim + j];
+          }
+        }
+
+        // nearest node volume
+        double inv_volNN = 1.0 / volNN;
+
+        // assemble to nearest node
+        for (int i = 0; i < nDim; ++i) {
+          const int row_gradQ = i * nDim;
+          double qip = qIp[i];
+          for (int j = 0; j < nDim; ++j) {
+            double fac = qip * areaVec[ip * nDim + j];
+            gradQNN[row_gradQ + j] += fac * inv_volNN;
+          }
+        }
+      }
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/src/AssembleNodalGradUElemAlgorithm.C
+++ b/src/AssembleNodalGradUElemAlgorithm.C
@@ -1,0 +1,208 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+// nalu
+#include <AssembleNodalGradUElemAlgorithm.h>
+#include <Algorithm.h>
+
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <TimeIntegrator.h>
+#include <master_element/MasterElement.h>
+#include "master_element/MasterElementRepo.h"
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra {
+namespace nalu {
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// AssembleNodalGradUElemAlgorithm - Green-Gauss gradient
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+AssembleNodalGradUElemAlgorithm::AssembleNodalGradUElemAlgorithm(
+  Realm& realm,
+  stk::mesh::Part* part,
+  VectorFieldType* vectorQ,
+  GenericFieldType* dqdx,
+  const bool useShifted)
+  : Algorithm(realm, part),
+    vectorQ_(vectorQ),
+    dqdx_(dqdx),
+    useShifted_(useShifted)
+{
+  // nothing to do
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleNodalGradUElemAlgorithm::execute()
+{
+
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  // extract fields
+  ScalarFieldType* dualNodalVolume = meta_data.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "dual_nodal_volume");
+  VectorFieldType* coordinates = meta_data.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, realm_.get_coordinates_name());
+
+  // nodal fields to gather; gather everything other than what we are assembling
+  std::vector<double> ws_vectorQ;
+  std::vector<double> ws_dualVolume;
+  std::vector<double> ws_coordinates;
+
+  // geometry related to populate
+  std::vector<double> ws_scs_areav;
+  std::vector<double> ws_shape_function;
+
+  // ip data
+  std::vector<double> qIp(nDim);
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union = meta_data.locally_owned_part() &
+                                              stk::mesh::selectUnion(partVec_) &
+                                              !(realm_.get_inactive_selector());
+
+  stk::mesh::BucketVector const& elem_buckets =
+    realm_.get_buckets(stk::topology::ELEMENT_RANK, s_locally_owned_union);
+  for (stk::mesh::BucketVector::const_iterator ib = elem_buckets.begin();
+       ib != elem_buckets.end(); ++ib) {
+    stk::mesh::Bucket& b = **ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+
+    // extract master element
+    MasterElement* meSCS =
+      sierra::nalu::MasterElementRepo::get_surface_master_element_on_host(
+        b.topology());
+
+    // extract master element specifics
+    const int nodesPerElement = meSCS->nodesPerElement_;
+    const int numScsIp = meSCS->num_integration_points();
+    const int* lrscv = meSCS->adjacentNodes();
+
+    // algorithm related
+    ws_vectorQ.resize(nodesPerElement * nDim);
+    ws_dualVolume.resize(nodesPerElement);
+    ws_coordinates.resize(nodesPerElement * nDim);
+    ws_scs_areav.resize(numScsIp * nDim);
+    ws_shape_function.resize(numScsIp * nodesPerElement);
+
+    // pointers.
+    double* p_vectorQ = &ws_vectorQ[0];
+    double* p_dualVolume = &ws_dualVolume[0];
+    double* p_coordinates = &ws_coordinates[0];
+    double* p_scs_areav = &ws_scs_areav[0];
+    SharedMemView<double**, HostShmem> p_shape_function(
+      ws_shape_function.data(), numScsIp, nodesPerElement);
+
+    if (useShifted_)
+      meSCS->shifted_shape_fcn<>(p_shape_function);
+    else
+      meSCS->shape_fcn<>(p_shape_function);
+
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+
+      //===============================================
+      // gather nodal data; this is how we do it now..
+      //===============================================
+      stk::mesh::Entity const* node_rels = b.begin_nodes(k);
+      int num_nodes = b.num_nodes(k);
+
+      // sanity check on num nodes
+      ThrowAssert(num_nodes == nodesPerElement);
+
+      // note: we absolutely need to gather coords since it
+      // is required to compute the area vector. however,
+      // ws_scalarQ and ws_dualVolume are choices to avoid
+      // field data call for interpolation
+
+      for (int ni = 0; ni < num_nodes; ++ni) {
+        stk::mesh::Entity node = node_rels[ni];
+
+        // pointers to real data
+        double* coords = stk::mesh::field_data(*coordinates, node);
+        double* vectorQ = stk::mesh::field_data(*vectorQ_, node);
+
+        // gather scalars
+        p_dualVolume[ni] = *stk::mesh::field_data(*dualNodalVolume, node);
+
+        // gather vectors
+        const int offSet = ni * nDim;
+        for (int j = 0; j < nDim; ++j) {
+          p_coordinates[offSet + j] = coords[j];
+          p_vectorQ[offSet + j] = vectorQ[j];
+        }
+      }
+
+      // compute geometry
+      sierra::nalu::SharedMemView<double*> areav(p_scs_areav, numScsIp * nDim);
+      sierra::nalu::SharedMemView<double**> elemCoords(
+        p_coordinates, nodesPerElement, nDim);
+      meSCS->determinant(elemCoords, areav);
+
+      // start assembly
+      for (int ip = 0; ip < numScsIp; ++ip) {
+
+        // left and right nodes for this ip
+        const int il = lrscv[2 * ip];
+        const int ir = lrscv[2 * ip + 1];
+
+        stk::mesh::Entity nodeL = node_rels[il];
+        stk::mesh::Entity nodeR = node_rels[ir];
+
+        // pointer to fields to assemble
+        double* gradQL = stk::mesh::field_data(*dqdx_, nodeL);
+        double* gradQR = stk::mesh::field_data(*dqdx_, nodeR);
+
+        // interpolate to scs point; operate on saved off ws_field
+        for (int j = 0; j < nDim; ++j)
+          qIp[j] = 0.0;
+
+        for (int ic = 0; ic < nodesPerElement; ++ic) {
+          const double r = p_shape_function(ip, ic);
+          for (int j = 0; j < nDim; ++j) {
+            qIp[j] += r * p_vectorQ[ic * nDim + j];
+          }
+        }
+
+        // left and right volume
+        double inv_volL = 1.0 / p_dualVolume[il];
+        double inv_volR = 1.0 / p_dualVolume[ir];
+
+        // assemble to il/ir
+        for (int i = 0; i < nDim; ++i) {
+          const int row_gradQ = i * nDim;
+          const double qip = qIp[i];
+          for (int j = 0; j < nDim; ++j) {
+            double fac = qip * p_scs_areav[ip * nDim + j];
+            gradQL[row_gradQ + j] += fac * inv_volL;
+            gradQR[row_gradQ + j] -= fac * inv_volR;
+          }
+        }
+      }
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,9 @@ target_sources(
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleMomentumNonConformalSolverAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleNodalGradNonConformalAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleNodalGradUNonConformalAlgorithm.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/AssembleNodalGradUElemAlgorithm.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/AssembleNodalGradUAlgorithmDriver.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/AssembleNodalGradUBoundaryAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleNodeSolverAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssembleNGPNodeSolverAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/AssemblePNGBoundarySolverAlgorithm.C

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -22,6 +22,7 @@
 // all concrete EquationSystem's
 #include <EnthalpyEquationSystem.h>
 #include <LowMachEquationSystem.h>
+#include <mesh_motion/MeshDisplacementEquationSystem.h>
 
 #ifdef NALU_HAS_MATRIXFREE
 #include <MatrixFreeHeatCondEquationSystem.h>

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -158,6 +158,17 @@ EquationSystems::load(const YAML::Node& y_node)
           if (root()->debug())
             NaluEnv::self().naluOutputP0() << "eqSys = tke " << std::endl;
           eqSys = new TurbKineticEnergyEquationSystem(*this);
+        } else if (expect_map(y_system, "MeshDisplacement", true)) {
+          y_eqsys = expect_map(y_system, "MeshDisplacement", true);
+          bool activateMass = false;
+          bool deformWrtModelCoords = false;
+          get_if_present_no_default(y_eqsys, "activate_mass", activateMass);
+          get_if_present_no_default(
+            y_eqsys, "deform_wrt_model_coordinates", deformWrtModelCoords);
+          if (root()->debug())
+            NaluEnv::self().naluOutputP0()
+              << "eqSys = MeshDisplacement " << std::endl;
+          eqSys = new MeshDisplacementEquationSystem(*this, activateMass, deformWrtModelCoords);
         } else if (expect_map(y_system, "Enthalpy", true)) {
           y_eqsys = expect_map(y_system, "Enthalpy", true);
           if (root()->debug())

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -1118,7 +1118,7 @@ MomentumEquationSystem::pre_timestep_work()
   if (
     (realm_.solutionOptions_->turbulenceModel_ == TurbulenceModel::SST_AMS) &&
     (realm_.solutionOptions_->meshMotion_ ||
-     realm_.solutionOptions_->externalMeshDeformation_)) {
+     realm_.solutionOptions_->meshDeformation_)) {
     AMSAlgDriver_->compute_metric_tensor();
   }
 }

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -620,7 +620,7 @@ Realm::look_ahead_and_creation(const YAML::Node& node)
   // Contains actuators and FSI data structures
   aeroModels_ = std::make_unique<AeroContainer>(node);
   if (aeroModels_->has_fsi())
-    solutionOptions_->openfastFSI_ = true;
+    solutionOptions_->meshDeformation_ = true;
 
   // Boundary Layer Statistics post-processing
   if (node["boundary_layer_statistics"]) {
@@ -880,7 +880,7 @@ Realm::load(const YAML::Node& node)
   const YAML::Node meshMotionNode = expect_sequence(node, "mesh_motion", true);
   if (meshMotionNode) {
     // has a user stated that mesh motion is external?
-    if (solutionOptions_->externalMeshDeformation_) {
+    if (solutionOptions_->meshDeformation_) {
       NaluEnv::self().naluOutputP0()
         << "mesh motion set to external (will prevail over mesh motion "
            "specification)!"
@@ -1858,7 +1858,7 @@ Realm::update_geometry_due_to_mesh_motion()
       }
     }
 
-    if (solutionOptions_->externalMeshDeformation_) {
+    if (solutionOptions_->meshDeformation_) {
       std::vector<std::string> targetNames = get_physics_target_names();
       for (size_t itarget = 0; itarget < targetNames.size(); ++itarget) {
         stk::mesh::Part* targetPart =
@@ -1942,7 +1942,7 @@ Realm::advance_time_step()
 
   // evaluate new geometry based on latest mesh motion geometry state
   // (provided that external is active)
-  if (solutionOptions_->externalMeshDeformation_)
+  if (solutionOptions_->meshDeformation_)
     compute_geometry();
 
   // evaluate properties based on latest state including boundary and and

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -1308,7 +1308,7 @@ Realm::setup_initial_conditions()
           std::vector<double> genSpec = genIC.data_[ifield];
           stk::mesh::FieldBase* field = stk::mesh::get_field_by_name(
             genIC.fieldNames_[ifield], meta_data());
-          ThrowAssert(field);
+          ThrowAssertMsg(field,"Field not registered: " + genIC.fieldNames_[ifield]);
 
           stk::mesh::FieldBase* fieldWithState =
             (field->number_of_states() > 1)

--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -54,8 +54,7 @@ SolutionOptions::SolutionOptions()
     turbulenceModel_(TurbulenceModel::LAMINAR),
     meshMotion_(false),
     meshTransformation_(false),
-    externalMeshDeformation_(false),
-    openfastFSI_(false),
+    meshDeformation_(false),
     ncAlgGaussLabatto_(true),
     ncAlgUpwindAdvection_(true),
     ncAlgIncludePstab_(true),
@@ -140,7 +139,7 @@ SolutionOptions::load(const YAML::Node& y_node)
     // external mesh motion expected
     get_if_present(
       y_solution_options, "externally_provided_mesh_deformation",
-      externalMeshDeformation_, externalMeshDeformation_);
+      meshDeformation_, meshDeformation_);
 
     // shift mdot for continuity (CVFEM)
     get_if_present(

--- a/src/mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.C
+++ b/src/mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.C
@@ -1,0 +1,330 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+// nalu
+#include <mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.h>
+#include <EquationSystem.h>
+#include <SolverAlgorithm.h>
+
+#include <FieldTypeDef.h>
+#include <LinearSystem.h>
+#include <Realm.h>
+#include <SolutionOptions.h>
+#include <TimeIntegrator.h>
+#include <master_element/MasterElement.h>
+#include <master_element/MasterElementRepo.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/Part.hpp>
+
+namespace sierra {
+namespace nalu {
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// AssembleMeshDisplacementElemSolverAlgorithm - add LHS/RHS for uvw momentum
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+AssembleMeshDisplacementElemSolverAlgorithm::
+  AssembleMeshDisplacementElemSolverAlgorithm(
+    Realm& realm,
+    stk::mesh::Part* part,
+    EquationSystem* eqSystem,
+    const bool deformWrtModelCoords)
+  : SolverAlgorithm(realm, part, eqSystem),
+    deformWrtModelCoords_(deformWrtModelCoords)
+{
+  // save off data
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+  meshDisplacement_ = meta_data.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "mesh_displacement");
+  coordinates_ = meta_data.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, realm_.get_coordinates_name());
+  modelCoordinates_ = meta_data.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "coordinates");
+
+  // property
+  mu_ =
+    meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "lame_mu");
+  lambda_ = meta_data.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "lame_lambda");
+
+  /* Matrix layout follows momentum */
+}
+
+//--------------------------------------------------------------------------
+//-------- initialize_connectivity -----------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMeshDisplacementElemSolverAlgorithm::initialize_connectivity()
+{
+  eqSystem_->linsys_->buildElemToNodeGraph(partVec_);
+}
+
+//--------------------------------------------------------------------------
+//-------- execute ---------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+AssembleMeshDisplacementElemSolverAlgorithm::execute()
+{
+
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  // space for LHS/RHS; nodesPerElem*nDim*nodesPerElem*nDim and
+  // nodesPerElem*nDim
+  std::vector<double> lhs;
+  std::vector<double> rhs;
+  std::vector<int> scratchIds;
+  std::vector<double> scratchVals;
+  std::vector<stk::mesh::Entity> connected_nodes;
+
+  // nodal fields to gather
+  std::vector<double> ws_displacementNp1;
+  std::vector<double> ws_coordinates;
+  std::vector<double> ws_modelCoordinates;
+  std::vector<double> ws_mu;
+  std::vector<double> ws_lambda;
+
+  // geometry related to populate
+  std::vector<double> ws_scs_areav;
+  std::vector<double> ws_dndx;
+  std::vector<double> ws_deriv;
+  std::vector<double> ws_det_j;
+  std::vector<double> ws_shape_function;
+
+  // deal with state
+  VectorFieldType& displacementNp1 =
+    meshDisplacement_->field_of_state(stk::mesh::StateNP1);
+
+  // define some common selectors
+  stk::mesh::Selector s_locally_owned_union =
+    meta_data.locally_owned_part() & stk::mesh::selectUnion(partVec_);
+
+  stk::mesh::BucketVector const& elem_buckets =
+    realm_.get_buckets(stk::topology::ELEMENT_RANK, s_locally_owned_union);
+  for (stk::mesh::BucketVector::const_iterator ib = elem_buckets.begin();
+       ib != elem_buckets.end(); ++ib) {
+    stk::mesh::Bucket& b = **ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+
+    // extract master element
+    MasterElement* meSCS =
+      sierra::nalu::MasterElementRepo::get_surface_master_element_on_host(
+        b.topology());
+
+    // extract master element specifics
+    const int nodesPerElement = meSCS->nodesPerElement_;
+    const int numScsIp = meSCS->num_integration_points();
+    const int* lrscv = meSCS->adjacentNodes();
+
+    // resize some things; matrix related
+    const int lhsSize = nodesPerElement * nDim * nodesPerElement * nDim;
+    const int rhsSize = nodesPerElement * nDim;
+    lhs.resize(lhsSize);
+    rhs.resize(rhsSize);
+    scratchIds.resize(rhsSize);
+    scratchVals.resize(rhsSize);
+    connected_nodes.resize(nodesPerElement);
+
+    // algorithm related
+    ws_displacementNp1.resize(nodesPerElement * nDim);
+    ws_coordinates.resize(nodesPerElement * nDim);
+    ws_modelCoordinates.resize(nodesPerElement * nDim);
+    ws_mu.resize(nodesPerElement);
+    ws_lambda.resize(nodesPerElement);
+    ws_scs_areav.resize(numScsIp * nDim);
+    ws_dndx.resize(nDim * numScsIp * nodesPerElement);
+    ws_deriv.resize(nDim * numScsIp * nodesPerElement);
+    ws_det_j.resize(numScsIp);
+    ws_shape_function.resize(numScsIp * nodesPerElement);
+
+    // pointer to lhs/rhs
+    double* p_lhs = &lhs[0];
+    double* p_rhs = &rhs[0];
+    double* p_displacementNp1 = &ws_displacementNp1[0];
+    double* p_coordinates = &ws_coordinates[0];
+    double* p_modelCoordinates = &ws_modelCoordinates[0];
+    double* p_mu = &ws_mu[0];
+    double* p_lambda = &ws_lambda[0];
+    double* p_scs_areav = &ws_scs_areav[0];
+    double* p_dndx = &ws_dndx[0];
+    SharedMemView<double**, HostShmem> p_shape_function(
+      ws_shape_function.data(), numScsIp, nodesPerElement);
+
+    // extract shape function
+    meSCS->shape_fcn<>(p_shape_function);
+
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+
+      // zero lhs/rhs
+      for (int p = 0; p < lhsSize; ++p)
+        p_lhs[p] = 0.0;
+      for (int p = 0; p < rhsSize; ++p)
+        p_rhs[p] = 0.0;
+
+      //===============================================
+      // gather nodal data; this is how we do it now..
+      //===============================================
+      stk::mesh::Entity const* node_rels = b.begin_nodes(k);
+      int num_nodes = b.num_nodes(k);
+
+      // sanity check on num nodes
+      ThrowAssert(num_nodes == nodesPerElement);
+
+      for (int ni = 0; ni < num_nodes; ++ni) {
+        stk::mesh::Entity node = node_rels[ni];
+
+        // set connected nodes
+        connected_nodes[ni] = node;
+
+        // pointers to real data
+        const double* dxNp1 = stk::mesh::field_data(displacementNp1, node);
+        const double* coords = stk::mesh::field_data(*coordinates_, node);
+        const double* modelCoords =
+          stk::mesh::field_data(*modelCoordinates_, node);
+        const double mu = *stk::mesh::field_data(*mu_, node);
+        const double lambda = *stk::mesh::field_data(*lambda_, node);
+
+        // gather scalars
+        p_mu[ni] = mu;
+        p_lambda[ni] = lambda;
+
+        // gather vectors
+        const int niNdim = ni * nDim;
+        for (int i = 0; i < nDim; ++i) {
+          p_displacementNp1[niNdim + i] = dxNp1[i];
+          p_coordinates[niNdim + i] = coords[i];
+          p_modelCoordinates[niNdim + i] = modelCoords[i];
+        }
+      }
+
+      // compute geometry
+      SharedMemView<double**, HostShmem> areav(
+        ws_scs_areav.data(), numScsIp, nDim);
+      SharedMemView<double**, HostShmem> elemCoords(
+        p_coordinates, nodesPerElement, nDim);
+      meSCS->determinant(elemCoords, areav);
+
+      // compute dndx; model coords or displaced?
+      SharedMemView<double***, HostShmem> dndx(
+        ws_dndx.data(), numScsIp, nodesPerElement, nDim);
+      SharedMemView<double***, HostShmem> der(
+        ws_deriv.data(), numScsIp, nodesPerElement, nDim);
+      SharedMemView<double**, HostShmem> vModelCoords(
+        p_modelCoordinates, nodesPerElement, nDim);
+      if (deformWrtModelCoords_) {
+        meSCS->grad_op(vModelCoords, dndx, der);
+      } else {
+        meSCS->grad_op(elemCoords, dndx, der);
+      }
+
+      for (int ip = 0; ip < numScsIp; ++ip) {
+
+        const int ipNdim = ip * nDim;
+
+        // left and right nodes for this ip
+        const int il = lrscv[2 * ip];
+        const int ir = lrscv[2 * ip + 1];
+
+        // save off some offsets
+        const int ilNdim = il * nDim;
+        const int irNdim = ir * nDim;
+
+        // compute scs point values; offset to Shape Function; sneak in divU
+        double muIp = 0.0;
+        double lambdaIp = 0.0;
+        double divDx = 0.0;
+        for (int ic = 0; ic < nodesPerElement; ++ic) {
+          const double r = p_shape_function(ip, ic);
+          muIp += r * p_mu[ic];
+          lambdaIp += r * p_lambda[ic];
+          const int offSetDnDx = nDim * nodesPerElement * ip + ic * nDim;
+          for (int j = 0; j < nDim; ++j) {
+            const double dxj = p_displacementNp1[ic * nDim + j];
+            divDx += dxj * p_dndx[offSetDnDx + j];
+          }
+        }
+
+        // assemble divDx term (explicit)
+        for (int i = 0; i < nDim; ++i) {
+          // divU stress term
+          const double divTerm = -lambdaIp * divDx * p_scs_areav[ipNdim + i];
+          const int indexL = ilNdim + i;
+          const int indexR = irNdim + i;
+          // right hand side; L and R
+          p_rhs[indexL] -= divTerm;
+          p_rhs[indexR] += divTerm;
+        }
+
+        // stress
+        for (int ic = 0; ic < nodesPerElement; ++ic) {
+
+          const int icNdim = ic * nDim;
+
+          for (int i = 0; i < nDim; ++i) {
+
+            const int indexL = ilNdim + i;
+            const int indexR = irNdim + i;
+
+            const int rowL = indexL * nodesPerElement * nDim;
+            const int rowR = indexR * nodesPerElement * nDim;
+
+            const int rLiC_i = rowL + icNdim + i;
+            const int rRiC_i = rowR + icNdim + i;
+
+            // viscous stress
+            const int offSetDnDx = nDim * nodesPerElement * ip + icNdim;
+            double lhs_riC_i = 0.0;
+            for (int j = 0; j < nDim; ++j) {
+
+              const double axj = p_scs_areav[ipNdim + j];
+              const double dxj = p_displacementNp1[icNdim + j];
+
+              // -mu*dxi/dxj*A_j; fixed i over j loop; see below..
+              const double lhsfacDiff_i = -muIp * p_dndx[offSetDnDx + j] * axj;
+              // lhs; il then ir
+              lhs_riC_i += lhsfacDiff_i;
+
+              // -mu*dxj/dxi*A_j
+              const double lhsfacDiff_j = -muIp * p_dndx[offSetDnDx + i] * axj;
+              // lhs; il then ir
+              p_lhs[rowL + icNdim + j] += lhsfacDiff_j;
+              p_lhs[rowR + icNdim + j] -= lhsfacDiff_j;
+
+              // rhs; il then ir
+              p_rhs[indexL] -= lhsfacDiff_j * dxj;
+              p_rhs[indexR] += lhsfacDiff_j * dxj;
+            }
+
+            // deal with accumulated lhs and flux for -mu*dxi/dxj*Aj
+            p_lhs[rLiC_i] += lhs_riC_i;
+            p_lhs[rRiC_i] -= lhs_riC_i;
+            const double dxi = p_displacementNp1[icNdim + i];
+            p_rhs[indexL] -= lhs_riC_i * dxi;
+            p_rhs[indexR] += lhs_riC_i * dxi;
+          }
+        }
+      }
+
+      apply_coeff(connected_nodes, scratchIds, scratchVals, rhs, lhs, __FILE__);
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/src/mesh_motion/CMakeLists.txt
+++ b/src/mesh_motion/CMakeLists.txt
@@ -5,6 +5,9 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/MeshMotionAlg.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MeshTransformationAlg.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionDeformingInteriorKernel.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/MeshDisplacementEquationSystem.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/MeshDisplacementMassBackwardEulerNodeSuppAlg.C
+   ${CMAKE_CURRENT_SOURCE_DIR}/AssembleMeshDisplacementElemSolverAlgorithm.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionRotationKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionScalingKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MotionTranslationKernel.C

--- a/src/mesh_motion/MeshDisplacementEquationSystem.C
+++ b/src/mesh_motion/MeshDisplacementEquationSystem.C
@@ -1,0 +1,560 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include <mesh_motion/MeshDisplacementEquationSystem.h>
+#include <mesh_motion/MeshDisplacementMassBackwardEulerNodeSuppAlg.h>
+#include <mesh_motion/AssembleMeshDisplacementElemSolverAlgorithm.h>
+
+#include <AlgorithmDriver.h>
+#include <AssembleNodalGradUAlgorithmDriver.h>
+#include <AssembleNodalGradUElemAlgorithm.h>
+#include <AssembleNodalGradUBoundaryAlgorithm.h>
+#include <AssembleNodeSolverAlgorithm.h>
+#include <AuxFunctionAlgorithm.h>
+#include <ConstantAuxFunction.h>
+#include <CopyFieldAlgorithm.h>
+#include <DirichletBC.h>
+#include <Enums.h>
+#include <EquationSystem.h>
+#include <EquationSystems.h>
+#include <FieldFunctions.h>
+#include <LinearSolver.h>
+#include <LinearSolvers.h>
+#include <LinearSystem.h>
+#include <master_element/MasterElement.h>
+#include <NaluEnv.h>
+#include <NaluParsing.h>
+#include <Realm.h>
+#include <Realms.h>
+#include <Simulation.h>
+#include <SolutionOptions.h>
+#include <SolverAlgorithmDriver.h>
+#include <TimeIntegrator.h>
+
+#include <overset/UpdateOversetFringeAlgorithmDriver.h>
+
+// stk_util
+#include <stk_util/parallel/Parallel.hpp>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/Field.hpp>
+#include <stk_mesh/base/FieldParallel.hpp>
+#include <stk_mesh/base/GetBuckets.hpp>
+#include <stk_mesh/base/GetEntities.hpp>
+#include <stk_mesh/base/CoordinateSystems.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/SkinMesh.hpp>
+#include <stk_mesh/base/Comm.hpp>
+
+// stk_io
+#include <stk_io/IossBridge.hpp>
+
+// stk_topo
+#include <stk_topology/topology.hpp>
+
+// basic c++
+#include <utility>
+#include <vector>
+
+namespace sierra {
+namespace nalu {
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// MeshDisplacementEquationSystem - manages uvw pde system
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+MeshDisplacementEquationSystem::MeshDisplacementEquationSystem(
+  EquationSystems& eqSystems,
+  const bool activateMass,
+  const bool deformWrtModelCoords)
+  : EquationSystem(eqSystems, "MeshDisplacementEQS"),
+    activateMass_(activateMass),
+    deformWrtModelCoords_(deformWrtModelCoords),
+    isInit_(false),
+    meshDisplacement_(NULL),
+    meshVelocity_(NULL),
+    dvdx_(NULL),
+    divV_(NULL),
+    coordinates_(NULL),
+    currentCoordinates_(NULL),
+    dualNodalVolume_(NULL),
+    density_(NULL),
+    lameMu_(NULL),
+    lameLambda_(NULL),
+    dxTmp_(NULL),
+    assembleNodalGradAlgDriver_(
+      new AssembleNodalGradUAlgorithmDriver(realm_, "dvdx"))
+{
+  // extract solver name and solver object
+  std::string solverName =
+    realm_.equationSystems_.get_solver_block_name("mesh_displacement");
+  LinearSolver* solver = realm_.root()->linearSolvers_->create_solver(
+    solverName, realm_.name(), EQ_MESH_DISPLACEMENT);
+  linsys_ =
+    LinearSystem::create(realm_, realm_.spatialDimension_, this, solver);
+
+  // determine nodal gradient form; use the edgeNodalGradient_ data member since
+  // mesh_displacement EQ does not need this
+  set_nodal_gradient("mesh_velocity");
+  NaluEnv::self().naluOutputP0()
+    << "Edge projected nodal gradient for mesh_velocity: " << edgeNodalGradient_
+    << std::endl;
+
+  // push back EQ to manager
+  realm_.push_equation_to_systems(this);
+
+  realm_.solutionOptions_->meshDeformation_ = true;
+}
+
+//--------------------------------------------------------------------------
+//-------- destructor ------------------------------------------------------
+//--------------------------------------------------------------------------
+MeshDisplacementEquationSystem::~MeshDisplacementEquationSystem()
+{
+  delete assembleNodalGradAlgDriver_;
+}
+
+//--------------------------------------------------------------------------
+//-------- initial_work ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::initial_work()
+{
+  // call base class method
+  EquationSystem::initial_work();
+}
+
+//--------------------------------------------------------------------------
+//-------- register_nodal_fields -------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::register_nodal_fields(stk::mesh::Part* part)
+{
+
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+  const int numStates = realm_.number_of_states();
+
+  // register dof; set it as a restart variable
+  meshDisplacement_ = &(meta_data.declare_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "mesh_displacement", numStates));
+  stk::mesh::put_field_on_mesh(*meshDisplacement_, *part, nDim, nullptr);
+  realm_.augment_restart_variable_list("mesh_displacement");
+
+  // mesh velocity (used for fluids coupling)
+  meshVelocity_ = &(meta_data.declare_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "mesh_velocity"));
+  stk::mesh::put_field_on_mesh(*meshVelocity_, *part, nDim, nullptr);
+
+  // projected nodal gradient
+  dvdx_ = &(meta_data.declare_field<GenericFieldType>(
+    stk::topology::NODE_RANK, "dvdx"));
+  stk::mesh::put_field_on_mesh(*dvdx_, *part, nDim * nDim, nullptr);
+
+  divV_ = &(meta_data.declare_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "div_mesh_velocity"));
+  stk::mesh::put_field_on_mesh(*divV_, *part, nullptr);
+
+  // delta solution for linear solver
+  dxTmp_ = &(meta_data.declare_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "dxTmp"));
+  stk::mesh::put_field_on_mesh(*dxTmp_, *part, nDim, nullptr);
+
+  // geometry
+  coordinates_ = &(meta_data.declare_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "coordinates"));
+  stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);
+
+  currentCoordinates_ = &(meta_data.declare_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "current_coordinates"));
+  stk::mesh::put_field_on_mesh(*currentCoordinates_, *part, nDim, nullptr);
+
+  dualNodalVolume_ = &(meta_data.declare_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "dual_nodal_volume", numStates));
+  stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
+  realm_.augment_restart_variable_list("dual_nodal_volume");
+
+  // properties
+  if (activateMass_) {
+    density_ = &(meta_data.declare_field<ScalarFieldType>(
+      stk::topology::NODE_RANK, "density"));
+    stk::mesh::put_field_on_mesh(*density_, *part, nullptr);
+    realm_.augment_property_map(DENSITY_ID, density_);
+  }
+
+  lameMu_ = &(meta_data.declare_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "lame_mu"));
+  stk::mesh::put_field_on_mesh(*lameMu_, *part, nullptr);
+
+  lameLambda_ = &(meta_data.declare_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "lame_lambda"));
+  stk::mesh::put_field_on_mesh(*lameLambda_, *part, nullptr);
+
+  // push to property list
+  realm_.augment_property_map(LAME_MU_ID, lameLambda_);
+  realm_.augment_property_map(LAME_LAMBDA_ID, lameMu_);
+
+  // make sure all states are properly populated (restart can handle this)
+  if (
+    numStates > 2 &&
+    (!realm_.restarted_simulation() || realm_.support_inconsistent_restart())) {
+    ScalarFieldType& dualNdVolN =
+      dualNodalVolume_->field_of_state(stk::mesh::StateN);
+    ScalarFieldType& dualNdVolNp1 =
+      dualNodalVolume_->field_of_state(stk::mesh::StateNP1);
+
+    CopyFieldAlgorithm* theCopyAlgDlNdVol = new CopyFieldAlgorithm(
+      realm_, part, &dualNdVolNp1, &dualNdVolN, 0, 1, stk::topology::NODE_RANK);
+    copyStateAlg_.push_back(theCopyAlgDlNdVol);
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- register_element_fields -------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::register_element_fields(
+  stk::mesh::Part* /* part */, const stk::topology& /* theTopo */)
+{
+  // n/a
+}
+
+//--------------------------------------------------------------------------
+//-------- register_interior_algorithm -------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::register_interior_algorithm(
+  stk::mesh::Part* part)
+{
+
+  // types of algorithms
+  const AlgorithmType algType = INTERIOR;
+  const AlgorithmType algMass = MASS;
+
+  // solver; interior elem contribution
+  std::map<AlgorithmType, SolverAlgorithm*>::iterator itsi =
+    solverAlgDriver_->solverAlgMap_.find(algType);
+  if (itsi == solverAlgDriver_->solverAlgMap_.end()) {
+    AssembleMeshDisplacementElemSolverAlgorithm* theAlg =
+      new AssembleMeshDisplacementElemSolverAlgorithm(
+        realm_, part, this, deformWrtModelCoords_);
+    solverAlgDriver_->solverAlgMap_[algType] = theAlg;
+  } else {
+    itsi->second->partVec_.push_back(part);
+  }
+
+  // solver; time contribution (lumped mass matrix)
+  if (activateMass_) {
+    std::map<AlgorithmType, SolverAlgorithm*>::iterator itsm =
+      solverAlgDriver_->solverAlgMap_.find(algMass);
+    if (itsm == solverAlgDriver_->solverAlgMap_.end()) {
+      AssembleNodeSolverAlgorithm* theAlg =
+        new AssembleNodeSolverAlgorithm(realm_, part, this);
+      solverAlgDriver_->solverAlgMap_[algMass] = theAlg;
+
+      // now create the supplemental alg for mass term; generalize for BDF2
+      MeshDisplacementMassBackwardEulerNodeSuppAlg* theMass =
+        new MeshDisplacementMassBackwardEulerNodeSuppAlg(realm_);
+      theAlg->supplementalAlg_.push_back(theMass);
+    } else {
+      itsm->second->partVec_.push_back(part);
+    }
+  }
+
+  // non-solver; contribution to Gjvi; allow for element-based shifted
+  std::map<AlgorithmType, Algorithm*>::iterator itgv =
+    assembleNodalGradAlgDriver_->algMap_.find(algType);
+  if (itgv == assembleNodalGradAlgDriver_->algMap_.end()) {
+    AssembleNodalGradUElemAlgorithm* theAlg =
+      new AssembleNodalGradUElemAlgorithm(
+        realm_, part, meshVelocity_, dvdx_, edgeNodalGradient_);
+    assembleNodalGradAlgDriver_->algMap_[algType] = theAlg;
+  } else {
+    itgv->second->partVec_.push_back(part);
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- register_wall_bc ------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::register_wall_bc(
+  stk::mesh::Part* part,
+  const stk::topology& /* theTopo */,
+  const WallBoundaryConditionData& wallBCData)
+{
+
+  // algorithm type
+  const AlgorithmType algType = WALL;
+
+  // np1 mesh displacement
+  VectorFieldType& displacementNp1 =
+    meshDisplacement_->field_of_state(stk::mesh::StateNP1);
+
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+  const unsigned nDim = meta_data.spatial_dimension();
+
+  // extract the value for user specified velocity and save off the AuxFunction
+  WallUserData userData = wallBCData.userData_;
+  std::string displacementName = "mesh_displacement";
+  std::string pressureName = "pressure";
+
+  if (bc_data_specified(userData, displacementName)) {
+
+    // register boundary data; mesh_displacement_bc
+    VectorFieldType* theBcField = &(meta_data.declare_field<VectorFieldType>(
+      stk::topology::NODE_RANK, "mesh_displacement_bc"));
+    stk::mesh::put_field_on_mesh(*theBcField, *part, nDim, nullptr);
+
+    AuxFunction* theAuxFunc = NULL;
+
+    UserDataType theDataType = get_bc_data_type(userData, displacementName);
+    if (CONSTANT_UD == theDataType) {
+      // constant data type specification
+      Velocity dx = userData.dx_;
+      std::vector<double> userSpec(nDim);
+      userSpec[0] = dx.ux_;
+      userSpec[1] = dx.uy_;
+      if (nDim > 2)
+        userSpec[2] = dx.uz_;
+      theAuxFunc = new ConstantAuxFunction(0, nDim, userSpec);
+    }
+
+    // proceed with aux function and dirichlet setup
+
+    AuxFunctionAlgorithm* auxAlg = new AuxFunctionAlgorithm(
+      realm_, part, theBcField, theAuxFunc, stk::topology::NODE_RANK);
+
+    // check to see if this is an FSI interface to determine how we handle
+    // mesh_displacement population
+    if (userData.isFsiInterface_) {
+      // xfer will handle population; only need to populate the initial value
+      realm_.initCondAlg_.push_back(auxAlg);
+    } else {
+      bcDataAlg_.push_back(auxAlg);
+    }
+
+    // copy mesh_displacement_bc to mesh_displacement np1...
+    CopyFieldAlgorithm* theCopyAlg = new CopyFieldAlgorithm(
+      realm_, part, theBcField, &displacementNp1, 0, nDim,
+      stk::topology::NODE_RANK);
+    bcDataMapAlg_.push_back(theCopyAlg);
+
+    // Dirichlet bc
+    std::map<AlgorithmType, SolverAlgorithm*>::iterator itd =
+      solverAlgDriver_->solverDirichAlgMap_.find(algType);
+    if (itd == solverAlgDriver_->solverDirichAlgMap_.end()) {
+      DirichletBC* theAlg = new DirichletBC(
+        realm_, this, part, &displacementNp1, theBcField, 0, nDim);
+      solverAlgDriver_->solverDirichAlgMap_[algType] = theAlg;
+    } else {
+      itd->second->partVec_.push_back(part);
+    }
+  } else {
+    NaluEnv::self().naluOutputP0()
+      << "No displacement specified: zero surface traction applied"
+      << std::endl;
+  }
+
+  // non-solver; contribution to Gjvi; allow for element-based shifted
+  std::map<AlgorithmType, Algorithm*>::iterator itgv =
+    assembleNodalGradAlgDriver_->algMap_.find(algType);
+  if (itgv == assembleNodalGradAlgDriver_->algMap_.end()) {
+    AssembleNodalGradUBoundaryAlgorithm* theAlg =
+      new AssembleNodalGradUBoundaryAlgorithm(
+        realm_, part, meshVelocity_, dvdx_, edgeNodalGradient_);
+    assembleNodalGradAlgDriver_->algMap_[algType] = theAlg;
+  } else {
+    itgv->second->partVec_.push_back(part);
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- register_overset_bc ---------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::register_overset_bc()
+{
+  create_constraint_algorithm(meshVelocity_);
+
+  int nDim = realm_.meta_data().spatial_dimension();
+  equationSystems_.register_overset_field_update(meshVelocity_, 1, nDim);
+}
+
+//--------------------------------------------------------------------------
+//-------- initialize ------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::initialize()
+{
+  solverAlgDriver_->initialize_connectivity();
+  linsys_->finalizeLinearSystem();
+}
+
+//--------------------------------------------------------------------------
+//-------- reinitialize_linear_system --------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::reinitialize_linear_system()
+{
+
+  // delete linsys
+  delete linsys_;
+
+  // create new solver
+  std::string solverName =
+    realm_.equationSystems_.get_solver_block_name("mesh_velocity");
+  LinearSolver* solver = realm_.root()->linearSolvers_->reinitialize_solver(
+    solverName, realm_.name(), EQ_MESH_DISPLACEMENT);
+  linsys_ =
+    LinearSystem::create(realm_, realm_.spatialDimension_, this, solver);
+
+  // initialize new solver
+  solverAlgDriver_->initialize_connectivity();
+  linsys_->finalizeLinearSystem();
+}
+
+//--------------------------------------------------------------------------
+//-------- predict_state ---------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::predict_state()
+{
+  // copy state n to state np1
+  VectorFieldType& dN = meshDisplacement_->field_of_state(stk::mesh::StateN);
+  VectorFieldType& dNp1 =
+    meshDisplacement_->field_of_state(stk::mesh::StateNP1);
+  field_copy(
+    realm_.meta_data(), realm_.bulk_data(), dN, dNp1,
+    realm_.get_activate_aura());
+}
+
+//--------------------------------------------------------------------------
+//-------- solve_and_update ------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::solve_and_update()
+{
+
+  // nothing to do
+  if (isInit_) {
+    isInit_ = false;
+  }
+
+  // start the iteration loop
+  for (int k = 0; k < maxIterations_; ++k) {
+
+    NaluEnv::self().naluOutputP0()
+      << " " << k + 1 << "/" << maxIterations_ << std::setw(15) << std::right
+      << userSuppliedName_ << std::endl;
+
+    // tke assemble, load_complete and solve
+    assemble_and_solve(dxTmp_);
+
+    // update
+    double timeA = NaluEnv::self().nalu_time();
+    field_axpby(
+      realm_.meta_data(), realm_.bulk_data(), 1.0, *dxTmp_, 1.0,
+      meshDisplacement_->field_of_state(stk::mesh::StateNP1),
+      realm_.get_activate_aura());
+    double timeB = NaluEnv::self().nalu_time();
+    timerAssemble_ += (timeB - timeA);
+
+    compute_current_coordinates();
+  }
+
+  // compute nodal projected gradient and nodal divV
+  assembleNodalGradAlgDriver_->execute();
+
+  compute_div_mesh_velocity();
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_current_coordinates -------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::compute_current_coordinates()
+{
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+
+  VectorFieldType& displacementN =
+    meshDisplacement_->field_of_state(stk::mesh::StateN);
+  VectorFieldType& displacementNp1 =
+    meshDisplacement_->field_of_state(stk::mesh::StateNP1);
+
+  const int nDim = meta_data.spatial_dimension();
+  const double dt = realm_.get_time_step();
+
+  stk::mesh::Selector s_all_nodes =
+    (meta_data.locally_owned_part() | meta_data.globally_shared_part()) &
+    stk::mesh::selectField(*meshDisplacement_);
+
+  stk::mesh::BucketVector const& node_buckets =
+    realm_.get_buckets(stk::topology::NODE_RANK, s_all_nodes);
+  for (stk::mesh::BucketVector::const_iterator ib = node_buckets.begin();
+       ib != node_buckets.end(); ++ib) {
+    stk::mesh::Bucket& b = **ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+    const double* dxN = stk::mesh::field_data(displacementN, b);
+    const double* dxNp1 = stk::mesh::field_data(displacementNp1, b);
+    double* meshVelocity = stk::mesh::field_data(*meshVelocity_, b);
+    const double* coordinates = stk::mesh::field_data(*coordinates_, b);
+    double* currentCoordinates = stk::mesh::field_data(*currentCoordinates_, b);
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+      size_t offSet = k * nDim;
+      for (int j = 0; j < nDim; ++j) {
+        currentCoordinates[offSet + j] =
+          coordinates[offSet + j] + dxNp1[offSet + j];
+        // hack a mesh velocity to be first order backward Euler
+        meshVelocity[offSet + j] = (dxNp1[offSet + j] - dxN[offSet + j]) / dt;
+      }
+    }
+  }
+}
+
+//--------------------------------------------------------------------------
+//-------- compute_div_mesh_velocity ---------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementEquationSystem::compute_div_mesh_velocity()
+{
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+
+  const int nDim = meta_data.spatial_dimension();
+
+  stk::mesh::Selector s_all_nodes =
+    (meta_data.locally_owned_part() | meta_data.globally_shared_part()) &
+    stk::mesh::selectField(*divV_);
+
+  stk::mesh::BucketVector const& node_buckets =
+    realm_.get_buckets(stk::topology::NODE_RANK, s_all_nodes);
+  for (stk::mesh::BucketVector::const_iterator ib = node_buckets.begin();
+       ib != node_buckets.end(); ++ib) {
+    stk::mesh::Bucket& b = **ib;
+    const stk::mesh::Bucket::size_type length = b.size();
+    const double* dvdx = stk::mesh::field_data(*dvdx_, b);
+    double* divV = stk::mesh::field_data(*divV_, b);
+    for (stk::mesh::Bucket::size_type k = 0; k < length; ++k) {
+      size_t offSet = k * nDim * nDim;
+      double sum = 0.0;
+      for (int j = 0; j < nDim; ++j)
+        sum += dvdx[offSet + nDim * j + j];
+      divV[k] = sum;
+    }
+  }
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/src/mesh_motion/MeshDisplacementMassBackwardEulerNodeSuppAlg.C
+++ b/src/mesh_motion/MeshDisplacementMassBackwardEulerNodeSuppAlg.C
@@ -1,0 +1,89 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include <mesh_motion/MeshDisplacementMassBackwardEulerNodeSuppAlg.h>
+#include <SupplementalAlgorithm.h>
+#include <FieldTypeDef.h>
+#include <Realm.h>
+#include <TimeIntegrator.h>
+
+// stk_mesh/base/fem
+#include <stk_mesh/base/Entity.hpp>
+#include <stk_mesh/base/MetaData.hpp>
+#include <stk_mesh/base/BulkData.hpp>
+#include <stk_mesh/base/FieldBase.hpp>
+#include <stk_mesh/base/Field.hpp>
+
+namespace sierra {
+namespace nalu {
+
+//==========================================================================
+// Class Definition
+//==========================================================================
+// MeshDisplacementMassBackwardEulerNodeSuppAlg - lumped mass BDF2
+//==========================================================================
+//--------------------------------------------------------------------------
+//-------- constructor -----------------------------------------------------
+//--------------------------------------------------------------------------
+MeshDisplacementMassBackwardEulerNodeSuppAlg::
+  MeshDisplacementMassBackwardEulerNodeSuppAlg(Realm& realm)
+  : SupplementalAlgorithm(realm),
+    displacementN_(NULL),
+    displacementNp1_(NULL),
+    density_(NULL),
+    dualNodalVolume_(NULL),
+    dt_(0.0),
+    nDim_(1)
+{
+  // save off fields
+  stk::mesh::MetaData& meta_data = realm_.meta_data();
+  VectorFieldType* displacement = meta_data.get_field<VectorFieldType>(
+    stk::topology::NODE_RANK, "mesh_displacement");
+  displacementNp1_ = &(displacement->field_of_state(stk::mesh::StateNP1));
+  displacementN_ = &(displacement->field_of_state(stk::mesh::StateN));
+  density_ =
+    meta_data.get_field<ScalarFieldType>(stk::topology::NODE_RANK, "density");
+  dualNodalVolume_ = meta_data.get_field<ScalarFieldType>(
+    stk::topology::NODE_RANK, "dual_nodal_volume");
+  nDim_ = meta_data.spatial_dimension();
+}
+
+//--------------------------------------------------------------------------
+//-------- setup -----------------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementMassBackwardEulerNodeSuppAlg::setup()
+{
+  dt_ = realm_.timeIntegrator_->get_time_step();
+}
+
+//--------------------------------------------------------------------------
+//-------- node_execute ----------------------------------------------------
+//--------------------------------------------------------------------------
+void
+MeshDisplacementMassBackwardEulerNodeSuppAlg::node_execute(
+  double* lhs, double* rhs, stk::mesh::Entity node)
+{
+  // deal with lumped mass matrix (diagonal matrix)
+  const double* dxN = stk::mesh::field_data(*displacementN_, node);
+  const double* dxNp1 = stk::mesh::field_data(*displacementNp1_, node);
+  const double rho = *stk::mesh::field_data(*density_, node);
+  const double dualVolume = *stk::mesh::field_data(*dualNodalVolume_, node);
+
+  const double lhsfac = rho * dualVolume / dt_ / dt_;
+  const int nDim = nDim_;
+  for (int i = 0; i < nDim; ++i) {
+    rhs[i] += -lhsfac * (dxNp1[i] - dxN[i]);
+    const int row = i * nDim;
+    lhs[row + i] += lhsfac;
+  }
+}
+
+} // namespace nalu
+} // namespace sierra

--- a/unit_tests/aero/UnitTestDisplacements.C
+++ b/unit_tests/aero/UnitTestDisplacements.C
@@ -9,29 +9,9 @@
 
 #include <gtest/gtest.h>
 #include <aero/aero_utils/displacements.h>
-
-testing::Message&
-operator<<(testing::Message& out, const vs::Vector& vec)
-{
-  out << "(" << vec.x() << " " << vec.y() << " " << vec.z() << ")";
-  return out;
-}
+#include "WmpTestUtils.h"
 
 namespace test_displacements {
-//! Test that two WM Params give the same end location for a point
-void
-test_wiener_milenkovic(
-  vs::Vector goldWmp, vs::Vector testWmp, vs::Vector testPoint, double eps)
-{
-  auto goldPnt = wmp::rotate(goldWmp, testPoint);
-  auto testPnt = wmp::rotate(testWmp, testPoint);
-  EXPECT_NEAR(goldPnt.x(), testPnt.x(), eps)
-    << "Gold WMP: " << goldWmp << " testWmp: " << testWmp;
-  EXPECT_NEAR(goldPnt.y(), testPnt.y(), eps)
-    << "Gold WMP: " << goldWmp << " testWmp: " << testWmp;
-  EXPECT_NEAR(goldPnt.z(), testPnt.z(), eps)
-    << "Gold WMP: " << goldWmp << " testWmp: " << testWmp;
-}
 
 TEST(AeroDisplacements, creation_from_pointer)
 {

--- a/unit_tests/aero/UnitTestWienerMilenkovic.C
+++ b/unit_tests/aero/UnitTestWienerMilenkovic.C
@@ -7,14 +7,12 @@
 // for more details.
 //
 
-#include "vs/vector.h"
-#include "vs/vstraits.h"
-#include <gtest/gtest.h>
-#include <aero/aero_utils/WienerMilenkovic.h>
 #include <vs/trig_ops.h>
 #include "KokkosInterface.h"
+#include "WmpTestUtils.h"
 
 namespace {
+
 using KVector =
   Kokkos::View<vs::Vector*, Kokkos::LayoutRight, sierra::nalu::MemSpace>;
 using KDouble =
@@ -191,10 +189,20 @@ TEST(WienerMilenkovic, NGP_compose_two_rotations_same_as_two_quaternions)
 
 TEST(WienerMilenkovic, NGP_compose_push_then_pop_param)
 {
-  const auto wmp1 = wmp::create_wm_param(vs::Vector::khat(), 30.0);
-  const auto wmp2 = wmp::create_wm_param({1.0, 1.0, 1.0}, 25.0);
+  const auto wmp1 = wmp::create_wm_param(vs::Vector::khat(), utils::radians(30.0));
+  const auto wmp2 = wmp::create_wm_param({1.0, 1.0, 1.0}, utils::radians(25.0));
   const vs::Vector point = {1.0, 1.0, 1.0};
   impl_test_WM_compose_add_sub(wmp1, wmp2, point);
+}
+
+TEST(WienerMilenkovic, interpolate_rotation){
+const auto wmp1 = wmp::create_wm_param(vs::Vector::khat(), utils::radians(45.0));
+const auto wmp2 = wmp::create_wm_param(vs::Vector::khat(), utils::radians(55.0));
+const auto gold_wmp = wmp::create_wm_param(vs::Vector::khat(), utils::radians(50.0));
+const double fac = 0.5;
+const auto interp = wmp::linear_interp_rotation(wmp1, wmp2, fac);
+
+test_wiener_milenkovic(gold_wmp, interp, vs::Vector::ihat(), 1e-12);
 }
 
 } // namespace test_wmp

--- a/unit_tests/aero/UnitTestWienerMilenkovic.C
+++ b/unit_tests/aero/UnitTestWienerMilenkovic.C
@@ -202,8 +202,6 @@ TEST(WienerMilenkovic, interpolate_rotation)
     wmp::create_wm_param(vs::Vector::khat(), utils::radians(45.0));
   const auto wmp2 =
     wmp::create_wm_param(vs::Vector::khat(), utils::radians(55.0));
-  const auto gold_wmp =
-    wmp::create_wm_param(vs::Vector::khat(), utils::radians(50.0));
   const double fac = 0.5;
   const auto interp = wmp::linear_interp_rotation(wmp1, wmp2, fac);
 

--- a/unit_tests/aero/UnitTestWienerMilenkovic.C
+++ b/unit_tests/aero/UnitTestWienerMilenkovic.C
@@ -189,20 +189,25 @@ TEST(WienerMilenkovic, NGP_compose_two_rotations_same_as_two_quaternions)
 
 TEST(WienerMilenkovic, NGP_compose_push_then_pop_param)
 {
-  const auto wmp1 = wmp::create_wm_param(vs::Vector::khat(), utils::radians(30.0));
+  const auto wmp1 =
+    wmp::create_wm_param(vs::Vector::khat(), utils::radians(30.0));
   const auto wmp2 = wmp::create_wm_param({1.0, 1.0, 1.0}, utils::radians(25.0));
   const vs::Vector point = {1.0, 1.0, 1.0};
   impl_test_WM_compose_add_sub(wmp1, wmp2, point);
 }
 
-TEST(WienerMilenkovic, interpolate_rotation){
-const auto wmp1 = wmp::create_wm_param(vs::Vector::khat(), utils::radians(45.0));
-const auto wmp2 = wmp::create_wm_param(vs::Vector::khat(), utils::radians(55.0));
-const auto gold_wmp = wmp::create_wm_param(vs::Vector::khat(), utils::radians(50.0));
-const double fac = 0.5;
-const auto interp = wmp::linear_interp_rotation(wmp1, wmp2, fac);
+TEST(WienerMilenkovic, interpolate_rotation)
+{
+  const auto wmp1 =
+    wmp::create_wm_param(vs::Vector::khat(), utils::radians(45.0));
+  const auto wmp2 =
+    wmp::create_wm_param(vs::Vector::khat(), utils::radians(55.0));
+  const auto gold_wmp =
+    wmp::create_wm_param(vs::Vector::khat(), utils::radians(50.0));
+  const double fac = 0.5;
+  const auto interp = wmp::linear_interp_rotation(wmp1, wmp2, fac);
 
-test_wiener_milenkovic(gold_wmp, interp, vs::Vector::ihat(), 1e-12);
+  test_wiener_milenkovic_angle(50.0, interp, 1e-8);
 }
 
 } // namespace test_wmp

--- a/unit_tests/aero/WmpTestUtils.h
+++ b/unit_tests/aero/WmpTestUtils.h
@@ -33,3 +33,17 @@ test_wiener_milenkovic(
   EXPECT_NEAR(goldPnt.z(), testPnt.z(), eps)
     << "Gold WMP: " << goldWmp << " testWmp: " << testWmp;
 }
+
+inline void
+test_wiener_milenkovic_angle(
+  double goldAngle,
+  vs::Vector testWmp,
+  double eps,
+  bool radians = false)
+{
+  const auto testAngle = stk::math::atan(vs::mag(testWmp) * 0.25) * 4.0;
+  if (radians)
+    EXPECT_NEAR(goldAngle, testAngle, eps);
+  else
+    EXPECT_NEAR(goldAngle, utils::degrees(testAngle), eps);
+}

--- a/unit_tests/aero/WmpTestUtils.h
+++ b/unit_tests/aero/WmpTestUtils.h
@@ -1,0 +1,35 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#include <gtest/gtest.h>
+#include "vs/vector.h"
+#include "vs/vstraits.h"
+#include <aero/aero_utils/WienerMilenkovic.h>
+
+inline testing::Message&
+operator<<(testing::Message& out, const vs::Vector& vec)
+{
+  out << "(" << vec.x() << " " << vec.y() << " " << vec.z() << ")";
+  return out;
+}
+
+//! Test that two WM Params give the same end location for a point
+inline void
+test_wiener_milenkovic(
+  vs::Vector goldWmp, vs::Vector testWmp, vs::Vector testPoint, double eps)
+{
+  auto goldPnt = wmp::rotate(goldWmp, testPoint);
+  auto testPnt = wmp::rotate(testWmp, testPoint);
+  EXPECT_NEAR(goldPnt.x(), testPnt.x(), eps)
+    << "Gold WMP: " << goldWmp << " testWmp: " << testWmp;
+  EXPECT_NEAR(goldPnt.y(), testPnt.y(), eps)
+    << "Gold WMP: " << goldWmp << " testWmp: " << testWmp;
+  EXPECT_NEAR(goldPnt.z(), testPnt.z(), eps)
+    << "Gold WMP: " << goldWmp << " testWmp: " << testWmp;
+}

--- a/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityAdvEdge.C
@@ -115,7 +115,7 @@ TEST_F(ContinuityEdgeHex8Mesh, NGP_advection)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.mdotInterpRhoUTogether_ = true;
 
   unit_test_utils::EdgeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1);

--- a/unit_tests/edge_kernels/UnitTestContinuityOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestContinuityOpenEdge.C
@@ -116,7 +116,7 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_open_edge)
 
   // Setup solution options for velocityRTM queries
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   auto* part = meta_->get_part("surface_2");
   const int numDof = 1;

--- a/unit_tests/edge_kernels/UnitTestMomentumABLWallFuncEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumABLWallFuncEdge.C
@@ -26,7 +26,7 @@ TEST_F(MomentumABLKernelHex8Mesh, NGP_abl_wall_func)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   auto* part = meta_->get_part("surface_5");
   unit_test_utils::HelperObjects helperObjs(

--- a/unit_tests/edge_kernels/UnitTestMomentumAdvDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumAdvDiffEdge.C
@@ -238,7 +238,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_advection_diffusion)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.alphaMap_["velocity"] = 0.0;
   solnOpts_.alphaUpwMap_["velocity"] = 0.0;
   solnOpts_.upwMap_["velocity"] = 0.0;

--- a/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumOpenEdge.C
@@ -230,7 +230,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_open_edge)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   auto* part = meta_->get_part("surface_2");
   bool isEdge = true;

--- a/unit_tests/edge_kernels/UnitTestMomentumSSTAMSDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumSSTAMSDiffEdge.C
@@ -529,7 +529,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_diff)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.includeDivU_ = false;
   solnOpts_.alphaMap_["velocity"] = 0.0;
   solnOpts_.alphaUpwMap_["velocity"] = 0.0;

--- a/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
+++ b/unit_tests/edge_kernels/UnitTestMomentumSymmetryEdge.C
@@ -193,7 +193,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   auto* part = meta_->get_part("surface_2");
   bool isEdge = true;
@@ -225,7 +225,7 @@ TEST_F(MomentumKernelHex8Mesh, NGP_symmetry_edge_penalty)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.symmetryBcPenaltyFactor_ = 2.0;
 
   auto* part = meta_->get_part("surface_2");

--- a/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarAdvDiffEdge.C
@@ -168,7 +168,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.alphaMap_["mixture_fraction"] = 0.0;
   solnOpts_.alphaUpwMap_["mixture_fraction"] = 0.0;
   solnOpts_.upwMap_["mixture_fraction"] = 0.0;
@@ -246,7 +246,7 @@ TEST_F(
 
   // Setup solution options for default advection kernel
   solnOpts->meshMotion_ = false;
-  solnOpts->externalMeshDeformation_ = false;
+  solnOpts->meshDeformation_ = false;
   solnOpts->alphaMap_["mixture_fraction"] = 0.0;
   solnOpts->alphaUpwMap_["mixture_fraction"] = 0.0;
   solnOpts->upwMap_["mixture_fraction"] = 0.0;
@@ -309,7 +309,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, NGP_adv_diff_edge_tpetra_dirichlet)
 
   // Setup solution options for default advection kernel
   solnOpts->meshMotion_ = false;
-  solnOpts->externalMeshDeformation_ = false;
+  solnOpts->meshDeformation_ = false;
   solnOpts->alphaMap_["mixture_fraction"] = 0.0;
   solnOpts->alphaUpwMap_["mixture_fraction"] = 0.0;
   solnOpts->upwMap_["mixture_fraction"] = 0.0;

--- a/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
+++ b/unit_tests/edge_kernels/UnitTestScalarOpenEdge.C
@@ -117,7 +117,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_edge_open_solver_alg)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   auto* part = meta_->get_part("surface_2");
   unit_test_utils::FaceElemHelperObjects helperObjs(
@@ -169,7 +169,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_scalar_open_edge)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.relaxFactorMap_["turbulent_ke"] = 0.5;
 
   auto* part = meta_->get_part("surface_5");

--- a/unit_tests/edge_kernels/UnitTestVOFAdvectionEdge.C
+++ b/unit_tests/edge_kernels/UnitTestVOFAdvectionEdge.C
@@ -128,7 +128,7 @@ TEST_F(VOFKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
   fill_mesh_and_init_fields();
 
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.alphaMap_["volume_of_fluid"] = 0.0;
   solnOpts_.alphaUpwMap_["volume_of_fluid"] = 0.0;
   solnOpts_.upwMap_["volume_of_fluid"] = 0.0;

--- a/unit_tests/edge_kernels/UnitTestWallDistEdgeSolver.C
+++ b/unit_tests/edge_kernels/UnitTestWallDistEdgeSolver.C
@@ -109,7 +109,7 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_edge)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   unit_test_utils::EdgeHelperObjects helperObjs(bulk_, stk::topology::HEX_8, 1);
   helperObjs.create<sierra::nalu::WallDistEdgeSolverAlg>(partVec_[0]);

--- a/unit_tests/kernels/UnitTestContinuityInflowElem.C
+++ b/unit_tests/kernels/UnitTestContinuityInflowElem.C
@@ -29,7 +29,7 @@ TEST_F(ContinuityKernelHex8Mesh, NGP_inflow)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.cvfemShiftMdot_ = true;
   solnOpts_.shiftedGradOpMap_["pressure"] = true;
   solnOpts_.cvfemReducedSensPoisson_ = true;

--- a/unit_tests/kernels/UnitTestScalarOpenElem.C
+++ b/unit_tests/kernels/UnitTestScalarOpenElem.C
@@ -118,7 +118,7 @@ TEST_F(MixtureFractionKernelHex8Mesh, open_advection)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.cvfemShiftMdot_ = true;
   solnOpts_.cvfemReducedSensPoisson_ = true;
   solnOpts_.activateOpenMdotCorrection_ = true;

--- a/unit_tests/kernels/UnitTestWallDistElem.C
+++ b/unit_tests/kernels/UnitTestWallDistElem.C
@@ -193,7 +193,7 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   unit_test_utils::HelperObjects helperObjs(
     bulk_, stk::topology::HEX_8, 1, partVec_[0]);
@@ -226,7 +226,7 @@ TEST_F(WallDistKernelHex8Mesh, NGP_wall_dist_shifted)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.shiftedGradOpMap_["ndtw"] = true;
 
   unit_test_utils::HelperObjects helperObjs(

--- a/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
+++ b/unit_tests/ngp_algorithms/UnitTestMdotAlg.C
@@ -28,7 +28,7 @@ TEST_F(MomentumEdgeHex8Mesh, NGP_mdot_calc_edge)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.mdotInterpRhoUTogether_ = true;
 
   unit_test_utils::HelperObjects helperObjs(

--- a/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestAMSNodeKernel.C
@@ -243,7 +243,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_tke_ams_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -275,7 +275,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_sdr_ams_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -307,7 +307,7 @@ TEST_F(AMSKernelHex8Mesh, NGP_ams_forcing)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
   solnOpts_.eastVector_ = {1.0, 0.0, 0.0};
   solnOpts_.northVector_ = {0.0, 1.0, 0.0};

--- a/unit_tests/node_kernels/UnitTestKENodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestKENodeKernel.C
@@ -215,7 +215,7 @@ TEST_F(KEKernelHex8Mesh, NGP_tke_ke_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -250,7 +250,7 @@ TEST_F(KEKernelHex8Mesh, NGP_tdr_ke_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(

--- a/unit_tests/node_kernels/UnitTestKONodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestKONodeKernel.C
@@ -210,7 +210,7 @@ TEST_F(KOKernelHex8Mesh, NGP_tke_ko_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -245,7 +245,7 @@ TEST_F(KOKernelHex8Mesh, NGP_sdr_ko_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(

--- a/unit_tests/node_kernels/UnitTestKsgsNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestKsgsNodeKernel.C
@@ -120,7 +120,7 @@ TEST_F(KsgsKernelHex8Mesh, NGP_tke_ksgs_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(

--- a/unit_tests/node_kernels/UnitTestMomentumActuatorNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestMomentumActuatorNodeKernel.C
@@ -28,7 +28,7 @@ TEST_F(ActuatorSourceKernelHex8Mesh, NGP_momentum_actuator)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   unit_test_utils::NodeHelperObjects helperObjs(
     bulk_, stk::topology::HEX_8, 3, partVec_[0]);

--- a/unit_tests/node_kernels/UnitTestMomentumBoussinesqNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumBoussinesqNode.C
@@ -29,7 +29,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_boussinesq)
 
   // Setup solution options for default advection kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.gravity_.resize(spatialDim_, 0.0);
   solnOpts_.gravity_[2] = -9.81;
   solnOpts_.referenceDensity_ = ref_densities(rng);

--- a/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
+++ b/unit_tests/node_kernels/UnitTestMomentumCoriolisNode.C
@@ -32,7 +32,7 @@ TEST_F(MomentumNodeHex8Mesh, NGP_momentum_coriolis)
 
   // Setup solution options for default kernel
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
 
   // Setup Coriolis specific options.  Mimics the Ekman spiral test
   solnOpts_.earthAngularVelocity_ = 7.2921159e-5;

--- a/unit_tests/node_kernels/UnitTestSSTNodeKernel.C
+++ b/unit_tests/node_kernels/UnitTestSSTNodeKernel.C
@@ -640,7 +640,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -675,7 +675,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_sust_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -713,7 +713,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sstlr_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -748,7 +748,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -783,7 +783,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_tke_sst_des_sust_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -821,7 +821,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -856,7 +856,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_sust_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -894,7 +894,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sstlr_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -929,7 +929,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_des_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(
@@ -965,7 +965,7 @@ TEST_F(SSTKernelHex8Mesh, NGP_sdr_sst_des_sust_node)
 
   // Setup solution options
   solnOpts_.meshMotion_ = false;
-  solnOpts_.externalMeshDeformation_ = false;
+  solnOpts_.meshDeformation_ = false;
   solnOpts_.initialize_turbulence_constants();
 
   unit_test_utils::NodeHelperObjects helperObjs(


### PR DESCRIPTION
WIP to revive the MeshDeformationEqSys removed in #835.  The goal is to solve this equation system with boundary conditions coming from our FSI deformation mapping scheme to reduce the probability of getting inverted elements.