### PR TITLE
Updating IBlank

### DIFF
--- a/src/overset/TiogaSTKIface.C
+++ b/src/overset/TiogaSTKIface.C
@@ -178,7 +178,7 @@ TiogaSTKIface::post_connectivity_work(const bool isDecoupled)
   ScalarIntFieldType* ibf =
     meta_.get_field<ScalarIntFieldType>(stk::topology::NODE_RANK, "iblank");
   std::vector<const stk::mesh::FieldBase*> pvec{ibf};
-  stk::mesh::copy_owned_to_shared(bulk_, pvec);
+  stk::mesh::parallel_max(bulk_, {ibf});
 
   post_connectivity_sync();
 


### PR DESCRIPTION
I am not sure update shared is the right operation. It seems like if a cell is detected as fringe anywhere it should be fringe even if it is not the owner.  In this case `parallel_max` makes more sense to me. I have not tested this.  

This could explain the behavior https://github.com/Exawind/exawind-driver/issues/65