### PR TITLE
Loosen the VOF unit test tolerance

### DIFF
--- a/unit_tests/UnitTestTpetraHelperObjects.h
+++ b/unit_tests/UnitTestTpetraHelperObjects.h
@@ -107,7 +107,8 @@ struct TpetraHelperObjectsBase
     const std::vector<int>& rowOffsets,
     const std::vector<int>& cols,
     const std::vector<double>& vals,
-    const std::vector<double>& rhs)
+    const std::vector<double>& rhs,
+    const double tol = 1.e-14)
   {
     auto localMatrix = linsys->getOwnedMatrix()->getLocalMatrixHost();
     auto localRhs =
@@ -126,18 +127,18 @@ struct TpetraHelperObjectsBase
         for (int j = 0; j < constRowView.length; ++j) {
           if (constRowView.colidx(j) == goldCol) {
             foundGoldCol = true;
-            EXPECT_NEAR(vals[offset], constRowView.value(j), 1.e-14)
+            EXPECT_NEAR(vals[offset], constRowView.value(j), tol)
               << "i: " << i << ", j: " << j;
           } else if (!find_col(
                        constRowView.colidx(j), cols, rowOffsets[i],
                        rowOffsets[i + 1])) {
-            EXPECT_NEAR(0.0, constRowView.value(j), 1.e-14);
+            EXPECT_NEAR(0.0, constRowView.value(j), tol);
           }
         }
         EXPECT_TRUE(foundGoldCol);
       }
 
-      EXPECT_NEAR(rhs[i], localRhs(i, 0), 1.e-14) << "i: " << i;
+      EXPECT_NEAR(rhs[i], localRhs(i, 0), tol) << "i: " << i;
     }
   }
 

--- a/unit_tests/edge_kernels/UnitTestVOFAdvectionEdge.C
+++ b/unit_tests/edge_kernels/UnitTestVOFAdvectionEdge.C
@@ -147,17 +147,20 @@ TEST_F(VOFKernelHex8Mesh, NGP_adv_diff_edge_tpetra)
 
   namespace golds = ::hex8_golds::adv_diff;
 
+  const double tol = 1e-13;
   if (numProcs == 1) {
     helperObjs.check_against_sparse_gold_values(
       golds::rowOffsets_serial, golds::cols_serial, golds::vals_serial,
-      golds::rhs_serial);
+      golds::rhs_serial, tol);
   } else {
     if (myProc == 0) {
       helperObjs.check_against_sparse_gold_values(
-        golds::rowOffsets_P0, golds::cols_P0, golds::vals_P0, golds::rhs_P0);
+        golds::rowOffsets_P0, golds::cols_P0, golds::vals_P0, golds::rhs_P0,
+        tol);
     } else {
       helperObjs.check_against_sparse_gold_values(
-        golds::rowOffsets_P1, golds::cols_P1, golds::vals_P1, golds::rhs_P1);
+        golds::rowOffsets_P1, golds::cols_P1, golds::vals_P1, golds::rhs_P1,
+        tol);
     }
   }
 }


### PR DESCRIPTION
On my laptop, this:
```
[+]  z3fyz4z  nalu-wind@master%apple-clang@15.0.0 cxxflags=-D_LIBCPP_ENABLE_CXX17_REMOVED_UNARY_BINARY_FUNCTION ~asan~boost~catalyst~cdash_submit~cuda~fftw~fsi~gpu-aware-mpi+hypre~ipo~ninja~openfast+pic~rocm~shared~tests~tioga+trilinos-solvers~umpire+unit-tests~wind-utils abs_tol=1e-15 build_system=cmake build_type=Release ctest_args='-R unit' dev_path=/Users/mhenryde/exawind/exawind-manager/environments/nalu-wind-dev/nalu-wind generator=make reference_golds=default rel_tol=1e-12 arch=darwin-ventura-m1
```

leads to a unit test failure in `VOFKernelHex8Mesh.NGP_adv_diff_edge_tpetra`
```
  RUN      ] VOFKernelHex8Mesh.NGP_adv_diff_edge_tpetra
/Users/mhenryde/exawind/exawind-manager/environments/nalu-wind-dev/nalu-wind/unit_tests/UnitTestTpetraHelperObjects.h:130: Failure
The difference between vals[offset] and constRowView.value(j) is 1.4210854715202004e-14, which exceeds tol, where
vals[offset] evaluates to -83.128243716220496,
constRowView.value(j) evaluates to -83.12824371622051, and
tol evaluates to 1e-14.
i: 1, j: 2
/Users/mhenryde/exawind/exawind-manager/environments/nalu-wind-dev/nalu-wind/unit_tests/UnitTestTpetraHelperObjects.h:141: Failure
The difference between rhs[i] and localRhs(i, 0) is 2.8421709430404007e-14, which exceeds tol, where
rhs[i] evaluates to 166.25648743244099,
localRhs(i, 0) evaluates to 166.25648743244102, and
tol evaluates to 1e-14.
i: 1
```
I am attributing this to some compiler differences since the unit tests don't fail on ellis. I would still like them to pass on my machine so I am loosening the tolerance to 1e-13 for this test.