### PR TITLE
Remove FSI compile option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,7 @@ option(ENABLE_HYPRE "Use HYPRE Solver library" ON)
 option(ENABLE_TRILINOS_SOLVERS "Use Trilinos Solvers" ON)
 
 option(ENABLE_OPENFAST
-       "Use OPENFAST tpl to get actuator line positions and forces" OFF)
-cmake_dependent_option(ENABLE_OPENFAST_FSI "Temporary option while FSI features are not merged into main OpenFAST"
-  OFF "ENABLE_OPENFAST" OFF)
+       "Use OPENFAST TPL to get actuator line positions and forces" OFF)
 option(ENABLE_PARAVIEW_CATALYST
       "Enable ParaView Catalyst. Requires external installation of Trilinos Catalyst IOSS adapter."
        OFF)
@@ -173,9 +171,6 @@ if(ENABLE_TRILINOS_SOLVERS)
 endif()
 
 ########################## OPENFAST ####################################
-if(ENABLE_OPENFAST_FSI)
-  target_compile_definitions(nalu PUBLIC NALU_USES_OPENFAST_FSI)
-endif()
 if(ENABLE_OPENFAST)
   set(CMAKE_PREFIX_PATH ${OpenFAST_DIR} ${CMAKE_PREFIX_PATH})
   enable_language(Fortran)

--- a/src/aero/AeroContainer.C
+++ b/src/aero/AeroContainer.C
@@ -9,7 +9,7 @@
 #include <aero/AeroContainer.h>
 #include <NaluEnv.h>
 #include <NaluParsingHelper.h>
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
 #include "aero/fsi/OpenfastFSI.h"
 #endif
 #include <FieldTypeDef.h>
@@ -20,7 +20,7 @@ namespace nalu {
 void
 AeroContainer::clean_up()
 {
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi())
     fsiContainer_->end_openfast();
 #endif
@@ -28,7 +28,7 @@ AeroContainer::clean_up()
 
 AeroContainer::~AeroContainer()
 {
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     delete fsiContainer_;
   }
@@ -49,7 +49,7 @@ AeroContainer::AeroContainer(const YAML::Node& node) : fsiContainer_(nullptr)
   // std::vector<const YAML::Node*> foundFsi;
   // NaluParsingHelper::find_nodes_given_key("openfast_fsi", node, foundFsi);
   if (node["openfast_fsi"]) {
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
     // if (foundFsi.size() != 1)
     //   throw std::runtime_error(
     //     "look_ahead_and_create::error: Too many openfast_fsi blocks");
@@ -88,7 +88,7 @@ AeroContainer::setup(double timeStep, std::shared_ptr<stk::mesh::BulkData> bulk)
   if (has_actuators()) {
     actuatorModel_.setup(timeStep, *bulk_);
   }
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     fsiContainer_->setup(timeStep, bulk_);
   }
@@ -101,7 +101,7 @@ AeroContainer::init(double currentTime, double restartFrequency)
   if (has_actuators()) {
     actuatorModel_.init(*bulk_);
   }
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     fsiContainer_->initialize(restartFrequency, currentTime);
   }
@@ -122,7 +122,7 @@ void
 AeroContainer::update_displacements(
   const double currentTime, bool updateCC, bool predict)
 {
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     NaluEnv::self().naluOutputP0()
       << "Calling update displacements inside AeroContainer" << std::endl;
@@ -141,7 +141,7 @@ void
 AeroContainer::predict_model_time_step(const double currentTime)
 {
   (void)currentTime;
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     fsiContainer_->predict_struct_timestep(currentTime);
   }
@@ -153,7 +153,7 @@ AeroContainer::predict_model_time_step(const double currentTime)
 void
 AeroContainer::advance_model_time_step(const double currentTime)
 {
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     fsiContainer_->advance_struct_timestep(currentTime);
   }
@@ -165,7 +165,7 @@ AeroContainer::advance_model_time_step(const double currentTime)
 void
 AeroContainer::compute_div_mesh_velocity()
 {
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     fsiContainer_->compute_div_mesh_velocity();
   }
@@ -176,7 +176,7 @@ const stk::mesh::PartVector
 AeroContainer::fsi_parts()
 {
   stk::mesh::PartVector all_part_vec;
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     auto n_turbines = fsiContainer_->get_nTurbinesGlob();
     for (auto i_turb = 0; i_turb < n_turbines; i_turb++) {
@@ -193,7 +193,7 @@ const stk::mesh::PartVector
 AeroContainer::fsi_bndry_parts()
 {
   stk::mesh::PartVector all_bndry_part_vec;
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     auto n_turbines = fsiContainer_->get_nTurbinesGlob();
     for (auto i_turb = 0; i_turb < n_turbines; i_turb++) {
@@ -211,7 +211,7 @@ const std::vector<std::string>
 AeroContainer::fsi_bndry_part_names()
 {
   std::vector<std::string> bndry_part_names;
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi()) {
     auto n_turbines = fsiContainer_->get_nTurbinesGlob();
     for (auto i_turb = 0; i_turb < n_turbines; i_turb++) {
@@ -228,7 +228,7 @@ AeroContainer::fsi_bndry_part_names()
 double
 AeroContainer::openfast_accumulated_time()
 {
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi())
     return fsiContainer_->total_openfastfsi_execution_time();
   else
@@ -240,7 +240,7 @@ AeroContainer::openfast_accumulated_time()
 double
 AeroContainer::nalu_fsi_accumulated_time()
 {
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
   if (has_fsi())
     return fsiContainer_->total_nalu_fsi_execution_time();
   else

--- a/src/aero/CMakeLists.txt
+++ b/src/aero/CMakeLists.txt
@@ -4,7 +4,7 @@ target_sources(nalu PRIVATE
 
 add_subdirectory(actuator)
 
-if(ENABLE_OPENFAST_FSI)
+if(ENABLE_OPENFAST)
 add_subdirectory(fsi)
 endif()
 

--- a/src/aero/actuator/ActuatorParsingFAST.C
+++ b/src/aero/actuator/ActuatorParsingFAST.C
@@ -166,10 +166,8 @@ actuator_FAST_parse(const YAML::Node& y_node, const ActuatorMeta& actMeta)
     // TODO Do we need this for anything in FSI?
     /* get_required(y_actuator, "restartFreq", fi.restartFreq); */
     int* restartFreq;
-#ifdef NALU_USES_OPENFAST_FSI
+#ifdef NALU_USES_OPENFAST
     restartFreq = &fi.restartFreq;
-#else
-    restartFreq = &fi.nEveryCheckPoint;
 #endif
     get_required(y_actuator, "n_every_checkpoint", *restartFreq);
     get_required(y_actuator, "dt_fast", fi.dtFAST);

--- a/unit_tests/actuator/UnitTestActuatorBulkFAST.C
+++ b/unit_tests/actuator/UnitTestActuatorBulkFAST.C
@@ -58,9 +58,7 @@ TEST_F(ActuatorBulkFastTests, initializeActuatorBulk)
   ASSERT_EQ(fi.nTurbinesGlob, 1);
   ASSERT_EQ(fi.tStart, 0.0);
   ASSERT_EQ(fi.simStart, fast::init);
-#ifdef NALU_USES_OPENFAST_FSI
   ASSERT_EQ(fi.restartFreq, 1);
-#endif
   ASSERT_EQ(fi.dtFAST, 0.00625);
   ASSERT_EQ(fi.tMax, 0.3625);
 

--- a/unit_tests/aero/CMakeLists.txt
+++ b/unit_tests/aero/CMakeLists.txt
@@ -5,7 +5,7 @@ target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestPt2Line.C
 )
 
-if(ENABLE_OPENFAST_FSI)
+if(ENABLE_OPENFAST)
 target_sources(${utest_ex_name} PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/UnitTestFSIturbine.C
 )


### PR DESCRIPTION
We use OF4.0 so we can just enable it with openfast. 
Related spack PR: https://github.com/spack/spack/pull/49209
Related exawind-manager PR: https://github.com/Exawind/exawind-manager/pull/242