### PR TITLE
Default value of SDRWallFactor: 1 -> 10

### DIFF
--- a/src/SolutionOptions.C
+++ b/src/SolutionOptions.C
@@ -653,7 +653,7 @@ SolutionOptions::initialize_turbulence_constants()
   turbModelConstantMap_[TM_cmuCs] = 0.17;
   turbModelConstantMap_[TM_Cw] = 0.325;
   turbModelConstantMap_[TM_CbTwo] = 0.35;
-  turbModelConstantMap_[TM_SDRWallFactor] = 1.0;
+  turbModelConstantMap_[TM_SDRWallFactor] = 10.0;
   turbModelConstantMap_[TM_zCV] = 0.5;
   turbModelConstantMap_[TM_ci] = 0.9;
   turbModelConstantMap_[TM_elog] = 9.8;


### PR DESCRIPTION
The SDRWallFactor is a constant for the wall boundary condition of the omega in the SST turbulence model.

<img width="270" alt="1" src="https://github.com/Exawind/nalu-wind/assets/87391424/3e40b9bf-cd72-4dfc-b0aa-04b5f84efbd6">


However, there are some uncertainties about this in Nalu-Wind. The original SST model by Menter uses 10 for the SDRWallFactor. Currently, in Nalu-Wind, users can specify the SDRWallFactor in the input yaml file, and the default value is 1 if not explicitly specified. Many users run RANS simulations with the default value. Some reg test cases in the repository used 0.625. Marc orignally performed the validation of the NASA’s 2D Zero Pressure Gradient (ZPG) Flat Plate Verification Case with SDRWallFactor of 10. 


The wall boundary condition plays a crucial role in transition simulations because the transition model triggers laminar-turbulent transition based on flow quantities close to the middle of the boundary layer, which is very near the wall.  

For this reason, I tested different values of SDRWallFactor for the NASA TMR’s 2D ZPG flat plate and NACA 0012 airfoil cases and adjusted the default value to 10 based on the test results, which I believe is the correct value.

 
I've attached some results for the ZPG flat pate cases below

<img width="1102" alt="2" src="https://github.com/Exawind/nalu-wind/assets/87391424/74f67e41-325b-4ccd-9567-b383d61bb2b5">

<img width="1121" alt="3" src="https://github.com/Exawind/nalu-wind/assets/87391424/8216db54-a71f-4557-bbfa-3dfec639b7b6">

<img width="1112" alt="4" src="https://github.com/Exawind/nalu-wind/assets/87391424/6423e80c-9f86-46d3-99a9-0d2b06a9d5a2">

Please refer to the attached file for more detailed analysis. Any discussion about the is welcomed!
 
[SDR_Wall_factor.pdf](https://github.com/Exawind/nalu-wind/files/14886922/SDR_Wall_factor.pdf)
