### PR TITLE
Fixes for FSI with ROCM

### DIFF
--- a/src/gcl/MeshVelocityAlg.C
+++ b/src/gcl/MeshVelocityAlg.C
@@ -79,9 +79,12 @@ MeshVelocityAlg<AlgTraits>::MeshVelocityAlg(Realm& realm, stk::mesh::Part* part)
     NUM_IP, isoParCoords_, isoCoordsShapeFcnHostView_.data());
   Kokkos::deep_copy(isoCoordsShapeFcnDeviceView_, isoCoordsShapeFcnHostView_);
 
-  Kokkos::View<
-    const int**, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-    scsFaceNodeMapHostView(&scsFaceNodeMap_[0][0], 12, 4);
+  Kokkos::View<int[12][4], Kokkos::HostSpace>scsFaceNodeMapHostView;
+  for(int i=0; i<12; ++i){
+    for(int j=0; j<4; ++j){
+      scsFaceNodeMapHostView(i, j) = scsFaceNodeMap_[i][j];
+    }
+  }
   Kokkos::deep_copy(scsFaceNodeMapDeviceView_, scsFaceNodeMapHostView);
 
 } // namespace nalu

--- a/src/gcl/MeshVelocityAlg.C
+++ b/src/gcl/MeshVelocityAlg.C
@@ -79,9 +79,9 @@ MeshVelocityAlg<AlgTraits>::MeshVelocityAlg(Realm& realm, stk::mesh::Part* part)
     NUM_IP, isoParCoords_, isoCoordsShapeFcnHostView_.data());
   Kokkos::deep_copy(isoCoordsShapeFcnDeviceView_, isoCoordsShapeFcnHostView_);
 
-  Kokkos::View<int[12][4], Kokkos::HostSpace>scsFaceNodeMapHostView;
-  for(int i=0; i<12; ++i){
-    for(int j=0; j<4; ++j){
+  Kokkos::View<int[12][4], Kokkos::HostSpace> scsFaceNodeMapHostView;
+  for (int i = 0; i < 12; ++i) {
+    for (int j = 0; j < 4; ++j) {
       scsFaceNodeMapHostView(i, j) = scsFaceNodeMap_[i][j];
     }
   }

--- a/src/gcl/MeshVelocityAlg.C
+++ b/src/gcl/MeshVelocityAlg.C
@@ -79,7 +79,8 @@ MeshVelocityAlg<AlgTraits>::MeshVelocityAlg(Realm& realm, stk::mesh::Part* part)
     NUM_IP, isoParCoords_, isoCoordsShapeFcnHostView_.data());
   Kokkos::deep_copy(isoCoordsShapeFcnDeviceView_, isoCoordsShapeFcnHostView_);
 
-  Kokkos::View<int[12][4], Kokkos::HostSpace> scsFaceNodeMapHostView;
+  auto scsFaceNodeMapHostView =
+    Kokkos::create_mirror(scsFaceNodeMapDeviceView_);
   for (int i = 0; i < 12; ++i) {
     for (int j = 0; j < 4; ++j) {
       scsFaceNodeMapHostView(i, j) = scsFaceNodeMap_[i][j];

--- a/src/gcl/MeshVelocityEdgeAlg.C
+++ b/src/gcl/MeshVelocityEdgeAlg.C
@@ -71,7 +71,8 @@ MeshVelocityEdgeAlg<AlgTraits>::MeshVelocityEdgeAlg(
     19, &isoParCoords_[0], isoCoordsShapeFcnHostView_.data());
   Kokkos::deep_copy(isoCoordsShapeFcnDeviceView_, isoCoordsShapeFcnHostView_);
 
-  Kokkos::View<int[12][4], Kokkos::HostSpace> scsFaceNodeMapHostView;
+  auto scsFaceNodeMapHostView =
+    Kokkos::create_mirror(scsFaceNodeMapDeviceView_);
   for (int i = 0; i < 12; ++i) {
     for (int j = 0; j < 4; ++j) {
       scsFaceNodeMapHostView(i, j) = scsFaceNodeMap_[i][j];

--- a/src/gcl/MeshVelocityEdgeAlg.C
+++ b/src/gcl/MeshVelocityEdgeAlg.C
@@ -71,9 +71,12 @@ MeshVelocityEdgeAlg<AlgTraits>::MeshVelocityEdgeAlg(
     19, &isoParCoords_[0], isoCoordsShapeFcnHostView_.data());
   Kokkos::deep_copy(isoCoordsShapeFcnDeviceView_, isoCoordsShapeFcnHostView_);
 
-  Kokkos::View<
-    const int**, Kokkos::HostSpace, Kokkos::MemoryTraits<Kokkos::Unmanaged>>
-    scsFaceNodeMapHostView(&scsFaceNodeMap_[0][0], 12, 4);
+  Kokkos::View<int[12][4], Kokkos::HostSpace>scsFaceNodeMapHostView;
+  for(int i=0; i<12; ++i){
+    for(int j=0; j<4; ++j){
+      scsFaceNodeMapHostView(i, j) = scsFaceNodeMap_[i][j];
+    }
+  }
   Kokkos::deep_copy(scsFaceNodeMapDeviceView_, scsFaceNodeMapHostView);
   if (!std::is_same<AlgTraits, AlgTraitsHex8>::value) {
     throw std::runtime_error("MeshVelocityEdgeAlg is only supported for Hex8");

--- a/src/gcl/MeshVelocityEdgeAlg.C
+++ b/src/gcl/MeshVelocityEdgeAlg.C
@@ -71,9 +71,9 @@ MeshVelocityEdgeAlg<AlgTraits>::MeshVelocityEdgeAlg(
     19, &isoParCoords_[0], isoCoordsShapeFcnHostView_.data());
   Kokkos::deep_copy(isoCoordsShapeFcnDeviceView_, isoCoordsShapeFcnHostView_);
 
-  Kokkos::View<int[12][4], Kokkos::HostSpace>scsFaceNodeMapHostView;
-  for(int i=0; i<12; ++i){
-    for(int j=0; j<4; ++j){
+  Kokkos::View<int[12][4], Kokkos::HostSpace> scsFaceNodeMapHostView;
+  for (int i = 0; i < 12; ++i) {
+    for (int j = 0; j < 4; ++j) {
       scsFaceNodeMapHostView(i, j) = scsFaceNodeMap_[i][j];
     }
   }


### PR DESCRIPTION
The original code failed to compile with ROCM. Evidently the types must be more explicit for ROCM than Cuda in this instance.