### PR TITLE
Split up NGP minmax tests

### DIFF
--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -885,7 +885,18 @@ TEST_F(NgpLoopTest, NGP_basic_node_reduce_minmax)
   fill_mesh_and_init_fields("generated:16x16x16");
 
   basic_node_reduce_minmax(*bulk, 0.0, 16.0);
+}
+
+TEST_F(NgpLoopTest, NGP_basic_node_reduce_minmax_alt)
+{
+  fill_mesh_and_init_fields("generated:16x16x16");
+
   basic_node_reduce_minmax_alt(*bulk, 0.0, 16.0);
+}
+
+TEST_F(NgpLoopTest, NGP_basic_node_reduce_minmaxsum)
+{
+  fill_mesh_and_init_fields("generated:16x16x16");
 
   stk::mesh::Selector sel = bulk->mesh_meta_data().universal_part();
   const auto& bkts = bulk->get_buckets(stk::topology::NODE_RANK, sel);


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

`NgpLoopTest.NGP_basic_node_reduce_minmax` currently fails with

```
C++ exception with description "Requirement( m_isDeviceMeshRegistered==false ) FAILED
Error occurred at: stk_mesh/stk_mesh/base/BulkData.cpp:434

Error: Cannot register more than one DeviceMesh against a BulkData
" thrown in the test body.
```

The problem is using `stk::mesh::NgpMesh ngpMesh(bulk)` multiple times on the same `BulkData` object. Splitting up the test fixes the error.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (Unit test fix):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [x] on GPU (Kestrel, GCC 12.2.1)
  - [x] on CPU (macOS 14.7.2, Apple clang 16.0.0)
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
