### PR TITLE
LinearSystem.C: add missing header to correct Perlmutter build failure

### DIFF
--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -13,6 +13,7 @@
 #include <Simulation.h>
 #include <LinearSolver.h>
 #include <master_element/MasterElement.h>
+#include <NaluEnv.h>
 
 #ifdef NALU_USES_HYPRE
 #include "HypreLinearSystem.h"


### PR DESCRIPTION
@overfelt, this small change (to `$NALU_WIND_ROOT/src/LinearSystem.C`) addresses a NERSC Perlmutter build error:

```
/pscratch/sd/a/ajpowel/nalu_wind_ECP_supercontainers/nalu-wind/src/LinearSystem.C(96): error: name followed by "::" must be a class or namespace name
```

Briefly, I added ` #include <NaluEnv.h>` to the file mentioned above, and this change fixed the build error.

Here's my build environment:

```
ajpowel@perlmutter:login17:/pscratch/sd/a/ajpowel/nalu_wind_amy_fork/nalu-wind> module list

Currently Loaded Modules:
  1) craype-x86-milan                        5) PrgEnv-gnu/8.3.3        9) craype/2.7.20           13) xalt/2.10.2              17) craype-accel-nvidia80
  2) libfabric/1.15.2.0                      6) cray-dsmml/0.2.2       10) gcc/11.2.0              14) Nsight-Compute/2022.1.1  18) gpu/1.0
  3) craype-network-ofi                      7) cray-libsci/23.02.1.1  11) perftools-base/23.03.0  15) Nsight-Systems/2022.2.1
  4) xpmem/2.5.2-2.4_3.44__gd0f7936.shasta   8) cray-mpich/8.1.25      12) cpe/23.03               16) cudatoolkit/11.7

```

This build was done with Nalu-Wind `master` (2a28487d1fe1cfb68ef3e487d27e82c5d0339436) and Trilinos `develop` (f4e9c78c030fcea798b62141fb2742383e634dba).

CMake build command:

```
export EXTRA_ARGS=$@

find . -name "CMakeFiles" -exec rm -rf {} \;
rm -f CMakeCache.txt

cmake \
  -DCMAKE_INSTALL_PREFIX:PATH=$nw_install_dir/nalu_wind \
  -DCMAKE_EXE_LINKER_FLAGS="-L$nw_install_dir/hdf5/lib -lhdf5 -lhdf5_hl" \
  -DCMAKE_CXX_COMPILER=`which mpicxx` \
  -DENABLE_CUDA:BOOL=ON \
  -DTrilinos_DIR:PATH=$tril_install_dir \
  -DYAML_DIR:PATH=$nw_install_dir/yaml \
  -DCMAKE_BUILD_TYPE=RELEASE \
  -DENABLE_TESTS:BOOL=ON \
  -DCMAKE_CXX_FLAGS:STRING="-Wall" \
  -DENABLE_TESTS:BOOL=ON \
[?4mNABLE_HYPRE:BOOL=OFF \
$EXTRA_ARGS \
../
```