### PR TITLE
FSI: Set ramping defaults to false

### DIFF
--- a/include/aero/fsi/FSIturbine.h
+++ b/include/aero/fsi/FSIturbine.h
@@ -45,9 +45,9 @@ struct DeflectionRampingParams
   double thetaRampSpan_{10.0};
   double startTimeTemporalRamp_{0.0};
   double endTimeTemporalRamp_{0.0};
-  bool enableSpanRamping_{true};
-  bool enableThetaRamping_{true};
-  bool enableTemporalRamping_{true};
+  bool enableSpanRamping_{false};
+  bool enableThetaRamping_{false};
+  bool enableTemporalRamping_{false};
 };
 
 // TODO(psakiev) find a better place for this

--- a/reg_tests/test_files/fsiTurbineSurrogate/fsiTurbineSurrogate.yaml
+++ b/reg_tests/test_files/fsiTurbineSurrogate/fsiTurbineSurrogate.yaml
@@ -246,6 +246,9 @@ realms:
 #        z_ref: 90.0
 #        shear_exp: 0.0          
 #        deflection_ramping:
+#          enable_temporal_ramping: true
+#          enable_span_ramping: true
+#          enable_theta_ramping: true
 #          span_ramp_distance: 10.0
 #          temporal_ramp_start: 5000 
 #          temporal_ramp_end: 1e6

--- a/src/aero/fsi/FSIturbine.C
+++ b/src/aero/fsi/FSIturbine.C
@@ -96,9 +96,9 @@ fsiTurbine::fsiTurbine(int iTurb, const YAML::Node& node)
     double* thetaRamp = &defParams.thetaRampSpan_;
     // clang-format off
     // defaults of all are true from struct defintion
-    get_if_present(defNode, "enable_theta_ramping", defParams.enableThetaRamping_, true);
-    get_if_present(defNode, "enable_span_ramping", defParams.enableSpanRamping_, true);
-    get_if_present(defNode, "enable_temporal_ramping", defParams.enableTemporalRamping_, true);
+    get_if_present(defNode, "enable_theta_ramping", defParams.enableThetaRamping_, false);
+    get_if_present(defNode, "enable_span_ramping", defParams.enableSpanRamping_, false);
+    get_if_present(defNode, "enable_temporal_ramping", defParams.enableTemporalRamping_, false);
 
     if(defParams.enableTemporalRamping_){
       get_required(defNode, "temporal_ramp_start", defParams.startTimeTemporalRamp_);


### PR DESCRIPTION
Since we are moving to split meshes as the current strategy setting ramping defaults to `False`.

I have been investigating why the temporal ramping is causing simulations to fail since the bug fixes regarding hub motion, and I can't find any issues with it at the moment. So it seems best to keep that turned off as well.