### PR TITLE
Fix nrel5MWactuatorLine test and ActuatorBulkFastTests unit test

### DIFF
--- a/include/aero/actuator/ActuatorBulkFAST.h
+++ b/include/aero/actuator/ActuatorBulkFAST.h
@@ -16,13 +16,12 @@
 namespace sierra {
 namespace nalu {
 
-struct
-ActuatorMetaFAST : public ActuatorMeta
+struct ActuatorMetaFAST : public ActuatorMeta
 {
   ActuatorMetaFAST(const ActuatorMeta& actMeta);
 
   // HOST ONLY
-  void set_dt_driver(const double dt){fastInputs_.dtDriver=dt;}
+  void set_dt_driver(const double dt) { fastInputs_.dtDriver = dt; }
   fast::fastInputs fastInputs_;
   std::vector<std::string> turbineNames_;
   std::vector<std::string> turbineOutputFileNames_;

--- a/include/aero/actuator/ActuatorBulkFAST.h
+++ b/include/aero/actuator/ActuatorBulkFAST.h
@@ -16,11 +16,13 @@
 namespace sierra {
 namespace nalu {
 
-struct ActuatorMetaFAST : public ActuatorMeta
+struct
+ActuatorMetaFAST : public ActuatorMeta
 {
   ActuatorMetaFAST(const ActuatorMeta& actMeta);
 
   // HOST ONLY
+  void set_dt_driver(const double dt){fastInputs_.dtDriver=dt;}
   fast::fastInputs fastInputs_;
   std::vector<std::string> turbineNames_;
   std::vector<std::string> turbineOutputFileNames_;
@@ -42,7 +44,7 @@ struct ActuatorMetaFAST : public ActuatorMeta
 
 struct ActuatorBulkFAST : public ActuatorBulk
 {
-  ActuatorBulkFAST(const ActuatorMetaFAST& actMeta, double naluTimeStep);
+  ActuatorBulkFAST(ActuatorMetaFAST& actMeta, double naluTimeStep);
 
   Kokkos::RangePolicy<Kokkos::DefaultHostExecutionSpace> local_range_policy();
 

--- a/reg_tests/test_files/nrel5MWactuatorLine/5MW_Baseline/NRELOffshrBsline5MW_Onshore_AeroDyn15.dat
+++ b/reg_tests/test_files/nrel5MWactuatorLine/5MW_Baseline/NRELOffshrBsline5MW_Onshore_AeroDyn15.dat
@@ -10,6 +10,7 @@ False         Echo               - Echo the input to "<rootname>.AD.ech"?  (flag
 True          TwrAero            - Calculate tower aerodynamic loads? (flag)
 False         FrozenWake         - Assume frozen wake during linearization? (flag) [used only when WakeMod=1 and when linearizing]
 False         CavitCheck         - Perform cavitation check? (flag) [AFAeroMod must be 1 when CavitCheck=true]
+False         Buoyancy           - Include buoyancy effects? (flag)
 False         CompAA             - Flag to compute AeroAcoustics calculation [only used when WakeMod=1 or 2]
 "unused"      AA_InputFile       - Aeroacoustics input file
 ======  Environmental Conditions  ===================================================================
@@ -57,22 +58,31 @@ True          UseBlCm            - Include aerodynamic pitching moment in calcul
 "NRELOffshrBsline5MW_AeroDyn_blade.dat"    ADBlFile(1)        - Name of file containing distributed aerodynamic properties for Blade #1 (-)
 "NRELOffshrBsline5MW_AeroDyn_blade.dat"    ADBlFile(2)        - Name of file containing distributed aerodynamic properties for Blade #2 (-) [unused if NumBl < 2]
 "NRELOffshrBsline5MW_AeroDyn_blade.dat"    ADBlFile(3)        - Name of file containing distributed aerodynamic properties for Blade #3 (-) [unused if NumBl < 3]
-======  Tower Influence and Aerodynamics ============================================================= [used only when TwrPotent/=0, TwrShadow=True, or TwrAero=True]
-         12   NumTwrNds         - Number of tower nodes used in the analysis  (-) [used only when TwrPotent/=0, TwrShadow=True, or TwrAero=True]
-TwrElev        TwrDiam        TwrCd          TwrTI (used only with TwrShadow=2)
-(m)              (m)           (-)            (-)
-0.0000000E+00  6.0000000E+00  1.0000000E+00  1.0000000E-01
-8.5261000E+00  5.7870000E+00  1.0000000E+00  1.0000000E-01
-1.7053000E+01  5.5740000E+00  1.0000000E+00  1.0000000E-01
-2.5579000E+01  5.3610000E+00  1.0000000E+00  1.0000000E-01
-3.4105000E+01  5.1480000E+00  1.0000000E+00  1.0000000E-01
-4.2633000E+01  4.9350000E+00  1.0000000E+00  1.0000000E-01
-5.1158000E+01  4.7220000E+00  1.0000000E+00  1.0000000E-01
-5.9685000E+01  4.5090000E+00  1.0000000E+00  1.0000000E-01
-6.8211000E+01  4.2960000E+00  1.0000000E+00  1.0000000E-01
-7.6738000E+01  4.0830000E+00  1.0000000E+00  1.0000000E-01
-8.5268000E+01  3.8700000E+00  1.0000000E+00  1.0000000E-01
-8.7600000E+01  3.8700000E+00  1.0000000E+00  1.0000000E-01         
+======  Hub Properties ============================================================================== [used only when Buoyancy=True]
+0.0   VolHub             - Hub volume (m^3)
+0.0   HubCenBx           - Hub center of buoyancy x direction offset (m)
+======  Nacelle Properties ========================================================================== [used only when Buoyancy=True]
+0.0   VolNac             - Nacelle volume (m^3)
+0,0,0 NacCenB            - Position of nacelle center of buoyancy from yaw bearing in nacelle coordinates (m)
+======  Tail fin Aerodynamics ======================================================================== 
+False         TFinAero           - Calculate tail fin aerodynamics model (flag)
+"unused"      TFinFile           - Input file for tail fin aerodynamics [used only when TFinAero=True]
+======  Tower Influence and Aerodynamics ============================================================ [used only when TwrPotent/=0, TwrShadow/=0, TwrAero=True, or Buoyancy=True]
+         12   NumTwrNds         - Number of tower nodes used in the analysis  (-) [used only when TwrPotent/=0, TwrShadow/=0, TwrAero=True, or Buoyancy=True]
+TwrElev        TwrDiam        TwrCd          TwrTI          TwrCb !TwrTI used only with TwrShadow=2, TwrCb used only with Buoyancy=True
+(m)              (m)           (-)            (-)           (-)
+0.0000000E+00  6.0000000E+00  1.0000000E+00  1.0000000E-01  0.0
+8.5261000E+00  5.7870000E+00  1.0000000E+00  1.0000000E-01  0.0
+1.7053000E+01  5.5740000E+00  1.0000000E+00  1.0000000E-01  0.0
+2.5579000E+01  5.3610000E+00  1.0000000E+00  1.0000000E-01  0.0
+3.4105000E+01  5.1480000E+00  1.0000000E+00  1.0000000E-01  0.0
+4.2633000E+01  4.9350000E+00  1.0000000E+00  1.0000000E-01  0.0
+5.1158000E+01  4.7220000E+00  1.0000000E+00  1.0000000E-01  0.0
+5.9685000E+01  4.5090000E+00  1.0000000E+00  1.0000000E-01  0.0
+6.8211000E+01  4.2960000E+00  1.0000000E+00  1.0000000E-01  0.0
+7.6738000E+01  4.0830000E+00  1.0000000E+00  1.0000000E-01  0.0
+8.5268000E+01  3.8700000E+00  1.0000000E+00  1.0000000E-01  0.0
+8.7600000E+01  3.8700000E+00  1.0000000E+00  1.0000000E-01  0.0         
 ======  Outputs  ====================================================================================
 True          SumPrint            - Generate a summary file listing input options and interpolated properties to "<rootname>.AD.sum"?  (flag)
           7   NBlOuts             - Number of blade node outputs [0 - 9] (-)

--- a/reg_tests/test_files/nrel5MWactuatorLine/5MW_Baseline/NRELOffshrBsline5MW_Onshore_ElastoDyn.dat
+++ b/reg_tests/test_files/nrel5MWactuatorLine/5MW_Baseline/NRELOffshrBsline5MW_Onshore_ElastoDyn.dat
@@ -95,6 +95,11 @@ False         PtfmYDOF    - Platform yaw rotation DOF (flag)
           0   TeetHStP    - Rotor-teeter hard-stop position (degrees) [used only for 2 blades and when TeetMod=1]
           0   TeetSSSp    - Rotor-teeter soft-stop linear-spring constant (N-m/rad) [used only for 2 blades and when TeetMod=1]
           0   TeetHSSp    - Rotor-teeter hard-stop linear-spring constant (N-m/rad) [used only for 2 blades and when TeetMod=1]
+---------------------- YAW-FRICTION --------------------------------------------
+          0   YawFrctMod  - {0: none, 1: friction without Fz term at the yaw bearing, 2: friction includes Fz term at yaw bearing, 3: user defined model} (switch)
+        300   M_CSmax     - Maximum Coulomb friction torque (N-m)[mu_s*D_eff when YawFrctMod=1 and Fz*mu_s*D_eff when YawFrctMod=2]
+         40   M_CD        - Dynamic friction moment at null yaw rate (N-m) [mu_d*D_eff when YawFrctMod=1 and Fz*mu_d*D_eff when YawFrctMod=2]
+          0   sig_v       - Viscous friction coefficient (N-m/(rad/s))
 ---------------------- DRIVETRAIN ----------------------------------------------
         100   GBoxEff     - Gearbox efficiency (%)
          97   GBRatio     - Gearbox ratio (-)

--- a/reg_tests/test_files/nrel5MWactuatorLine/nrel5mw.fst.in
+++ b/reg_tests/test_files/nrel5MWactuatorLine/nrel5mw.fst.in
@@ -14,6 +14,7 @@ false         Echo            - Echo input data to <RootName>.ech (flag)
           2   CompInflow      - Compute inflow wind velocities (switch) {0=still air; 1=InflowWind; 2=external from OpenFOAM}
           2   CompAero        - Compute aerodynamic loads (switch) {0=None; 1=AeroDyn v14; 2=AeroDyn v15}
           1   CompServo       - Compute control and electrical-drive dynamics (switch) {0=None; 1=ServoDyn}
+          0   CompSeaSt       - Compute sea state information (switch) {0=None; 1=SeaState}
           0   CompHydro       - Compute hydrodynamic loads (switch) {0=None; 1=HydroDyn}
           0   CompSub         - Compute sub-structural dynamics (switch) {0=None; 1=SubDyn}
           0   CompMooring     - Compute mooring system (switch) {0=None; 1=MAP++; 2=FEAMooring; 3=MoorDyn; 4=OrcaFlex}
@@ -37,6 +38,7 @@ false         Echo            - Echo input data to <RootName>.ech (flag)
 "@CMAKE_CURRENT_BINARY_DIR@/5MW_Baseline/NRELOffshrBsline5MW_InflowWind_12mps.dat"    InflowFile      - Name of file containing inflow wind input parameters (quoted string)
 "@CMAKE_CURRENT_BINARY_DIR@/5MW_Baseline/NRELOffshrBsline5MW_Onshore_AeroDyn15.dat"    AeroFile        - Name of file containing aerodynamic input parameters (quoted string)
 "@CMAKE_CURRENT_BINARY_DIR@/5MW_Baseline/NRELOffshrBsline5MW_Onshore_ServoDyn.dat"    ServoFile       - Name of file containing control and electrical-drive input parameters (quoted string)
+"unused"      SeaStFile       - Name of file containing sea state input parameters (quoted string)
 "unused"      HydroFile       - Name of file containing hydrodynamic input parameters (quoted string)
 "unused"      SubFile         - Name of file containing sub-structural input parameters (quoted string)
 "unused"      MooringFile     - Name of file containing mooring system input parameters (quoted string)

--- a/src/aero/actuator/ActuatorBulkDiskFAST.C
+++ b/src/aero/actuator/ActuatorBulkDiskFAST.C
@@ -26,6 +26,7 @@ ActuatorBulkDiskFAST::ActuatorBulkDiskFAST(
 {
 
   STK_ThrowErrorIf(!actMeta.is_disk());
+  actMeta.set_dt_driver(naluTimeStep);
   compute_swept_point_count(actMeta);
   resize_arrays(actMeta);
   Kokkos::parallel_for(

--- a/src/aero/actuator/ActuatorBulkFAST.C
+++ b/src/aero/actuator/ActuatorBulkFAST.C
@@ -44,7 +44,7 @@ ActuatorMetaFAST::is_disk()
 }
 
 ActuatorBulkFAST::ActuatorBulkFAST(
-  const ActuatorMetaFAST& actMeta, double naluTimeStep)
+  ActuatorMetaFAST& actMeta, double naluTimeStep)
   : ActuatorBulk(actMeta),
     turbineThrust_("turbineThrust", actMeta.numberOfActuators_),
     turbineTorque_("turbineTorque", actMeta.numberOfActuators_),
@@ -55,6 +55,7 @@ ActuatorBulkFAST::ActuatorBulkFAST(
       actMeta.isotropicGaussian_ ? 0 : actMeta.numPointsTotal_),
     tStepRatio_(std::round(naluTimeStep / actMeta.fastInputs_.dtFAST))
 {
+  actMeta.set_dt_driver(naluTimeStep);
   init_openfast(actMeta, naluTimeStep);
   init_epsilon(actMeta);
   RunActFastUpdatePoints(*this);

--- a/src/aero/actuator/ActuatorParsingFAST.C
+++ b/src/aero/actuator/ActuatorParsingFAST.C
@@ -174,9 +174,6 @@ actuator_FAST_parse(const YAML::Node& y_node, const ActuatorMeta& actMeta)
     get_required(y_actuator, "n_every_checkpoint", *restartFreq);
     get_required(y_actuator, "dt_fast", fi.dtFAST);
 
-    // FIXME this needs to be defined. No idea how
-    fi.dtDriver = 0.0625;
-
     get_required(y_actuator, "t_max", fi.tMax);
 
     if (y_actuator["super_controller"]) {

--- a/src/aero/actuator/ActuatorParsingFAST.C
+++ b/src/aero/actuator/ActuatorParsingFAST.C
@@ -174,6 +174,9 @@ actuator_FAST_parse(const YAML::Node& y_node, const ActuatorMeta& actMeta)
     get_required(y_actuator, "n_every_checkpoint", *restartFreq);
     get_required(y_actuator, "dt_fast", fi.dtFAST);
 
+    // FIXME this needs to be defined. No idea how
+    fi.dtDriver = 0.0625;
+
     get_required(y_actuator, "t_max", fi.tMax);
 
     if (y_actuator["super_controller"]) {

--- a/src/aero/actuator/ActuatorParsingFAST.C
+++ b/src/aero/actuator/ActuatorParsingFAST.C
@@ -83,11 +83,11 @@ readTurbineData(int iTurb, ActuatorMetaFAST& actMetaFAST, YAML::Node turbNode)
 
   get_required(
     turbNode, "turbine_base_pos", fi.globTurbineData[iTurb].TurbineBasePos);
-  if (turbNode["turbine_hub_pos"]) {
-    NaluEnv::self().naluOutputP0()
-      << "WARNING::turbine_hub_pos is not used. "
-      << "The hub location is computed in OpenFAST and is controlled by the "
-         "ElastoDyn input file.";
+  if (turbNode["turbine_hub_pos"].IsSequence()) {
+    fi.globTurbineData[iTurb].TurbineHubPos =
+      turbNode["turbine_hub_pos"].as<std::vector<double>>();
+  } else {
+    fi.globTurbineData[iTurb].TurbineHubPos = std::vector<double>(3, 0.0);
   }
   get_required(
     turbNode, "num_force_pts_blade",


### PR DESCRIPTION
This is the fix to the segfault in `nrel5MWactuatorLine`. https://github.com/OpenFAST/openfast/blob/dev/glue-codes/openfast-cpp/src/OpenFAST.cpp#L2072 needs valid values in `TurbineHubPos`. Curious to get thoughts from people who know this stuff better: @psakievich and @gantech.

Not quite the end of the story because the input files have drifted from the dev openfast so I still need to fix 

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  FAST_InitializeAll:FAST_Init:FAST_ReadPrimaryFile:Invalid numerical input for file "nrel5mw.fst" occurred while trying to read MHK
```

But that's much easier to deal with ;) 