### PR TITLE
change default of vof_sharpening_scaling_factor

### DIFF
--- a/include/SolutionOptions.h
+++ b/include/SolutionOptions.h
@@ -102,7 +102,7 @@ public:
 
   bool use_balanced_buoyancy_force_{false};
   bool realm_has_vof_{false};
-  double vof_sharpening_scaling_factor_{5.0};
+  double vof_sharpening_scaling_factor_{3.0};
   double vof_diffusion_scaling_factor_{0.6};
 
   double hybridDefault_;


### PR DESCRIPTION
this seems to be the necessary value for keeping our OC6 simulations stable.