### PR TITLE
split out compile-time known information for master elements

### DIFF
--- a/include/master_element/CompileTimeElements.h
+++ b/include/master_element/CompileTimeElements.h
@@ -1,0 +1,184 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef COMPILE_TIME_ELEMENTS_H
+#define COMPILE_TIME_ELEMENTS_H
+
+#include "AlgTraits.h"
+#include "master_element/IntegrationRules.h"
+#include "master_element/MasterElementFunctions.h"
+#include "ArrayND.h"
+#include "SimdInterface.h"
+#include "KokkosInterface.h"
+
+#include "ElementBasis.h"
+
+namespace sierra::nalu::impl {
+
+template <typename BasisT, typename IntgT>
+struct CVFEMData
+{
+  using basis_t = BasisT;
+  using intg_t = IntgT;
+  static constexpr auto scs_interp = utils::interpolants<basis_t>(intg_t::scs);
+  static constexpr auto scv_interp = utils::interpolants<basis_t>(intg_t::scv);
+  static constexpr auto scs_deriv = utils::deriv_coeffs<basis_t>(intg_t::scs);
+  static constexpr auto scv_deriv = utils::deriv_coeffs<basis_t>(intg_t::scv);
+};
+
+template <typename AlgTraits, QuadType q>
+struct ElemDataSelector
+{
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsTri3_2D, q>
+{
+  using elem_data_t = CVFEMData<Tri3Basis, TriIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsQuad4_2D, q>
+{
+  using elem_data_t = CVFEMData<Quad42DBasis, QuadIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsHex8, q>
+{
+  using elem_data_t = CVFEMData<Hex8Basis, HexIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsTet4, q>
+{
+  using elem_data_t = CVFEMData<Tet4Basis, TetIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsWed6, q>
+{
+  using elem_data_t = CVFEMData<Wed6Basis, WedIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsPyr5, q>
+{
+  using elem_data_t = CVFEMData<
+    std::conditional_t<q == QuadType::MID, Pyr5Basis, Pyr5DegenHexBasis>,
+    PyrIntegrationRule<q>>;
+};
+
+} // namespace sierra::nalu::impl
+
+namespace sierra::nalu {
+
+template <typename AlgTraits, QuadType q>
+using elem_data_t = typename impl::ElemDataSelector<AlgTraits, q>::elem_data_t;
+
+enum class QuadRank { SCS, SCV };
+} // namespace sierra::nalu
+
+namespace sierra::nalu {
+template <typename AlgTraits, QuadRank rank>
+std::enable_if_t<rank == QuadRank::SCS, double>
+shape_fcn(QuadType quad, int ip, int n)
+{
+  if (quad == QuadType::SHIFTED) {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::SHIFTED>::scs_interp;
+    return shp(ip, n);
+  } else {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::MID>::scs_interp;
+    return shp(ip, n);
+  }
+}
+
+template <typename AlgTraits, QuadRank rank>
+std::enable_if_t<rank == QuadRank::SCV, double>
+shape_fcn(QuadType quad, int ip, int n)
+{
+  if (quad == QuadType::SHIFTED) {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::SHIFTED>::scv_interp;
+    return shp(ip, n);
+  } else {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::MID>::scv_interp;
+    return shp(ip, n);
+  }
+}
+
+template <typename AlgTraits, QuadRank rank>
+KOKKOS_FUNCTION std::enable_if_t<
+  rank == QuadRank::SCS,
+  decltype(elem_data_t<AlgTraits, QuadType::MID>::scs_interp)>
+shape_fcn(QuadType quad)
+{
+  if (quad == QuadType::SHIFTED) {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::SHIFTED>::scs_interp;
+    return shp;
+  } else {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::MID>::scs_interp;
+    return shp;
+  }
+}
+
+template <typename AlgTraits, QuadRank rank>
+KOKKOS_FUNCTION std::enable_if_t<
+  rank == QuadRank::SCV,
+  decltype(elem_data_t<AlgTraits, QuadType::MID>::scv_interp)>
+shape_fcn(QuadType quad)
+{
+  if (quad == QuadType::SHIFTED) {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::SHIFTED>::scv_interp;
+    return shp;
+  } else {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::MID>::scv_interp;
+    return shp;
+  }
+}
+
+namespace impl {
+template <
+  typename AlgTraits,
+  QuadRank rank,
+  QuadType q,
+  typename CoordViewT,
+  typename GradViewT>
+KOKKOS_FUNCTION std::enable_if_t<rank == QuadRank::SCS, void>
+grad_op(const CoordViewT& x, const GradViewT& grad_coeff)
+{
+  static constexpr auto deriv = elem_data_t<AlgTraits, q>::scs_deriv;
+  generic_grad_op<AlgTraits>(deriv, x, grad_coeff);
+}
+
+template <
+  typename AlgTraits,
+  QuadRank rank,
+  QuadType q,
+  typename CoordViewT,
+  typename GradViewT>
+KOKKOS_FUNCTION std::enable_if_t<rank == QuadRank::SCV, void>
+grad_op(const CoordViewT& x, const GradViewT& grad_coeff)
+{
+  static constexpr auto deriv = elem_data_t<AlgTraits, q>::scv_deriv;
+  generic_grad_op<AlgTraits>(deriv, x, grad_coeff);
+}
+
+} // namespace impl
+
+} // namespace sierra::nalu
+
+#endif

--- a/include/master_element/ElementBasis.h
+++ b/include/master_element/ElementBasis.h
@@ -1,0 +1,447 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef ELEMENT_BASIS_H
+#define ELEMENT_BASIS_H
+
+#include "AlgTraits.h"
+#include "ArrayND.h"
+
+namespace sierra::nalu {
+
+template <typename ViewLikeT>
+using val_t = typename ViewLikeT::value_type;
+
+struct Tri3Basis
+{
+  using traits_t = AlgTraitsTri3_2D;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    return (n > 0) ? x[n - 1] : 1 - (x[0] + x[1]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int d)
+  {
+    return -1. + (n > 0) * (1. + (d == (n - 1)));
+  }
+};
+
+struct Quad42DBasis
+{
+  using traits_t = AlgTraitsQuad4_2D;
+  static constexpr int N1D = 2;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  static constexpr int tensor_map(int k, int j, int i)
+  {
+    constexpr ArrayND<int[N1D][N1D][N1D]> map{
+      {{{0, 1}, {3, 2}}, {{4, 5}, {7, 6}}}};
+    return map(k, j, i);
+  }
+
+  static constexpr ArrayND<int[2]> to_tensor(int n)
+  {
+    constexpr ArrayND<int[NNODES][2]> map{{{0, 0}, {1, 0}, {1, 1}, {0, 1}}};
+    return {map(n, 0), map(n, 1)};
+  }
+
+  template <typename LocT>
+  static constexpr auto interp_1(int l, const LocT& x)
+  {
+    return 0.5 * (1 + (2 * l - 1) * x);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_1(int l, const LocT& /*unused*/)
+  {
+    return 0.5 * (2 * l - 1);
+  }
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    const auto ij = to_tensor(n);
+    return interp_1(ij[0], x[0]) * interp_1(ij[1], x[1]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    const auto ij = to_tensor(n);
+    const auto xv = (d == 0) ? deriv_1(ij(0), x[0]) : interp_1(ij(0), x[0]);
+    const auto yv = (d == 1) ? deriv_1(ij(1), x[1]) : interp_1(ij(1), x[1]);
+    return xv * yv;
+  }
+};
+
+struct Quad4Basis
+{
+  using traits_t = AlgTraitsQuad4_2D;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    return (n > 0) ? x[n - 1] : 1 - (x[0] + x[1] + x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int d)
+  {
+    return -1. + (n > 0) * (1. + (d == (n - 1)));
+  }
+};
+
+struct Tet4Basis
+{
+  using traits_t = AlgTraitsTet4;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    return (n > 0) ? x[n - 1] : 1 - (x[0] + x[1] + x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int d)
+  {
+    return -1. + (n > 0) * (1. + (d == (n - 1)));
+  }
+};
+
+struct Pyr5Basis
+{
+  using traits_t = AlgTraitsPyr5;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  static constexpr int sgn(int n, int d)
+  {
+    constexpr auto map =
+      ArrayND<int[4][2]>{{{-1, -1}, {+1, -1}, {+1, +1}, {-1, +1}}};
+    return map(n % 4, d);
+  }
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    if (n >= 4 || x[2] == val_t<LocT>(1.)) {
+      return x[2];
+    }
+    return 0.25 * (1 + sgn(n, 0) * x[0] - x[2]) *
+           (1 + sgn(n, 1) * x[1] - x[2]) / (1 - x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    if (n >= 4 || x[2] == 1.) {
+      return val_t<LocT>(d == 2);
+    }
+    const auto apex = 0.25 / (1 - x[2]);
+    const auto square_x = 1 + sgn(n, 0) * x[0] - x[2];
+    const auto square_y = 1 + sgn(n, 1) * x[1] - x[2];
+    const ArrayND<val_t<LocT>[3]> dsquare{
+      {sgn(n, 0) * square_y, square_x * sgn(n, 1), -(square_x + square_y)}};
+    const ArrayND<val_t<LocT>[3]> dinv_term{0, 0, 4 * apex * apex};
+    return dsquare(d) * apex + square_x * square_y * dinv_term(d);
+  }
+};
+
+struct Pyr5DegenHexBasis
+{
+  using traits_t = AlgTraitsPyr5;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  static constexpr int sgn(int n, int d)
+  {
+    constexpr auto map =
+      ArrayND<int[4][2]>{{{-1, -1}, {+1, -1}, {+1, +1}, {-1, +1}}};
+    return map(n % 4, d);
+  }
+
+  template <typename LocT>
+  static constexpr auto interpolant(int n, const LocT& x)
+  {
+    if (n >= 4) {
+      return x[2];
+    }
+    return 0.25 * (1 + sgn(n, 0) * x[0]) * (1 + sgn(n, 1) * x[1]) * (1 - x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    if (n >= 4) {
+      return val_t<LocT>(d == 2);
+    }
+    const ArrayND<val_t<LocT>[3]> dsq = {
+      sgn(n, 0) * (1 + sgn(n, 1) * x[1]), (1 + sgn(n, 0) * x[0]) * sgn(n, 1),
+      0};
+    return 0.25 * dsq(d) * (1 - x[2]) -
+           (d == 2) * (1 + sgn(n, 0) * x[0]) * (1 + sgn(n, 1) * x[1]);
+  }
+};
+
+struct Wed6Basis
+{
+  using traits_t = AlgTraitsWed6;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    const ArrayND<typename LocT::value_type[3]> tri{
+      1 - (x[0] + x[1]), x[0], x[1]};
+    return tri(n % 3) * (0.5 * (1 + (2 * (n > 2) - 1) * x[2]));
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    const ArrayND<val_t<LocT>[3]> tri{1 - (x[0] + x[1]), x[0], x[1]};
+    constexpr ArrayND<val_t<LocT>[3][3]> dtri{
+      {{-1, -1, 0}, {1, 0, 0}, {0, 1, 0}}};
+    const auto prism = 0.5 * (1 + (2 * (n > 2) - 1) * x[2]);
+    const auto dprism = ArrayND<val_t<LocT>[3]>{0, 0, 0.5 * (2 * (n > 2) - 1)};
+    return dtri(n % 3, d) * prism + tri(n % 3) * dprism(d);
+  }
+};
+
+struct Hex8Basis
+{
+  using traits_t = AlgTraitsHex8;
+  static constexpr int N1D = 2;
+  static constexpr int DIM = 3;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  static constexpr int tensor_map(int k, int j, int i)
+  {
+    constexpr ArrayND<int[N1D][N1D][N1D]> map{
+      {{{0, 1}, {3, 2}}, {{4, 5}, {7, 6}}}};
+    return map(k, j, i);
+  }
+
+  static constexpr ArrayND<int[3]> to_tensor(int n)
+  {
+    constexpr ArrayND<int[NNODES][3]> map{
+      {{0, 0, 0},
+       {1, 0, 0},
+       {1, 1, 0},
+       {0, 1, 0},
+       {0, 0, 1},
+       {1, 0, 1},
+       {1, 1, 1},
+       {0, 1, 1}}};
+    return {map(n, 0), map(n, 1), map(n, 2)};
+  }
+
+  template <typename LocT>
+  static constexpr auto interp_1(int l, const LocT& x)
+  {
+    return 0.5 * (1 + (2 * l - 1) * x);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_1(int l, const LocT& /*unused*/)
+  {
+    return 0.5 * (2 * l - 1);
+  }
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    const auto ijk = to_tensor(n);
+    return interp_1(ijk[0], x[0]) * interp_1(ijk[1], x[1]) *
+           interp_1(ijk[2], x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    const auto ijk = to_tensor(n);
+    const auto xv = (d == 0) ? deriv_1(ijk(0), x[0]) : interp_1(ijk(0), x[0]);
+    const auto yv = (d == 1) ? deriv_1(ijk(1), x[1]) : interp_1(ijk(1), x[1]);
+    const auto zv = (d == 2) ? deriv_1(ijk(2), x[2]) : interp_1(ijk(2), x[2]);
+    return xv * yv * zv;
+  }
+};
+
+namespace impl {
+template <typename AlgTraits>
+struct BasisSelector
+{
+};
+template <>
+struct BasisSelector<AlgTraitsTet4>
+{
+  using basis_t = Tet4Basis;
+};
+template <>
+struct BasisSelector<AlgTraitsPyr5>
+{
+  using basis_t = Pyr5Basis;
+};
+template <>
+struct BasisSelector<AlgTraitsWed6>
+{
+  using basis_t = Wed6Basis;
+};
+template <>
+struct BasisSelector<AlgTraitsHex8>
+{
+  using basis_t = Hex8Basis;
+};
+} // namespace impl
+
+template <typename AlgTraits>
+using alg_basis_t = typename impl::BasisSelector<AlgTraits>::basis_t;
+
+} // namespace sierra::nalu
+
+namespace sierra::nalu::utils {
+
+template <class T, class = void>
+struct is_tensor_compatible : std::false_type
+{
+};
+
+template <class T>
+struct is_tensor_compatible<T, std::void_t<decltype(&T::interp_1)>>
+  : std::true_type
+{
+};
+
+template <typename BasisT, typename ParCoordsArrayT, typename ValArrayT>
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+  is_tensor_compatible<BasisT>::value,
+  ArrayND<typename ValArrayT::value_type[ParCoordsArrayT::extent_int(0)]
+                                        [ValArrayT::extent_int(1)]>>
+interpolate(const ParCoordsArrayT& par_coords)
+{
+  constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  using res_val_t = typename ValArrayT::value_type;
+
+  ArrayND<res_val_t[nparcoords]> result;
+  for (int l = 0; l < nparcoords; ++l) {
+    for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
+      result(l, d) = 0;
+    }
+    for (int i = 0; i < BasisT::N1D; ++i) {
+      const auto interp_x = BasisT::interp_1(i, par_coords(l, 0));
+      for (int j = 0; j < BasisT::N1D; ++j) {
+        const auto interp_xy = BasisT::interp_1(j, par_coords(l, 1)) * interp_x;
+        for (int k = 0; k < BasisT::N1D; ++k) {
+          const auto interp_xyz =
+            interp_xy * BasisT::interp_1(i, par_coords(l, 2));
+          for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
+            result(l, d) += interp_xyz * vals(BasisT::tensor_map(k, j, i), d);
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+template <typename BasisT, typename ParCoordsArrayT, typename ValArrayT>
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+  !is_tensor_compatible<BasisT>::value,
+  ArrayND<typename ValArrayT::value_type[ParCoordsArrayT::extent_int(0)]
+                                        [ValArrayT::extent_int(1)]>>
+interpolate(const ParCoordsArrayT& par_coords, const ValArrayT& vals)
+{
+  constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  using res_val_t = std::decay_t<decltype(par_coords(0, 0) * vals(0, 0))>;
+
+  ArrayND<res_val_t[ParCoordsArrayT::extent_int(0)][vals.extent_int(1)]> result;
+  for (int l = 0; l < nparcoords; ++l) {
+
+    ArrayND<res_val_t[ParCoordsArrayT::extent_int(1)]> point;
+    for (int d = 0; d < ParCoordsArrayT::extent_int(1); ++d) {
+      point(d) = par_coords(l, d);
+    }
+    for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
+      result(l, d) = 0;
+    }
+
+    for (int n = 0; n < BasisT::NNODES; ++n) {
+      const auto interp_n = BasisT::interp(n, point);
+      for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
+        result(l, d) += interp_n * vals(n, d);
+      }
+    }
+  }
+  return result;
+}
+
+template <typename BasisT, typename ParCoordsArrayT>
+KOKKOS_INLINE_FUNCTION constexpr ArrayND<
+  typename ParCoordsArrayT::value_type[ParCoordsArrayT::extent_int(0)]
+                                      [BasisT::NNODES]>
+interpolants(const ParCoordsArrayT& par_coords)
+{
+  constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  using res_val_t = std::decay_t<decltype(par_coords(0, 0))>;
+
+  ArrayND<res_val_t[ParCoordsArrayT::extent_int(0)][BasisT::NNODES]> result;
+  for (int l = 0; l < nparcoords; ++l) {
+
+    ArrayND<res_val_t[ParCoordsArrayT::extent_int(1)]> point;
+    for (int d = 0; d < ParCoordsArrayT::extent_int(1); ++d) {
+      point(d) = par_coords(l, d);
+    }
+    for (int n = 0; n < BasisT::NNODES; ++n) {
+      result(l, n) = BasisT::interpolant(n, point);
+    }
+  }
+  return result;
+}
+
+template <typename BasisT, typename ParCoordsArrayT>
+KOKKOS_INLINE_FUNCTION constexpr ArrayND<
+  typename ParCoordsArrayT::value_type[ParCoordsArrayT::extent_int(0)]
+                                      [BasisT::NNODES][BasisT::DIM]>
+deriv_coeffs(const ParCoordsArrayT& par_coords)
+{
+  constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  using res_val_t = std::decay_t<decltype(par_coords(0, 0))>;
+
+  ArrayND<
+    res_val_t[ParCoordsArrayT::extent_int(0)][BasisT::NNODES][BasisT::DIM]>
+    result;
+  for (int l = 0; l < nparcoords; ++l) {
+
+    ArrayND<res_val_t[ParCoordsArrayT::extent_int(1)]> point;
+    for (int d = 0; d < ParCoordsArrayT::extent_int(1); ++d) {
+      point(d) = par_coords(l, d);
+    }
+    for (int n = 0; n < BasisT::NNODES; ++n) {
+      for (int d = 0; d < BasisT::DIM; ++d) {
+        result(l, n, d) = BasisT::deriv_coeff(n, point, d);
+      }
+    }
+  }
+  return result;
+}
+
+} // namespace sierra::nalu::utils
+
+#endif

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -10,6 +10,9 @@
 #ifndef Hex8CVFEM_h
 #define Hex8CVFEM_h
 
+#include "master_element/ElementBasis.h"
+#include "master_element/IntegrationRules.h"
+
 #include <array>
 
 #include <master_element/MasterElement.h>
@@ -22,6 +25,9 @@ namespace nalu {
 class HexSCV : public MasterElement
 {
 public:
+  using basis_t = Hex8Basis;
+  template <QuadType q>
+  using quad_t = HexIntegrationRule<q>;
   using AlgTraits = AlgTraitsHex8;
 
   KOKKOS_FUNCTION
@@ -120,6 +126,9 @@ private:
 class HexSCS : public MasterElement
 {
 public:
+  using basis_t = Hex8Basis;
+  template <QuadType q>
+  using quad_t = HexIntegrationRule<q>;
   using AlgTraits = AlgTraitsHex8;
   using AlgTraitsFace = AlgTraitsQuad4;
   using MasterElement::adjacentNodes;

--- a/include/master_element/IntegrationRules.h
+++ b/include/master_element/IntegrationRules.h
@@ -1,0 +1,289 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef INTEGRATION_RULES_H
+#define INTEGRATION_RULES_H
+
+#include "AlgTraits.h"
+#include "master_element/utils.h"
+#include "ArrayND.h"
+#include "SimdInterface.h"
+#include "KokkosInterface.h"
+
+#include "ElementBasis.h"
+
+namespace sierra::nalu {
+
+enum class QuadType { MID, SHIFTED };
+
+template <QuadType>
+struct TriIntegrationRule
+{
+};
+
+template <>
+struct TriIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[3][2]> scs{
+    {{5. / 12., 2. / 12.},   // surf 1: 0->1
+     {5. / 12., 5. / 12.},   // surf 2: 1->3
+     {2. / 12., 5. / 12.}}}; // surf 3: 0->2
+
+  static constexpr ArrayND<double[3][2]> scv{
+    {{5. / 24., 5. / 24.}, {7. / 12., 5. / 24.}, {5. / 24., 7. / 12.}}};
+};
+
+template <>
+struct TriIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[3][2]> scs{
+    {{0.5, 0.0},   // surf 1: 0->1
+     {0.5, 0.5},   // surf 2: 1->3
+     {0.0, 0.5}}}; // surf 3: 0->2
+
+  static constexpr ArrayND<double[3][2]> scv{{{0, 0}, {1, 0}, {0, 1}}};
+};
+
+template <QuadType>
+struct QuadIntegrationRule
+{
+};
+
+template <>
+struct QuadIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[4][2]> scs{
+    {{+0.0, -0.5},   // surf 1; 1->2
+     {+0.5, +0.0},   // surf 2; 2->3
+     {+0.0, +0.5},   // surf 3; 3->4
+     {-0.5, +0.0}}}; // surf 3; 1->5};
+
+  static constexpr ArrayND<double[4][2]> scv{
+    {{-0.5, -0.5}, {+0.5, -0.5}, {+0.5, +0.5}, {-0.5, +0.5}}};
+};
+
+template <>
+struct QuadIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[4][2]> scs{
+    {{+0, -1}, {+1, +0}, {+0, +1}, {-1, +0}}};
+
+  static constexpr ArrayND<double[4][2]> scv{
+    {{-1, -1}, {+1, -1}, {+1, +1}, {-1, +1}}};
+};
+
+template <QuadType>
+struct HexIntegrationRule
+{
+};
+
+template <>
+struct HexIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[12][3]> scs{
+    {{+0.0, -0.5, -0.5},   // surf 1    1->2
+     {+0.5, +0.0, -0.5},   // surf 2    2->3
+     {+0.0, +0.5, -0.5},   // surf 3    3->4
+     {-0.5, +0.0, -0.5},   // surf 4    1->4
+     {+0.0, -0.5, +0.5},   // surf 5    5->6
+     {+0.5, +0.0, +0.5},   // surf 6    6->7
+     {+0.0, +0.5, +0.5},   // surf 7    7->8
+     {-0.5, +0.0, +0.5},   // surf 8    5->8
+     {-0.5, -0.5, +0.0},   // surf 9    1->5
+     {+0.5, -0.5, +0.0},   // surf 10   2->6
+     {+0.5, +0.5, +0.0},   // surf 11   3->7
+     {-0.5, +0.5, +0.0}}}; // surf 12   4->8
+
+  static constexpr ArrayND<double[8][3]> scv{
+    {{-0.5, -0.5, -0.5},
+     {+0.5, -0.5, -0.5},
+     {+0.5, +0.5, -0.5},
+     {-0.5, +0.5, -0.5},
+     {-0.5, -0.5, +0.5},
+     {+0.5, -0.5, +0.5},
+     {+0.5, +0.5, +0.5},
+     {-0.5, +0.5, +0.5}}};
+};
+
+template <>
+struct HexIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[12][3]> scs{
+    {{+0, -1, -1},   // surf 1    1->2
+     {+1, +0, -1},   // surf 2    2->3
+     {+0, +1, -1},   // surf 3    3->4
+     {-1, +0, -1},   // surf 4    1->4
+     {+0, -1, +1},   // surf 5    5->6
+     {+1, +0, +1},   // surf 6    6->7
+     {+0, +1, +1},   // surf 7    7->8
+     {-1, +0, +1},   // surf 8    5->8
+     {-1, -1, +0},   // surf 9    1->5
+     {+1, -1, +0},   // surf 10   2->6
+     {+1, +1, +0},   // surf 11   3->7
+     {-1, +1, +0}}}; // surf 12   4->8
+
+  static constexpr ArrayND<double[8][3]> scv{
+    {{-1, -1, -1},
+     {+1, -1, -1},
+     {+1, +1, -1},
+     {-1, +1, -1},
+     {-1, -1, +1},
+     {+1, -1, +1},
+     {+1, +1, +1},
+     {-1, +1, +1}}};
+};
+
+template <QuadType>
+struct TetIntegrationRule
+{
+};
+
+template <>
+struct TetIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[6][3]> scs{
+    {{13. / 36., 05. / 36., 05. / 36.}, // surf 1    1->2
+     {13. / 36., 13. / 36., 05. / 36.}, // surf 2    2->3
+     {05. / 36., 13. / 36., 05. / 36.}, // surf 3    1->3
+     {05. / 36., 05. / 36., 13. / 36.}, // surf 4    1->4
+     {13. / 36., 05. / 36., 13. / 36.}, // surf 5    2->4
+     {05. / 36., 13. / 36., 13. / 36.}}};
+
+  static constexpr ArrayND<double[4][3]> scv{
+    {{17. / 96., 17. / 96., 17. / 96.},
+     {45. / 96., 17. / 96., 17. / 96.},
+     {17. / 96., 45. / 96., 17. / 96.},
+     {17. / 96., 17. / 96., 45. / 96.}}};
+};
+
+template <>
+struct TetIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[6][3]> scs{{
+    {0.5, 0.0, 0.0}, // surf 1    1->2
+    {0.5, 0.5, 0.0}, // surf 2    2->3
+    {0.0, 0.5, 0.0}, // surf 3    1->3
+    {0.0, 0.0, 0.5}, // surf 4    1->4
+    {0.5, 0.0, 0.5}, // surf 5    2->4
+    {0.0, 0.5, 0.5}  // surf 6    3->4
+  }};
+
+  static constexpr ArrayND<double[4][3]> scv{
+    {{0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}};
+};
+
+template <QuadType>
+struct WedIntegrationRule
+{
+};
+
+template <>
+struct WedIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[9][3]> scs{
+    {{+05. / 12., +01. / 06., -01. / 02.},
+     {+05. / 12., +05. / 12., -01. / 02.},
+     {+01. / 06., +05. / 12., -01. / 02.},
+     {+05. / 12., +01. / 06., +01. / 02.},
+     {+05. / 12., +05. / 12., +01. / 02.},
+     {+01. / 06., +05. / 12., +01. / 02.},
+     {+07. / 36., +07. / 36., +00. / 02.},
+     {+11. / 18., +07. / 36., +00. / 02.},
+     {+07. / 36., +11. / 18., +00. / 02.}}};
+
+  static constexpr ArrayND<double[6][3]> scv{
+    {{+07. / 36., +07. / 36., -01. / 02.},
+     {+11. / 18., +07. / 36., -01. / 02.},
+     {+07. / 36., +11. / 18., -01. / 02.},
+     {+07. / 36., +07. / 36., +01. / 02.},
+     {+11. / 18., +07. / 36., +01. / 02.},
+     {+07. / 36., +11. / 18., +01. / 02.}}};
+};
+
+template <>
+struct WedIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[9][3]> scs{
+    {{+0.5, +0.0, -1.0},
+     {+0.5, +0.5, -1.0},
+     {+0.0, +0.5, -1.0},
+     {+0.5, +0.0, +1.0},
+     {+0.5, +0.5, +1.0},
+     {+0.0, +0.5, +1.0},
+     {+0.0, +0.0, +0.0},
+     {+1.0, +0.0, +0.0},
+     {+0.0, +1.0, +0.0}}};
+
+  static constexpr ArrayND<double[6][3]> scv{
+    {{+0, +0, -1},
+     {+1, +0, -1},
+     {+0, +1, -1},
+     {+0, +0, +1},
+     {+1, +0, +1},
+     {+0, +1, +1}}};
+};
+
+template <QuadType>
+struct PyrIntegrationRule
+{
+};
+
+template <>
+struct PyrIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[12][3]> scs{{
+    {+000. / 315., -145. / 315., +041. / 315.}, // surf 0  1->2
+    {+145. / 315., +000. / 315., +041. / 315.}, // surf 1  2->3
+    {+000. / 315., +145. / 315., +041. / 315.}, // surf 2  3->4
+    {-145. / 315., +000. / 315., +041. / 315.}, // surf 3  1->4
+    {-070. / 315., -070. / 315., +091. / 315.}, // surf 4  1->5 inner
+    {-007. / 018., -007. / 018., +007. / 018.}, // surf 5  1->5 outer
+    {+070. / 315., -070. / 315., +091. / 315.}, // surf 6  2->5 inner
+    {+007. / 018., -007. / 018., +007. / 018.}, // surf 7  2->5 outer
+    {+070. / 315., +070. / 315., +091. / 315.}, // surf 8  3->5 inner
+    {+007. / 018., +007. / 018., +007. / 018.}, // surf 9  3->5 outer
+    {-070. / 315., +070. / 315., +091. / 315.}, // surf 10  4->5 inner
+    {-007. / 018., +007. / 018., +007. / 018.}  // surf 11  4->5 outer
+  }};
+
+  static constexpr double one69r384 = 169.0 / 384.0;
+  static constexpr double five77r3840 = 577.0 / 3840.0;
+  static constexpr double seven73r1560 = 773.0 / 1560.0;
+  static constexpr ArrayND<double[5][3]> scv{
+    {{-one69r384, -one69r384, five77r3840},
+     {one69r384, -one69r384, five77r3840},
+     {one69r384, one69r384, five77r3840},
+     {-one69r384, one69r384, five77r3840},
+     {0.0, 0.0, seven73r1560}}};
+};
+
+template <>
+struct PyrIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[12][3]> scs{{
+    {+0.0, -1.0, +0.0}, // surf 1    1->2
+    {+1.0, +0.0, +0.0}, // surf 2    2->3
+    {+0.0, +1.0, +0.0}, // surf 3    3->4
+    {-1.0, +0.0, +0.0}, // surf 4    1->4
+    {-0.5, -0.5, +0.5}, // surf 5    1->5 I
+    {-0.5, -0.5, +0.5}, // surf 6    1->5 O
+    {+0.5, -0.5, +0.5}, // surf 7    2->5 I
+    {+0.5, -0.5, +0.5}, // surf 8    2->5 O
+    {+0.5, +0.5, +0.5}, // surf 9    3->5 I
+    {+0.5, +0.5, +0.5}, // surf 10   3->5 O
+    {-0.5, +0.5, +0.5}, // surf 11   4->5 I
+    {-0.5, +0.5, +0.5}  // surf 12   4->5 O
+  }};
+
+  static constexpr ArrayND<double[5][3]> scv{
+    {{-1, -1, +0}, {+1, -1, +0}, {+1, +1, +0}, {-1, +1, +0}, {+0, +0, +1}}};
+};
+
+} // namespace sierra::nalu
+#endif

--- a/include/master_element/MasterElementFunctions.h
+++ b/include/master_element/MasterElementFunctions.h
@@ -72,7 +72,7 @@ generic_grad_op(
 
   using ftype = typename CoordViewType::value_type;
   static_assert(
-    std::is_same<ftype, typename GradViewType::value_type>::value,
+    std::is_convertible_v<typename GradViewType::value_type, ftype>,
     "Incompatiable value type for views");
   static_assert(
     std::is_same<ftype, typename OutputViewType::value_type>::value,
@@ -83,12 +83,13 @@ generic_grad_op(
   static_assert(OutputViewType::rank == 3, "Weight view assumed to be rank 3");
 
   STK_NGP_ThrowAssert(
-    AlgTraits::nodesPerElement_ == referenceGradWeights.extent(1));
-  STK_NGP_ThrowAssert(AlgTraits::nDim_ == referenceGradWeights.extent(2));
+    AlgTraits::nodesPerElement_ == referenceGradWeights.extent_int(1));
+  STK_NGP_ThrowAssert(AlgTraits::nDim_ == referenceGradWeights.extent_int(2));
   for (int i = 0; i < dim; ++i)
-    STK_NGP_ThrowAssert(weights.extent(i) == referenceGradWeights.extent(i));
+    STK_NGP_ThrowAssert(
+      weights.extent_int(i) == referenceGradWeights.extent_int(i));
 
-  for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
+  for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
     NALU_ALIGNED ftype jact[dim][dim];
     for (int i = 0; i < dim; ++i)
       for (int j = 0; j < dim; ++j)
@@ -154,7 +155,7 @@ generic_gij_3d(
   static_assert(OutputViewType::rank == 3, "gij view assumed to be 3D");
   static_assert(AlgTraits::nDim_ == 3, "3D method");
 
-  for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
+  for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
 
     NALU_ALIGNED ftype jac[3][3] = {
       {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
@@ -338,7 +339,7 @@ generic_Mij_2d(
   static_assert(AlgTraits::nDim_ == 2, "2D method");
 
   const int npe = AlgTraits::nodesPerElement_;
-  const int nint = referenceGradWeights.extent(0);
+  const int nint = referenceGradWeights.extent_int(0);
 
   ftype dx_ds[2][2];
   ftype norm;
@@ -487,8 +488,8 @@ generic_Mij_3d(
 
     // At this point we have Q, the eigenvectors and D the eigenvalues of Mij^2,
     // so to create Mij, we use Q sqrt(D) Q^T
-    for (unsigned i = 0; i < 3; i++)
-      for (unsigned j = 0; j < 3; j++) {
+    for (int i = 0; i < 3; i++)
+      for (int j = 0; j < 3; j++) {
         metric[(ip * AlgTraits::nDim_ + i) * AlgTraits::nDim_ + j] =
           Q[i][0] * Q[j][0] * stk::math::sqrt(D[0][0]) +
           Q[i][1] * Q[j][1] * stk::math::sqrt(D[1][1]) +
@@ -520,7 +521,7 @@ generic_Mij_3d(
   static_assert(OutputViewType::rank == 3, "Mij view assumed to be 3D");
   static_assert(AlgTraits::nDim_ == 3, "3D method");
 
-  for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
+  for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
 
     ftype jac[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
@@ -566,8 +567,8 @@ generic_Mij_3d(
 
     // At this point we have Q, the eigenvectors and D the eigenvalues of Mij^2,
     // so to create Mij, we use Q sqrt(D) Q^T
-    for (unsigned i = 0; i < 3; i++) {
-      for (unsigned j = 0; j < 3; j++) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 3; j++) {
         metric(ip, i, j) = Q[i][0] * Q[j][0] * stk::math::sqrt(D[0][0]) +
                            Q[i][1] * Q[j][1] * stk::math::sqrt(D[1][1]) +
                            Q[i][2] * Q[j][2] * stk::math::sqrt(D[2][2]);
@@ -600,12 +601,12 @@ generic_determinant_3d(
   static_assert(AlgTraits::nDim_ == 3, "3D method");
 
   STK_NGP_ThrowAssert(
-    AlgTraits::nodesPerElement_ == referenceGradWeights.extent(1));
-  STK_NGP_ThrowAssert(AlgTraits::nDim_ == referenceGradWeights.extent(2));
+    AlgTraits::nodesPerElement_ == referenceGradWeights.extent_int(1));
+  STK_NGP_ThrowAssert(AlgTraits::nDim_ == referenceGradWeights.extent_int(2));
 
-  STK_NGP_ThrowAssert(detj.extent(0) == referenceGradWeights.extent(0));
+  STK_NGP_ThrowAssert(detj.extent_int(0) == referenceGradWeights.extent_int(0));
 
-  for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
+  for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
     NALU_ALIGNED ftype jac[3][3] = {
       {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -17,6 +17,8 @@
 // NGP-based includes
 #include "SimdInterface.h"
 #include "KokkosInterface.h"
+#include "master_element/CompileTimeElements.h"
+#include "master_element/IntegrationRules.h"
 
 #include <cstdlib>
 #include <stdexcept>
@@ -42,6 +44,9 @@ public:
   using MasterElement::shape_fcn;
   using MasterElement::shifted_grad_op;
   using MasterElement::shifted_shape_fcn;
+
+  template <QuadType q>
+  using pyr_data_t = elem_data_t<AlgTraits, q>;
 
   KOKKOS_FUNCTION
   PyrSCV();
@@ -144,6 +149,9 @@ public:
   using MasterElement::determinant;
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
+
+  template <QuadType q>
+  using pyr_data_t = elem_data_t<AlgTraits, q>;
 
   KOKKOS_FUNCTION
   PyrSCS();

--- a/src/master_element/Hex8CVFEM.C
+++ b/src/master_element/Hex8CVFEM.C
@@ -12,6 +12,7 @@
 #include <master_element/MasterElementFunctions.h>
 #include <master_element/TensorOps.h>
 #include <master_element/Hex8GeometryFunctions.h>
+#include <master_element/CompileTimeElements.h>
 
 #include <NaluEnv.h>
 
@@ -327,6 +328,7 @@ HexSCV::shape_fcn(SharedMemView<SCALAR**, SHMEM>& shpfc)
 {
   hex8_shape_fcn(numIntPoints_, &intgLoc_[0], shpfc);
 }
+
 KOKKOS_FUNCTION void
 HexSCV::shape_fcn(SharedMemView<DoubleType**, DeviceShmem>& shpfc)
 {
@@ -409,24 +411,18 @@ void
 HexSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 void
 HexSCV::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>&)
 {
-  const SharedMemView<const double**, HostShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -437,12 +433,10 @@ void
 HexSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLocShift_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -537,40 +531,32 @@ void
 HexSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 HexSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>&)
 {
-  const SharedMemView<const double**, HostShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
 //-------- shifted_grad_op -------------------------------------------------
-//--------------------------------------c------------------------------------
+//--------------------------------------------------------------------------
 KOKKOS_FUNCTION
 void
 HexSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLocShift_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/Pyr5CVFEM.C
+++ b/src/master_element/Pyr5CVFEM.C
@@ -7,6 +7,7 @@
 // for more details.
 //
 
+#include "master_element/CompileTimeElements.h"
 #include <master_element/MasterElement.h>
 #include <master_element/Pyr5CVFEM.h>
 #include <master_element/Hex8GeometryFunctions.h>
@@ -593,10 +594,9 @@ void
 PyrSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  pyr_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -608,10 +608,10 @@ void
 PyrSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  shifted_pyr_deriv(numIntPoints_, &intgLocShift_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 template <typename SCALAR, typename SHMEM>
@@ -642,6 +642,7 @@ PyrSCV::shifted_shape_fcn(SharedMemView<DoubleType**, DeviceShmem>& shpfc)
 {
   shifted_shape_fcn<>(shpfc);
 }
+
 void
 PyrSCV::shifted_shape_fcn(SharedMemView<double**, HostShmem>& shpfc)
 {
@@ -921,20 +922,18 @@ void
 PyrSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  pyr_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 PyrSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>& /*deriv*/)
 {
-  pyr_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -945,10 +944,10 @@ void
 PyrSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  shifted_pyr_deriv(numIntPoints_, &intgLocShift_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/Tet4CVFEM.C
+++ b/src/master_element/Tet4CVFEM.C
@@ -11,6 +11,7 @@
 #include <master_element/MasterElementFunctions.h>
 #include <master_element/Tet4CVFEM.h>
 #include <master_element/Hex8GeometryFunctions.h>
+#include "master_element/CompileTimeElements.h"
 
 #include <AlgTraits.h>
 
@@ -363,10 +364,9 @@ void
 TetSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  tet_deriv(deriv);
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -377,10 +377,10 @@ void
 TetSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  tet_deriv(deriv);
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -638,20 +638,18 @@ void
 TetSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  tet_deriv(deriv);
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 TetSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>&)
 {
-  tet_deriv(deriv);
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -662,11 +660,10 @@ void
 TetSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  tet_deriv(deriv);
-
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/Wed6CVFEM.C
+++ b/src/master_element/Wed6CVFEM.C
@@ -7,6 +7,7 @@
 // for more details.
 //
 
+#include "master_element/CompileTimeElements.h"
 #include "master_element/Wed6CVFEM.h"
 #include "master_element/MasterElementFunctions.h"
 #include "master_element/Hex8GeometryFunctions.h"
@@ -388,10 +389,9 @@ void
 WedSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  wed_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -402,10 +402,10 @@ void
 WedSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  wed_deriv(numIntPoints_, &intgLocShift_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 template <typename SCALAR, typename SHMEM>
@@ -667,20 +667,18 @@ void
 WedSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  wed_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 WedSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>&)
 {
-  wed_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 KOKKOS_FUNCTION
@@ -688,10 +686,10 @@ void
 WedSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  wed_deriv(numIntPoints_, &intgLocShift_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -132,7 +132,7 @@ GeometryInteriorAlg<AlgTraits>::impl_negative_jacobian_check()
     "negative_volume_check_" + std::to_string(AlgTraits::topo_);
   nalu_ngp::run_elem_par_reduce(
     algName, meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
-    KOKKOS_LAMBDA(ElemSimdDataType & edata, size_t & threadVal) {
+    KOKKOS_LAMBDA(ElemSimdDataType & edata, size_t& threadVal) {
       auto& scrView = edata.simdScrView;
       const auto& meViews = scrView.get_me_views(CURRENT_COORDINATES);
       const auto& v_scv_vol = meViews.scv_volume;

--- a/unit_tests/UnitTestArrayND.C
+++ b/unit_tests/UnitTestArrayND.C
@@ -8,6 +8,7 @@
 //
 
 #include "ArrayND.h"
+#include "master_element/CompileTimeElements.h"
 #include "matrix_free/KokkosFramework.h"
 
 #include "StkSimdComparisons.h"

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -20,7 +20,152 @@
 #include <random>
 
 #include "UnitTestUtils.h"
+#include "StkSimdComparisons.h"
 
+namespace sierra::nalu {
+
+namespace {
+constexpr auto
+near(double x, double y)
+{
+  return (x - y) > 0 ? x - y < 1e-12 : y - x < 1e-12;
+}
+} // namespace
+
+TEST(master_element_coeffs, static_asserts)
+{
+  static constexpr auto interp_hex =
+    utils::interpolants<Hex8Basis>(HexIntegrationRule<QuadType::SHIFTED>::scv);
+
+  static_assert(near(interp_hex(0, 0), 1));
+  static_assert(near(interp_hex(1, 0), 0));
+  static_assert(near(interp_hex(1, 1), 1));
+  static_assert(near(interp_hex(2, 1), 0));
+  static_assert(near(interp_hex(2, 2), 1));
+  static_assert(near(interp_hex(5, 6), 0));
+  static_assert(near(interp_hex(7, 7), 1));
+}
+
+namespace {
+std::vector<DoubleType>
+me_shape(stk::topology topo, QuadRank r, QuadType q)
+{
+  auto me =
+    (r == QuadRank::SCS)
+      ? sierra::nalu::MasterElementRepo::get_surface_master_element_on_host(
+          topo)
+      : sierra::nalu::MasterElementRepo::get_volume_master_element_on_host(
+          topo);
+  std::vector<DoubleType> meShapeFunctions(
+    me->nodesPerElement_ * me->num_integration_points());
+  sierra::nalu::SharedMemView<DoubleType**, sierra::nalu::DeviceShmem>
+    ShmemView(
+      meShapeFunctions.data(), me->num_integration_points(),
+      me->nodesPerElement_);
+
+  if (q == QuadType::SHIFTED) {
+    me->shifted_shape_fcn<>(ShmemView);
+  } else {
+    me->shape_fcn<>(ShmemView);
+  }
+  return meShapeFunctions;
+}
+
+} // namespace
+
+TEST(master_element_coeffs, interp_scs)
+{
+  for (auto q : {QuadType::SHIFTED, QuadType::MID}) {
+
+    {
+      const auto shp = shape_fcn<AlgTraitsHex8, QuadRank::SCS>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::HEX_8, QuadRank::SCS, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsPyr5, QuadRank::SCS>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::PYRAMID_5, QuadRank::SCS, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsWed6, QuadRank::SCS>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::WEDGE_6, QuadRank::SCS, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsTet4, QuadRank::SCS>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::TET_4, QuadRank::SCS, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+  }
+}
+
+TEST(master_element_coeffs, interp_scv)
+{
+  for (auto q : {QuadType::SHIFTED, QuadType::MID}) {
+
+    {
+      const auto shp = shape_fcn<AlgTraitsHex8, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::HEX_8, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsPyr5, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::PYRAMID_5, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsWed6, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::WEDGE_6, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsTet4, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::TET_4, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+  }
+}
+
+} // namespace sierra::nalu
 namespace {
 
 TEST(pyramid, is_in_element)


### PR DESCRIPTION
Splits out compile-time known information out of the master element, so you can use the isoparametric information directly in gpu kernels if you want.

This was done before in a different and I had a good experience with it. Having the compile-time known information available at compile time simplifies a lot of the data wrangling with the master elements and speeds up the code, at the expense of making the master element-style computations a little more cumbersome. 

Implemented for volume-rank SCS and SCV master elements but not face-rank ones. I just want volume for the GCL, so that's the origin of that. I can finish up the face stuff in a bit or as part of this if it's wanted.

