### PR TITLE
Miscellaneous fixes for memory corruption errors

### DIFF
--- a/include/Enums.h
+++ b/include/Enums.h
@@ -105,6 +105,7 @@ static const std::string EquationTypeMap[] = {
   "PNG_U",
   "PNG_TKE",
   "Wall_Distance",
+  "Gamma_Transition",
   "Volume_of_Fluid"};
 
 enum UserDataType {

--- a/src/FieldRegistry.C
+++ b/src/FieldRegistry.C
@@ -83,7 +83,7 @@ Registry()
     {"pressure",                  SingleStateNodalScalar},
     {"rans_time_scale" ,          SingleStateNodalScalar},
     {"scalarQ",                   SingleStateNodalScalar},
-    {"specific_dissipation_rate", SingleStateNodalScalar},
+    {"specific_dissipation_rate", MultiStateNodalScalar},
     {"specific_heat" ,            SingleStateNodalScalar},
     {"sst_f_one_blending"  ,      SingleStateNodalScalar},
     {"sst_max_length_scale",      SingleStateNodalScalar},

--- a/unit_tests/UnitTestSideWriter.C
+++ b/unit_tests/UnitTestSideWriter.C
@@ -31,8 +31,9 @@ public:
     stk::mesh::put_field_on_mesh(
       *test_field, meta->universal_part(), 1, &minus_one);
 
+    double minus_one_vec[3] = {-1.0, -1.0, -1.0};
     stk::mesh::put_field_on_mesh(
-      *test_vector_field, meta->universal_part(), 3, &minus_one);
+      *test_vector_field, meta->universal_part(), 3, minus_one_vec);
     stk::io::set_field_output_type(
       *test_vector_field, stk::io::FieldOutputType::VECTOR_3D);
 

--- a/unit_tests/UnitTestUtils.h
+++ b/unit_tests/UnitTestUtils.h
@@ -96,9 +96,10 @@ protected:
 
     double one = 1.0;
     double zero = 0.0;
+    double zeroVec[3] = {0.0, 0.0, 0.0};
     const stk::mesh::PartVector parts(1, &meta->universal_part());
     elemCentroidField =
-      fieldManager->register_field<double>("elemCentroid", parts, &zero);
+      fieldManager->register_field<double>("elemCentroid", parts, zeroVec);
     nodalPressureField =
       fieldManager->register_field<double>("nodalPressure", parts, &one);
     discreteLaplacianOfPressure =

--- a/unit_tests/kernels/UnitTestKernelUtils.h
+++ b/unit_tests/kernels/UnitTestKernelUtils.h
@@ -1454,7 +1454,7 @@ public:
     stk::mesh::put_field_on_mesh(
       *volumeOfFluid_, meta_->universal_part(), nullptr);
     stk::mesh::put_field_on_mesh(
-      *dvolumeOfFluidDx_, meta_->universal_part(), nullptr);
+      *dvolumeOfFluidDx_, meta_->universal_part(), spatialDim_, nullptr);
     stk::mesh::put_field_on_mesh(
       *velocity_, meta_->universal_part(), spatialDim_, nullptr);
     stk::io::set_field_output_type(
@@ -1486,7 +1486,7 @@ public:
   }
 
   sierra::nalu::ScalarFieldType* volumeOfFluid_{nullptr};
-  sierra::nalu::ScalarFieldType* dvolumeOfFluidDx_{nullptr};
+  sierra::nalu::VectorFieldType* dvolumeOfFluidDx_{nullptr};
   sierra::nalu::VectorFieldType* velocity_{nullptr};
   sierra::nalu::ScalarFieldType* density_{nullptr};
   sierra::nalu::ScalarFieldType* viscosity_{nullptr};

--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -55,7 +55,7 @@ public:
       *velocity, stk::io::FieldOutputType::VECTOR_3D);
     stk::mesh::put_field_on_mesh(
       *massFlowRate, meta->universal_part(), hex8SCS.num_integration_points(),
-      &zero);
+      nullptr);
     stk::mesh::put_field_on_mesh(*mdotEdge, meta->universal_part(), &zero);
   }
 


### PR DESCRIPTION
These are either insignificant, not yet tripped in the code, or isolated to unit test code only.  These are almost certainly not the cause of the seg-fault on Frontier, but they should still be fixed.