### PR TITLE
Fix error in unit test from unsynched bulk

### DIFF
--- a/unit_tests/UnitTestUtils.C
+++ b/unit_tests/UnitTestUtils.C
@@ -157,9 +157,10 @@ create_one_element(
   }
   auto elem = stk::mesh::declare_element(
     bulk, block_1, bulk.parallel_rank() + 1, nodeIds);
-  stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
   bulk.modification_end();
+
+  stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
   auto surfaceSelector = stk::mesh::selectUnion(allSurfaces);
   stk::mesh::EntityVector all_faces;

--- a/unit_tests/matrix_free/UnitTestConductionFields.C
+++ b/unit_tests/matrix_free/UnitTestConductionFields.C
@@ -91,9 +91,10 @@ protected:
     }
     auto elem = stk::mesh::declare_element(
       *bulk, block_1, bulk->parallel_rank() + 1, nodeIds);
-    stk::mesh::create_all_sides(*bulk, block_1, allSurfaces, false);
 
     bulk->modification_end();
+
+    stk::mesh::create_all_sides(*bulk, block_1, allSurfaces, false);
 
     auto surfaceSelector = stk::mesh::selectUnion(allSurfaces);
     stk::mesh::EntityVector all_faces;

--- a/unit_tests/matrix_free/UnitTestStkSimdConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdConnectivityMap.C
@@ -87,9 +87,10 @@ protected:
     }
     auto elem = stk::mesh::declare_element(
       bulk, block_1, bulk.parallel_rank() + 1, nodeIds);
-    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
     bulk.modification_end();
+
+    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
     auto surfaceSelector = stk::mesh::selectUnion(allSurfaces);
     stk::mesh::EntityVector all_faces;

--- a/unit_tests/matrix_free/UnitTestStkSimdFaceConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdFaceConnectivityMap.C
@@ -98,9 +98,10 @@ protected:
     }
     auto elem = stk::mesh::declare_element(
       bulk, block_1, bulk.parallel_rank() + 1, nodeIds);
-    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
     bulk.modification_end();
+
+    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
     auto surfaceSelector = stk::mesh::selectUnion(allSurfaces);
     stk::mesh::EntityVector all_faces;

--- a/unit_tests/matrix_free/UnitTestStkSimdGatheredElementData.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdGatheredElementData.C
@@ -105,9 +105,10 @@ protected:
     }
     auto elem = stk::mesh::declare_element(
       bulk, block_1, bulk.parallel_rank() + 1, nodeIds);
-    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
     bulk.modification_end();
+
+    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
     std::vector<std::vector<double>> nodeLocations = {
       {-1, -1, -1}, {+1, -1, -1}, {+1, +1, -1}, {-1, +1, -1},

--- a/unit_tests/matrix_free/UnitTestStkSimdNodeConnectivityMap.C
+++ b/unit_tests/matrix_free/UnitTestStkSimdNodeConnectivityMap.C
@@ -82,9 +82,10 @@ protected:
         stk::topology::NODE_RANK, id, stk::mesh::PartVector{});
     }
     auto elem = stk::mesh::declare_element(bulk, block_1, 1, nodeIds);
-    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
     bulk.modification_end();
+
+    stk::mesh::create_all_sides(bulk, block_1, allSurfaces, false);
 
     auto surfaceSelector = stk::mesh::selectUnion(allSurfaces);
     stk::mesh::EntityVector all_faces;


### PR DESCRIPTION
Fixes these errors:
```
error: 'show' is not a valid command.
C++ exception with description "Requirement( bulkData.in_synchronized_state() ) FAILED                                                                                                                                                                                [63/29722]
Error occurred at: stk_mesh/stk_mesh/base/SkinBoundary.cpp:88

Error: Cannot use create_all_sides while in another mod cycle.
" thrown in the test body.
```