### PR TITLE
WIP : Fixes to mesh velocity algorithms

### DIFF
--- a/src/gcl/MeshVelocityAlg.C
+++ b/src/gcl/MeshVelocityAlg.C
@@ -172,8 +172,12 @@ MeshVelocityAlg<AlgTraits>::execute()
           scs_vol_coords[5][j] = scs_coords_np1[scsFaceNodeMap(ip, 1)][j];
           scs_vol_coords[6][j] = scs_coords_np1[scsFaceNodeMap(ip, 2)][j];
           scs_vol_coords[7][j] = scs_coords_np1[scsFaceNodeMap(ip, 3)][j];
+          printf("ip: %d ids: %d %d %d %d \n", ip, scsFaceNodeMap(ip, 0),scsFaceNodeMap(ip, 1),scsFaceNodeMap(ip, 2),scsFaceNodeMap(ip, 3));
+          printf("ip: %d pos n: %f %f %f %f \n", ip, scs_vol_coords[0][j],scs_vol_coords[1][j],scs_vol_coords[2][j],scs_vol_coords[3][j]);
+          printf("ip: %d pos np1: %f %f %f %f \n", ip, scs_vol_coords[4][j],scs_vol_coords[5][j],scs_vol_coords[6][j],scs_vol_coords[7][j]);
         }
         DoubleType tmp = hex_volume_grandy(scs_vol_coords);
+        printf("Swept Vol: %f \n", tmp);
 
         sweptVolOps(edata, ip) = tmp;
 
@@ -181,6 +185,11 @@ MeshVelocityAlg<AlgTraits>::execute()
           (gamma1 * tmp + (gamma1 + gamma2) * sweptVolN(ip)) / dt;
       }
     });
+
+  ngpSweptVol.modify_on_device();
+  faceVel.modify_on_device();
+  ngpSweptVol.sync_to_host();
+  faceVel.sync_to_host();
 }
 
 INSTANTIATE_KERNEL(MeshVelocityAlg)

--- a/src/gcl/MeshVelocityAlg.C
+++ b/src/gcl/MeshVelocityAlg.C
@@ -129,6 +129,9 @@ MeshVelocityAlg<AlgTraits>::execute()
   constexpr int Hex8numScsIp = AlgTraitsHex8::numScsIp_;
   const int nip = std::min(Hex8numScsIp, AlgTraits::numScsIp_);
 
+  ngpSweptVol.sync_to_device();
+  faceVel.clear_sync_state();
+
   nalu_ngp::run_elem_algorithm(
     algName, meshInfo, stk::topology::ELEM_RANK, elemData_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata) {
@@ -172,12 +175,8 @@ MeshVelocityAlg<AlgTraits>::execute()
           scs_vol_coords[5][j] = scs_coords_np1[scsFaceNodeMap(ip, 1)][j];
           scs_vol_coords[6][j] = scs_coords_np1[scsFaceNodeMap(ip, 2)][j];
           scs_vol_coords[7][j] = scs_coords_np1[scsFaceNodeMap(ip, 3)][j];
-          printf("ip: %d ids: %d %d %d %d \n", ip, scsFaceNodeMap(ip, 0),scsFaceNodeMap(ip, 1),scsFaceNodeMap(ip, 2),scsFaceNodeMap(ip, 3));
-          printf("ip: %d pos n: %f %f %f %f \n", ip, scs_vol_coords[0][j],scs_vol_coords[1][j],scs_vol_coords[2][j],scs_vol_coords[3][j]);
-          printf("ip: %d pos np1: %f %f %f %f \n", ip, scs_vol_coords[4][j],scs_vol_coords[5][j],scs_vol_coords[6][j],scs_vol_coords[7][j]);
         }
         DoubleType tmp = hex_volume_grandy(scs_vol_coords);
-        printf("Swept Vol: %f \n", tmp);
 
         sweptVolOps(edata, ip) = tmp;
 

--- a/src/gcl/MeshVelocityAlg.C
+++ b/src/gcl/MeshVelocityAlg.C
@@ -75,7 +75,9 @@ MeshVelocityAlg<AlgTraits>::MeshVelocityAlg(Realm& realm, stk::mesh::Part* part)
   elemData_.add_gathered_nodal_field(meshDispN_, AlgTraits::nDim_);
 
   elemData_.add_master_element_call(SCS_AREAV, CURRENT_COORDINATES);
-  meSCS_->general_shape_fcn(
+  auto* hostMeSCS =
+    MasterElementRepo::get_surface_master_element_on_host(AlgTraits::topo_);
+  hostMeSCS->general_shape_fcn(
     NUM_IP, isoParCoords_, isoCoordsShapeFcnHostView_.data());
   Kokkos::deep_copy(isoCoordsShapeFcnDeviceView_, isoCoordsShapeFcnHostView_);
 

--- a/src/gcl/MeshVelocityEdgeAlg.C
+++ b/src/gcl/MeshVelocityEdgeAlg.C
@@ -115,6 +115,9 @@ MeshVelocityEdgeAlg<AlgTraits>::execute()
   const auto nDim = AlgTraits::nDim_;
   const auto numScsIp = AlgTraits::numScsIp_;
 
+  edgeSweptVol.sync_to_device();
+  edgeFaceVelMag.clear_sync_state();
+
   const std::string algName =
     "compute_mesh_vel_" + std::to_string(AlgTraits::topo_);
   nalu_ngp::run_elem_algorithm(
@@ -197,6 +200,10 @@ MeshVelocityEdgeAlg<AlgTraits>::execute()
         }
       }
     });
+  edgeSweptVol.modify_on_device();
+  edgeFaceVelMag.modify_on_device();
+  edgeSweptVol.sync_to_host();
+  edgeFaceVelMag.sync_to_host();
 }
 
 INSTANTIATE_KERNEL(MeshVelocityEdgeAlg)

--- a/src/ngp_algorithms/GeometryAlgDriver.C
+++ b/src/ngp_algorithms/GeometryAlgDriver.C
@@ -142,17 +142,24 @@ GeometryAlgDriver::mesh_motion_prework()
                                                  : stk::topology::ELEM_RANK;
   const std::string fvmFieldName =
     realm_.realmUsesEdges_ ? "edge_face_velocity_mag" : "face_velocity_mag";
+
   auto ngpFaceVelMag =
     nalu_ngp::get_ngp_field(realm_.mesh_info(), fvmFieldName, entityRank);
-  ngpFaceVelMag.clear_sync_state();  ngpFaceVelMag.set_all(ngpMesh, 0.0);
+
+  ngpFaceVelMag.clear_sync_state();
+  ngpFaceVelMag.set_all(ngpMesh, 0.0);
+
   auto* faceVelMag = meta.get_field<GenericFieldType>(entityRank, fvmFieldName);
   stk::mesh::field_fill(0.0, *faceVelMag);
   const std::string svFieldName =
     realm_.realmUsesEdges_ ? "edge_swept_face_volume" : "swept_face_volume";
+
   auto ngpSweptVol =
     nalu_ngp::get_ngp_field(realm_.mesh_info(), svFieldName, entityRank);
+
   ngpSweptVol.clear_sync_state();
   ngpSweptVol.set_all(ngpMesh, 0.0);
+
   auto* sweptVol = meta.get_field<GenericFieldType>(entityRank, svFieldName);
   stk::mesh::field_fill(0.0, *sweptVol);
   ngpSweptVol.sync_to_device();

--- a/unit_tests/gcl/UnitTestGCL.C
+++ b/unit_tests/gcl/UnitTestGCL.C
@@ -9,8 +9,6 @@
 
 #include "gcl/UnitTestGCL.h"
 
-//#ifndef KOKKOS_ENABLE_GPU
-
 namespace {
 
 namespace hex8_golds_x_rot {
@@ -341,5 +339,3 @@ TEST_F(GCLTest, mesh_airy_waves)
   compute_dvoldt();
   compute_absolute_error();
 }
-
-//#endif // KOKKOS_ENABLE_GPU

--- a/unit_tests/gcl/UnitTestGCL.C
+++ b/unit_tests/gcl/UnitTestGCL.C
@@ -9,7 +9,7 @@
 
 #include "gcl/UnitTestGCL.h"
 
-#ifndef KOKKOS_ENABLE_GPU
+//#ifndef KOKKOS_ENABLE_GPU
 
 namespace {
 
@@ -342,4 +342,4 @@ TEST_F(GCLTest, mesh_airy_waves)
   compute_absolute_error();
 }
 
-#endif // KOKKOS_ENABLE_GPU
+//#endif // KOKKOS_ENABLE_GPU

--- a/unit_tests/gcl/UnitTestMeshVelocityAlg.C
+++ b/unit_tests/gcl/UnitTestMeshVelocityAlg.C
@@ -23,7 +23,7 @@
 #include "UnitTestRealm.h"
 #include "UnitTestUtils.h"
 
-#ifndef KOKKOS_ENABLE_GPU
+//#ifndef KOKKOS_ENABLE_GPU
 
 namespace {
 
@@ -476,4 +476,4 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot_scs_center)
   } // namespace =::hex8_golds_y_rot::mesh_velocity;
 }
 
-#endif // KOKKOS_ENABLE_GPU
+//#endif // KOKKOS_ENABLE_GPU

--- a/unit_tests/gcl/UnitTestMeshVelocityAlg.C
+++ b/unit_tests/gcl/UnitTestMeshVelocityAlg.C
@@ -23,8 +23,6 @@
 #include "UnitTestRealm.h"
 #include "UnitTestUtils.h"
 
-//#ifndef KOKKOS_ENABLE_GPU
-
 namespace {
 
 std::vector<double>
@@ -475,5 +473,3 @@ TEST_F(TestKernelHex8Mesh, mesh_velocity_y_rot_scs_center)
     EXPECT_EQ(counter, 12);
   } // namespace =::hex8_golds_y_rot::mesh_velocity;
 }
-
-//#endif // KOKKOS_ENABLE_GPU


### PR DESCRIPTION
1) add hostMeSCS for computing general_shape_fcn. This fixes the seg faulting unit tests.
2) Changes to the unit tests allow these to run on device.