### PR TITLE
Replace stk::mesh::Part* with stk::mesh::PartVector&.  Issue #1183

### DIFF
--- a/include/AMSAlgDriver.h
+++ b/include/AMSAlgDriver.h
@@ -34,7 +34,7 @@ public:
 
   AMSAlgDriver(Realm& realm);
   virtual ~AMSAlgDriver() = default;
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
   virtual void register_edge_fields(stk::mesh::Part* part);
   void register_interior_algorithm(stk::mesh::Part* part);
   void execute();

--- a/include/Algorithm.h
+++ b/include/Algorithm.h
@@ -33,7 +33,7 @@ public:
   Algorithm(Realm& realm, stk::mesh::Part* part);
 
   // provide part vector
-  Algorithm(Realm& realm, stk::mesh::PartVector& partVec);
+  Algorithm(Realm& realm, const stk::mesh::PartVector& partVec);
 
   virtual ~Algorithm();
 

--- a/include/ChienKEpsilonEquationSystem.h
+++ b/include/ChienKEpsilonEquationSystem.h
@@ -40,7 +40,7 @@ public:
 
   virtual void initialize();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   virtual void register_wall_bc(
     stk::mesh::Part* part,

--- a/include/CopyFieldAlgorithm.h
+++ b/include/CopyFieldAlgorithm.h
@@ -34,6 +34,15 @@ class CopyFieldAlgorithm : public Algorithm
 public:
   CopyFieldAlgorithm(
     Realm& realm,
+    const stk::mesh::PartVector &part_vec,
+    stk::mesh::FieldBase* fromField,
+    stk::mesh::FieldBase* toField,
+    const unsigned beginPos,
+    const unsigned endPos,
+    const stk::mesh::EntityRank entityRank);
+
+  CopyFieldAlgorithm(
+    Realm& realm,
     stk::mesh::Part* part,
     stk::mesh::FieldBase* fromField,
     stk::mesh::FieldBase* toField,

--- a/include/CopyFieldAlgorithm.h
+++ b/include/CopyFieldAlgorithm.h
@@ -34,7 +34,7 @@ class CopyFieldAlgorithm : public Algorithm
 public:
   CopyFieldAlgorithm(
     Realm& realm,
-    const stk::mesh::PartVector &part_vec,
+    const stk::mesh::PartVector& part_vec,
     stk::mesh::FieldBase* fromField,
     stk::mesh::FieldBase* toField,
     const unsigned beginPos,

--- a/include/EnthalpyEquationSystem.h
+++ b/include/EnthalpyEquationSystem.h
@@ -45,7 +45,7 @@ public:
     const bool outputClippingDiag);
   virtual ~EnthalpyEquationSystem();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   void register_interior_algorithm(stk::mesh::Part* part);
 

--- a/include/EquationSystem.h
+++ b/include/EquationSystem.h
@@ -69,7 +69,7 @@ public:
   virtual void populate_derived_quantities() {}
 
   // base class with desired default no-op
-  virtual void register_nodal_fields(stk::mesh::Part* /* part */) {}
+  virtual void register_nodal_fields(const stk::mesh::PartVector& /* part */) {}
 
   virtual void register_edge_fields(stk::mesh::Part* /* part */) {}
 

--- a/include/GammaEquationSystem.h
+++ b/include/GammaEquationSystem.h
@@ -34,7 +34,7 @@ public:
   GammaEquationSystem(EquationSystems& equationSystems);
   virtual ~GammaEquationSystem();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   void register_interior_algorithm(stk::mesh::Part* part);
 

--- a/include/LowMachEquationSystem.h
+++ b/include/LowMachEquationSystem.h
@@ -56,40 +56,42 @@ public:
     EquationSystems& equationSystems, const bool elementContinuityEqs);
   virtual ~LowMachEquationSystem();
 
-  virtual void load(const YAML::Node&);
+  virtual void load(const YAML::Node&) override;
 
-  virtual void initialize();
-
-  virtual void register_nodal_fields(stk::mesh::Part* part);
-
-  virtual void register_edge_fields(stk::mesh::Part* part);
+  virtual void initialize() override;
 
   virtual void
-  register_element_fields(stk::mesh::Part* part, const stk::topology& theTopo);
+  register_nodal_fields(const stk::mesh::PartVector& part_vec) override;
+
+  virtual void register_edge_fields(stk::mesh::Part* part) override;
+
+  virtual void register_element_fields(
+    stk::mesh::Part* part, const stk::topology& theTopo) override;
 
   virtual void register_open_bc(
     stk::mesh::Part* part,
     const stk::topology& partTopo,
-    const OpenBoundaryConditionData& openBCData);
+    const OpenBoundaryConditionData& openBCData) override;
 
   virtual void register_surface_pp_algorithm(
-    const PostProcessingData& theData, stk::mesh::PartVector& partVector);
+    const PostProcessingData& theData,
+    stk::mesh::PartVector& partVector) override;
 
   virtual void register_initial_condition_fcn(
     stk::mesh::Part* part,
     const std::map<std::string, std::string>& theNames,
-    const std::map<std::string, std::vector<double>>& theParams);
+    const std::map<std::string, std::vector<double>>& theParams) override;
 
-  virtual void pre_iter_work();
-  virtual void solve_and_update();
+  virtual void pre_iter_work() override;
+  virtual void solve_and_update() override;
 
-  virtual void predict_state();
+  virtual void predict_state() override;
 
   void project_nodal_velocity();
 
-  void post_converged_work();
+  void post_converged_work() override;
 
-  virtual void post_iter_work();
+  virtual void post_iter_work() override;
 
   const bool
     elementContinuityEqs_; /* allow for mixed element/edge for continuity */
@@ -120,7 +122,8 @@ public:
   virtual void initial_work() override;
   virtual void pre_timestep_work() override;
 
-  virtual void register_nodal_fields(stk::mesh::Part* part) override;
+  virtual void
+  register_nodal_fields(const stk::mesh::PartVector& part_vec) override;
 
   virtual void register_edge_fields(stk::mesh::Part* part) override;
 
@@ -236,57 +239,58 @@ public:
     EquationSystems& equationSystems, const bool elementContinuityEqs);
   virtual ~ContinuityEquationSystem();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
-
-  virtual void register_edge_fields(stk::mesh::Part* part);
-
   virtual void
-  register_element_fields(stk::mesh::Part* part, const stk::topology& theTopo);
+  register_nodal_fields(const stk::mesh::PartVector& part_vec) override;
 
-  virtual void register_interior_algorithm(stk::mesh::Part* part);
+  virtual void register_edge_fields(stk::mesh::Part* part) override;
+
+  virtual void register_element_fields(
+    stk::mesh::Part* part, const stk::topology& theTopo) override;
+
+  virtual void register_interior_algorithm(stk::mesh::Part* part) override;
 
   virtual void register_inflow_bc(
     stk::mesh::Part* part,
     const stk::topology& partTopo,
-    const InflowBoundaryConditionData& inflowBCData);
+    const InflowBoundaryConditionData& inflowBCData) override;
 
   virtual void register_open_bc(
     stk::mesh::Part* part,
     const stk::topology& partTopo,
-    const OpenBoundaryConditionData& openBCData);
+    const OpenBoundaryConditionData& openBCData) override;
 
   virtual void register_wall_bc(
     stk::mesh::Part* part,
     const stk::topology& theTopo,
-    const WallBoundaryConditionData& wallBCData);
+    const WallBoundaryConditionData& wallBCData) override;
 
   virtual void register_symmetry_bc(
     stk::mesh::Part* part,
     const stk::topology& theTopo,
-    const SymmetryBoundaryConditionData& symmetryBCData);
+    const SymmetryBoundaryConditionData& symmetryBCData) override;
 
   virtual void register_abltop_bc(
     stk::mesh::Part* part,
     const stk::topology& partTopo,
-    const ABLTopBoundaryConditionData& ablTopBCData);
+    const ABLTopBoundaryConditionData& ablTopBCData) override;
 
   virtual void register_non_conformal_bc(
-    stk::mesh::Part* part, const stk::topology& theTopo);
+    stk::mesh::Part* part, const stk::topology& theTopo) override;
 
-  virtual void register_overset_bc();
+  virtual void register_overset_bc() override;
 
-  virtual void initialize();
-  virtual void reinitialize_linear_system();
+  virtual void initialize() override;
+  virtual void reinitialize_linear_system() override;
 
   virtual void register_initial_condition_fcn(
     stk::mesh::Part* part,
     const std::map<std::string, std::string>& theNames,
-    const std::map<std::string, std::vector<double>>& theParams);
+    const std::map<std::string, std::vector<double>>& theParams) override;
 
   virtual void manage_projected_nodal_gradient(EquationSystems& eqSystems);
   virtual void compute_projected_nodal_gradient();
 
-  virtual void create_constraint_algorithm(stk::mesh::FieldBase*);
+  virtual void create_constraint_algorithm(stk::mesh::FieldBase*) override;
 
   const bool elementContinuityEqs_;
   const bool managePNG_;

--- a/include/MatrixFreeHeatCondEquationSystem.h
+++ b/include/MatrixFreeHeatCondEquationSystem.h
@@ -37,7 +37,7 @@ public:
   virtual ~MatrixFreeHeatCondEquationSystem();
 
   void initialize() final;
-  void register_nodal_fields(stk::mesh::Part* part) final;
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
   void register_interior_algorithm(stk::mesh::Part* part) final;
   void register_wall_bc(
     stk::mesh::Part* part,

--- a/include/MatrixFreeLowMachEquationSystem.h
+++ b/include/MatrixFreeLowMachEquationSystem.h
@@ -47,7 +47,7 @@ public:
   MatrixFreeLowMachEquationSystem(EquationSystems&);
   virtual ~MatrixFreeLowMachEquationSystem();
   void initialize() final;
-  void register_nodal_fields(stk::mesh::Part*) final;
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
   void register_interior_algorithm(stk::mesh::Part*) final;
   double provide_norm() const final;
   double provide_scaled_norm() const final;
@@ -143,9 +143,9 @@ private:
   void sync_field_on_periodic_nodes(std::string name, int len) const;
   void setup_and_compute_continuity_preconditioner();
   void compute_courant_reynolds();
-  void check_part_is_valid(const stk::mesh::Part*);
-  void
-  register_copy_state_algorithm(std::string, int dim, stk::mesh::Part& part);
+  void check_part_is_valid(const stk::mesh::PartVector&);
+  void register_copy_state_algorithm(
+    std::string, int dim, const stk::mesh::PartVector&);
 
   std::string get_muelu_xml_file_name();
 

--- a/include/ProjectedNodalGradientEquationSystem.h
+++ b/include/ProjectedNodalGradientEquationSystem.h
@@ -48,7 +48,7 @@ public:
 
   std::string get_name_given_bc(BoundaryConditionType BC);
 
-  void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   void register_interior_algorithm(stk::mesh::Part* part);
 

--- a/include/Realm.h
+++ b/include/Realm.h
@@ -188,7 +188,7 @@ public:
 
   void register_interior_algorithm(stk::mesh::Part* part);
 
-  void register_nodal_fields(stk::mesh::Part* part);
+  void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   void register_wall_bc(stk::mesh::Part* part, const stk::topology& theTopo);
 

--- a/include/ShearStressTransportEquationSystem.h
+++ b/include/ShearStressTransportEquationSystem.h
@@ -41,7 +41,7 @@ public:
 
   virtual void initialize();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   virtual void register_wall_bc(
     stk::mesh::Part* part,

--- a/include/SpecificDissipationRateEquationSystem.h
+++ b/include/SpecificDissipationRateEquationSystem.h
@@ -34,7 +34,7 @@ public:
   SpecificDissipationRateEquationSystem(EquationSystems& equationSystems);
   virtual ~SpecificDissipationRateEquationSystem();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   void register_interior_algorithm(stk::mesh::Part* part);
 

--- a/include/TotalDissipationRateEquationSystem.h
+++ b/include/TotalDissipationRateEquationSystem.h
@@ -34,7 +34,7 @@ public:
   TotalDissipationRateEquationSystem(EquationSystems& equationSystems);
   virtual ~TotalDissipationRateEquationSystem();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   void register_interior_algorithm(stk::mesh::Part* part);
 

--- a/include/TurbKineticEnergyEquationSystem.h
+++ b/include/TurbKineticEnergyEquationSystem.h
@@ -37,7 +37,7 @@ public:
 
   virtual ~TurbKineticEnergyEquationSystem() = default;
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   void register_interior_algorithm(stk::mesh::Part* part);
 

--- a/include/VolumeOfFluidEquationSystem.h
+++ b/include/VolumeOfFluidEquationSystem.h
@@ -44,7 +44,7 @@ public:
   VolumeOfFluidEquationSystem(EquationSystems& equationSystems);
   virtual ~VolumeOfFluidEquationSystem();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   virtual void register_edge_fields(stk::mesh::Part* part);
 

--- a/include/WallDistEquationSystem.h
+++ b/include/WallDistEquationSystem.h
@@ -33,7 +33,7 @@ public:
 
   void initial_work();
 
-  void register_nodal_fields(stk::mesh::Part*);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   void register_edge_fields(stk::mesh::Part*);
 

--- a/include/WilcoxKOmegaEquationSystem.h
+++ b/include/WilcoxKOmegaEquationSystem.h
@@ -40,7 +40,7 @@ public:
 
   virtual void initialize();
 
-  virtual void register_nodal_fields(stk::mesh::Part* part);
+  virtual void register_nodal_fields(const stk::mesh::PartVector& part_vec);
 
   virtual void register_wall_bc(
     stk::mesh::Part* part,

--- a/include/aero/AeroContainer.h
+++ b/include/aero/AeroContainer.h
@@ -37,7 +37,8 @@ public:
   void setup(double timeStep, std::shared_ptr<stk::mesh::BulkData> stkBulk);
   void execute(double& timer);
   void init(double currentTime, double restartFrequency);
-  void register_nodal_fields(stk::mesh::MetaData& meta, stk::mesh::Part* part);
+  void register_nodal_fields(
+    stk::mesh::MetaData& meta, const stk::mesh::PartVector& part_vec);
   void update_displacements(const double currentTime);
   void predict_model_time_step(const double /*currentTime*/);
   void advance_model_time_step(const double /*currentTime*/);

--- a/include/property_evaluator/ThermalConductivityFromPrandtlPropAlgorithm.h
+++ b/include/property_evaluator/ThermalConductivityFromPrandtlPropAlgorithm.h
@@ -31,7 +31,7 @@ class ThermalConductivityFromPrandtlPropAlgorithm : public Algorithm
 public:
   ThermalConductivityFromPrandtlPropAlgorithm(
     Realm& realm,
-    stk::mesh::Part* part,
+    const stk::mesh::PartVector& part_vec,
     ScalarFieldType* thermalCond,
     ScalarFieldType* specificHeat,
     ScalarFieldType* viscosity,

--- a/include/utils/StkHelpers.h
+++ b/include/utils/StkHelpers.h
@@ -102,14 +102,14 @@ get_node_field(
 void register_scalar_nodal_field_on_part(
   stk::mesh::MetaData& meta,
   std::string name,
-  const stk::mesh::Part& selector,
+  const stk::mesh::Selector& selector,
   int num_states,
   double ic = 0);
 
 void register_vector_nodal_field_on_part(
   stk::mesh::MetaData& meta,
   std::string name,
-  const stk::mesh::Part& selector,
+  const stk::mesh::Selector& selector,
   int num_states,
   std::array<double, 3> x = {{0, 0, 0}});
 

--- a/src/AMSAlgDriver.C
+++ b/src/AMSAlgDriver.C
@@ -61,10 +61,11 @@ AMSAlgDriver::AMSAlgDriver(Realm& realm)
 }
 
 void
-AMSAlgDriver::register_nodal_fields(stk::mesh::Part* part)
+AMSAlgDriver::register_nodal_fields(const stk::mesh::PartVector& part_vec)
 {
   stk::mesh::MetaData& meta = realm_.meta_data();
   const int nDim = meta.spatial_dimension();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   // Set numStates as 2, so avg quantities can be updated through Picard iters
   const int numStates = 2;
@@ -72,11 +73,11 @@ AMSAlgDriver::register_nodal_fields(stk::mesh::Part* part)
   // Nodal fields
   beta_ =
     &(meta.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "k_ratio"));
-  stk::mesh::put_field_on_mesh(*beta_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*beta_, selector, nullptr);
 
   avgVelocity_ = &(meta.declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "average_velocity", numStates));
-  stk::mesh::put_field_on_mesh(*avgVelocity_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*avgVelocity_, selector, nDim, nullptr);
   realm_.augment_restart_variable_list("average_velocity");
 
   if (
@@ -84,44 +85,44 @@ AMSAlgDriver::register_nodal_fields(stk::mesh::Part* part)
     realm_.solutionOptions_->externalMeshDeformation_) {
     avgVelocityRTM_ = &(meta.declare_field<VectorFieldType>(
       stk::topology::NODE_RANK, "average_velocity_rtm"));
-    stk::mesh::put_field_on_mesh(*avgVelocityRTM_, *part, nDim, nullptr);
+    stk::mesh::put_field_on_mesh(*avgVelocityRTM_, selector, nDim, nullptr);
   }
 
   avgProduction_ = &(meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "average_production", numStates));
-  stk::mesh::put_field_on_mesh(*avgProduction_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*avgProduction_, selector, nullptr);
   realm_.augment_restart_variable_list("average_production");
 
   avgDudx_ = &(meta.declare_field<GenericFieldType>(
     stk::topology::NODE_RANK, "average_dudx", numStates));
-  stk::mesh::put_field_on_mesh(*avgDudx_, *part, nDim * nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*avgDudx_, selector, nDim * nDim, nullptr);
   realm_.augment_restart_variable_list("average_dudx");
 
   avgTkeResolved_ = &(meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "average_tke_resolved", numStates));
-  stk::mesh::put_field_on_mesh(*avgTkeResolved_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*avgTkeResolved_, selector, nullptr);
   realm_.augment_restart_variable_list("average_tke_resolved");
 
   avgTime_ = &(meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "rans_time_scale"));
-  stk::mesh::put_field_on_mesh(*avgTime_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*avgTime_, selector, nullptr);
 
   metric_ = &(meta.declare_field<GenericFieldType>(
     stk::topology::NODE_RANK, "metric_tensor"));
-  stk::mesh::put_field_on_mesh(*metric_, *part, nDim * nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*metric_, selector, nDim * nDim, nullptr);
 
   resAdequacy_ = &(meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "resolution_adequacy_parameter"));
-  stk::mesh::put_field_on_mesh(*resAdequacy_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*resAdequacy_, selector, nullptr);
 
   avgResAdequacy_ = &(meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "avg_res_adequacy_parameter", numStates));
-  stk::mesh::put_field_on_mesh(*avgResAdequacy_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*avgResAdequacy_, selector, nullptr);
   realm_.augment_restart_variable_list("avg_res_adequacy_parameter");
 
   forcingComp_ = &(meta.declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "forcing_components", numStates));
-  stk::mesh::put_field_on_mesh(*forcingComp_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*forcingComp_, selector, nDim, nullptr);
 }
 
 void

--- a/src/Algorithm.C
+++ b/src/Algorithm.C
@@ -22,14 +22,14 @@ namespace nalu {
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-Algorithm::Algorithm(Realm& realm, stk::mesh::Part* part) : realm_(realm)
+Algorithm::Algorithm(Realm& realm, stk::mesh::Part* part) : 
+  realm_(realm), partVec_(1,part)
 {
-  // push back on partVec
-  partVec_.push_back(part);
+  // nothing to do
 }
 
 // alternative; provide full partVec
-Algorithm::Algorithm(Realm& realm, stk::mesh::PartVector& partVec)
+Algorithm::Algorithm(Realm& realm, const stk::mesh::PartVector& partVec)
   : realm_(realm), partVec_(partVec)
 {
   // nothing to do

--- a/src/Algorithm.C
+++ b/src/Algorithm.C
@@ -22,8 +22,8 @@ namespace nalu {
 //--------------------------------------------------------------------------
 //-------- constructor -----------------------------------------------------
 //--------------------------------------------------------------------------
-Algorithm::Algorithm(Realm& realm, stk::mesh::Part* part) : 
-  realm_(realm), partVec_(1,part)
+Algorithm::Algorithm(Realm& realm, stk::mesh::Part* part)
+  : realm_(realm), partVec_(1, part)
 {
   // nothing to do
 }

--- a/src/ChienKEpsilonEquationSystem.C
+++ b/src/ChienKEpsilonEquationSystem.C
@@ -112,27 +112,29 @@ ChienKEpsilonEquationSystem::initialize()
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-ChienKEpsilonEquationSystem::register_nodal_fields(stk::mesh::Part* part)
+ChienKEpsilonEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
 
   stk::mesh::MetaData& meta_data = realm_.meta_data();
   const int numStates = realm_.number_of_states();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   // re-register tke and tdr for convenience
   tke_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "turbulent_ke", numStates));
-  stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*tke_, selector, nullptr);
   tdr_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "total_dissipation_rate", numStates));
-  stk::mesh::put_field_on_mesh(*tdr_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*tdr_, selector, nullptr);
 
   // SST parameters that everyone needs
   minDistanceToWall_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "minimum_distance_to_wall"));
-  stk::mesh::put_field_on_mesh(*minDistanceToWall_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*minDistanceToWall_, selector, nullptr);
   dplus_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "dplus_wall_function"));
-  stk::mesh::put_field_on_mesh(*dplus_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*dplus_, selector, nullptr);
 
   // add to restart field
   realm_.augment_restart_variable_list("minimum_distance_to_wall");

--- a/src/CopyFieldAlgorithm.C
+++ b/src/CopyFieldAlgorithm.C
@@ -34,6 +34,22 @@ namespace nalu {
 //==========================================================================
 CopyFieldAlgorithm::CopyFieldAlgorithm(
   Realm& realm,
+  const stk::mesh::PartVector &part_vec,
+  stk::mesh::FieldBase* fromField,
+  stk::mesh::FieldBase* toField,
+  const unsigned beginPos,
+  const unsigned endPos,
+  const stk::mesh::EntityRank entityRank)
+  : Algorithm(realm, part_vec),
+    fromField_(fromField),
+    toField_(toField),
+    beginPos_(beginPos),
+    endPos_(endPos),
+    entityRank_(entityRank)
+{
+}
+CopyFieldAlgorithm::CopyFieldAlgorithm(
+  Realm& realm,
   stk::mesh::Part* part,
   stk::mesh::FieldBase* fromField,
   stk::mesh::FieldBase* toField,

--- a/src/CopyFieldAlgorithm.C
+++ b/src/CopyFieldAlgorithm.C
@@ -34,7 +34,7 @@ namespace nalu {
 //==========================================================================
 CopyFieldAlgorithm::CopyFieldAlgorithm(
   Realm& realm,
-  const stk::mesh::PartVector &part_vec,
+  const stk::mesh::PartVector& part_vec,
   stk::mesh::FieldBase* fromField,
   stk::mesh::FieldBase* toField,
   const unsigned beginPos,

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -258,19 +258,19 @@ EquationSystems::register_nodal_fields(
 
   stk::mesh::PartVector part_vec;
   part_vec.reserve(targetNames.size());
-  for (const auto &part_name : targetNames) {
+  for (const auto& part_name : targetNames) {
     part_vec.push_back(meta_data.get_part(part_name));
     if (nullptr == part_vec.back()) {
       NaluEnv::self().naluOutputP0()
         << "Trouble with part " << part_name << std::endl;
       throw std::runtime_error(
         "Sorry, no part name found by the name " + part_name);
-    } 
+    }
   }
   realm_.register_nodal_fields(part_vec);
   EquationSystemVector::iterator ii;
-  for (ii = equationSystemVector_.begin();
-       ii != equationSystemVector_.end(); ++ii)
+  for (ii = equationSystemVector_.begin(); ii != equationSystemVector_.end();
+       ++ii)
     (*ii)->register_nodal_fields(part_vec);
 }
 

--- a/src/EquationSystems.C
+++ b/src/EquationSystems.C
@@ -256,21 +256,22 @@ EquationSystems::register_nodal_fields(
 {
   stk::mesh::MetaData& meta_data = realm_.meta_data();
 
-  for (size_t itarget = 0; itarget < targetNames.size(); ++itarget) {
-    stk::mesh::Part* targetPart = meta_data.get_part(targetNames[itarget]);
-    if (NULL == targetPart) {
+  stk::mesh::PartVector part_vec;
+  part_vec.reserve(targetNames.size());
+  for (const auto &part_name : targetNames) {
+    part_vec.push_back(meta_data.get_part(part_name));
+    if (nullptr == part_vec.back()) {
       NaluEnv::self().naluOutputP0()
-        << "Trouble with part " << targetNames[itarget] << std::endl;
+        << "Trouble with part " << part_name << std::endl;
       throw std::runtime_error(
-        "Sorry, no part name found by the name " + targetNames[itarget]);
-    } else {
-      realm_.register_nodal_fields(targetPart);
-      EquationSystemVector::iterator ii;
-      for (ii = equationSystemVector_.begin();
-           ii != equationSystemVector_.end(); ++ii)
-        (*ii)->register_nodal_fields(targetPart);
-    }
+        "Sorry, no part name found by the name " + part_name);
+    } 
   }
+  realm_.register_nodal_fields(part_vec);
+  EquationSystemVector::iterator ii;
+  for (ii = equationSystemVector_.begin();
+       ii != equationSystemVector_.end(); ++ii)
+    (*ii)->register_nodal_fields(part_vec);
 }
 
 //--------------------------------------------------------------------------

--- a/src/GammaEquationSystem.C
+++ b/src/GammaEquationSystem.C
@@ -137,40 +137,42 @@ GammaEquationSystem::~GammaEquationSystem() = default;
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-GammaEquationSystem::register_nodal_fields(stk::mesh::Part* part)
+GammaEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
 
   stk::mesh::MetaData& meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
   const int numStates = realm_.number_of_states();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   // register dof; set it as a restart variable
   gamma_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "gamma_transition", numStates));
-  stk::mesh::put_field_on_mesh(*gamma_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*gamma_, selector, nullptr);
   realm_.augment_restart_variable_list("gamma_transition");
 
   dgamdx_ = &(meta_data.declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "dgamdx"));
-  stk::mesh::put_field_on_mesh(*dgamdx_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*dgamdx_, selector, nDim, nullptr);
 
   // delta solution for linear solver; share delta since this is a split system
   gamTmp_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "gamTmp"));
-  stk::mesh::put_field_on_mesh(*gamTmp_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*gamTmp_, selector, nullptr);
 
   visc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "viscosity"));
-  stk::mesh::put_field_on_mesh(*visc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*visc_, selector, nullptr);
 
   tvisc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "turbulent_viscosity"));
-  stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*tvisc_, selector, nullptr);
 
   evisc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "effective_viscosity_gamma"));
-  stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*evisc_, selector, nullptr);
 
   // make sure all states are properly populated (restart can handle this)
   if (
@@ -180,7 +182,7 @@ GammaEquationSystem::register_nodal_fields(stk::mesh::Part* part)
     ScalarFieldType& gammaNp1 = gamma_->field_of_state(stk::mesh::StateNP1);
 
     CopyFieldAlgorithm* theCopyAlg = new CopyFieldAlgorithm(
-      realm_, part, &gammaNp1, &gammaN, 0, 1, stk::topology::NODE_RANK);
+      realm_, part_vec, &gammaNp1, &gammaN, 0, 1, stk::topology::NODE_RANK);
     copyStateAlg_.push_back(theCopyAlg);
   }
 }

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -294,7 +294,8 @@ LowMachEquationSystem::initialize()
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-LowMachEquationSystem::register_nodal_fields(const stk::mesh::PartVector &part_vec)
+LowMachEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
   stk::mesh::MetaData& meta_data = realm_.meta_data();
   stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
@@ -343,7 +344,8 @@ LowMachEquationSystem::register_nodal_fields(const stk::mesh::PartVector &part_v
       dualNodalVolume_->field_of_state(stk::mesh::StateNP1);
 
     CopyFieldAlgorithm* theCopyAlgDlNdVol = new CopyFieldAlgorithm(
-      realm_, part_vec, &dualNdVolNp1, &dualNdVolN, 0, 1, stk::topology::NODE_RANK);
+      realm_, part_vec, &dualNdVolNp1, &dualNdVolN, 0, 1,
+      stk::topology::NODE_RANK);
     copyStateAlg_.push_back(theCopyAlgDlNdVol);
   }
 }
@@ -1128,7 +1130,8 @@ MomentumEquationSystem::pre_timestep_work()
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-MomentumEquationSystem::register_nodal_fields(const stk::mesh::PartVector &part_vec)
+MomentumEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
   stk::mesh::MetaData& meta_data = realm_.meta_data();
   stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
@@ -2819,7 +2822,8 @@ ContinuityEquationSystem::~ContinuityEquationSystem() {}
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-ContinuityEquationSystem::register_nodal_fields(const stk::mesh::PartVector &part_vec)
+ContinuityEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
 
   stk::mesh::MetaData& meta_data = realm_.meta_data();

--- a/src/MatrixFreeHeatCondEquationSystem.C
+++ b/src/MatrixFreeHeatCondEquationSystem.C
@@ -89,21 +89,24 @@ register_vector_nodal_field_on_part(
 } // namespace
 
 void
-MatrixFreeHeatCondEquationSystem::register_nodal_fields(stk::mesh::Part* part)
+MatrixFreeHeatCondEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
   constexpr int three_states = 3;
   constexpr int one_state = 1;
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
   register_scalar_nodal_field_on_part(
-    meta_, names::temperature, *part, three_states);
-  register_scalar_nodal_field_on_part(meta_, names::delta, *part, one_state);
+    meta_, names::temperature, selector, three_states);
+  register_scalar_nodal_field_on_part(meta_, names::delta, selector, one_state);
   register_scalar_nodal_field_on_part(
-    meta_, names::volume_weight, *part, one_state);
-  register_scalar_nodal_field_on_part(meta_, names::density, *part, one_state);
+    meta_, names::volume_weight, selector, one_state);
   register_scalar_nodal_field_on_part(
-    meta_, names::specific_heat, *part, one_state);
+    meta_, names::density, selector, one_state);
   register_scalar_nodal_field_on_part(
-    meta_, names::thermal_conductivity, *part, one_state);
-  register_vector_nodal_field_on_part(meta_, names::dtdx, *part, one_state);
+    meta_, names::specific_heat, selector, one_state);
+  register_scalar_nodal_field_on_part(
+    meta_, names::thermal_conductivity, selector, one_state);
+  register_vector_nodal_field_on_part(meta_, names::dtdx, selector, one_state);
 
   realm_.augment_restart_variable_list(names::temperature);
   realm_.augment_property_map(

--- a/src/ProjectedNodalGradientEquationSystem.C
+++ b/src/ProjectedNodalGradientEquationSystem.C
@@ -130,20 +130,21 @@ ProjectedNodalGradientEquationSystem::get_name_given_bc(
 //--------------------------------------------------------------------------
 void
 ProjectedNodalGradientEquationSystem::register_nodal_fields(
-  stk::mesh::Part* part)
+  const stk::mesh::PartVector& part_vec)
 {
   stk::mesh::MetaData& meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   dqdx_ = &(meta_data.declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, dofName_));
-  stk::mesh::put_field_on_mesh(*dqdx_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*dqdx_, selector, nDim, nullptr);
 
   // delta solution for linear solver
   qTmp_ = &(meta_data.declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, deltaName_));
-  stk::mesh::put_field_on_mesh(*qTmp_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*qTmp_, selector, nDim, nullptr);
 }
 
 //--------------------------------------------------------------------------

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -2715,31 +2715,30 @@ Realm::compute_l2_scaling()
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-Realm::register_nodal_fields(stk::mesh::Part* part)
+Realm::register_nodal_fields(const stk::mesh::PartVector& part_vec)
 {
   if (!fieldManager_) {
     setup_field_manager();
   }
   // register high level common fields
   // Declare volume/area_vector fields
-  const stk::mesh::PartVector parts(1, part);
   const int numVolStates = does_mesh_move() ? number_of_states() : 1;
-  fieldManager_->register_field("dual_nodal_volume", parts, numVolStates);
-  fieldManager_->register_field("element_volume", parts);
+  fieldManager_->register_field("dual_nodal_volume", part_vec, numVolStates);
+  fieldManager_->register_field("element_volume", part_vec);
 
   if (realmUsesEdges_) {
-    fieldManager_->register_field("edge_area_vector", parts);
+    fieldManager_->register_field("edge_area_vector", part_vec);
   }
 
   // mesh motion/deformation is high level
   if (does_mesh_move()) {
-    fieldManager_->register_field("mesh_displacement", parts);
-    fieldManager_->register_field("current_coordinates", parts);
-    fieldManager_->register_field("mesh_velocity", parts);
-    fieldManager_->register_field("velocity_rtm", parts);
-    fieldManager_->register_field("div_mesh_velocity", parts);
+    fieldManager_->register_field("mesh_displacement", part_vec);
+    fieldManager_->register_field("current_coordinates", part_vec);
+    fieldManager_->register_field("mesh_velocity", part_vec);
+    fieldManager_->register_field("velocity_rtm", part_vec);
+    fieldManager_->register_field("div_mesh_velocity", part_vec);
     if (has_mesh_deformation()) {
-      fieldManager_->register_field("div_mesh_velocity", parts);
+      fieldManager_->register_field("div_mesh_velocity", part_vec);
     }
     augment_restart_variable_list("dual_nodal_volume");
     augment_restart_variable_list("mesh_displacement");
@@ -2747,7 +2746,7 @@ Realm::register_nodal_fields(stk::mesh::Part* part)
     augment_restart_variable_list("mesh_velocity");
   }
 
-  fieldManager_->register_field("iblank", parts);
+  fieldManager_->register_field("iblank", part_vec);
 }
 
 //--------------------------------------------------------------------------

--- a/src/ShearStressTransportEquationSystem.C
+++ b/src/ShearStressTransportEquationSystem.C
@@ -130,32 +130,34 @@ ShearStressTransportEquationSystem::initialize()
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-ShearStressTransportEquationSystem::register_nodal_fields(stk::mesh::Part* part)
+ShearStressTransportEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
 
   stk::mesh::MetaData& meta_data = realm_.meta_data();
   const int numStates = realm_.number_of_states();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   // re-register tke and sdr for convenience
   tke_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "turbulent_ke", numStates));
-  stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*tke_, selector, nullptr);
   sdr_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "specific_dissipation_rate", numStates));
-  stk::mesh::put_field_on_mesh(*sdr_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*sdr_, selector, nullptr);
   if (realm_.solutionOptions_->gammaEqActive_) {
     gamma_ = &(meta_data.declare_field<ScalarFieldType>(
       stk::topology::NODE_RANK, "gamma_transition", numStates));
-    stk::mesh::put_field_on_mesh(*gamma_, *part, nullptr);
+    stk::mesh::put_field_on_mesh(*gamma_, selector, nullptr);
   }
 
   // SST parameters that everyone needs
   minDistanceToWall_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "minimum_distance_to_wall"));
-  stk::mesh::put_field_on_mesh(*minDistanceToWall_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*minDistanceToWall_, selector, nullptr);
   fOneBlending_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "sst_f_one_blending"));
-  stk::mesh::put_field_on_mesh(*fOneBlending_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*fOneBlending_, selector, nullptr);
 
   // DES model
   if (
@@ -163,7 +165,7 @@ ShearStressTransportEquationSystem::register_nodal_fields(stk::mesh::Part* part)
     (TurbulenceModel::SST_IDDES == realm_.solutionOptions_->turbulenceModel_)) {
     maxLengthScale_ = &(meta_data.declare_field<ScalarFieldType>(
       stk::topology::NODE_RANK, "sst_max_length_scale"));
-    stk::mesh::put_field_on_mesh(*maxLengthScale_, *part, nullptr);
+    stk::mesh::put_field_on_mesh(*maxLengthScale_, selector, nullptr);
   }
 
   // add to restart field

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -153,40 +153,41 @@ SpecificDissipationRateEquationSystem::
 //--------------------------------------------------------------------------
 void
 SpecificDissipationRateEquationSystem::register_nodal_fields(
-  stk::mesh::Part* part)
+  const stk::mesh::PartVector& part_vec)
 {
 
   stk::mesh::MetaData& meta_data = realm_.meta_data();
 
   const int nDim = meta_data.spatial_dimension();
   const int numStates = realm_.number_of_states();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   // register dof; set it as a restart variable
   sdr_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "specific_dissipation_rate", numStates));
-  stk::mesh::put_field_on_mesh(*sdr_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*sdr_, selector, nullptr);
   realm_.augment_restart_variable_list("specific_dissipation_rate");
 
   dwdx_ = &(
     meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dwdx"));
-  stk::mesh::put_field_on_mesh(*dwdx_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*dwdx_, selector, nDim, nullptr);
 
   // delta solution for linear solver; share delta since this is a split system
   wTmp_ = &(
     meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "wTmp"));
-  stk::mesh::put_field_on_mesh(*wTmp_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*wTmp_, selector, nullptr);
 
   visc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "viscosity"));
-  stk::mesh::put_field_on_mesh(*visc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*visc_, selector, nullptr);
 
   tvisc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "turbulent_viscosity"));
-  stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*tvisc_, selector, nullptr);
 
   evisc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "effective_viscosity_sdr"));
-  stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*evisc_, selector, nullptr);
 
   // make sure all states are properly populated (restart can handle this)
   if (
@@ -196,7 +197,7 @@ SpecificDissipationRateEquationSystem::register_nodal_fields(
     ScalarFieldType& sdrNp1 = sdr_->field_of_state(stk::mesh::StateNP1);
 
     CopyFieldAlgorithm* theCopyAlg = new CopyFieldAlgorithm(
-      realm_, part, &sdrNp1, &sdrN, 0, 1, stk::topology::NODE_RANK);
+      realm_, part_vec, &sdrNp1, &sdrN, 0, 1, stk::topology::NODE_RANK);
     copyStateAlg_.push_back(theCopyAlg);
   }
 }

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -183,10 +183,12 @@ TurbKineticEnergyEquationSystem::check_for_valid_turblence_model(
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-TurbKineticEnergyEquationSystem::register_nodal_fields(stk::mesh::Part* part)
+TurbKineticEnergyEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
 
   stk::mesh::MetaData& meta_data = realm_.meta_data();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   const int nDim = meta_data.spatial_dimension();
   const int numStates = realm_.number_of_states();
@@ -194,29 +196,29 @@ TurbKineticEnergyEquationSystem::register_nodal_fields(stk::mesh::Part* part)
   // register dof; set it as a restart variable
   tke_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "turbulent_ke", numStates));
-  stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*tke_, selector, nullptr);
   realm_.augment_restart_variable_list("turbulent_ke");
 
   dkdx_ = &(
     meta_data.declare_field<VectorFieldType>(stk::topology::NODE_RANK, "dkdx"));
-  stk::mesh::put_field_on_mesh(*dkdx_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*dkdx_, selector, nDim, nullptr);
 
   // delta solution for linear solver; share delta since this is a split system
   kTmp_ = &(
     meta_data.declare_field<ScalarFieldType>(stk::topology::NODE_RANK, "pTmp"));
-  stk::mesh::put_field_on_mesh(*kTmp_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*kTmp_, selector, nullptr);
 
   visc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "viscosity"));
-  stk::mesh::put_field_on_mesh(*visc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*visc_, selector, nullptr);
 
   tvisc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "turbulent_viscosity"));
-  stk::mesh::put_field_on_mesh(*tvisc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*tvisc_, selector, nullptr);
 
   evisc_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "effective_viscosity_tke"));
-  stk::mesh::put_field_on_mesh(*evisc_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*evisc_, selector, nullptr);
 
   // make sure all states are properly populated (restart can handle this)
   if (
@@ -226,7 +228,7 @@ TurbKineticEnergyEquationSystem::register_nodal_fields(stk::mesh::Part* part)
     ScalarFieldType& tkeNp1 = tke_->field_of_state(stk::mesh::StateNP1);
 
     CopyFieldAlgorithm* theCopyAlg = new CopyFieldAlgorithm(
-      realm_, part, &tkeNp1, &tkeN, 0, 1, stk::topology::NODE_RANK);
+      realm_, part_vec, &tkeNp1, &tkeN, 0, 1, stk::topology::NODE_RANK);
     copyStateAlg_.push_back(theCopyAlg);
   }
 }

--- a/src/WallDistEquationSystem.C
+++ b/src/WallDistEquationSystem.C
@@ -112,32 +112,34 @@ WallDistEquationSystem::initial_work()
 }
 
 void
-WallDistEquationSystem::register_nodal_fields(stk::mesh::Part* part)
+WallDistEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
   auto& meta = realm_.meta_data();
   const int nDim = meta.spatial_dimension();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   wallDistPhi_ = &(meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "wall_distance_phi"));
-  stk::mesh::put_field_on_mesh(*wallDistPhi_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*wallDistPhi_, selector, nullptr);
 
   dphidx_ = &(meta.declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, "dwalldistdx"));
-  stk::mesh::put_field_on_mesh(*dphidx_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*dphidx_, selector, nDim, nullptr);
 
   wallDistance_ = &(meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "minimum_distance_to_wall"));
-  stk::mesh::put_field_on_mesh(*wallDistance_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*wallDistance_, selector, nullptr);
 
   coordinates_ = &(meta.declare_field<VectorFieldType>(
     stk::topology::NODE_RANK, realm_.get_coordinates_name()));
-  stk::mesh::put_field_on_mesh(*coordinates_, *part, nDim, nullptr);
+  stk::mesh::put_field_on_mesh(*coordinates_, selector, nDim, nullptr);
 
   const int numVolStates =
     realm_.does_mesh_move() ? realm_.number_of_states() : 1;
   dualNodalVolume_ = &(meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "dual_nodal_volume", numVolStates));
-  stk::mesh::put_field_on_mesh(*dualNodalVolume_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*dualNodalVolume_, selector, nullptr);
 }
 
 void

--- a/src/WilcoxKOmegaEquationSystem.C
+++ b/src/WilcoxKOmegaEquationSystem.C
@@ -111,24 +111,26 @@ WilcoxKOmegaEquationSystem::initialize()
 //-------- register_nodal_fields -------------------------------------------
 //--------------------------------------------------------------------------
 void
-WilcoxKOmegaEquationSystem::register_nodal_fields(stk::mesh::Part* part)
+WilcoxKOmegaEquationSystem::register_nodal_fields(
+  const stk::mesh::PartVector& part_vec)
 {
 
   stk::mesh::MetaData& meta_data = realm_.meta_data();
   const int numStates = realm_.number_of_states();
+  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
 
   // re-register tke and sdr for convenience
   tke_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "turbulent_ke", numStates));
-  stk::mesh::put_field_on_mesh(*tke_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*tke_, selector, nullptr);
   sdr_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "specific_dissipation_rate", numStates));
-  stk::mesh::put_field_on_mesh(*sdr_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*sdr_, selector, nullptr);
 
   // SST parameters that everyone needs
   minDistanceToWall_ = &(meta_data.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, "minimum_distance_to_wall"));
-  stk::mesh::put_field_on_mesh(*minDistanceToWall_, *part, nullptr);
+  stk::mesh::put_field_on_mesh(*minDistanceToWall_, selector, nullptr);
 
   // add to restart field
   realm_.augment_restart_variable_list("minimum_distance_to_wall");

--- a/src/aero/AeroContainer.C
+++ b/src/aero/AeroContainer.C
@@ -61,16 +61,17 @@ AeroContainer::AeroContainer(const YAML::Node& node) : fsiContainer_(nullptr)
 
 void
 AeroContainer::register_nodal_fields(
-  stk::mesh::MetaData& meta, stk::mesh::Part* part)
+  stk::mesh::MetaData& meta, const stk::mesh::PartVector& part_vec)
 {
   if (has_actuators()) {
+    stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
     const int nDim = meta.spatial_dimension();
     VectorFieldType* actuatorSource = &(meta.declare_field<VectorFieldType>(
       stk::topology::NODE_RANK, "actuator_source"));
     VectorFieldType* actuatorSourceLHS = &(meta.declare_field<VectorFieldType>(
       stk::topology::NODE_RANK, "actuator_source_lhs"));
-    stk::mesh::put_field_on_mesh(*actuatorSource, *part, nDim, nullptr);
-    stk::mesh::put_field_on_mesh(*actuatorSourceLHS, *part, nDim, nullptr);
+    stk::mesh::put_field_on_mesh(*actuatorSource, selector, nDim, nullptr);
+    stk::mesh::put_field_on_mesh(*actuatorSourceLHS, selector, nDim, nullptr);
   }
 }
 
@@ -99,6 +100,7 @@ AeroContainer::init(double currentTime, double restartFrequency)
     fsiContainer_->initialize(restartFrequency, currentTime);
   }
 #else
+  (void)currentTime;
   (void)restartFrequency;
 #endif
 }

--- a/src/property_evaluator/ThermalConductivityFromPrandtlPropAlgorithm.C
+++ b/src/property_evaluator/ThermalConductivityFromPrandtlPropAlgorithm.C
@@ -32,12 +32,12 @@ namespace nalu {
 ThermalConductivityFromPrandtlPropAlgorithm::
   ThermalConductivityFromPrandtlPropAlgorithm(
     Realm& realm,
-    stk::mesh::Part* part,
+    const stk::mesh::PartVector& part_vec,
     ScalarFieldType* thermalCond,
     ScalarFieldType* specHeat,
     ScalarFieldType* viscosity,
     const double Pr)
-  : Algorithm(realm, part),
+  : Algorithm(realm, part_vec),
     thermalCond_(thermalCond),
     specHeat_(specHeat),
     viscosity_(viscosity),

--- a/src/utils/StkHelpers.C
+++ b/src/utils/StkHelpers.C
@@ -219,20 +219,20 @@ void
 register_scalar_nodal_field_on_part(
   stk::mesh::MetaData& meta,
   std::string name,
-  const stk::mesh::Part& part,
+  const stk::mesh::Selector& selector,
   int num_states,
   double ic)
 {
   auto& field = meta.declare_field<ScalarFieldType>(
     stk::topology::NODE_RANK, name, num_states);
-  stk::mesh::put_field_on_mesh(field, part, &ic);
+  stk::mesh::put_field_on_mesh(field, selector, &ic);
 }
 
 void
 register_vector_nodal_field_on_part(
   stk::mesh::MetaData& meta,
   std::string name,
-  const stk::mesh::Part& selector,
+  const stk::mesh::Selector& selector,
   int num_states,
   std::array<double, 3> x)
 {

--- a/unit_tests/UnitTestTpetra.C
+++ b/unit_tests/UnitTestTpetra.C
@@ -283,7 +283,7 @@ setup_realm(unit_test_utils::NaluTest& naluObj, const std::string& meshSpec)
   realm.setup_field_manager();
   realm.setup_nodal_fields();
   auto& part = realm.meta_data().declare_part("block_1");
-  realm.register_nodal_fields(&part);
+  realm.register_nodal_fields(stk::mesh::PartVector(1, &part));
   unit_test_utils::fill_hex8_mesh(meshSpec, realm.bulk_data());
   realm.set_global_id();
 

--- a/unit_tests/mesh_motion/UnitTestCompositeFrames.C
+++ b/unit_tests/mesh_motion/UnitTestCompositeFrames.C
@@ -150,7 +150,8 @@ TEST(meshMotion, NGP_initialize)
   realm.timeIntegrator_ = &timeIntegrator;
 
   // register mesh motion fields and initialize coordinate fields
-  realm.register_nodal_fields(&(realm.meta_data().universal_part()));
+  realm.register_nodal_fields(
+    stk::mesh::PartVector(1, &(realm.meta_data().universal_part())));
 
   // create field to copy coordinates
   // NOTE: This is done to allow computation of gold values later on
@@ -256,7 +257,8 @@ TEST(meshMotion, NGP_execute)
   realm.timeIntegrator_ = &timeIntegrator;
 
   // register mesh motion fields and initialize coordinate fields
-  realm.register_nodal_fields(&(realm.meta_data().universal_part()));
+  realm.register_nodal_fields(
+    stk::mesh::PartVector(1, &(realm.meta_data().universal_part())));
 
   // create field to copy coordinates
   // NOTE: This is done to allow computation of gold values later on

--- a/unit_tests/mesh_motion/UnitTestComputeCentroid.C
+++ b/unit_tests/mesh_motion/UnitTestComputeCentroid.C
@@ -101,7 +101,8 @@ TEST(meshMotion, NGP_compute_centroid)
   realm.timeIntegrator_ = &timeIntegrator;
 
   // register mesh motion fields and initialize coordinate fields
-  realm.register_nodal_fields(&(realm.meta_data().universal_part()));
+  realm.register_nodal_fields(
+    stk::mesh::PartVector(1, &(realm.meta_data().universal_part())));
 
   // create field to copy coordinates
   // NOTE: This is done to allow computation of gold values later on


### PR DESCRIPTION
PartVectors allow for the specification of a field on a list of parts instead of one part at a time. For some classes it was only possible to pass a single part pointer for the field specification where a part vector would be more flexible.

Started with register_nodal_fields:
from: register_nodal_fields(stk::mesh::Part* part)
to:   register_nodal_fields(const stk::mesh::PartVector &part_vec)

The stk::mesh::put_field_on_mesh function does not take a PartVector so create a Selector form a PartVector:
  stk::mesh::Selector selector = stk::mesh::selectUnion(part_vec);
and use that instead. There were a couple of places where the construction of a PartVector from a single Part pointer:
   PartVector(1,Part*)
was useful.

There were a lot of files changed, but the changes are trivial.