### PR TITLE
Fix unit test kernel that accesses uninitialized memory

### DIFF
--- a/unit_tests/UnitTestScratchViews.C
+++ b/unit_tests/UnitTestScratchViews.C
@@ -47,7 +47,7 @@ public:
     auto& v_vel = scratchViews.get_scratch_view_2D(velocityOrdinal);
     auto& v_pres = scratchViews.get_scratch_view_1D(pressureOrdinal);
 
-    rhs(0) += v_vel(0, 0) + v_pres(0);
+    rhs(0) = v_vel(0, 0) + v_pres(0);
   }
 
 private:


### PR DESCRIPTION
Any kernel that tried to accumulate values into the shared memory lhs/rhs views provided by run_algorithm would be working with uninitialized data.

EDIT 9/15/2025: Switched focus of this PR to changing the accumulation to assignment, since it doesn't make sense to use a lambda function to do a reduction inside a parallel_for, especially using scratch memory to accumulate values. Also taking out the checks of `smdata.simdrhs` that were originally part of this PR, since it doesn't make sense to check scratch memory values during a parallel_for (we should be checking things that are set after the parallel_for concludes).