### PR TITLE
Add Timers for FSI

### DIFF
--- a/include/aero/AeroContainer.h
+++ b/include/aero/AeroContainer.h
@@ -55,6 +55,8 @@ public:
   const stk::mesh::PartVector fsi_parts();
   const stk::mesh::PartVector fsi_bndry_parts();
   const std::vector<std::string> fsi_bndry_part_names();
+  double openfast_accumulated_time();
+  double nalu_fsi_accumulated_time();
 
 private:
   bool has_actuators() { return actuatorModel_.is_active(); }

--- a/include/aero/fsi/OpenfastFSI.h
+++ b/include/aero/fsi/OpenfastFSI.h
@@ -47,8 +47,8 @@ public:
     std::array<double, 3> axis, double omega, double curTime);
   void end_openfast();
 
-  double total_openfastfsi_execution_time(){ return openFastTimer_.second;}
-  double total_nalu_fsi_execution_time(){ return naluTimer_.second;}
+  double total_openfastfsi_execution_time() { return openFastTimer_.second; }
+  double total_nalu_fsi_execution_time() { return naluTimer_.second; }
 
 private:
   OpenfastFSI() = delete;
@@ -84,8 +84,10 @@ private:
 
   double dt_{-1.0}; // Store nalu-wind step
 
-  std::pair<double, double> openFastTimer_{0.0, 0.0}; // store time taken in openfast calls
-  std::pair<double, double> naluTimer_{0.0, 0.0}; // store time taken in openfast calls
+  std::pair<double, double> openFastTimer_{
+    0.0, 0.0}; // store time taken in openfast calls
+  std::pair<double, double> naluTimer_{
+    0.0, 0.0}; // store time taken in openfast calls
 
   int writeFreq_{
     30}; // Frequency to write line loads and deflections to netcdf file

--- a/include/aero/fsi/OpenfastFSI.h
+++ b/include/aero/fsi/OpenfastFSI.h
@@ -47,6 +47,9 @@ public:
     std::array<double, 3> axis, double omega, double curTime);
   void end_openfast();
 
+  double total_openfastfsi_execution_time(){ return openFastTimer_.second;}
+  double total_nalu_fsi_execution_time(){ return naluTimer_.second;}
+
 private:
   OpenfastFSI() = delete;
   OpenfastFSI(const OpenfastFSI&) = delete;
@@ -58,6 +61,8 @@ private:
   void compute_mapping();
 
   void send_loads(const double curTime);
+  void timer_start(std::pair<double, double>& timer);
+  void timer_stop(std::pair<double, double>& timer);
 
   std::shared_ptr<stk::mesh::BulkData> bulk_;
 
@@ -78,6 +83,9 @@ private:
   int tStep_{0}; // Time step count
 
   double dt_{-1.0}; // Store nalu-wind step
+
+  std::pair<double, double> openFastTimer_{0.0, 0.0}; // store time taken in openfast calls
+  std::pair<double, double> naluTimer_{0.0, 0.0}; // store time taken in openfast calls
 
   int writeFreq_{
     30}; // Frequency to write line loads and deflections to netcdf file

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -4038,7 +4038,7 @@ Realm::dump_simulation_time()
       << std::endl;
   }
 
-  if(aeroModels_->has_fsi()){
+  if (aeroModels_->has_fsi()) {
     double naluFsiTimer = aeroModels_->nalu_fsi_accumulated_time();
     double openFastFsiTimer = aeroModels_->openfast_accumulated_time();
     // nalu fsi calculations
@@ -4050,12 +4050,12 @@ Realm::dump_simulation_time()
     stk::all_reduce_sum(
       NaluEnv::self().parallel_comm(), &naluFsiTimer, &g_totalNalu, 1);
 
-    NaluEnv::self().naluOutputP0() << "Timing for FSI Computations :    " << std::endl;
+    NaluEnv::self().naluOutputP0()
+      << "Timing for FSI Computations :    " << std::endl;
     NaluEnv::self().naluOutputP0()
       << "        Nalu-Wind::computations --  "
-      << " \tavg: " << g_totalNalu / double(nprocs)
-      << " \tmin: " << g_minNalu << " \tmax: " << g_maxNalu
-      << std::endl;
+      << " \tavg: " << g_totalNalu / double(nprocs) << " \tmin: " << g_minNalu
+      << " \tmax: " << g_maxNalu << std::endl;
 
     // openfast calculations (excluding data fetch operations)
     double g_totalFast = 0.0, g_minFast = 0.0, g_maxFast = 0.0;
@@ -4068,9 +4068,8 @@ Realm::dump_simulation_time()
 
     NaluEnv::self().naluOutputP0()
       << "        OpenFAST::computations --  "
-      << " \tavg: " << g_totalFast / double(nprocs)
-      << " \tmin: " << g_minFast << " \tmax: " << g_maxFast
-      << std::endl;
+      << " \tavg: " << g_totalFast / double(nprocs) << " \tmin: " << g_minFast
+      << " \tmax: " << g_maxFast << std::endl;
   }
 
   // consolidated sort

--- a/src/aero/AeroContainer.C
+++ b/src/aero/AeroContainer.C
@@ -213,5 +213,25 @@ AeroContainer::fsi_bndry_part_names()
   return bndry_part_names;
 }
 
+double AeroContainer::openfast_accumulated_time(){
+#ifdef NALU_USES_OPENFAST_FSI
+  if(has_fsi())
+    return fsiContainer_->total_openfastfsi_execution_time();
+  else
+    return -1.0;
+#endif
+  return -1.0;
+}
+
+double AeroContainer::nalu_fsi_accumulated_time(){
+#ifdef NALU_USES_OPENFAST_FSI
+  if(has_fsi())
+    return fsiContainer_->total_nalu_fsi_execution_time();
+  else
+    return -1.0;
+#endif
+  return -1.0;
+}
+
 } // namespace nalu
 } // namespace sierra

--- a/src/aero/AeroContainer.C
+++ b/src/aero/AeroContainer.C
@@ -213,9 +213,11 @@ AeroContainer::fsi_bndry_part_names()
   return bndry_part_names;
 }
 
-double AeroContainer::openfast_accumulated_time(){
+double
+AeroContainer::openfast_accumulated_time()
+{
 #ifdef NALU_USES_OPENFAST_FSI
-  if(has_fsi())
+  if (has_fsi())
     return fsiContainer_->total_openfastfsi_execution_time();
   else
     return -1.0;
@@ -223,9 +225,11 @@ double AeroContainer::openfast_accumulated_time(){
   return -1.0;
 }
 
-double AeroContainer::nalu_fsi_accumulated_time(){
+double
+AeroContainer::nalu_fsi_accumulated_time()
+{
 #ifdef NALU_USES_OPENFAST_FSI
-  if(has_fsi())
+  if (has_fsi())
     return fsiContainer_->total_nalu_fsi_execution_time();
   else
     return -1.0;

--- a/src/aero/fsi/OpenfastFSI.C
+++ b/src/aero/fsi/OpenfastFSI.C
@@ -592,7 +592,6 @@ void
 OpenfastFSI::map_displacements(double current_time, bool updateCurCoor)
 {
 
-
   timer_start(naluTimer_);
   get_displacements(current_time);
 
@@ -675,11 +674,15 @@ OpenfastFSI::map_loads(const int tStep, const double curTime)
   timer_stop(naluTimer_);
 }
 
-void OpenfastFSI::timer_start(std::pair<double, double>& timer){
+void
+OpenfastFSI::timer_start(std::pair<double, double>& timer)
+{
   timer.first = NaluEnv::self().nalu_time();
 }
 
-void OpenfastFSI::timer_stop(std::pair<double, double>& timer){
+void
+OpenfastFSI::timer_stop(std::pair<double, double>& timer)
+{
   timer.first = NaluEnv::self().nalu_time() - timer.first;
   timer.second += timer.first;
 }


### PR DESCRIPTION
Results from simple FSI debug case running on my laptop.
``` console
 Timing for FSI Computations :
         Nalu-Wind::computations --    avg: 0.0957177  min: 0.0957177  max: 0.0957177
         OpenFAST::computations --     avg: 0.194977   min: 0.194977   max: 0.194977
```

Timers are not all inclusive but I tried to capture the things that are doing the most work.