### PR TITLE
Remove simple_fields namespace that is being deleted

### DIFF
--- a/unit_tests/UnitTestHexElementPromotion.C
+++ b/unit_tests/UnitTestHexElementPromotion.C
@@ -53,8 +53,8 @@ protected:
   void init(int nx, int ny, int nz, int in_polyOrder)
   {
     auto aura = stk::mesh::BulkData::NO_AUTO_AURA;
-    fixture = std::make_unique<stk::mesh::fixtures::HexFixture>(
-      comm, nx, ny, nz, aura);
+    fixture =
+      std::make_unique<stk::mesh::fixtures::HexFixture>(comm, nx, ny, nz, aura);
     meta = &fixture->m_meta;
     bulk = &fixture->m_bulk_data;
     surfSupPart = nullptr;
@@ -84,9 +84,8 @@ protected:
     stk::mesh::put_field_on_entire_mesh(*intField);
 
     fixture->m_meta.commit();
-    fixture->generate_mesh(
-      stk::mesh::fixtures::FixedCartesianCoordinateMapping(
-        nx, ny, nz, nx, ny, nz));
+    fixture->generate_mesh(stk::mesh::fixtures::FixedCartesianCoordinateMapping(
+      nx, ny, nz, nx, ny, nz));
     stk::mesh::PartVector surfParts = {surfSubPart};
     stk::mesh::skin_mesh(*bulk, surfParts);
   }

--- a/unit_tests/UnitTestHexElementPromotion.C
+++ b/unit_tests/UnitTestHexElementPromotion.C
@@ -53,7 +53,7 @@ protected:
   void init(int nx, int ny, int nz, int in_polyOrder)
   {
     auto aura = stk::mesh::BulkData::NO_AUTO_AURA;
-    fixture = std::make_unique<stk::mesh::fixtures::simple_fields::HexFixture>(
+    fixture = std::make_unique<stk::mesh::fixtures::HexFixture>(
       comm, nx, ny, nz, aura);
     meta = &fixture->m_meta;
     bulk = &fixture->m_bulk_data;
@@ -85,7 +85,7 @@ protected:
 
     fixture->m_meta.commit();
     fixture->generate_mesh(
-      stk::mesh::fixtures::simple_fields::FixedCartesianCoordinateMapping(
+      stk::mesh::fixtures::FixedCartesianCoordinateMapping(
         nx, ny, nz, nx, ny, nz));
     stk::mesh::PartVector surfParts = {surfSubPart};
     stk::mesh::skin_mesh(*bulk, surfParts);
@@ -147,7 +147,7 @@ protected:
 
   stk::ParallelMachine comm;
   unsigned nDim;
-  std::unique_ptr<stk::mesh::fixtures::simple_fields::HexFixture> fixture;
+  std::unique_ptr<stk::mesh::fixtures::HexFixture> fixture;
   stk::mesh::MetaData* meta;
   stk::mesh::BulkData* bulk;
   unsigned poly_order;

--- a/unit_tests/matrix_free/StkConductionFixture.h
+++ b/unit_tests/matrix_free/StkConductionFixture.h
@@ -63,7 +63,7 @@ protected:
   static constexpr int order = 2;
   ConductionFixtureP2(int nx, double scale);
   stk::mesh::Field<double>& coordinate_field();
-  stk::mesh::fixtures::simple_fields::Hex27Fixture fixture;
+  stk::mesh::fixtures::Hex27Fixture fixture;
   stk::mesh::MetaData& meta;
   stk::mesh::BulkData& bulk;
   stk::io::StkMeshIoBroker io;


### PR DESCRIPTION
from STK. Functionality remains the same.