### PR TITLE
Option to disable FSI ramping parameters

### DIFF
--- a/include/aero/aero_utils/DeflectionRamping.h
+++ b/include/aero/aero_utils/DeflectionRamping.h
@@ -15,10 +15,10 @@
 namespace fsi {
 
 double KOKKOS_FORCEINLINE_FUNCTION
-linear_ramp_span(const double spanLocation, const double zeroRampDistance)
+linear_ramp_span(const double spanLocation, const double zeroRampDistance, const bool useRamp=true)
 {
   return 1.0 - stk::math::max(
-                 (zeroRampDistance - spanLocation) / zeroRampDistance, 0.0);
+                 (zeroRampDistance - spanLocation) / zeroRampDistance, 0.0)*static_cast<double>(useRamp);
 }
 
 double KOKKOS_FORCEINLINE_FUNCTION
@@ -27,7 +27,8 @@ linear_ramp_theta(
   const vs::Vector& root,
   const vs::Vector& position,
   const double rampSpan,
-  const double zeroRampLoc)
+  const double zeroRampLoc,
+  const bool useRamp=true)
 {
   auto v1 = (root - hub.position_).normalize();
   auto v2 = (position - hub.position_).normalize();
@@ -42,17 +43,17 @@ linear_ramp_theta(
   const auto angle = vs::angle(v1, v2);
 
   return stk::math::min(
-    1.0, stk::math::max(0.0, (zeroRampLoc - angle) / rampSpan));
+    1.0, stk::math::max(static_cast<double>(!useRamp), (zeroRampLoc - angle) / rampSpan));
 }
 
 //! ramp from 0 to 1 to allow turbines to only experience rigid body blade
 //! motion until time == startRamp, then linearly ramp to full bladeDeflections
 //! over the time window startRamp to endRamp
 double KOKKOS_FORCEINLINE_FUNCTION
-temporal_ramp(const double time, const double startRamp, const double endRamp)
+temporal_ramp(const double time, const double startRamp, const double endRamp, const bool useRamp=true)
 {
   const double denom = stk::math::max(endRamp - startRamp, 1e-12);
-  return stk::math::max(0.0, stk::math::min(1.0, (time - startRamp) / denom));
+  return stk::math::max(static_cast<double>(!useRamp), stk::math::min(1.0, (time - startRamp) / denom));
 }
 
 } // namespace fsi

--- a/include/aero/aero_utils/DeflectionRamping.h
+++ b/include/aero/aero_utils/DeflectionRamping.h
@@ -15,10 +15,14 @@
 namespace fsi {
 
 double KOKKOS_FORCEINLINE_FUNCTION
-linear_ramp_span(const double spanLocation, const double zeroRampDistance, const bool useRamp=true)
+linear_ramp_span(
+  const double spanLocation,
+  const double zeroRampDistance,
+  const bool useRamp = true)
 {
   return 1.0 - stk::math::max(
-                 (zeroRampDistance - spanLocation) / zeroRampDistance, 0.0)*static_cast<double>(useRamp);
+                 (zeroRampDistance - spanLocation) / zeroRampDistance, 0.0) *
+                 static_cast<double>(useRamp);
 }
 
 double KOKKOS_FORCEINLINE_FUNCTION
@@ -28,7 +32,7 @@ linear_ramp_theta(
   const vs::Vector& position,
   const double rampSpan,
   const double zeroRampLoc,
-  const bool useRamp=true)
+  const bool useRamp = true)
 {
   auto v1 = (root - hub.position_).normalize();
   auto v2 = (position - hub.position_).normalize();
@@ -43,17 +47,24 @@ linear_ramp_theta(
   const auto angle = vs::angle(v1, v2);
 
   return stk::math::min(
-    1.0, stk::math::max(static_cast<double>(!useRamp), (zeroRampLoc - angle) / rampSpan));
+    1.0, stk::math::max(
+           static_cast<double>(!useRamp), (zeroRampLoc - angle) / rampSpan));
 }
 
 //! ramp from 0 to 1 to allow turbines to only experience rigid body blade
 //! motion until time == startRamp, then linearly ramp to full bladeDeflections
 //! over the time window startRamp to endRamp
 double KOKKOS_FORCEINLINE_FUNCTION
-temporal_ramp(const double time, const double startRamp, const double endRamp, const bool useRamp=true)
+temporal_ramp(
+  const double time,
+  const double startRamp,
+  const double endRamp,
+  const bool useRamp = true)
 {
   const double denom = stk::math::max(endRamp - startRamp, 1e-12);
-  return stk::math::max(static_cast<double>(!useRamp), stk::math::min(1.0, (time - startRamp) / denom));
+  return stk::math::max(
+    static_cast<double>(!useRamp),
+    stk::math::min(1.0, (time - startRamp) / denom));
 }
 
 } // namespace fsi

--- a/include/aero/fsi/FSIturbine.h
+++ b/include/aero/fsi/FSIturbine.h
@@ -45,6 +45,9 @@ struct DeflectionRampingParams
   double thetaRampSpan_{10.0};
   double startTimeTemporalRamp_{0.0};
   double endTimeTemporalRamp_{0.0};
+  bool enableSpanRamping_{true};
+  bool enableThetaRamping_{true};
+  bool enableTemporalRamping_{true};
 };
 
 // TODO(psakiev) find a better place for this

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -1358,7 +1358,8 @@ fsiTurbine::mapDisplacements(double time)
 
   const DeflectionRampingParams& defParams = deflectionRampParams_;
   const double temporalDeflectionRamp = fsi::temporal_ramp(
-    time, defParams.startTimeTemporalRamp_, defParams.endTimeTemporalRamp_, defParams.endTimeTemporalRamp_);
+    time, defParams.startTimeTemporalRamp_, defParams.endTimeTemporalRamp_,
+    defParams.endTimeTemporalRamp_);
 
   auto& meta = bulk_->mesh_meta_data();
   VectorFieldType* modelCoords =
@@ -1461,8 +1462,9 @@ fsiTurbine::mapDisplacements(double time)
           spanLocI + *dispMapInterpNode * (spanLocIp1 - spanLocI);
 
         double deflectionRamp =
-          temporalDeflectionRamp *
-          fsi::linear_ramp_span(spanLocation, defParams.spanRampDistance_, defParams.enableSpanRamping_);
+          temporalDeflectionRamp * fsi::linear_ramp_span(
+                                     spanLocation, defParams.spanRampDistance_,
+                                     defParams.enableSpanRamping_);
 
         // things for theta mapping
         const aero::SixDOF hubPos(brFSIdata_.hub_ref_pos.data());

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -95,11 +95,22 @@ fsiTurbine::fsiTurbine(int iTurb, const YAML::Node& node)
     double* zeroTheta = &defParams.zeroRampLocTheta_;
     double* thetaRamp = &defParams.thetaRampSpan_;
     // clang-format off
-    get_required(defNode, "temporal_ramp_start", defParams.startTimeTemporalRamp_);
-    get_required(defNode, "temporal_ramp_end",   defParams.endTimeTemporalRamp_);
-    get_required(defNode, "span_ramp_distance",  defParams.spanRampDistance_);
-    get_if_present(defNode, "zero_theta_ramp_angle", *zeroTheta, *zeroTheta);
-    get_if_present(defNode, "theta_ramp_span",       *thetaRamp, *thetaRamp);
+    // defaults of all are true from struct defintion
+    get_if_present(defNode, "enable_theta_ramping", defParams.enableThetaRamping_);
+    get_if_present(defNode, "enable_span_ramping", defParams.enableSpanRamping_);
+    get_if_present(defNode, "enable_temporal_ramping", defParams.enableTemporalRamping_);
+
+    if(defParams.enableTemporalRamping_){
+      get_required(defNode, "temporal_ramp_start", defParams.startTimeTemporalRamp_);
+      get_required(defNode, "temporal_ramp_end",   defParams.endTimeTemporalRamp_);
+    }
+    if(defParams.enableSpanRamping_){
+      get_required(defNode, "span_ramp_distance",  defParams.spanRampDistance_);
+    }
+    if(defParams.enableThetaRamping_){
+      get_if_present(defNode, "zero_theta_ramp_angle", *zeroTheta, *zeroTheta);
+      get_if_present(defNode, "theta_ramp_span",       *thetaRamp, *thetaRamp);
+    }
     // clang-format on
     // ---------- conversionions ----------
     defParams.zeroRampLocTheta_ = utils::radians(defParams.zeroRampLocTheta_);
@@ -1347,7 +1358,7 @@ fsiTurbine::mapDisplacements(double time)
 
   const DeflectionRampingParams& defParams = deflectionRampParams_;
   const double temporalDeflectionRamp = fsi::temporal_ramp(
-    time, defParams.startTimeTemporalRamp_, defParams.endTimeTemporalRamp_);
+    time, defParams.startTimeTemporalRamp_, defParams.endTimeTemporalRamp_, defParams.endTimeTemporalRamp_);
 
   auto& meta = bulk_->mesh_meta_data();
   VectorFieldType* modelCoords =
@@ -1451,7 +1462,7 @@ fsiTurbine::mapDisplacements(double time)
 
         double deflectionRamp =
           temporalDeflectionRamp *
-          fsi::linear_ramp_span(spanLocation, defParams.spanRampDistance_);
+          fsi::linear_ramp_span(spanLocation, defParams.spanRampDistance_, defParams.enableSpanRamping_);
 
         // things for theta mapping
         const aero::SixDOF hubPos(brFSIdata_.hub_ref_pos.data());
@@ -1460,7 +1471,7 @@ fsiTurbine::mapDisplacements(double time)
 
         deflectionRamp *= fsi::linear_ramp_theta(
           hubPos, rootPos.position_, nodePosition, defParams.thetaRampSpan_,
-          defParams.zeroRampLocTheta_);
+          defParams.zeroRampLocTheta_, defParams.enableThetaRamping_);
 
         *stk::mesh::field_data(*deflectionRamp_, node) = deflectionRamp;
 

--- a/unit_tests/aero/UnitTestDeflectionRamping.C
+++ b/unit_tests/aero/UnitTestDeflectionRamping.C
@@ -128,15 +128,21 @@ TEST(DeflectionRamping, booleanDisablesTheta)
   const auto rotation = wmp::create_wm_param(vs::Vector::ihat(), theta);
 
   const auto pClockWise = wmp::rotate(rotation, root);
-  EXPECT_DOUBLE_EQ(0.0, fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero, true));
-  EXPECT_DOUBLE_EQ(1.0, fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero, false));
+  EXPECT_DOUBLE_EQ(
+    0.0,
+    fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero, true));
+  EXPECT_DOUBLE_EQ(
+    1.0,
+    fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero, false));
 }
 
 TEST(DeflectionRamping, booleanDisablesSpan)
 {
   const double spanLocation = 0.3;
   const double zeroRampLocation = 0.4;
-  EXPECT_DOUBLE_EQ(0.75, fsi::linear_ramp_span(spanLocation, zeroRampLocation, true));
-  EXPECT_DOUBLE_EQ(1.0, fsi::linear_ramp_span(spanLocation, zeroRampLocation, false));
+  EXPECT_DOUBLE_EQ(
+    0.75, fsi::linear_ramp_span(spanLocation, zeroRampLocation, true));
+  EXPECT_DOUBLE_EQ(
+    1.0, fsi::linear_ramp_span(spanLocation, zeroRampLocation, false));
 }
 } // namespace

--- a/unit_tests/aero/UnitTestDeflectionRamping.C
+++ b/unit_tests/aero/UnitTestDeflectionRamping.C
@@ -107,4 +107,36 @@ TEST(DeflectionRamping, temporalRampingPhases)
   EXPECT_DOUBLE_EQ(1.0, fsi::temporal_ramp(endRamp, startRamp, endRamp));
   EXPECT_DOUBLE_EQ(1.0, fsi::temporal_ramp(5.0, startRamp, endRamp));
 }
+
+TEST(DeflectionRamping, booleanDisablesTemporal)
+{
+  const double startRamp = 1.0;
+  const double endRamp = 2.0;
+  const double time = 0.0;
+  EXPECT_DOUBLE_EQ(1.0, fsi::temporal_ramp(time, startRamp, endRamp, false));
+  EXPECT_DOUBLE_EQ(0.0, fsi::temporal_ramp(time, startRamp, endRamp, true));
+}
+
+TEST(DeflectionRamping, booleanDisablesTheta)
+{
+  const double theta = utils::radians(90.0);
+  const double rampSpan = utils::radians(20.0);
+  const double thetaZero = utils::radians(60.0);
+
+  const aero::SixDOF hub(vs::Vector::zero(), vs::Vector::ihat());
+  const vs::Vector root(vs::Vector::one());
+  const auto rotation = wmp::create_wm_param(vs::Vector::ihat(), theta);
+
+  const auto pClockWise = wmp::rotate(rotation, root);
+  EXPECT_DOUBLE_EQ(0.0, fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero, true));
+  EXPECT_DOUBLE_EQ(1.0, fsi::linear_ramp_theta(hub, root, pClockWise, rampSpan, thetaZero, false));
+}
+
+TEST(DeflectionRamping, booleanDisablesSpan)
+{
+  const double spanLocation = 0.3;
+  const double zeroRampLocation = 0.4;
+  EXPECT_DOUBLE_EQ(0.75, fsi::linear_ramp_span(spanLocation, zeroRampLocation, true));
+  EXPECT_DOUBLE_EQ(1.0, fsi::linear_ramp_span(spanLocation, zeroRampLocation, false));
+}
 } // namespace


### PR DESCRIPTION
Add 3 booleans to disable the fsi ramping for split meshes with gaps between the blades. In those cases we should no longer need to ramp spatially. We should keep temporal ramping on always except for targeted tests, but this gives a clear way to turn it off.


- `enable_temporal_ramping: false`
- `enable_span_ramping: false`
- `enable_theta_ramping: false`


All of these are defaulted to `true` and they are optional parameters i.e. no input decks are backwards compatible.