### PR TITLE
Proposed fix to WMP rotation interpolation

### DIFF
--- a/include/aero/aero_utils/WienerMilenkovic.h
+++ b/include/aero/aero_utils/WienerMilenkovic.h
@@ -135,12 +135,10 @@ vs::Vector
 linear_interp_rotation(
   const vs::Vector qStart, const vs::Vector qEnd, const double interpFac)
 {
-  return compose(interpFac * compose(qEnd, qStart, false, true), qStart);
-
   // remove rigid body rotation
   auto qIntermediate = pop(qStart, qEnd);
   qIntermediate *= interpFac;
-  return push(qIntermediate, qStart);
+  return push(qStart, qIntermediate);
 }
 
 KOKKOS_FORCEINLINE_FUNCTION

--- a/unit_tests/aero/UnitTestWienerMilenkovic.C
+++ b/unit_tests/aero/UnitTestWienerMilenkovic.C
@@ -206,8 +206,7 @@ TEST(WienerMilenkovic, rotation_interpolation)
     wmp::create_wm_param(vs::Vector::khat(), utils::radians(angleEnd));
   const auto interp = wmp::linear_interp_rotation(qStart, qEnd, factor);
   const auto goldAngle = utils::radians(factor * (angleStart + angleEnd));
-  const double interpAngle =
-    4.0* stk::math::atan(0.25*vs::mag(interp));
+  const double interpAngle = 4.0 * stk::math::atan(0.25 * vs::mag(interp));
   EXPECT_NEAR(goldAngle, interpAngle, 1e-4);
 }
 } // namespace test_wmp

--- a/unit_tests/aero/UnitTestWienerMilenkovic.C
+++ b/unit_tests/aero/UnitTestWienerMilenkovic.C
@@ -197,4 +197,17 @@ TEST(WienerMilenkovic, NGP_compose_push_then_pop_param)
   impl_test_WM_compose_add_sub(wmp1, wmp2, point);
 }
 
+TEST(WienerMilenkovic, rotation_interpolation)
+{
+  const double angleStart{30.0}, angleEnd{40.0}, factor{0.5};
+  const auto qStart =
+    wmp::create_wm_param(vs::Vector::khat(), utils::radians(angleStart));
+  const auto qEnd =
+    wmp::create_wm_param(vs::Vector::khat(), utils::radians(angleEnd));
+  const auto interp = wmp::linear_interp_rotation(qStart, qEnd, factor);
+  const auto goldAngle = utils::radians(factor * (angleStart + angleEnd));
+  const double interpAngle =
+    4.0* stk::math::atan(0.25*vs::mag(interp));
+  EXPECT_NEAR(goldAngle, interpAngle, 1e-4);
+}
 } // namespace test_wmp


### PR DESCRIPTION
Testing the current interpolation leads to an error in the interpolation in excess of 1 degree for the test below.  The proposed change drives it to the 4 significant figure in my local testing.  

Running the blade deformation case with this change eliminates inverted elements, and spurious deformations when crossing the x-y plane for the test case.