### PR TITLE
AMD GPU Fixes

### DIFF
--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -46,7 +46,7 @@ namespace nalu {
 #if defined(KOKKOS_ENABLE_CUDA)
 typedef Kokkos::CudaSpace MemSpace;
 #elif defined(KOKKOS_ENABLE_HIP)
-typedef Kokkos::Experimental::HIPSpace MemSpace;
+typedef Kokkos::HIPSpace MemSpace;
 #elif defined(KOKKOS_HAVE_OPENMP)
 typedef Kokkos::OpenMP MemSpace;
 #else

--- a/include/aero/actuator/ActuatorTypes.h
+++ b/include/aero/actuator/ActuatorTypes.h
@@ -24,7 +24,7 @@ namespace nalu {
 using ActuatorMemSpace = Kokkos::CudaSpace;
 using ActuatorExecutionSpace = Kokkos::DefaultExecutionSpace;
 #elif defined(KOKKOS_ENABLE_HIP)
-using ActuatorMemSpace = Kokkos::Experimental::HIPSpace;
+using ActuatorMemSpace = Kokkos::HIPSpace;
 using ActuatorExecutionSpace = Kokkos::DefaultExecutionSpace;
 #else
 using ActuatorMemSpace = Kokkos::HostSpace;

--- a/include/matrix_free/KokkosFramework.h
+++ b/include/matrix_free/KokkosFramework.h
@@ -62,12 +62,12 @@ struct ExecTraits<Kokkos::Cuda>
 
 #if defined(KOKKOS_ENABLE_HIP)
 template <>
-struct ExecTraits<Kokkos::Experimental::HIP>
+struct ExecTraits<Kokkos::HIP>
 {
   using data_type = double;
   using memory_traits =
     Kokkos::MemoryTraits<Kokkos::Restrict | Kokkos::Aligned>;
-  using memory_space = typename Kokkos::Experimental::HIP::memory_space;
+  using memory_space = typename Kokkos::HIP::memory_space;
   using layout = Kokkos::LayoutLeft;
   static constexpr int alignment = alignof(data_type);
   static constexpr int simd_len = 1;

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -50,8 +50,7 @@ Simulation::Simulation(const YAML::Node& root_node)
   cudaDeviceGetLimit(&default_stack_size, cudaLimitStackSize);
   cudaDeviceSetLimit(cudaLimitStackSize, nalu_stack_size);
 #elif defined(KOKKOS_ENABLE_HIP)
-  hipError_t err =
-    hipDeviceGetLimit(&default_stack_size, hipLimitStackSize);
+  hipError_t err = hipDeviceGetLimit(&default_stack_size, hipLimitStackSize);
   if (err != hipSuccess) {
     /*
      This might be useful at some point so keeping it and commenting out.
@@ -82,8 +81,7 @@ Simulation::~Simulation()
 #if defined(KOKKOS_ENABLE_CUDA)
   cudaDeviceSetLimit(cudaLimitStackSize, default_stack_size);
 #elif defined(KOKKOS_ENABLE_HIP)
-  hipError_t err =
-    hipDeviceSetLimit(hipLimitStackSize, default_stack_size);
+  hipError_t err = hipDeviceSetLimit(hipLimitStackSize, default_stack_size);
   if (err != hipSuccess) {
     /*
      This might be useful at some point so keeping it and commenting out.

--- a/src/Simulation.C
+++ b/src/Simulation.C
@@ -51,7 +51,7 @@ Simulation::Simulation(const YAML::Node& root_node)
   cudaDeviceSetLimit(cudaLimitStackSize, nalu_stack_size);
 #elif defined(KOKKOS_ENABLE_HIP)
   hipError_t err =
-    hipDeviceGetLimit(&default_stack_size, hipLimitMallocHeapSize);
+    hipDeviceGetLimit(&default_stack_size, hipLimitStackSize);
   if (err != hipSuccess) {
     /*
      This might be useful at some point so keeping it and commenting out.
@@ -61,7 +61,7 @@ Simulation::Simulation(const YAML::Node& root_node)
     */
   }
 
-  err = hipDeviceSetLimit(hipLimitMallocHeapSize, nalu_stack_size);
+  err = hipDeviceSetLimit(hipLimitStackSize, nalu_stack_size);
   if (err != hipSuccess) {
     /*
      This might be useful at some point so keeping it and commenting out.
@@ -83,7 +83,7 @@ Simulation::~Simulation()
   cudaDeviceSetLimit(cudaLimitStackSize, default_stack_size);
 #elif defined(KOKKOS_ENABLE_HIP)
   hipError_t err =
-    hipDeviceSetLimit(hipLimitMallocHeapSize, default_stack_size);
+    hipDeviceSetLimit(hipLimitStackSize, default_stack_size);
   if (err != hipSuccess) {
     /*
      This might be useful at some point so keeping it and commenting out.

--- a/unit_tests.C
+++ b/unit_tests.C
@@ -30,7 +30,7 @@ main(int argc, char** argv)
   cudaDeviceSetLimit(cudaLimitStackSize, nalu_stack_size);
 #elif defined(KOKKOS_ENABLE_HIP)
   const size_t nalu_stack_size = 16384;
-  hipError_t err = hipDeviceSetLimit(hipLimitMallocHeapSize, nalu_stack_size);
+  hipError_t err = hipDeviceSetLimit(hipLimitStackSize, nalu_stack_size);
   if (err != hipSuccess) {
     /*
      This might be useful at some point so keeping it and commenting out.

--- a/unit_tests/UnitTestBasicKokkos.C
+++ b/unit_tests/UnitTestBasicKokkos.C
@@ -28,7 +28,7 @@ TEST(BasicKokkos, discover_execution_space)
 #endif
 
 #if defined(KOKKOS_ENABLE_HIP)
-    std::cout << "Kokkos::Experimental::HIP is available." << std::endl;
+    std::cout << "Kokkos::HIP is available." << std::endl;
 #endif
 
     std::cout << "Default execution space info: ";


### PR DESCRIPTION
This commit has 2 parts. The first uses the correct APIs to set 16KB of stack per device thread. It is this commit that enables more nalu reg tests to run. The 2nd commit removes the Experimental from the HIP namespacing.

Now, we see:
      Start  1: fsiTurbineSurrogate
 1/10 Test  #1: fsiTurbineSurrogate ..............   Passed   23.75 sec
      Start  2: airfoilRANSEdgeNGPHypre.rst
 2/10 Test  #2: airfoilRANSEdgeNGPHypre.rst ......   Passed   38.38 sec
      Start  3: ablNeutralNGPHypre
 3/10 Test  #3: ablNeutralNGPHypre ...............***Failed   21.60 sec
      Start  4: ablNeutralNGPHypreSegregated
 4/10 Test  #4: ablNeutralNGPHypreSegregated .....***Failed   21.30 sec
      Start  5: multiElemCylinder
 5/10 Test  #5: multiElemCylinder ................   Passed   26.71 sec
      Start  6: VOFZalDisk
 6/10 Test  #6: VOFZalDisk .......................***Failed   19.30 sec
      Start  7: airfoilSST_Gamma_Trans
 7/10 Test  #7: airfoilSST_Gamma_Trans ...........   Passed   26.09 sec
      Start  8: oversetRotCylNGPHypre
 8/10 Test  #8: oversetRotCylNGPHypre ............   Passed   26.66 sec
      Start  9: convTaylorVortex
 9/10 Test  #9: convTaylorVortex .................***Failed   27.12 sec
      Start 10: unitTestGPU
10/10 Test #10: unitTestGPU ......................   Passed   47.02 sec


The convTaylorVortex and VORZalDisk run to completion but fail based on diffs. The ablNeutralNGPHypre* tests seg fault at the beginning and require further investigation. It may be that we need more than 16KB per stack thread. This is under investigation.