### PR TITLE
Clean up SIMD instruction test logic

### DIFF
--- a/unit_tests/UnitTestSimdBasic.C
+++ b/unit_tests/UnitTestSimdBasic.C
@@ -18,16 +18,8 @@ TEST(Simd, basic)
 
 TEST(Simd, whichInstructions)
 {
-#if defined(STK_SIMD_AVX512)
-  std::cout << "STK_SIMD_AVX512";
-#elif defined(STK_SIMD_AVX)
-  std::cout << "STK_SIMD_AVX";
-#elif defined(STK_SIMD_SSE)
-  std::cout << "STK_SIMD_SSE";
-#else
-  std::cout << "no simd instructions!" << std::endl;
-#endif
-  std::cout << ", stk::simd::ndoubles=" << stk::simd::ndoubles << std::endl;
+  std::cout << "STK simd native type: " << typeid(kokkos_simd::simd_abi::native).name() << std::endl;
+  std::cout << "stk::simd::ndoubles = " << stk::simd::ndoubles << std::endl;
 }
 
 typedef std::vector<double, non_std::AlignedAllocator<double, 64>>

--- a/unit_tests/UnitTestSimdBasic.C
+++ b/unit_tests/UnitTestSimdBasic.C
@@ -18,7 +18,8 @@ TEST(Simd, basic)
 
 TEST(Simd, whichInstructions)
 {
-  std::cout << "STK simd native type: " << typeid(kokkos_simd::simd_abi::native).name() << std::endl;
+  std::cout << "STK simd native type: "
+            << typeid(kokkos_simd::simd_abi::native).name() << std::endl;
   std::cout << "stk::simd::ndoubles = " << stk::simd::ndoubles << std::endl;
 }
 


### PR DESCRIPTION
The if/else ifdef chain is not complete, so it was possible to see a printout with "no simd instructions!" that also had ndoubles > 1. Now we print out the Kokkos type, which has the name of the simd instructions baked in.