### PR TITLE
Fix compiler warnings on Frontier

### DIFF
--- a/include/master_element/Tet4CVFEM.h
+++ b/include/master_element/Tet4CVFEM.h
@@ -332,7 +332,9 @@ private:
                                 {0, 3, 2},  // face 2
                                 {0, 2, 1}}; // face 3
 
+#if !defined(KOKKOS_ENABLE_GPU)
   int intgExpFaceShift_[4][3][3];
+#endif
 
   template <typename DBLTYPE, typename SHMEM>
   KOKKOS_INLINE_FUNCTION void determinant_scs(

--- a/include/master_element/Tri32DCVFEM.h
+++ b/include/master_element/Tri32DCVFEM.h
@@ -311,7 +311,9 @@ private:
      {1, 2},                   // face 1
      {2, 0}};                  // face 2
 
+#if !defined(KOKKOS_ENABLE_GPU)
   double intgExpFaceShift_[3][2][2];
+#endif
 
   template <typename DBLTYPE, typename SHMEM>
   KOKKOS_INLINE_FUNCTION void determinant_scs(

--- a/src/aero/AeroContainer.C
+++ b/src/aero/AeroContainer.C
@@ -132,6 +132,8 @@ AeroContainer::update_displacements(
   }
 #else
   (void)currentTime;
+  (void)updateCC;
+  (void)predict;
 #endif
 }
 

--- a/src/aero/actuator/ActuatorModel.C
+++ b/src/aero/actuator/ActuatorModel.C
@@ -70,13 +70,11 @@ ActuatorModel::setup(double timeStep, stk::mesh::BulkData& stkBulk)
   if (!is_active())
     return;
 
-  // hack to surpress Wunused-parameter on non-openfast builds
-  STK_ThrowErrorIf(timeStep <= 0.0);
-
   switch (actMeta_->actuatorType_) {
   case (ActuatorType::ActLineFASTNGP): {
 #ifndef NALU_USES_OPENFAST
     STK_ThrowErrorMsg("Actuator methods require OpenFAST");
+    (void)timeStep;
 #if !defined(KOKKOS_ENABLE_GPU)
     break;
 #endif

--- a/src/edge_kernels/VOFAdvectionEdgeAlg.C
+++ b/src/edge_kernels/VOFAdvectionEdgeAlg.C
@@ -85,7 +85,6 @@ VOFAdvectionEdgeAlg::execute()
   const double gradient_eps = 1.0e-9;
 
   const int ndim = realm_.meta_data().spatial_dimension();
-  const auto& meta = realm_.meta_data();
 
   const DblType sharpening_scaling =
     realm_.solutionOptions_->vof_sharpening_scaling_factor_;

--- a/src/ngp_algorithms/CourantReAlg.C
+++ b/src/ngp_algorithms/CourantReAlg.C
@@ -107,8 +107,6 @@ CourantReAlg<AlgTraits>::execute()
       auto& scrViews = edata.simdScrView;
       const auto& v_coords = scrViews.get_scratch_view_2D(coordID);
       const auto& v_vel = scrViews.get_scratch_view_2D(velID);
-      const auto& v_rho = scrViews.get_scratch_view_1D(rhoID);
-      const auto& v_visc = scrViews.get_scratch_view_1D(viscID);
 
       DoubleType elemCFL = -1.0;
 

--- a/src/node_kernels/SDRSSTBLTM2015NodeKernel.C
+++ b/src/node_kernels/SDRSSTBLTM2015NodeKernel.C
@@ -81,7 +81,6 @@ SDRSSTBLTM2015NodeKernel::execute(
 {
   using DblType = NodeKernelTraits::DblType;
 
-  const DblType tke = tke_.get(node, 0);
   const DblType sdr = sdr_.get(node, 0);
   const DblType density = density_.get(node, 0);
   const DblType tvisc = tvisc_.get(node, 0);
@@ -116,37 +115,6 @@ SDRSSTBLTM2015NodeKernel::execute(
   const DblType beta = fOneBlend * betaOne_ + omf1 * betaTwo_;
   const DblType gamma = fOneBlend * gammaOne_ + omf1 * gammaTwo_;
   const DblType sigmaD = 2.0 * omf1 * sigmaWTwo_;
-
-  DblType gammaOne_apply;
-  DblType gammaTwo_apply;
-  // apply limiter to gamma
-  if (lengthScaleLimiter_) {
-    // calculate mixing length
-    const DblType l_t =
-      stk::math::sqrt(tke) / (stk::math::pow(betaStar_, .25) * sdr);
-
-    // calculate maximum mixing length
-    // the proportionality constant (.00027) was found by fitting to
-    // measurements of atmospheric conditions as described in ref. Kob13
-    const DblType l_e = .00027 * referenceVelocity_ / corfac_;
-
-    // apply limiter to cEpsOne -> calculate gammaOne
-    const DblType cEpsOne_one = gammaOne_ + 1.;
-    const DblType cEpsTwo_one = betaOne_ / betaStar_ + 1.;
-    const DblType cEpsOneStar_one =
-      cEpsOne_one + (cEpsTwo_one - cEpsOne_one) * (l_t / l_e);
-    gammaOne_apply = cEpsOneStar_one - 1.;
-
-    // apply limiter to cEpsTwo -> calculate gammaTwo
-    const DblType cEpsOne_two = gammaTwo_ + 1.;
-    const DblType cEpsTwo_two = betaTwo_ / betaStar_ + 1.;
-    const DblType cEpsOneStar_two =
-      cEpsOne_two + (cEpsTwo_two - cEpsOne_two) * (l_t / l_e);
-    gammaTwo_apply = cEpsOneStar_two - 1.;
-  } else {
-    gammaOne_apply = gammaOne_;
-    gammaTwo_apply = gammaTwo_;
-  }
 
   // Production term with appropriate clipping of tvisc
   const DblType Pw = gamma * density * Pk / stk::math::max(tvisc, 1.0e-16);

--- a/src/node_kernels/SDRSSTBLTM2015NodeKernel.C
+++ b/src/node_kernels/SDRSSTBLTM2015NodeKernel.C
@@ -95,7 +95,6 @@ SDRSSTBLTM2015NodeKernel::execute(
 
   for (int i = 0; i < nDim_; ++i) {
     crossDiff += dkdx_.get(node, i) * dwdx_.get(node, i);
-    const int offset = nDim_ * i;
     for (int j = 0; j < nDim_; ++j) {
       const double duidxj = dudx_.get(node, nDim_ * i + j);
       const double dujdxi = dudx_.get(node, nDim_ * j + i);

--- a/src/node_kernels/TKESSTBLTM2015NodeKernel.C
+++ b/src/node_kernels/TKESSTBLTM2015NodeKernel.C
@@ -24,13 +24,13 @@ TKESSTBLTM2015NodeKernel::TKESSTBLTM2015NodeKernel(
   : NGPNodeKernel<TKESSTBLTM2015NodeKernel>(),
     tkeID_(get_field_ordinal(meta, "turbulent_ke")),
     sdrID_(get_field_ordinal(meta, "specific_dissipation_rate")),
+    gamintID_(get_field_ordinal(meta, "gamma_transition")),
     densityID_(get_field_ordinal(meta, "density")),
+    viscID_(get_field_ordinal(meta, "viscosity")),
     tviscID_(get_field_ordinal(meta, "turbulent_viscosity")),
     dudxID_(get_field_ordinal(meta, "dudx")),
-    dualNodalVolumeID_(get_field_ordinal(meta, "dual_nodal_volume")),
-    gamintID_(get_field_ordinal(meta, "gamma_transition")),
-    viscID_(get_field_ordinal(meta, "viscosity")),
     wallDistID_(get_field_ordinal(meta, "minimum_distance_to_wall")),
+    dualNodalVolumeID_(get_field_ordinal(meta, "dual_nodal_volume")),
     nDim_(meta.spatial_dimension())
 {
 }


### PR DESCRIPTION
Confirmed with @BumseokLee that the gamma limiter code in SDRSSTBLTM2015NodeKernel.C is not needed for that particular kernel, but is actively used in other SDR node kernels so can be copied back over if needed in future.