### PR TITLE
remove Kokkos directive

### DIFF
--- a/unit_tests/gcl/UnitTestGCL.C
+++ b/unit_tests/gcl/UnitTestGCL.C
@@ -9,8 +9,6 @@
 
 #include "gcl/UnitTestGCL.h"
 
-#ifndef KOKKOS_ENABLE_GPU
-
 namespace {
 
 namespace hex8_golds_x_rot {
@@ -341,5 +339,3 @@ TEST_F(GCLTest, mesh_airy_waves)
   compute_dvoldt();
   compute_absolute_error();
 }
-
-#endif // KOKKOS_ENABLE_GPU

--- a/unit_tests/gcl/UnitTestMeshVelocityAlg.C
+++ b/unit_tests/gcl/UnitTestMeshVelocityAlg.C
@@ -23,8 +23,6 @@
 #include "UnitTestRealm.h"
 #include "UnitTestUtils.h"
 
-#ifndef KOKKOS_ENABLE_GPU
-
 namespace {
 
 std::vector<double>
@@ -475,5 +473,3 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot_scs_center)
     EXPECT_EQ(counter, 12);
   } // namespace =::hex8_golds_y_rot::mesh_velocity;
 }
-
-#endif // KOKKOS_ENABLE_GPU


### PR DESCRIPTION
Make GCL and FSI-related united tests run with GPUs enabled