### PR TITLE
Update for openfast 4.1 (remove supercontroller)

### DIFF
--- a/src/aero/actuator/ActuatorParsingFAST.C
+++ b/src/aero/actuator/ActuatorParsingFAST.C
@@ -175,11 +175,8 @@ actuator_FAST_parse(const YAML::Node& y_node, const ActuatorMeta& actMeta)
     get_required(y_actuator, "t_max", fi.tMax);
 
     if (y_actuator["super_controller"]) {
-      get_required(y_actuator, "super_controller", fi.scStatus);
-      get_required(y_actuator, "sc_libFile", fi.scLibFile);
-      // Removed inputs from fast API may want to if/def later
-      // get_required(y_actuator, "num_sc_inputs", fi.numScInputs);
-      // get_required(y_actuator, "num_sc_outputs", fi.numScOutputs);
+      throw std::runtime_error(
+        "Super controller has been removed in OpenFAST 4.1 and above");
     }
 
     fi.globTurbineData.resize(fi.nTurbinesGlob);

--- a/src/aero/fsi/OpenfastFSI.C
+++ b/src/aero/fsi/OpenfastFSI.C
@@ -143,10 +143,8 @@ OpenfastFSI::load(const YAML::Node& node)
     // only at this point if you choose the binary file output.
 
     if (node["super_controller"]) {
-      get_required(node, "super_controller", fi.scStatus);
-      get_required(node, "sc_libFile", fi.scLibFile);
-      get_required(node, "num_sc_inputs", fi.numScInputs);
-      get_required(node, "num_sc_outputs", fi.numScOutputs);
+      throw std::runtime_error(
+        "Super controller has been removed in OpenFAST 4.1 and above");
     }
 
     fsiTurbineData_.resize(fi.nTurbinesGlob);


### PR DESCRIPTION
See https://github.com/OpenFAST/openfast/releases/tag/v4.1.0. 

This wont actually trigger any build issues with other versions of openfast so we don't really need to be wary of that.