### PR TITLE
Comp elements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 
 # Handle issues for Power9 builds
 if ((${CMAKE_SYSTEM_PROCESSOR} MATCHES "ppc") AND (NOT ENABLE_CUDA))
-  # Fix warnings regarding NALU_ALIGNED in CPU builds
+  # Fix warnings regarding  in CPU builds
   target_compile_definitions(nalu PUBLIC NALU_USE_POWER9_ALIGNMENT)
   if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND
       (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 9.0))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif()
 
 # Handle issues for Power9 builds
 if ((${CMAKE_SYSTEM_PROCESSOR} MATCHES "ppc") AND (NOT ENABLE_CUDA))
-  # Fix warnings regarding  in CPU builds
+  # Fix warnings regarding NALU_ALIGNED in CPU builds
   target_compile_definitions(nalu PUBLIC NALU_USE_POWER9_ALIGNMENT)
   if ((${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU") AND
       (${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS 9.0))

--- a/include/ArrayND.h
+++ b/include/ArrayND.h
@@ -18,11 +18,9 @@ using enable_if_rank = std::enable_if_t<std::rank_v<ArrayType> == r>;
 template <typename ArrayType>
 struct ArrayND<ArrayType, enable_if_rank<ArrayType, 1>>
 {
-  KOKKOS_DEFAULTED_FUNCTION constexpr ArrayND() = default;
-
   static constexpr int rank = 1;
   using value_type = std::remove_all_extents_t<ArrayType>;
-  value_type internal_data_[std::extent_v<ArrayType, 0>];
+  value_type internal_data_[std::extent_v<ArrayType, 0>]{};
 
   [[nodiscard]] static constexpr int extent_int(int /*unused*/)
   {
@@ -51,13 +49,11 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 1>>
 template <typename ArrayType>
 struct ArrayND<ArrayType, enable_if_rank<ArrayType, 2>>
 {
-  KOKKOS_DEFAULTED_FUNCTION constexpr ArrayND() = default;
-
   static constexpr int rank = 2;
 
   using value_type = std::remove_all_extents_t<ArrayType>;
   value_type internal_data_[std::extent_v<ArrayType, 0>]
-                           [std::extent_v<ArrayType, 1>];
+                           [std::extent_v<ArrayType, 1>]{};
 
   [[nodiscard]] static constexpr int extent_int(int n)
   {
@@ -81,8 +77,6 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 2>>
 template <typename ArrayType>
 struct ArrayND<ArrayType, enable_if_rank<ArrayType, 3>>
 {
-  KOKKOS_DEFAULTED_FUNCTION constexpr ArrayND() = default;
-
   static constexpr int rank = 3;
   [[nodiscard]] static constexpr int extent_int(int n)
   {
@@ -94,7 +88,7 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 3>>
   using value_type = std::remove_all_extents_t<ArrayType>;
   value_type internal_data_[std::extent_v<ArrayType, 0>]
                            [std::extent_v<ArrayType, 1>]
-                           [std::extent_v<ArrayType, 2>];
+                           [std::extent_v<ArrayType, 2>]{};
 
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr auto
   operator()(int k, int j, int i) const noexcept
@@ -112,8 +106,6 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 3>>
 template <typename ArrayType>
 struct ArrayND<ArrayType, enable_if_rank<ArrayType, 4>>
 {
-  KOKKOS_DEFAULTED_FUNCTION constexpr ArrayND() = default;
-
   static constexpr int rank = 4;
   [[nodiscard]] static constexpr int extent_int(int n)
   {
@@ -126,7 +118,7 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 4>>
   using value_type = std::remove_all_extents_t<ArrayType>;
   value_type
     internal_data_[std::extent_v<ArrayType, 0>][std::extent_v<ArrayType, 1>]
-                  [std::extent_v<ArrayType, 2>][std::extent_v<ArrayType, 3>];
+                  [std::extent_v<ArrayType, 2>][std::extent_v<ArrayType, 3>]{};
 
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr value_type
   operator()(int l, int k, int j, int i) const noexcept
@@ -144,8 +136,6 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 4>>
 template <typename ArrayType>
 struct ArrayND<ArrayType, enable_if_rank<ArrayType, 5>>
 {
-  KOKKOS_DEFAULTED_FUNCTION constexpr ArrayND() = default;
-
   static constexpr int rank = 5;
   [[nodiscard]] static constexpr int extent_int(int n)
   {
@@ -160,7 +150,7 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 5>>
   value_type
     internal_data_[std::extent_v<ArrayType, 0>][std::extent_v<ArrayType, 1>]
                   [std::extent_v<ArrayType, 2>][std::extent_v<ArrayType, 3>]
-                  [std::extent_v<ArrayType, 4>];
+                  [std::extent_v<ArrayType, 4>]{};
 
   [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION constexpr value_type
   operator()(int m, int l, int k, int j, int i) const noexcept

--- a/include/ArrayND.h
+++ b/include/ArrayND.h
@@ -44,6 +44,12 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 1>>
   {
     return internal_data_[i];
   }
+
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION const value_type*
+  data() const noexcept
+  {
+    return internal_data_;
+  }
 };
 
 template <typename ArrayType>
@@ -71,6 +77,12 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 2>>
   operator()(int j, int i) noexcept
   {
     return internal_data_[j][i];
+  }
+
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION const value_type*
+  data() const noexcept
+  {
+    return &(internal_data_[0][0]);
   }
 };
 
@@ -101,6 +113,12 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 3>>
   {
     return internal_data_[k][j][i];
   }
+
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION const value_type*
+  data() const noexcept
+  {
+    return &(internal_data_[0][0][0]);
+  }
 };
 
 template <typename ArrayType>
@@ -130,6 +148,12 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 4>>
   operator()(int l, int k, int j, int i) noexcept
   {
     return internal_data_[l][k][j][i];
+  }
+
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION const value_type*
+  data() const noexcept
+  {
+    return &(internal_data_[0][0][0][0]);
   }
 };
 
@@ -162,6 +186,12 @@ struct ArrayND<ArrayType, enable_if_rank<ArrayType, 5>>
   operator()(int m, int l, int k, int j, int i) noexcept
   {
     return internal_data_[m][l][k][j][i];
+  }
+
+  [[nodiscard]] KOKKOS_FORCEINLINE_FUNCTION const value_type*
+  data() const noexcept
+  {
+    return &(internal_data_[0][0][0][0][0]);
   }
 };
 

--- a/include/KokkosInterface.h
+++ b/include/KokkosInterface.h
@@ -16,14 +16,6 @@
 #include <Kokkos_Macros.hpp>
 #include <Kokkos_Core.hpp>
 
-#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP)
-#define NALU_ALIGNED alignas(sizeof(double))
-#elif defined(NALU_USE_POWER9_ALIGNMENT)
-#define NALU_ALIGNED alignas(16)
-#else
-#define NALU_ALIGNED alignas(KOKKOS_MEMORY_ALIGNMENT)
-#endif
-
 #if defined(__INTEL_COMPILER)
 #define POINTER_RESTRICT restrict
 #elif defined(__GNUC__)

--- a/include/LinearSolverTypes.h
+++ b/include/LinearSolverTypes.h
@@ -57,7 +57,6 @@ template <
   typename GlobalOrdinal,
   typename Node>
 class Preconditioner;
-
 }
 
 namespace sierra {

--- a/include/ScratchViews.h
+++ b/include/ScratchViews.h
@@ -93,14 +93,6 @@ public:
     int numFemIp);
 
   KOKKOS_FUNCTION
-  void fill_static_meviews(
-    const ElemDataRequestsGPU::DataEnumView& dataEnums,
-    MasterElement* meFC,
-    MasterElement* meSCS,
-    MasterElement* meSCV,
-    MasterElement* meFEM);
-
-  KOKKOS_FUNCTION
   void fill_master_element_views_new_me(
     const ElemDataRequestsGPU::DataEnumView& dataEnums,
     SharedMemView<DoubleType**, SHMEM>* coordsView,
@@ -131,14 +123,6 @@ public:
   SharedMemView<T***, SHMEM> gijUpper;
   SharedMemView<T***, SHMEM> gijLower;
   SharedMemView<T***, SHMEM> metric;
-  SharedMemView<T**, SHMEM> fc_shape_fcn;
-  SharedMemView<T**, SHMEM> fc_shifted_shape_fcn;
-  SharedMemView<T**, SHMEM> scs_shape_fcn;
-  SharedMemView<T**, SHMEM> scs_shifted_shape_fcn;
-  SharedMemView<T**, SHMEM> scv_shape_fcn;
-  SharedMemView<T**, SHMEM> scv_shifted_shape_fcn;
-  SharedMemView<T**, SHMEM> fem_shape_fcn;
-  SharedMemView<T**, SHMEM> fem_shifted_shape_fcn;
 };
 
 template <
@@ -283,9 +267,6 @@ public:
     return fieldViews;
   }
 
-  KOKKOS_FUNCTION
-  void fill_static_meviews(const ElemDataRequestsGPU&);
-
 private:
   KOKKOS_FUNCTION
   void create_needed_master_element_views(
@@ -395,24 +376,17 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
   const TEAMHANDLETYPE& team,
   const ElemDataRequestsGPU::DataEnumView& dataEnums,
   int nDim,
-  int nodesPerFace,
+  int /*nodesPerFace*/,
   int nodesPerElem,
   int numFaceIp,
   int numScsIp,
   int numScvIp,
-  int numFemIp)
+  int /*numFemIp*/)
 {
   int numScalars = 0;
-  bool needDeriv = false;
-  bool needDerivScv = false;
-  bool needDerivFem = false;
-  bool needDerivFC = false;
   bool needDetj = false;
   bool needDetjScv = false;
-  bool needDetjFem = false;
   bool needDetjFC = false;
-  bool femGradOp = false;
-  bool femShiftedGradOp = false;
   for (unsigned i = 0; i < dataEnums.size(); ++i) {
     switch (dataEnums(i)) {
     case FC_AREAV:
@@ -423,22 +397,6 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
         get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(team, numFaceIp, nDim);
       numScalars += numFaceIp * nDim;
       break;
-    case FC_SHAPE_FCN:
-      STK_NGP_ThrowRequireMsg(
-        numFaceIp > 0,
-        "ERROR, meFC must be non-null if FC_SHAPE_FCN is requested");
-      fc_shape_fcn = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numFaceIp, nodesPerFace);
-      numScalars += numFaceIp * nodesPerFace;
-      break;
-    case FC_SHIFTED_SHAPE_FCN:
-      STK_NGP_ThrowRequireMsg(
-        numFaceIp > 0,
-        "ERROR, meFC must be non-null if FC_SHIFTED_SHAPE_FCN is requested");
-      fc_shifted_shape_fcn = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numFaceIp, nodesPerFace);
-      numScalars += numFaceIp * nodesPerFace;
-      break;
     case SCS_FACE_GRAD_OP:
       STK_NGP_ThrowRequireMsg(
         numFaceIp > 0,
@@ -446,7 +404,6 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
       dndx_fc_scs = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
         team, numFaceIp, nodesPerElem, nDim);
       numScalars += nodesPerElem * numFaceIp * nDim;
-      needDerivFC = true;
       needDetjFC = true;
       break;
     case SCS_SHIFTED_FACE_GRAD_OP:
@@ -456,7 +413,6 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
       dndx_shifted_fc_scs = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
         team, numFaceIp, nodesPerElem, nDim);
       numScalars += nodesPerElem * numFaceIp * nDim;
-      needDerivFC = true;
       needDetjFC = true;
       break;
     case SCS_AREAV:
@@ -475,7 +431,6 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
       dndx = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
         team, numScsIp, nodesPerElem, nDim);
       numScalars += nodesPerElem * numScsIp * nDim;
-      needDeriv = true;
       needDetj = true;
       break;
 
@@ -486,7 +441,6 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
       dndx_shifted = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
         team, numScsIp, nodesPerElem, nDim);
       numScalars += nodesPerElem * numScsIp * nDim;
-      needDeriv = true;
       needDetj = true;
       break;
 
@@ -498,7 +452,6 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
       gijLower =
         get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScsIp, nDim, nDim);
       numScalars += 2 * numScsIp * nDim * nDim;
-      needDeriv = true;
       break;
 
     case SCV_MIJ:
@@ -507,27 +460,7 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
       metric =
         get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(team, numScvIp, nDim, nDim);
       numScalars += numScvIp * nDim * nDim;
-      needDeriv = true;
       break;
-
-    case SCS_SHAPE_FCN:
-      STK_NGP_ThrowRequireMsg(
-        numScsIp > 0,
-        "ERROR, meSCS must be non-null if SCS_SHAPE_FCN is requested");
-      scs_shape_fcn = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numScsIp, nodesPerElem);
-      numScalars += numScsIp * nodesPerElem;
-      break;
-
-    case SCS_SHIFTED_SHAPE_FCN:
-      STK_NGP_ThrowRequireMsg(
-        numScsIp > 0,
-        "ERROR, meSCS must be non-null if SCS_SHIFTED_SHAPE_FCN is requested");
-      scs_shifted_shape_fcn = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numScsIp, nodesPerElem);
-      numScalars += numScsIp * nodesPerElem;
-      break;
-
     case SCV_VOLUME:
       STK_NGP_ThrowRequireMsg(
         numScvIp > 0,
@@ -543,7 +476,6 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
       dndx_scv = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
         team, numScvIp, nodesPerElem, nDim);
       numScalars += nodesPerElem * numScvIp * nDim;
-      needDerivScv = true;
       needDetjScv = true;
       break;
 
@@ -554,97 +486,12 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
       dndx_scv_shifted = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
         team, numScvIp, nodesPerElem, nDim);
       numScalars += nodesPerElem * numScvIp * nDim;
-      needDerivScv = true;
       needDetjScv = true;
-      break;
-
-    case SCV_SHAPE_FCN:
-      STK_NGP_ThrowRequireMsg(
-        numScvIp > 0,
-        "ERROR, meSCV must be non-null if SCV_SHAPE_FCN is requested");
-      scv_shape_fcn = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numScvIp, nodesPerElem);
-      numScalars += numScvIp * nodesPerElem;
-      break;
-
-    case SCV_SHIFTED_SHAPE_FCN:
-      STK_NGP_ThrowRequireMsg(
-        numScvIp > 0,
-        "ERROR, meSCV must be non-null if SCV_SHIFTED_SHAPE_FCN is requested");
-      scv_shifted_shape_fcn = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numScvIp, nodesPerElem);
-      numScalars += numScvIp * nodesPerElem;
-      break;
-
-    case FEM_GRAD_OP:
-      STK_NGP_ThrowRequireMsg(
-        numFemIp > 0,
-        "ERROR, meFEM must be non-null if FEM_GRAD_OP is requested.");
-      dndx_fem = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numFemIp, nodesPerElem, nDim);
-      numScalars += nodesPerElem * numFemIp * nDim;
-      needDerivFem = true;
-      needDetjFem = true;
-      femGradOp = true;
-      break;
-
-    case FEM_SHIFTED_GRAD_OP:
-      STK_NGP_ThrowRequireMsg(
-        numFemIp > 0,
-        "ERROR, meFEM must be non-null if FEM_SHIFTED_GRAD_OP is requested.");
-      dndx_fem = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numFemIp, nodesPerElem, nDim);
-      numScalars += nodesPerElem * numFemIp * nDim;
-      needDerivFem = true;
-      needDetjFem = true;
-      femShiftedGradOp = true;
-      break;
-
-    case FEM_SHAPE_FCN:
-      STK_NGP_ThrowRequireMsg(
-        numFemIp > 0,
-        "ERROR, meFEM must be non-null if FEM_SHAPE_FCN is requested");
-      fem_shape_fcn = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numFemIp, nodesPerElem);
-      numScalars += numFemIp * nodesPerElem;
-      break;
-
-    case FEM_SHIFTED_SHAPE_FCN:
-      STK_NGP_ThrowRequireMsg(
-        numFemIp > 0,
-        "ERROR, meFEM must be non-null if FEM_SHIFTED_SHAPE_FCN is requested");
-      fem_shifted_shape_fcn = get_shmem_view_2D<T, TEAMHANDLETYPE, SHMEM>(
-        team, numFemIp, nodesPerElem);
-      numScalars += numFemIp * nodesPerElem;
       break;
 
     default:
       break;
     }
-  }
-
-  if (needDerivFC) {
-    deriv_fc_scs = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
-      team, numFaceIp, nodesPerElem, nDim);
-    numScalars += numFaceIp * nodesPerElem * nDim;
-  }
-
-  if (needDeriv) {
-    deriv = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
-      team, numScsIp, nodesPerElem, nDim);
-    numScalars += numScsIp * nodesPerElem * nDim;
-  }
-
-  if (needDerivScv) {
-    deriv_scv = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
-      team, numScvIp, nodesPerElem, nDim);
-    numScalars += numScvIp * nodesPerElem * nDim;
-  }
-
-  if (needDerivFem) {
-    deriv_fem = get_shmem_view_3D<T, TEAMHANDLETYPE, SHMEM>(
-      team, numFemIp, nodesPerElem, nDim);
-    numScalars += numFemIp * nodesPerElem * nDim;
   }
 
   if (needDetjFC) {
@@ -662,65 +509,7 @@ MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::create_master_element_views(
     numScalars += numScvIp;
   }
 
-  if (needDetjFem) {
-    det_j_fem = get_shmem_view_1D<T, TEAMHANDLETYPE, SHMEM>(team, numFemIp);
-    numScalars += numFemIp;
-  }
-
-  // error check
-  if (femGradOp && femShiftedGradOp)
-    STK_NGP_ThrowRequireMsg(
-      numFemIp > 0, "ERROR, femGradOp and femShiftedGradOp both requested.");
-
   return numScalars;
-}
-template <typename T, typename TEAMHANDLETYPE, typename SHMEM>
-KOKKOS_FUNCTION void
-MasterElementViews<T, TEAMHANDLETYPE, SHMEM>::fill_static_meviews(
-  const ElemDataRequestsGPU::DataEnumView& dataEnums,
-  MasterElement* meFC,
-  MasterElement* meSCS,
-  MasterElement* meSCV,
-  MasterElement* meFEM)
-{
-  for (unsigned i = 0; i < dataEnums.size(); ++i) {
-    switch (dataEnums(i)) {
-    case FC_SHAPE_FCN:
-      meFC->shape_fcn<>(fc_shape_fcn);
-      break;
-
-    case FC_SHIFTED_SHAPE_FCN:
-      meFC->shifted_shape_fcn<>(fc_shifted_shape_fcn);
-      break;
-
-    case SCS_SHAPE_FCN:
-      meSCS->shape_fcn<>(scs_shape_fcn);
-      break;
-
-    case SCS_SHIFTED_SHAPE_FCN:
-      meSCS->shifted_shape_fcn<>(scs_shifted_shape_fcn);
-      break;
-
-    case SCV_SHAPE_FCN:
-      meSCV->shape_fcn<>(scv_shape_fcn);
-      break;
-
-    case SCV_SHIFTED_SHAPE_FCN:
-      meSCV->shifted_shape_fcn<>(scv_shifted_shape_fcn);
-      break;
-
-    case FEM_SHAPE_FCN:
-      meFEM->shape_fcn<>(fem_shape_fcn);
-      break;
-
-    case FEM_SHIFTED_SHAPE_FCN:
-      meFEM->shifted_shape_fcn<>(fem_shifted_shape_fcn);
-      break;
-
-    default:
-      break;
-    }
-  }
 }
 
 template <typename T, typename TEAMHANDLETYPE, typename SHMEM>
@@ -918,29 +707,6 @@ ScratchViews<T, TEAMHANDLETYPE, SHMEM>::create_needed_master_element_views(
   }
 
   num_bytes_required += numScalars * sizeof(T);
-}
-
-template <typename T, typename TEAMHANDLETYPE, typename SHMEM>
-KOKKOS_FUNCTION void
-ScratchViews<T, TEAMHANDLETYPE, SHMEM>::fill_static_meviews(
-  const ElemDataRequestsGPU& dataNeeded)
-{
-  MasterElement* meFC = dataNeeded.get_cvfem_face_me();
-  MasterElement* meSCS = dataNeeded.get_cvfem_surface_me();
-  MasterElement* meSCV = dataNeeded.get_cvfem_volume_me();
-  MasterElement* meFEM = dataNeeded.get_fem_volume_me();
-
-  const typename ElemDataRequestsGPU::CoordsTypesView& coordsTypes =
-    dataNeeded.get_coordinates_types();
-  for (unsigned i = 0; i < coordsTypes.size(); ++i) {
-    auto cType = coordsTypes(i);
-
-    const typename ElemDataRequestsGPU::DataEnumView& dataEnums =
-      dataNeeded.get_data_enums(cType);
-    auto& meData = get_me_views(cType);
-
-    meData.fill_static_meviews(dataEnums, meFC, meSCS, meSCV, meFEM);
-  }
 }
 
 int get_num_scalars_pre_req_data(

--- a/include/ScratchWorkView.h
+++ b/include/ScratchWorkView.h
@@ -36,7 +36,7 @@ struct ScratchWorkView
   value_type* data() { return data_.data(); }
   const value_type* data() const { return data_.data(); }
 
-  NALU_ALIGNED Kokkos::Array<value_type, n> data_{};
+   Kokkos::Array<value_type, n> data_{};
   ViewType view_{data_.data()};
 };
 

--- a/include/ScratchWorkView.h
+++ b/include/ScratchWorkView.h
@@ -36,7 +36,7 @@ struct ScratchWorkView
   value_type* data() { return data_.data(); }
   const value_type* data() const { return data_.data(); }
 
-   Kokkos::Array<value_type, n> data_{};
+  Kokkos::Array<value_type, n> data_{};
   ViewType view_{data_.data()};
 };
 

--- a/include/SharedMemData.h
+++ b/include/SharedMemData.h
@@ -54,8 +54,6 @@ struct SharedMemData
     scratchIds = get_shmem_view_1D<int, TEAMHANDLETYPE, SHMEM>(team, rhsSize);
     sortPermutation =
       get_shmem_view_1D<int, TEAMHANDLETYPE, SHMEM>(team, rhsSize);
-
-    simdPrereqData.fill_static_meviews(dataNeededByKernels);
   }
 
   KOKKOS_DEFAULTED_FUNCTION
@@ -120,9 +118,6 @@ struct SharedMemData_FaceElem
     scratchIds = get_shmem_view_1D<int, TEAMHANDLETYPE, SHMEM>(team, rhsSize);
     sortPermutation =
       get_shmem_view_1D<int, TEAMHANDLETYPE, SHMEM>(team, rhsSize);
-
-    simdFaceViews.fill_static_meviews(faceDataNeeded);
-    simdElemViews.fill_static_meviews(elemDataNeeded);
   }
 
   KOKKOS_DEFAULTED_FUNCTION

--- a/include/SimdInterface.h
+++ b/include/SimdInterface.h
@@ -30,8 +30,7 @@ typedef stk::simd::Double SimdDouble;
 typedef SimdDouble DoubleType;
 
 template <typename T>
-using AlignedVector =
-  std::vector<T, non_std::AlignedAllocator<T, KOKKOS_MEMORY_ALIGNMENT>>;
+using AlignedVector = std::vector<T>;
 
 using ScalarAlignedVector = AlignedVector<DoubleType>;
 

--- a/include/TpetraSegregatedLinearSystem.h
+++ b/include/TpetraSegregatedLinearSystem.h
@@ -59,9 +59,9 @@ public:
   ~TpetraSegregatedLinearSystem();
 
   // Graph/Matrix Construction
-  void buildNodeGraph(
-    const stk::mesh::PartVector&
-      parts); // for nodal assembly (e.g., lumped mass and source)
+  void buildNodeGraph(const stk::mesh::PartVector& parts); // for nodal assembly
+                                                           // (e.g., lumped mass
+                                                           // and source)
   void buildFaceToNodeGraph(
     const stk::mesh::PartVector& parts); // face->node assembly
   void buildEdgeToNodeGraph(

--- a/include/aero/actuator/UtilitiesActuator.h
+++ b/include/aero/actuator/UtilitiesActuator.h
@@ -18,7 +18,7 @@
 #include <stk_mesh/base/Entity.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Selector.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/include/kernel/TensorProductCVFEMMomentumAdvDiff.h
+++ b/include/kernel/TensorProductCVFEMMomentumAdvDiff.h
@@ -402,7 +402,7 @@ area_weighted_face_normal_shear_stress(
   // haven't decided on a more general way to separate out the space
   // transformation from the assembly
 
-  NALU_ALIGNED Scalar base_box[3][8];
+   Scalar base_box[3][8];
   hex_vertex_coordinates<p, Scalar>(xc, base_box);
 
   const auto& nodalInterp = ops.mat_.linearNodalInterp;
@@ -417,22 +417,22 @@ area_weighted_face_normal_shear_stress(
   ops.scs_xhat_grad(vel, gradu_scs);
   ops.scs_xhat_interp(visc, visc_scs);
   for (int k = 0; k < p + 1; ++k) {
-    NALU_ALIGNED const Scalar interpk[2] = {
+     const Scalar interpk[2] = {
       nodalInterp(0, k), nodalInterp(1, k)};
     for (int j = 0; j < p + 1; ++j) {
-      NALU_ALIGNED const Scalar interpj[2] = {
+       const Scalar interpj[2] = {
         nodalInterp(0, j), nodalInterp(1, j)};
       for (int i = 0; i < p; ++i) {
-        NALU_ALIGNED const Scalar interpi[2] = {
+         const Scalar interpi[2] = {
           scsInterp(0, i), scsInterp(1, i)};
 
-        NALU_ALIGNED Scalar jact[3][3];
+         Scalar jact[3][3];
         hex_jacobian_t(base_box, interpi, interpj, interpk, jact);
 
-        NALU_ALIGNED Scalar adjJac[3][3];
+         Scalar adjJac[3][3];
         adjugate_matrix33(jact, adjJac);
 
-        NALU_ALIGNED Scalar local_grad[3][3];
+         Scalar local_grad[3][3];
         for (int d = 0; d < 3; ++d) {
           local_grad[d][XH] = adjJac[XH][XH] * gradu_scs(k, j, i, d, XH) +
                               adjJac[XH][YH] * gradu_scs(k, j, i, d, YH) +
@@ -445,7 +445,7 @@ area_weighted_face_normal_shear_stress(
                               adjJac[ZH][ZH] * gradu_scs(k, j, i, d, ZH);
         }
 
-        NALU_ALIGNED Scalar areav[3];
+         Scalar areav[3];
         areav_from_jacobian_t<XH>(jact, areav);
 
         const Scalar inv_detj =
@@ -482,21 +482,21 @@ area_weighted_face_normal_shear_stress(
   ops.scs_yhat_grad(vel, gradu_scs);
   ops.scs_yhat_interp(visc, visc_scs);
   for (int k = 0; k < p + 1; ++k) {
-    NALU_ALIGNED const Scalar interpk[2] = {
+     const Scalar interpk[2] = {
       nodalInterp(0, k), nodalInterp(1, k)};
     for (int j = 0; j < p; ++j) {
-      NALU_ALIGNED const Scalar interpj[2] = {scsInterp(0, j), scsInterp(1, j)};
+       const Scalar interpj[2] = {scsInterp(0, j), scsInterp(1, j)};
       for (int i = 0; i < p + 1; ++i) {
-        NALU_ALIGNED const Scalar interpi[2] = {
+         const Scalar interpi[2] = {
           nodalInterp(0, i), nodalInterp(1, i)};
 
-        NALU_ALIGNED Scalar jact[3][3];
+         Scalar jact[3][3];
         hex_jacobian_t(base_box, interpi, interpj, interpk, jact);
 
-        NALU_ALIGNED Scalar adjJac[3][3];
+         Scalar adjJac[3][3];
         adjugate_matrix33(jact, adjJac);
 
-        NALU_ALIGNED Scalar local_grad[3][3];
+         Scalar local_grad[3][3];
         for (int d = 0; d < 3; ++d) {
           local_grad[d][XH] = adjJac[XH][XH] * gradu_scs(k, j, i, d, XH) +
                               adjJac[XH][YH] * gradu_scs(k, j, i, d, YH) +
@@ -509,7 +509,7 @@ area_weighted_face_normal_shear_stress(
                               adjJac[ZH][ZH] * gradu_scs(k, j, i, d, ZH);
         }
 
-        NALU_ALIGNED Scalar areav[3];
+         Scalar areav[3];
         areav_from_jacobian_t<YH>(jact, areav);
 
         const Scalar inv_detj =
@@ -546,21 +546,21 @@ area_weighted_face_normal_shear_stress(
   ops.scs_zhat_grad(vel, gradu_scs);
   ops.scs_zhat_interp(visc, visc_scs);
   for (int k = 0; k < p; ++k) {
-    NALU_ALIGNED const Scalar interpk[2] = {scsInterp(0, k), scsInterp(1, k)};
+     const Scalar interpk[2] = {scsInterp(0, k), scsInterp(1, k)};
     for (int j = 0; j < p + 1; ++j) {
-      NALU_ALIGNED const Scalar interpj[2] = {
+       const Scalar interpj[2] = {
         nodalInterp(0, j), nodalInterp(1, j)};
       for (int i = 0; i < p + 1; ++i) {
-        NALU_ALIGNED const Scalar interpi[2] = {
+         const Scalar interpi[2] = {
           nodalInterp(0, i), nodalInterp(1, i)};
 
-        NALU_ALIGNED Scalar jact[3][3];
+         Scalar jact[3][3];
         hex_jacobian_t(base_box, interpi, interpj, interpk, jact);
 
-        NALU_ALIGNED Scalar adjJac[3][3];
+         Scalar adjJac[3][3];
         adjugate_matrix33(jact, adjJac);
 
-        NALU_ALIGNED Scalar local_grad[3][3];
+         Scalar local_grad[3][3];
         for (int d = 0; d < 3; ++d) {
           local_grad[d][XH] = adjJac[XH][XH] * gradu_scs(k, j, i, d, XH) +
                               adjJac[XH][YH] * gradu_scs(k, j, i, d, YH) +
@@ -573,7 +573,7 @@ area_weighted_face_normal_shear_stress(
                               adjJac[ZH][ZH] * gradu_scs(k, j, i, d, ZH);
         }
 
-        NALU_ALIGNED Scalar areav[3];
+         Scalar areav[3];
         areav_from_jacobian_t<ZH>(jact, areav);
         const Scalar inv_detj =
           2 * visc_scs(k, j, i) /

--- a/include/kernel/TensorProductCVFEMMomentumAdvDiff.h
+++ b/include/kernel/TensorProductCVFEMMomentumAdvDiff.h
@@ -402,7 +402,7 @@ area_weighted_face_normal_shear_stress(
   // haven't decided on a more general way to separate out the space
   // transformation from the assembly
 
-   Scalar base_box[3][8];
+  Scalar base_box[3][8];
   hex_vertex_coordinates<p, Scalar>(xc, base_box);
 
   const auto& nodalInterp = ops.mat_.linearNodalInterp;
@@ -417,22 +417,19 @@ area_weighted_face_normal_shear_stress(
   ops.scs_xhat_grad(vel, gradu_scs);
   ops.scs_xhat_interp(visc, visc_scs);
   for (int k = 0; k < p + 1; ++k) {
-     const Scalar interpk[2] = {
-      nodalInterp(0, k), nodalInterp(1, k)};
+    const Scalar interpk[2] = {nodalInterp(0, k), nodalInterp(1, k)};
     for (int j = 0; j < p + 1; ++j) {
-       const Scalar interpj[2] = {
-        nodalInterp(0, j), nodalInterp(1, j)};
+      const Scalar interpj[2] = {nodalInterp(0, j), nodalInterp(1, j)};
       for (int i = 0; i < p; ++i) {
-         const Scalar interpi[2] = {
-          scsInterp(0, i), scsInterp(1, i)};
+        const Scalar interpi[2] = {scsInterp(0, i), scsInterp(1, i)};
 
-         Scalar jact[3][3];
+        Scalar jact[3][3];
         hex_jacobian_t(base_box, interpi, interpj, interpk, jact);
 
-         Scalar adjJac[3][3];
+        Scalar adjJac[3][3];
         adjugate_matrix33(jact, adjJac);
 
-         Scalar local_grad[3][3];
+        Scalar local_grad[3][3];
         for (int d = 0; d < 3; ++d) {
           local_grad[d][XH] = adjJac[XH][XH] * gradu_scs(k, j, i, d, XH) +
                               adjJac[XH][YH] * gradu_scs(k, j, i, d, YH) +
@@ -445,7 +442,7 @@ area_weighted_face_normal_shear_stress(
                               adjJac[ZH][ZH] * gradu_scs(k, j, i, d, ZH);
         }
 
-         Scalar areav[3];
+        Scalar areav[3];
         areav_from_jacobian_t<XH>(jact, areav);
 
         const Scalar inv_detj =
@@ -482,21 +479,19 @@ area_weighted_face_normal_shear_stress(
   ops.scs_yhat_grad(vel, gradu_scs);
   ops.scs_yhat_interp(visc, visc_scs);
   for (int k = 0; k < p + 1; ++k) {
-     const Scalar interpk[2] = {
-      nodalInterp(0, k), nodalInterp(1, k)};
+    const Scalar interpk[2] = {nodalInterp(0, k), nodalInterp(1, k)};
     for (int j = 0; j < p; ++j) {
-       const Scalar interpj[2] = {scsInterp(0, j), scsInterp(1, j)};
+      const Scalar interpj[2] = {scsInterp(0, j), scsInterp(1, j)};
       for (int i = 0; i < p + 1; ++i) {
-         const Scalar interpi[2] = {
-          nodalInterp(0, i), nodalInterp(1, i)};
+        const Scalar interpi[2] = {nodalInterp(0, i), nodalInterp(1, i)};
 
-         Scalar jact[3][3];
+        Scalar jact[3][3];
         hex_jacobian_t(base_box, interpi, interpj, interpk, jact);
 
-         Scalar adjJac[3][3];
+        Scalar adjJac[3][3];
         adjugate_matrix33(jact, adjJac);
 
-         Scalar local_grad[3][3];
+        Scalar local_grad[3][3];
         for (int d = 0; d < 3; ++d) {
           local_grad[d][XH] = adjJac[XH][XH] * gradu_scs(k, j, i, d, XH) +
                               adjJac[XH][YH] * gradu_scs(k, j, i, d, YH) +
@@ -509,7 +504,7 @@ area_weighted_face_normal_shear_stress(
                               adjJac[ZH][ZH] * gradu_scs(k, j, i, d, ZH);
         }
 
-         Scalar areav[3];
+        Scalar areav[3];
         areav_from_jacobian_t<YH>(jact, areav);
 
         const Scalar inv_detj =
@@ -546,21 +541,19 @@ area_weighted_face_normal_shear_stress(
   ops.scs_zhat_grad(vel, gradu_scs);
   ops.scs_zhat_interp(visc, visc_scs);
   for (int k = 0; k < p; ++k) {
-     const Scalar interpk[2] = {scsInterp(0, k), scsInterp(1, k)};
+    const Scalar interpk[2] = {scsInterp(0, k), scsInterp(1, k)};
     for (int j = 0; j < p + 1; ++j) {
-       const Scalar interpj[2] = {
-        nodalInterp(0, j), nodalInterp(1, j)};
+      const Scalar interpj[2] = {nodalInterp(0, j), nodalInterp(1, j)};
       for (int i = 0; i < p + 1; ++i) {
-         const Scalar interpi[2] = {
-          nodalInterp(0, i), nodalInterp(1, i)};
+        const Scalar interpi[2] = {nodalInterp(0, i), nodalInterp(1, i)};
 
-         Scalar jact[3][3];
+        Scalar jact[3][3];
         hex_jacobian_t(base_box, interpi, interpj, interpk, jact);
 
-         Scalar adjJac[3][3];
+        Scalar adjJac[3][3];
         adjugate_matrix33(jact, adjJac);
 
-         Scalar local_grad[3][3];
+        Scalar local_grad[3][3];
         for (int d = 0; d < 3; ++d) {
           local_grad[d][XH] = adjJac[XH][XH] * gradu_scs(k, j, i, d, XH) +
                               adjJac[XH][YH] * gradu_scs(k, j, i, d, YH) +
@@ -573,7 +566,7 @@ area_weighted_face_normal_shear_stress(
                               adjJac[ZH][ZH] * gradu_scs(k, j, i, d, ZH);
         }
 
-         Scalar areav[3];
+        Scalar areav[3];
         areav_from_jacobian_t<ZH>(jact, areav);
         const Scalar inv_detj =
           2 * visc_scs(k, j, i) /

--- a/include/master_element/CompileTimeElements.h
+++ b/include/master_element/CompileTimeElements.h
@@ -68,6 +68,24 @@ struct ElemDataSelector<AlgTraitsWed6, q>
 };
 
 template <QuadType q>
+struct ElemDataSelector<AlgTraitsQuad4, q>
+{
+  using elem_data_t = CVFEMData<Quad42DBasis, QuadIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsTri3, q>
+{
+  using elem_data_t = CVFEMData<Tri3Basis, TriIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsEdge_2D, q>
+{
+  using elem_data_t = CVFEMData<LineBasis, EdgeIntegrationRule<q>>;
+};
+
+template <QuadType q>
 struct ElemDataSelector<AlgTraitsPyr5, q>
 {
   using elem_data_t = CVFEMData<
@@ -178,6 +196,14 @@ grad_op(const CoordViewT& x, const GradViewT& grad_coeff)
 }
 
 } // namespace impl
+
+KOKKOS_INLINE_FUNCTION QuadType
+use_shifted_quad(bool shifted)
+{
+  return shifted ? QuadType::SHIFTED : QuadType::MID;
+}
+
+// çç
 
 } // namespace sierra::nalu
 

--- a/include/master_element/CompileTimeElements.h
+++ b/include/master_element/CompileTimeElements.h
@@ -203,8 +203,6 @@ use_shifted_quad(bool shifted)
   return shifted ? QuadType::SHIFTED : QuadType::MID;
 }
 
-// çç
-
 } // namespace sierra::nalu
 
 #endif

--- a/include/master_element/CompileTimeElements.h
+++ b/include/master_element/CompileTimeElements.h
@@ -1,0 +1,184 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef COMPILE_TIME_ELEMENTS_H
+#define COMPILE_TIME_ELEMENTS_H
+
+#include "AlgTraits.h"
+#include "master_element/IntegrationRules.h"
+#include "master_element/MasterElementFunctions.h"
+#include "ArrayND.h"
+#include "SimdInterface.h"
+#include "KokkosInterface.h"
+
+#include "ElementBasis.h"
+
+namespace sierra::nalu::impl {
+
+template <typename BasisT, typename IntgT>
+struct CVFEMData
+{
+  using basis_t = BasisT;
+  using intg_t = IntgT;
+  static constexpr auto scs_interp = utils::interpolants<basis_t>(intg_t::scs);
+  static constexpr auto scv_interp = utils::interpolants<basis_t>(intg_t::scv);
+  static constexpr auto scs_deriv = utils::deriv_coeffs<basis_t>(intg_t::scs);
+  static constexpr auto scv_deriv = utils::deriv_coeffs<basis_t>(intg_t::scv);
+};
+
+template <typename AlgTraits, QuadType q>
+struct ElemDataSelector
+{
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsTri3_2D, q>
+{
+  using elem_data_t = CVFEMData<Tri3Basis, TriIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsQuad4_2D, q>
+{
+  using elem_data_t = CVFEMData<Quad42DBasis, QuadIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsHex8, q>
+{
+  using elem_data_t = CVFEMData<Hex8Basis, HexIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsTet4, q>
+{
+  using elem_data_t = CVFEMData<Tet4Basis, TetIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsWed6, q>
+{
+  using elem_data_t = CVFEMData<Wed6Basis, WedIntegrationRule<q>>;
+};
+
+template <QuadType q>
+struct ElemDataSelector<AlgTraitsPyr5, q>
+{
+  using elem_data_t = CVFEMData<
+    std::conditional_t<q == QuadType::MID, Pyr5Basis, Pyr5DegenHexBasis>,
+    PyrIntegrationRule<q>>;
+};
+
+} // namespace sierra::nalu::impl
+
+namespace sierra::nalu {
+
+template <typename AlgTraits, QuadType q>
+using elem_data_t = typename impl::ElemDataSelector<AlgTraits, q>::elem_data_t;
+
+enum class QuadRank { SCS, SCV };
+} // namespace sierra::nalu
+
+namespace sierra::nalu {
+template <typename AlgTraits, QuadRank rank>
+std::enable_if_t<rank == QuadRank::SCS, double>
+shape_fcn(QuadType quad, int ip, int n)
+{
+  if (quad == QuadType::SHIFTED) {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::SHIFTED>::scs_interp;
+    return shp(ip, n);
+  } else {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::MID>::scs_interp;
+    return shp(ip, n);
+  }
+}
+
+template <typename AlgTraits, QuadRank rank>
+std::enable_if_t<rank == QuadRank::SCV, double>
+shape_fcn(QuadType quad, int ip, int n)
+{
+  if (quad == QuadType::SHIFTED) {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::SHIFTED>::scv_interp;
+    return shp(ip, n);
+  } else {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::MID>::scv_interp;
+    return shp(ip, n);
+  }
+}
+
+template <typename AlgTraits, QuadRank rank>
+KOKKOS_FUNCTION std::enable_if_t<
+  rank == QuadRank::SCS,
+  decltype(elem_data_t<AlgTraits, QuadType::MID>::scs_interp)>
+shape_fcn(QuadType quad)
+{
+  if (quad == QuadType::SHIFTED) {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::SHIFTED>::scs_interp;
+    return shp;
+  } else {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::MID>::scs_interp;
+    return shp;
+  }
+}
+
+template <typename AlgTraits, QuadRank rank>
+KOKKOS_FUNCTION std::enable_if_t<
+  rank == QuadRank::SCV,
+  decltype(elem_data_t<AlgTraits, QuadType::MID>::scv_interp)>
+shape_fcn(QuadType quad)
+{
+  if (quad == QuadType::SHIFTED) {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::SHIFTED>::scv_interp;
+    return shp;
+  } else {
+    static constexpr auto shp =
+      elem_data_t<AlgTraits, QuadType::MID>::scv_interp;
+    return shp;
+  }
+}
+
+namespace impl {
+template <
+  typename AlgTraits,
+  QuadRank rank,
+  QuadType q,
+  typename CoordViewT,
+  typename GradViewT>
+KOKKOS_FUNCTION std::enable_if_t<rank == QuadRank::SCS, void>
+grad_op(const CoordViewT& x, const GradViewT& grad_coeff)
+{
+  static constexpr auto deriv = elem_data_t<AlgTraits, q>::scs_deriv;
+  generic_grad_op<AlgTraits>(deriv, x, grad_coeff);
+}
+
+template <
+  typename AlgTraits,
+  QuadRank rank,
+  QuadType q,
+  typename CoordViewT,
+  typename GradViewT>
+KOKKOS_FUNCTION std::enable_if_t<rank == QuadRank::SCV, void>
+grad_op(const CoordViewT& x, const GradViewT& grad_coeff)
+{
+  static constexpr auto deriv = elem_data_t<AlgTraits, q>::scv_deriv;
+  generic_grad_op<AlgTraits>(deriv, x, grad_coeff);
+}
+
+} // namespace impl
+
+} // namespace sierra::nalu
+
+#endif

--- a/include/master_element/ElementBasis.h
+++ b/include/master_element/ElementBasis.h
@@ -64,13 +64,6 @@ struct Quad42DBasis
   static constexpr int DIM = traits_t::nDim_;
   static constexpr int NNODES = traits_t::nodesPerElement_;
 
-  [[nodiscard]] static constexpr int tensor_map(int k, int j, int i)
-  {
-    constexpr ArrayND<int[N1D][N1D][N1D]> map{
-      {{{0, 1}, {3, 2}}, {{4, 5}, {7, 6}}}};
-    return map(k, j, i);
-  }
-
   [[nodiscard]] static constexpr ArrayND<int[2]> to_tensor(int n)
   {
     constexpr ArrayND<int[NNODES][2]> map{{{0, 0}, {1, 0}, {1, 1}, {0, 1}}};
@@ -78,13 +71,13 @@ struct Quad42DBasis
   }
 
   template <typename LocT>
-  [[nodiscard]] static constexpr auto interp_1(int l, const LocT& x)
+  [[nodiscard]] static constexpr auto interp_1_2D(int l, const LocT& x)
   {
     return 0.5 * (1 + (2 * l - 1) * x);
   }
 
   template <typename LocT>
-  [[nodiscard]] static constexpr auto deriv_1(int l, const LocT& /*unused*/)
+  [[nodiscard]] static constexpr auto deriv_1_2d(int l, const LocT& /*unused*/)
   {
     return 0.5 * (2 * l - 1);
   }
@@ -93,15 +86,17 @@ struct Quad42DBasis
   [[nodiscard]] static constexpr double interpolant(int n, const LocT& x)
   {
     const auto ij = to_tensor(n);
-    return interp_1(ij[0], x[0]) * interp_1(ij[1], x[1]);
+    return interp_1_2D(ij[0], x[0]) * interp_1_2D(ij[1], x[1]);
   }
 
   template <typename LocT>
   [[nodiscard]] static constexpr auto deriv_coeff(int n, const LocT& x, int d)
   {
     const auto ij = to_tensor(n);
-    const auto xv = (d == 0) ? deriv_1(ij(0), x[0]) : interp_1(ij(0), x[0]);
-    const auto yv = (d == 1) ? deriv_1(ij(1), x[1]) : interp_1(ij(1), x[1]);
+    const auto xv =
+      (d == 0) ? deriv_1_2D(ij(0), x[0]) : interp_1_2D(ij(0), x[0]);
+    const auto yv =
+      (d == 1) ? deriv_1_2D(ij(1), x[1]) : interp_1_2D(ij(1), x[1]);
     return xv * yv;
   }
 };

--- a/include/master_element/ElementBasis.h
+++ b/include/master_element/ElementBasis.h
@@ -176,12 +176,9 @@ struct Pyr5Basis
     const auto apex = 0.25 / (1 - x[2]);
     const auto square_x = 1 + sgn(n, 0) * x[0] - x[2];
     const auto square_y = 1 + sgn(n, 1) * x[1] - x[2];
-    const ArrayND<val_t<LocT>[3]> dsquare {
-      {
-        sgn(n, 0) * square_y, square_x *sgn(n, 1), -(square_x + square_y)
-      }
-    };
-    const ArrayND<val_t<LocT>[3]> dinv_term { 0, 0, 4 * apex* apex };
+    const ArrayND<val_t<LocT>[3]> dsquare{
+      {sgn(n, 0) * square_y, square_x * sgn(n, 1), -(square_x + square_y)}};
+    const ArrayND<val_t<LocT>[3]> dinv_term{0, 0, 4 * apex * apex};
     return dsquare(d) * apex + square_x * square_y * dinv_term(d);
   }
 };
@@ -239,15 +236,11 @@ struct Wed6Basis
   template <typename LocT>
   [[nodiscard]] static constexpr auto deriv_coeff(int n, const LocT& x, int d)
   {
-    const ArrayND<val_t<LocT>[3]> tri { 1 - (x[0] + x[1]), x[0], x[1] };
-    constexpr ArrayND<val_t<LocT>[3][3]> dtri {
-      {
-        {-1, -1, 0}, {1, 0, 0}, { 0, 1, 0 }
-      }
-    };
+    const ArrayND<val_t<LocT>[3]> tri{1 - (x[0] + x[1]), x[0], x[1]};
+    constexpr ArrayND<val_t<LocT>[3][3]> dtri{
+      {{-1, -1, 0}, {1, 0, 0}, {0, 1, 0}}};
     const auto prism = 0.5 * (1 + (2 * (n > 2) - 1) * x[2]);
-    const auto dprism =
-      ArrayND<val_t<LocT>[3]> { 0, 0, 0.5 * (2 * (n > 2) - 1) };
+    const auto dprism = ArrayND<val_t<LocT>[3]>{0, 0, 0.5 * (2 * (n > 2) - 1)};
     return dtri(n % 3, d) * prism + tri(n % 3) * dprism(d);
   }
 };

--- a/include/master_element/ElementBasis.h
+++ b/include/master_element/ElementBasis.h
@@ -37,6 +37,26 @@ struct Tri3Basis
   }
 };
 
+struct LineBasis
+{
+  using traits_t = AlgTraitsEdge_2D;
+  static constexpr int N1D = 2;
+  static constexpr int DIM = 1;
+  static constexpr int NNODES = N1D;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    return 0.5 * (1 + (2 * n - 1) * x[0]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int /*d*/)
+  {
+    return 0.5 * (2 * n - 1);
+  }
+};
+
 struct Quad42DBasis
 {
   using traits_t = AlgTraitsQuad4_2D;
@@ -44,40 +64,40 @@ struct Quad42DBasis
   static constexpr int DIM = traits_t::nDim_;
   static constexpr int NNODES = traits_t::nodesPerElement_;
 
-  static constexpr int tensor_map(int k, int j, int i)
+  [[nodiscard]] static constexpr int tensor_map(int k, int j, int i)
   {
     constexpr ArrayND<int[N1D][N1D][N1D]> map{
       {{{0, 1}, {3, 2}}, {{4, 5}, {7, 6}}}};
     return map(k, j, i);
   }
 
-  static constexpr ArrayND<int[2]> to_tensor(int n)
+  [[nodiscard]] static constexpr ArrayND<int[2]> to_tensor(int n)
   {
     constexpr ArrayND<int[NNODES][2]> map{{{0, 0}, {1, 0}, {1, 1}, {0, 1}}};
     return {map(n, 0), map(n, 1)};
   }
 
   template <typename LocT>
-  static constexpr auto interp_1(int l, const LocT& x)
+  [[nodiscard]] static constexpr auto interp_1(int l, const LocT& x)
   {
     return 0.5 * (1 + (2 * l - 1) * x);
   }
 
   template <typename LocT>
-  static constexpr auto deriv_1(int l, const LocT& /*unused*/)
+  [[nodiscard]] static constexpr auto deriv_1(int l, const LocT& /*unused*/)
   {
     return 0.5 * (2 * l - 1);
   }
 
   template <typename LocT>
-  static constexpr double interpolant(int n, const LocT& x)
+  [[nodiscard]] static constexpr double interpolant(int n, const LocT& x)
   {
     const auto ij = to_tensor(n);
     return interp_1(ij[0], x[0]) * interp_1(ij[1], x[1]);
   }
 
   template <typename LocT>
-  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  [[nodiscard]] static constexpr auto deriv_coeff(int n, const LocT& x, int d)
   {
     const auto ij = to_tensor(n);
     const auto xv = (d == 0) ? deriv_1(ij(0), x[0]) : interp_1(ij(0), x[0]);
@@ -93,13 +113,14 @@ struct Quad4Basis
   static constexpr int NNODES = traits_t::nodesPerElement_;
 
   template <typename LocT>
-  static constexpr double interpolant(int n, const LocT& x)
+  [[nodiscard]] static constexpr double interpolant(int n, const LocT& x)
   {
     return (n > 0) ? x[n - 1] : 1 - (x[0] + x[1] + x[2]);
   }
 
   template <typename LocT>
-  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int d)
+  [[nodiscard]] static constexpr auto
+  deriv_coeff(int n, const LocT& /*x*/, int d)
   {
     return -1. + (n > 0) * (1. + (d == (n - 1)));
   }
@@ -112,13 +133,14 @@ struct Tet4Basis
   static constexpr int NNODES = traits_t::nodesPerElement_;
 
   template <typename LocT>
-  static constexpr double interpolant(int n, const LocT& x)
+  [[nodiscard]] static constexpr double interpolant(int n, const LocT& x)
   {
     return (n > 0) ? x[n - 1] : 1 - (x[0] + x[1] + x[2]);
   }
 
   template <typename LocT>
-  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int d)
+  [[nodiscard]] static constexpr auto
+  deriv_coeff(int n, const LocT& /*x*/, int d)
   {
     return -1. + (n > 0) * (1. + (d == (n - 1)));
   }
@@ -130,7 +152,7 @@ struct Pyr5Basis
   static constexpr int DIM = traits_t::nDim_;
   static constexpr int NNODES = traits_t::nodesPerElement_;
 
-  static constexpr int sgn(int n, int d)
+  [[nodiscard]] static constexpr int sgn(int n, int d)
   {
     constexpr auto map =
       ArrayND<int[4][2]>{{{-1, -1}, {+1, -1}, {+1, +1}, {-1, +1}}};
@@ -138,7 +160,7 @@ struct Pyr5Basis
   }
 
   template <typename LocT>
-  static constexpr double interpolant(int n, const LocT& x)
+  [[nodiscard]] static constexpr double interpolant(int n, const LocT& x)
   {
     if (n >= 4 || x[2] == val_t<LocT>(1.)) {
       return x[2];
@@ -148,7 +170,7 @@ struct Pyr5Basis
   }
 
   template <typename LocT>
-  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  [[nodiscard]] static constexpr auto deriv_coeff(int n, const LocT& x, int d)
   {
     if (n >= 4 || x[2] == 1.) {
       return val_t<LocT>(d == 2);
@@ -169,7 +191,7 @@ struct Pyr5DegenHexBasis
   static constexpr int DIM = traits_t::nDim_;
   static constexpr int NNODES = traits_t::nodesPerElement_;
 
-  static constexpr int sgn(int n, int d)
+  [[nodiscard]] static constexpr int sgn(int n, int d)
   {
     constexpr auto map =
       ArrayND<int[4][2]>{{{-1, -1}, {+1, -1}, {+1, +1}, {-1, +1}}};
@@ -177,7 +199,7 @@ struct Pyr5DegenHexBasis
   }
 
   template <typename LocT>
-  static constexpr auto interpolant(int n, const LocT& x)
+  [[nodiscard]] static constexpr auto interpolant(int n, const LocT& x)
   {
     if (n >= 4) {
       return x[2];
@@ -186,7 +208,7 @@ struct Pyr5DegenHexBasis
   }
 
   template <typename LocT>
-  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  [[nodiscard]] static constexpr auto deriv_coeff(int n, const LocT& x, int d)
   {
     if (n >= 4) {
       return val_t<LocT>(d == 2);
@@ -206,7 +228,7 @@ struct Wed6Basis
   static constexpr int NNODES = traits_t::nodesPerElement_;
 
   template <typename LocT>
-  static constexpr double interpolant(int n, const LocT& x)
+  [[nodiscard]] static constexpr double interpolant(int n, const LocT& x)
   {
     const ArrayND<typename LocT::value_type[3]> tri{
       1 - (x[0] + x[1]), x[0], x[1]};
@@ -214,7 +236,7 @@ struct Wed6Basis
   }
 
   template <typename LocT>
-  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  [[nodiscard]] static constexpr auto deriv_coeff(int n, const LocT& x, int d)
   {
     const ArrayND<val_t<LocT>[3]> tri{1 - (x[0] + x[1]), x[0], x[1]};
     constexpr ArrayND<val_t<LocT>[3][3]> dtri{
@@ -232,14 +254,14 @@ struct Hex8Basis
   static constexpr int DIM = 3;
   static constexpr int NNODES = traits_t::nodesPerElement_;
 
-  static constexpr int tensor_map(int k, int j, int i)
+  [[nodiscard]] static constexpr int tensor_map(int k, int j, int i)
   {
     constexpr ArrayND<int[N1D][N1D][N1D]> map{
       {{{0, 1}, {3, 2}}, {{4, 5}, {7, 6}}}};
     return map(k, j, i);
   }
 
-  static constexpr ArrayND<int[3]> to_tensor(int n)
+  [[nodiscard]] static constexpr ArrayND<int[3]> to_tensor(int n)
   {
     constexpr ArrayND<int[NNODES][3]> map{
       {{0, 0, 0},
@@ -254,19 +276,19 @@ struct Hex8Basis
   }
 
   template <typename LocT>
-  static constexpr auto interp_1(int l, const LocT& x)
+  [[nodiscard]] static constexpr auto interp_1(int l, const LocT& x)
   {
     return 0.5 * (1 + (2 * l - 1) * x);
   }
 
   template <typename LocT>
-  static constexpr auto deriv_1(int l, const LocT& /*unused*/)
+  [[nodiscard]] static constexpr auto deriv_1(int l, const LocT& /*unused*/)
   {
     return 0.5 * (2 * l - 1);
   }
 
   template <typename LocT>
-  static constexpr double interpolant(int n, const LocT& x)
+  [[nodiscard]] static constexpr double interpolant(int n, const LocT& x)
   {
     const auto ijk = to_tensor(n);
     return interp_1(ijk[0], x[0]) * interp_1(ijk[1], x[1]) *
@@ -274,7 +296,7 @@ struct Hex8Basis
   }
 
   template <typename LocT>
-  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  [[nodiscard]] static constexpr auto deriv_coeff(int n, const LocT& x, int d)
   {
     const auto ijk = to_tensor(n);
     const auto xv = (d == 0) ? deriv_1(ijk(0), x[0]) : interp_1(ijk(0), x[0]);
@@ -330,7 +352,7 @@ struct is_tensor_compatible<T, std::void_t<decltype(&T::interp_1)>>
 };
 
 template <typename BasisT, typename ParCoordsArrayT, typename ValArrayT>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+[[nodiscard]] KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
   is_tensor_compatible<BasisT>::value,
   ArrayND<typename ValArrayT::value_type[ParCoordsArrayT::extent_int(0)]
                                         [ValArrayT::extent_int(1)]>>
@@ -339,7 +361,7 @@ interpolate(const ParCoordsArrayT& par_coords)
   constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
   using res_val_t = typename ValArrayT::value_type;
 
-  ArrayND<res_val_t[nparcoords]> result;
+  ArrayND<res_val_t[nparcoords]> result{};
   for (int l = 0; l < nparcoords; ++l) {
     for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
       result(l, d) = 0;
@@ -362,7 +384,7 @@ interpolate(const ParCoordsArrayT& par_coords)
 }
 
 template <typename BasisT, typename ParCoordsArrayT, typename ValArrayT>
-KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+[[nodiscard]] KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
   !is_tensor_compatible<BasisT>::value,
   ArrayND<typename ValArrayT::value_type[ParCoordsArrayT::extent_int(0)]
                                         [ValArrayT::extent_int(1)]>>
@@ -371,7 +393,8 @@ interpolate(const ParCoordsArrayT& par_coords, const ValArrayT& vals)
   constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
   using res_val_t = std::decay_t<decltype(par_coords(0, 0) * vals(0, 0))>;
 
-  ArrayND<res_val_t[ParCoordsArrayT::extent_int(0)][vals.extent_int(1)]> result;
+  ArrayND<res_val_t[ParCoordsArrayT::extent_int(0)][vals.extent_int(1)]>
+    result{};
   for (int l = 0; l < nparcoords; ++l) {
 
     ArrayND<res_val_t[ParCoordsArrayT::extent_int(1)]> point;
@@ -393,7 +416,7 @@ interpolate(const ParCoordsArrayT& par_coords, const ValArrayT& vals)
 }
 
 template <typename BasisT, typename ParCoordsArrayT>
-KOKKOS_INLINE_FUNCTION constexpr ArrayND<
+[[nodiscard]] KOKKOS_INLINE_FUNCTION constexpr ArrayND<
   typename ParCoordsArrayT::value_type[ParCoordsArrayT::extent_int(0)]
                                       [BasisT::NNODES]>
 interpolants(const ParCoordsArrayT& par_coords)
@@ -416,7 +439,7 @@ interpolants(const ParCoordsArrayT& par_coords)
 }
 
 template <typename BasisT, typename ParCoordsArrayT>
-KOKKOS_INLINE_FUNCTION constexpr ArrayND<
+[[nodiscard]] KOKKOS_INLINE_FUNCTION constexpr ArrayND<
   typename ParCoordsArrayT::value_type[ParCoordsArrayT::extent_int(0)]
                                       [BasisT::NNODES][BasisT::DIM]>
 deriv_coeffs(const ParCoordsArrayT& par_coords)

--- a/include/master_element/ElementBasis.h
+++ b/include/master_element/ElementBasis.h
@@ -361,8 +361,9 @@ interpolate(const ParCoordsArrayT& par_coords)
 {
   constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
   using res_val_t = typename ValArrayT::value_type;
+  using array_t = res_val_t[nparcoords];
 
-  ArrayND<res_val_t[nparcoords]> result{};
+  ArrayND<array_t> result{};
   for (int l = 0; l < nparcoords; ++l) {
     for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
       result(l, d) = 0;
@@ -392,10 +393,11 @@ template <typename BasisT, typename ParCoordsArrayT, typename ValArrayT>
 interpolate(const ParCoordsArrayT& par_coords, const ValArrayT& vals)
 {
   constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  constexpr int nvals = ValArrayT::extent_int(1);
   using res_val_t = std::decay_t<decltype(par_coords(0, 0) * vals(0, 0))>;
+  using array_t = res_val_t[nparcoords][nvals];
 
-  ArrayND<res_val_t[ParCoordsArrayT::extent_int(0)][vals.extent_int(1)]>
-    result{};
+  ArrayND<array_t> result{};
   for (int l = 0; l < nparcoords; ++l) {
 
     ArrayND<res_val_t[ParCoordsArrayT::extent_int(1)]> point;

--- a/include/master_element/ElementBasis.h
+++ b/include/master_element/ElementBasis.h
@@ -1,0 +1,447 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef ELEMENT_BASIS_H
+#define ELEMENT_BASIS_H
+
+#include "AlgTraits.h"
+#include "ArrayND.h"
+
+namespace sierra::nalu {
+
+template <typename ViewLikeT>
+using val_t = typename ViewLikeT::value_type;
+
+struct Tri3Basis
+{
+  using traits_t = AlgTraitsTri3_2D;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    return (n > 0) ? x[n - 1] : 1 - (x[0] + x[1]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int d)
+  {
+    return -1. + (n > 0) * (1. + (d == (n - 1)));
+  }
+};
+
+struct Quad42DBasis
+{
+  using traits_t = AlgTraitsQuad4_2D;
+  static constexpr int N1D = 2;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  static constexpr int tensor_map(int k, int j, int i)
+  {
+    constexpr ArrayND<int[N1D][N1D][N1D]> map{
+      {{{0, 1}, {3, 2}}, {{4, 5}, {7, 6}}}};
+    return map(k, j, i);
+  }
+
+  static constexpr ArrayND<int[2]> to_tensor(int n)
+  {
+    constexpr ArrayND<int[NNODES][2]> map{{{0, 0}, {1, 0}, {1, 1}, {0, 1}}};
+    return {map(n, 0), map(n, 1)};
+  }
+
+  template <typename LocT>
+  static constexpr auto interp_1(int l, const LocT& x)
+  {
+    return 0.5 * (1 + (2 * l - 1) * x);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_1(int l, const LocT& /*unused*/)
+  {
+    return 0.5 * (2 * l - 1);
+  }
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    const auto ij = to_tensor(n);
+    return interp_1(ij[0], x[0]) * interp_1(ij[1], x[1]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    const auto ij = to_tensor(n);
+    const auto xv = (d == 0) ? deriv_1(ij(0), x[0]) : interp_1(ij(0), x[0]);
+    const auto yv = (d == 1) ? deriv_1(ij(1), x[1]) : interp_1(ij(1), x[1]);
+    return xv * yv;
+  }
+};
+
+struct Quad4Basis
+{
+  using traits_t = AlgTraitsQuad4_2D;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    return (n > 0) ? x[n - 1] : 1 - (x[0] + x[1] + x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int d)
+  {
+    return -1. + (n > 0) * (1. + (d == (n - 1)));
+  }
+};
+
+struct Tet4Basis
+{
+  using traits_t = AlgTraitsTet4;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    return (n > 0) ? x[n - 1] : 1 - (x[0] + x[1] + x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& /*x*/, int d)
+  {
+    return -1. + (n > 0) * (1. + (d == (n - 1)));
+  }
+};
+
+struct Pyr5Basis
+{
+  using traits_t = AlgTraitsPyr5;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  static constexpr int sgn(int n, int d)
+  {
+    constexpr auto map =
+      ArrayND<int[4][2]>{{{-1, -1}, {+1, -1}, {+1, +1}, {-1, +1}}};
+    return map(n % 4, d);
+  }
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    if (n >= 4 || x[2] == val_t<LocT>(1.)) {
+      return x[2];
+    }
+    return 0.25 * (1 + sgn(n, 0) * x[0] - x[2]) *
+           (1 + sgn(n, 1) * x[1] - x[2]) / (1 - x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    if (n >= 4 || x[2] == 1.) {
+      return val_t<LocT>(d == 2);
+    }
+    const auto apex = 0.25 / (1 - x[2]);
+    const auto square_x = 1 + sgn(n, 0) * x[0] - x[2];
+    const auto square_y = 1 + sgn(n, 1) * x[1] - x[2];
+    const ArrayND<val_t<LocT>[3]> dsquare{
+      {sgn(n, 0) * square_y, square_x * sgn(n, 1), -(square_x + square_y)}};
+    const ArrayND<val_t<LocT>[3]> dinv_term{0, 0, 4 * apex * apex};
+    return dsquare(d) * apex + square_x * square_y * dinv_term(d);
+  }
+};
+
+struct Pyr5DegenHexBasis
+{
+  using traits_t = AlgTraitsPyr5;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  static constexpr int sgn(int n, int d)
+  {
+    constexpr auto map =
+      ArrayND<int[4][2]>{{{-1, -1}, {+1, -1}, {+1, +1}, {-1, +1}}};
+    return map(n % 4, d);
+  }
+
+  template <typename LocT>
+  static constexpr auto interpolant(int n, const LocT& x)
+  {
+    if (n >= 4) {
+      return x[2];
+    }
+    return 0.25 * (1 + sgn(n, 0) * x[0]) * (1 + sgn(n, 1) * x[1]) * (1 - x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    if (n >= 4) {
+      return val_t<LocT>(d == 2);
+    }
+    const ArrayND<val_t<LocT>[3]> dsq = {
+      sgn(n, 0) * (1 + sgn(n, 1) * x[1]), (1 + sgn(n, 0) * x[0]) * sgn(n, 1),
+      0};
+    return 0.25 * dsq(d) * (1 - x[2]) -
+           (d == 2) * (1 + sgn(n, 0) * x[0]) * (1 + sgn(n, 1) * x[1]);
+  }
+};
+
+struct Wed6Basis
+{
+  using traits_t = AlgTraitsWed6;
+  static constexpr int DIM = traits_t::nDim_;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    const ArrayND<typename LocT::value_type[3]> tri{
+      1 - (x[0] + x[1]), x[0], x[1]};
+    return tri(n % 3) * (0.5 * (1 + (2 * (n > 2) - 1) * x[2]));
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    const ArrayND<val_t<LocT>[3]> tri{1 - (x[0] + x[1]), x[0], x[1]};
+    constexpr ArrayND<val_t<LocT>[3][3]> dtri{
+      {{-1, -1, 0}, {1, 0, 0}, {0, 1, 0}}};
+    const auto prism = 0.5 * (1 + (2 * (n > 2) - 1) * x[2]);
+    const auto dprism = ArrayND<val_t<LocT>[3]>{0, 0, 0.5 * (2 * (n > 2) - 1)};
+    return dtri(n % 3, d) * prism + tri(n % 3) * dprism(d);
+  }
+};
+
+struct Hex8Basis
+{
+  using traits_t = AlgTraitsHex8;
+  static constexpr int N1D = 2;
+  static constexpr int DIM = 3;
+  static constexpr int NNODES = traits_t::nodesPerElement_;
+
+  static constexpr int tensor_map(int k, int j, int i)
+  {
+    constexpr ArrayND<int[N1D][N1D][N1D]> map{
+      {{{0, 1}, {3, 2}}, {{4, 5}, {7, 6}}}};
+    return map(k, j, i);
+  }
+
+  static constexpr ArrayND<int[3]> to_tensor(int n)
+  {
+    constexpr ArrayND<int[NNODES][3]> map{
+      {{0, 0, 0},
+       {1, 0, 0},
+       {1, 1, 0},
+       {0, 1, 0},
+       {0, 0, 1},
+       {1, 0, 1},
+       {1, 1, 1},
+       {0, 1, 1}}};
+    return {map(n, 0), map(n, 1), map(n, 2)};
+  }
+
+  template <typename LocT>
+  static constexpr auto interp_1(int l, const LocT& x)
+  {
+    return 0.5 * (1 + (2 * l - 1) * x);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_1(int l, const LocT& /*unused*/)
+  {
+    return 0.5 * (2 * l - 1);
+  }
+
+  template <typename LocT>
+  static constexpr double interpolant(int n, const LocT& x)
+  {
+    const auto ijk = to_tensor(n);
+    return interp_1(ijk[0], x[0]) * interp_1(ijk[1], x[1]) *
+           interp_1(ijk[2], x[2]);
+  }
+
+  template <typename LocT>
+  static constexpr auto deriv_coeff(int n, const LocT& x, int d)
+  {
+    const auto ijk = to_tensor(n);
+    const auto xv = (d == 0) ? deriv_1(ijk(0), x[0]) : interp_1(ijk(0), x[0]);
+    const auto yv = (d == 1) ? deriv_1(ijk(1), x[1]) : interp_1(ijk(1), x[1]);
+    const auto zv = (d == 2) ? deriv_1(ijk(2), x[2]) : interp_1(ijk(2), x[2]);
+    return xv * yv * zv;
+  }
+};
+
+namespace impl {
+template <typename AlgTraits>
+struct BasisSelector
+{
+};
+template <>
+struct BasisSelector<AlgTraitsTet4>
+{
+  using basis_t = Tet4Basis;
+};
+template <>
+struct BasisSelector<AlgTraitsPyr5>
+{
+  using basis_t = Pyr5Basis;
+};
+template <>
+struct BasisSelector<AlgTraitsWed6>
+{
+  using basis_t = Wed6Basis;
+};
+template <>
+struct BasisSelector<AlgTraitsHex8>
+{
+  using basis_t = Hex8Basis;
+};
+} // namespace impl
+
+template <typename AlgTraits>
+using alg_basis_t = typename impl::BasisSelector<AlgTraits>::basis_t;
+
+} // namespace sierra::nalu
+
+namespace sierra::nalu::utils {
+
+template <class T, class = void>
+struct is_tensor_compatible : std::false_type
+{
+};
+
+template <class T>
+struct is_tensor_compatible<T, std::void_t<decltype(&T::interp_1)>>
+  : std::true_type
+{
+};
+
+template <typename BasisT, typename ParCoordsArrayT, typename ValArrayT>
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+  is_tensor_compatible<BasisT>::value,
+  ArrayND<typename ValArrayT::value_type[ParCoordsArrayT::extent_int(0)]
+                                        [ValArrayT::extent_int(1)]>>
+interpolate(const ParCoordsArrayT& par_coords)
+{
+  constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  using res_val_t = typename ValArrayT::value_type;
+
+  ArrayND<res_val_t[nparcoords]> result;
+  for (int l = 0; l < nparcoords; ++l) {
+    for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
+      result(l, d) = 0;
+    }
+    for (int i = 0; i < BasisT::N1D; ++i) {
+      const auto interp_x = BasisT::interp_1(i, par_coords(l, 0));
+      for (int j = 0; j < BasisT::N1D; ++j) {
+        const auto interp_xy = BasisT::interp_1(j, par_coords(l, 1)) * interp_x;
+        for (int k = 0; k < BasisT::N1D; ++k) {
+          const auto interp_xyz =
+            interp_xy * BasisT::interp_1(i, par_coords(l, 2));
+          for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
+            result(l, d) += interp_xyz * vals(BasisT::tensor_map(k, j, i), d);
+          }
+        }
+      }
+    }
+  }
+  return result;
+}
+
+template <typename BasisT, typename ParCoordsArrayT, typename ValArrayT>
+KOKKOS_INLINE_FUNCTION constexpr std::enable_if_t<
+  !is_tensor_compatible<BasisT>::value,
+  ArrayND<typename ValArrayT::value_type[ParCoordsArrayT::extent_int(0)]
+                                        [ValArrayT::extent_int(1)]>>
+interpolate(const ParCoordsArrayT& par_coords, const ValArrayT& vals)
+{
+  constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  using res_val_t = std::decay_t<decltype(par_coords(0, 0) * vals(0, 0))>;
+
+  ArrayND<res_val_t[ParCoordsArrayT::extent_int(0)][vals.extent_int(1)]> result;
+  for (int l = 0; l < nparcoords; ++l) {
+
+    ArrayND<res_val_t[ParCoordsArrayT::extent_int(1)]> point;
+    for (int d = 0; d < ParCoordsArrayT::extent_int(1); ++d) {
+      point(d) = par_coords(l, d);
+    }
+    for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
+      result(l, d) = 0;
+    }
+
+    for (int n = 0; n < BasisT::NNODES; ++n) {
+      const auto interp_n = BasisT::interp(n, point);
+      for (int d = 0; d < ValArrayT::extent_int(1); ++d) {
+        result(l, d) += interp_n * vals(n, d);
+      }
+    }
+  }
+  return result;
+}
+
+template <typename BasisT, typename ParCoordsArrayT>
+KOKKOS_INLINE_FUNCTION constexpr ArrayND<
+  typename ParCoordsArrayT::value_type[ParCoordsArrayT::extent_int(0)]
+                                      [BasisT::NNODES]>
+interpolants(const ParCoordsArrayT& par_coords)
+{
+  constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  using res_val_t = std::decay_t<decltype(par_coords(0, 0))>;
+
+  ArrayND<res_val_t[ParCoordsArrayT::extent_int(0)][BasisT::NNODES]> result;
+  for (int l = 0; l < nparcoords; ++l) {
+
+    ArrayND<res_val_t[ParCoordsArrayT::extent_int(1)]> point;
+    for (int d = 0; d < ParCoordsArrayT::extent_int(1); ++d) {
+      point(d) = par_coords(l, d);
+    }
+    for (int n = 0; n < BasisT::NNODES; ++n) {
+      result(l, n) = BasisT::interpolant(n, point);
+    }
+  }
+  return result;
+}
+
+template <typename BasisT, typename ParCoordsArrayT>
+KOKKOS_INLINE_FUNCTION constexpr ArrayND<
+  typename ParCoordsArrayT::value_type[ParCoordsArrayT::extent_int(0)]
+                                      [BasisT::NNODES][BasisT::DIM]>
+deriv_coeffs(const ParCoordsArrayT& par_coords)
+{
+  constexpr int nparcoords = ParCoordsArrayT::extent_int(0);
+  using res_val_t = std::decay_t<decltype(par_coords(0, 0))>;
+
+  ArrayND<
+    res_val_t[ParCoordsArrayT::extent_int(0)][BasisT::NNODES][BasisT::DIM]>
+    result;
+  for (int l = 0; l < nparcoords; ++l) {
+
+    ArrayND<res_val_t[ParCoordsArrayT::extent_int(1)]> point;
+    for (int d = 0; d < ParCoordsArrayT::extent_int(1); ++d) {
+      point(d) = par_coords(l, d);
+    }
+    for (int n = 0; n < BasisT::NNODES; ++n) {
+      for (int d = 0; d < BasisT::DIM; ++d) {
+        result(l, n, d) = BasisT::deriv_coeff(n, point, d);
+      }
+    }
+  }
+  return result;
+}
+
+} // namespace sierra::nalu::utils
+
+#endif

--- a/include/master_element/Hex8CVFEM.h
+++ b/include/master_element/Hex8CVFEM.h
@@ -10,6 +10,9 @@
 #ifndef Hex8CVFEM_h
 #define Hex8CVFEM_h
 
+#include "master_element/ElementBasis.h"
+#include "master_element/IntegrationRules.h"
+
 #include <array>
 
 #include <master_element/MasterElement.h>
@@ -22,6 +25,9 @@ namespace nalu {
 class HexSCV : public MasterElement
 {
 public:
+  using basis_t = Hex8Basis;
+  template <QuadType q>
+  using quad_t = HexIntegrationRule<q>;
   using AlgTraits = AlgTraitsHex8;
 
   KOKKOS_FUNCTION
@@ -120,6 +126,9 @@ private:
 class HexSCS : public MasterElement
 {
 public:
+  using basis_t = Hex8Basis;
+  template <QuadType q>
+  using quad_t = HexIntegrationRule<q>;
   using AlgTraits = AlgTraitsHex8;
   using AlgTraitsFace = AlgTraitsQuad4;
   using MasterElement::adjacentNodes;

--- a/include/master_element/IntegrationRules.h
+++ b/include/master_element/IntegrationRules.h
@@ -11,7 +11,6 @@
 #define INTEGRATION_RULES_H
 
 #include "AlgTraits.h"
-#include "master_element/utils.h"
 #include "ArrayND.h"
 #include "SimdInterface.h"
 #include "KokkosInterface.h"

--- a/include/master_element/IntegrationRules.h
+++ b/include/master_element/IntegrationRules.h
@@ -22,6 +22,25 @@ namespace sierra::nalu {
 enum class QuadType { MID, SHIFTED };
 
 template <QuadType>
+struct EdgeIntegrationRule
+{
+};
+
+template <>
+struct EdgeIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[1][1]> scs{{{0}}};
+  static constexpr ArrayND<double[2][1]> scv{{{-0.5}, {0.5}}};
+};
+
+template <>
+struct EdgeIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[1][1]> scs{{{0}}};
+  static constexpr ArrayND<double[2][1]> scv{{{-1}, {+1}}};
+};
+
+template <QuadType>
 struct TriIntegrationRule
 {
 };

--- a/include/master_element/IntegrationRules.h
+++ b/include/master_element/IntegrationRules.h
@@ -1,0 +1,289 @@
+// Copyright 2017 National Technology & Engineering Solutions of Sandia, LLC
+// (NTESS), National Renewable Energy Laboratory, University of Texas Austin,
+// Northwest Research Associates. Under the terms of Contract DE-NA0003525
+// with NTESS, the U.S. Government retains certain rights in this software.
+//
+// This software is released under the BSD 3-clause license. See LICENSE file
+// for more details.
+//
+
+#ifndef INTEGRATION_RULES_H
+#define INTEGRATION_RULES_H
+
+#include "AlgTraits.h"
+#include "master_element/utils.h"
+#include "ArrayND.h"
+#include "SimdInterface.h"
+#include "KokkosInterface.h"
+
+#include "ElementBasis.h"
+
+namespace sierra::nalu {
+
+enum class QuadType { MID, SHIFTED };
+
+template <QuadType>
+struct TriIntegrationRule
+{
+};
+
+template <>
+struct TriIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[3][2]> scs{
+    {{5. / 12., 2. / 12.},   // surf 1: 0->1
+     {5. / 12., 5. / 12.},   // surf 2: 1->3
+     {2. / 12., 5. / 12.}}}; // surf 3: 0->2
+
+  static constexpr ArrayND<double[3][2]> scv{
+    {{5. / 24., 5. / 24.}, {7. / 12., 5. / 24.}, {5. / 24., 7. / 12.}}};
+};
+
+template <>
+struct TriIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[3][2]> scs{
+    {{0.5, 0.0},   // surf 1: 0->1
+     {0.5, 0.5},   // surf 2: 1->3
+     {0.0, 0.5}}}; // surf 3: 0->2
+
+  static constexpr ArrayND<double[3][2]> scv{{{0, 0}, {1, 0}, {0, 1}}};
+};
+
+template <QuadType>
+struct QuadIntegrationRule
+{
+};
+
+template <>
+struct QuadIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[4][2]> scs{
+    {{+0.0, -0.5},   // surf 1; 1->2
+     {+0.5, +0.0},   // surf 2; 2->3
+     {+0.0, +0.5},   // surf 3; 3->4
+     {-0.5, +0.0}}}; // surf 3; 1->5};
+
+  static constexpr ArrayND<double[4][2]> scv{
+    {{-0.5, -0.5}, {+0.5, -0.5}, {+0.5, +0.5}, {-0.5, +0.5}}};
+};
+
+template <>
+struct QuadIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[4][2]> scs{
+    {{+0, -1}, {+1, +0}, {+0, +1}, {-1, +0}}};
+
+  static constexpr ArrayND<double[4][2]> scv{
+    {{-1, -1}, {+1, -1}, {+1, +1}, {-1, +1}}};
+};
+
+template <QuadType>
+struct HexIntegrationRule
+{
+};
+
+template <>
+struct HexIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[12][3]> scs{
+    {{+0.0, -0.5, -0.5},   // surf 1    1->2
+     {+0.5, +0.0, -0.5},   // surf 2    2->3
+     {+0.0, +0.5, -0.5},   // surf 3    3->4
+     {-0.5, +0.0, -0.5},   // surf 4    1->4
+     {+0.0, -0.5, +0.5},   // surf 5    5->6
+     {+0.5, +0.0, +0.5},   // surf 6    6->7
+     {+0.0, +0.5, +0.5},   // surf 7    7->8
+     {-0.5, +0.0, +0.5},   // surf 8    5->8
+     {-0.5, -0.5, +0.0},   // surf 9    1->5
+     {+0.5, -0.5, +0.0},   // surf 10   2->6
+     {+0.5, +0.5, +0.0},   // surf 11   3->7
+     {-0.5, +0.5, +0.0}}}; // surf 12   4->8
+
+  static constexpr ArrayND<double[8][3]> scv{
+    {{-0.5, -0.5, -0.5},
+     {+0.5, -0.5, -0.5},
+     {+0.5, +0.5, -0.5},
+     {-0.5, +0.5, -0.5},
+     {-0.5, -0.5, +0.5},
+     {+0.5, -0.5, +0.5},
+     {+0.5, +0.5, +0.5},
+     {-0.5, +0.5, +0.5}}};
+};
+
+template <>
+struct HexIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[12][3]> scs{
+    {{+0, -1, -1},   // surf 1    1->2
+     {+1, +0, -1},   // surf 2    2->3
+     {+0, +1, -1},   // surf 3    3->4
+     {-1, +0, -1},   // surf 4    1->4
+     {+0, -1, +1},   // surf 5    5->6
+     {+1, +0, +1},   // surf 6    6->7
+     {+0, +1, +1},   // surf 7    7->8
+     {-1, +0, +1},   // surf 8    5->8
+     {-1, -1, +0},   // surf 9    1->5
+     {+1, -1, +0},   // surf 10   2->6
+     {+1, +1, +0},   // surf 11   3->7
+     {-1, +1, +0}}}; // surf 12   4->8
+
+  static constexpr ArrayND<double[8][3]> scv{
+    {{-1, -1, -1},
+     {+1, -1, -1},
+     {+1, +1, -1},
+     {-1, +1, -1},
+     {-1, -1, +1},
+     {+1, -1, +1},
+     {+1, +1, +1},
+     {-1, +1, +1}}};
+};
+
+template <QuadType>
+struct TetIntegrationRule
+{
+};
+
+template <>
+struct TetIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[6][3]> scs{
+    {{13. / 36., 05. / 36., 05. / 36.}, // surf 1    1->2
+     {13. / 36., 13. / 36., 05. / 36.}, // surf 2    2->3
+     {05. / 36., 13. / 36., 05. / 36.}, // surf 3    1->3
+     {05. / 36., 05. / 36., 13. / 36.}, // surf 4    1->4
+     {13. / 36., 05. / 36., 13. / 36.}, // surf 5    2->4
+     {05. / 36., 13. / 36., 13. / 36.}}};
+
+  static constexpr ArrayND<double[4][3]> scv{
+    {{17. / 96., 17. / 96., 17. / 96.},
+     {45. / 96., 17. / 96., 17. / 96.},
+     {17. / 96., 45. / 96., 17. / 96.},
+     {17. / 96., 17. / 96., 45. / 96.}}};
+};
+
+template <>
+struct TetIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[6][3]> scs{{
+    {0.5, 0.0, 0.0}, // surf 1    1->2
+    {0.5, 0.5, 0.0}, // surf 2    2->3
+    {0.0, 0.5, 0.0}, // surf 3    1->3
+    {0.0, 0.0, 0.5}, // surf 4    1->4
+    {0.5, 0.0, 0.5}, // surf 5    2->4
+    {0.0, 0.5, 0.5}  // surf 6    3->4
+  }};
+
+  static constexpr ArrayND<double[4][3]> scv{
+    {{0.0, 0.0, 0.0}, {1.0, 0.0, 0.0}, {0.0, 1.0, 0.0}, {0.0, 0.0, 1.0}}};
+};
+
+template <QuadType>
+struct WedIntegrationRule
+{
+};
+
+template <>
+struct WedIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[9][3]> scs{
+    {{+05. / 12., +01. / 06., -01. / 02.},
+     {+05. / 12., +05. / 12., -01. / 02.},
+     {+01. / 06., +05. / 12., -01. / 02.},
+     {+05. / 12., +01. / 06., +01. / 02.},
+     {+05. / 12., +05. / 12., +01. / 02.},
+     {+01. / 06., +05. / 12., +01. / 02.},
+     {+07. / 36., +07. / 36., +00. / 02.},
+     {+11. / 18., +07. / 36., +00. / 02.},
+     {+07. / 36., +11. / 18., +00. / 02.}}};
+
+  static constexpr ArrayND<double[6][3]> scv{
+    {{+07. / 36., +07. / 36., -01. / 02.},
+     {+11. / 18., +07. / 36., -01. / 02.},
+     {+07. / 36., +11. / 18., -01. / 02.},
+     {+07. / 36., +07. / 36., +01. / 02.},
+     {+11. / 18., +07. / 36., +01. / 02.},
+     {+07. / 36., +11. / 18., +01. / 02.}}};
+};
+
+template <>
+struct WedIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[9][3]> scs{
+    {{+0.5, +0.0, -1.0},
+     {+0.5, +0.5, -1.0},
+     {+0.0, +0.5, -1.0},
+     {+0.5, +0.0, +1.0},
+     {+0.5, +0.5, +1.0},
+     {+0.0, +0.5, +1.0},
+     {+0.0, +0.0, +0.0},
+     {+1.0, +0.0, +0.0},
+     {+0.0, +1.0, +0.0}}};
+
+  static constexpr ArrayND<double[6][3]> scv{
+    {{+0, +0, -1},
+     {+1, +0, -1},
+     {+0, +1, -1},
+     {+0, +0, +1},
+     {+1, +0, +1},
+     {+0, +1, +1}}};
+};
+
+template <QuadType>
+struct PyrIntegrationRule
+{
+};
+
+template <>
+struct PyrIntegrationRule<QuadType::MID>
+{
+  static constexpr ArrayND<double[12][3]> scs{{
+    {+000. / 315., -145. / 315., +041. / 315.}, // surf 0  1->2
+    {+145. / 315., +000. / 315., +041. / 315.}, // surf 1  2->3
+    {+000. / 315., +145. / 315., +041. / 315.}, // surf 2  3->4
+    {-145. / 315., +000. / 315., +041. / 315.}, // surf 3  1->4
+    {-070. / 315., -070. / 315., +091. / 315.}, // surf 4  1->5 inner
+    {-007. / 018., -007. / 018., +007. / 018.}, // surf 5  1->5 outer
+    {+070. / 315., -070. / 315., +091. / 315.}, // surf 6  2->5 inner
+    {+007. / 018., -007. / 018., +007. / 018.}, // surf 7  2->5 outer
+    {+070. / 315., +070. / 315., +091. / 315.}, // surf 8  3->5 inner
+    {+007. / 018., +007. / 018., +007. / 018.}, // surf 9  3->5 outer
+    {-070. / 315., +070. / 315., +091. / 315.}, // surf 10  4->5 inner
+    {-007. / 018., +007. / 018., +007. / 018.}  // surf 11  4->5 outer
+  }};
+
+  static constexpr double one69r384 = 169.0 / 384.0;
+  static constexpr double five77r3840 = 577.0 / 3840.0;
+  static constexpr double seven73r1560 = 773.0 / 1560.0;
+  static constexpr ArrayND<double[5][3]> scv{
+    {{-one69r384, -one69r384, five77r3840},
+     {one69r384, -one69r384, five77r3840},
+     {one69r384, one69r384, five77r3840},
+     {-one69r384, one69r384, five77r3840},
+     {0.0, 0.0, seven73r1560}}};
+};
+
+template <>
+struct PyrIntegrationRule<QuadType::SHIFTED>
+{
+  static constexpr ArrayND<double[12][3]> scs{{
+    {+0.0, -1.0, +0.0}, // surf 1    1->2
+    {+1.0, +0.0, +0.0}, // surf 2    2->3
+    {+0.0, +1.0, +0.0}, // surf 3    3->4
+    {-1.0, +0.0, +0.0}, // surf 4    1->4
+    {-0.5, -0.5, +0.5}, // surf 5    1->5 I
+    {-0.5, -0.5, +0.5}, // surf 6    1->5 O
+    {+0.5, -0.5, +0.5}, // surf 7    2->5 I
+    {+0.5, -0.5, +0.5}, // surf 8    2->5 O
+    {+0.5, +0.5, +0.5}, // surf 9    3->5 I
+    {+0.5, +0.5, +0.5}, // surf 10   3->5 O
+    {-0.5, +0.5, +0.5}, // surf 11   4->5 I
+    {-0.5, +0.5, +0.5}  // surf 12   4->5 O
+  }};
+
+  static constexpr ArrayND<double[5][3]> scv{
+    {{-1, -1, +0}, {+1, -1, +0}, {+1, +1, +0}, {-1, +1, +0}, {+0, +0, +1}}};
+};
+
+} // namespace sierra::nalu
+#endif

--- a/include/master_element/MasterElementFunctions.h
+++ b/include/master_element/MasterElementFunctions.h
@@ -90,12 +90,12 @@ generic_grad_op(
       weights.extent_int(i) == referenceGradWeights.extent_int(i));
 
   for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
-     ftype jact[dim][dim];
+    ftype jact[dim][dim];
     for (int i = 0; i < dim; ++i)
       for (int j = 0; j < dim; ++j)
         jact[i][j] = ftype(0.0);
 
-     ftype refGrad[AlgTraits::nodesPerElement_][dim];
+    ftype refGrad[AlgTraits::nodesPerElement_][dim];
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       for (int i = 0; i < dim; ++i) {
         refGrad[n][i] = referenceGradWeights(ip, n, i);
@@ -107,17 +107,17 @@ generic_grad_op(
       }
     }
 
-     ftype adjJac[dim][dim];
+    ftype adjJac[dim][dim];
     cofactorMatrix(adjJac, jact);
 
-     ftype det = ftype(0.0);
+    ftype det = ftype(0.0);
     for (int i = 0; i < dim; ++i)
       det += jact[i][0] * adjJac[i][0];
     STK_NGP_ThrowAssertMsg(
       stk::simd::are_any(det > tiny_positive_value()),
       "Problem with Jacobian determinant");
 
-     const ftype inv_detj = ftype(1.0) / det;
+    const ftype inv_detj = ftype(1.0) / det;
 
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       for (int i = 0; i < dim; ++i) {
@@ -157,8 +157,7 @@ generic_gij_3d(
 
   for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
 
-     ftype jac[3][3] = {
-      {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
+    ftype jac[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       jac[0][0] += referenceGradWeights(ip, n, 0) * coords(n, 0);
       jac[0][1] += referenceGradWeights(ip, n, 1) * coords(n, 0);
@@ -193,7 +192,7 @@ generic_gij_3d(
 
     // the covariant is the inverse of the contravariant by definition
     // gUpper is symmetric
-     const ftype inv_detj =
+    const ftype inv_detj =
       ftype(1.0) /
       (gup(ip, 0, 0) *
          (gup(ip, 1, 1) * gup(ip, 2, 2) - gup(ip, 1, 2) * gup(ip, 1, 2)) -
@@ -607,8 +606,7 @@ generic_determinant_3d(
   STK_NGP_ThrowAssert(detj.extent_int(0) == referenceGradWeights.extent_int(0));
 
   for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
-     ftype jac[3][3] = {
-      {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
+    ftype jac[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       jac[0][0] += referenceGradWeights(ip, n, 0) * coords(n, 0);
       jac[0][1] += referenceGradWeights(ip, n, 1) * coords(n, 0);

--- a/include/master_element/MasterElementFunctions.h
+++ b/include/master_element/MasterElementFunctions.h
@@ -72,7 +72,7 @@ generic_grad_op(
 
   using ftype = typename CoordViewType::value_type;
   static_assert(
-    std::is_same<ftype, typename GradViewType::value_type>::value,
+    std::is_convertible_v<typename GradViewType::value_type, ftype>,
     "Incompatiable value type for views");
   static_assert(
     std::is_same<ftype, typename OutputViewType::value_type>::value,
@@ -83,12 +83,13 @@ generic_grad_op(
   static_assert(OutputViewType::rank == 3, "Weight view assumed to be rank 3");
 
   STK_NGP_ThrowAssert(
-    AlgTraits::nodesPerElement_ == referenceGradWeights.extent(1));
-  STK_NGP_ThrowAssert(AlgTraits::nDim_ == referenceGradWeights.extent(2));
+    AlgTraits::nodesPerElement_ == referenceGradWeights.extent_int(1));
+  STK_NGP_ThrowAssert(AlgTraits::nDim_ == referenceGradWeights.extent_int(2));
   for (int i = 0; i < dim; ++i)
-    STK_NGP_ThrowAssert(weights.extent(i) == referenceGradWeights.extent(i));
+    STK_NGP_ThrowAssert(
+      weights.extent_int(i) == referenceGradWeights.extent_int(i));
 
-  for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
+  for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
     NALU_ALIGNED ftype jact[dim][dim];
     for (int i = 0; i < dim; ++i)
       for (int j = 0; j < dim; ++j)
@@ -154,7 +155,7 @@ generic_gij_3d(
   static_assert(OutputViewType::rank == 3, "gij view assumed to be 3D");
   static_assert(AlgTraits::nDim_ == 3, "3D method");
 
-  for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
+  for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
 
     NALU_ALIGNED ftype jac[3][3] = {
       {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
@@ -338,7 +339,7 @@ generic_Mij_2d(
   static_assert(AlgTraits::nDim_ == 2, "2D method");
 
   const int npe = AlgTraits::nodesPerElement_;
-  const int nint = referenceGradWeights.extent(0);
+  const int nint = referenceGradWeights.extent_int(0);
 
   ftype dx_ds[2][2];
   ftype norm;
@@ -487,8 +488,8 @@ generic_Mij_3d(
 
     // At this point we have Q, the eigenvectors and D the eigenvalues of Mij^2,
     // so to create Mij, we use Q sqrt(D) Q^T
-    for (unsigned i = 0; i < 3; i++)
-      for (unsigned j = 0; j < 3; j++) {
+    for (int i = 0; i < 3; i++)
+      for (int j = 0; j < 3; j++) {
         metric[(ip * AlgTraits::nDim_ + i) * AlgTraits::nDim_ + j] =
           Q[i][0] * Q[j][0] * stk::math::sqrt(D[0][0]) +
           Q[i][1] * Q[j][1] * stk::math::sqrt(D[1][1]) +
@@ -520,7 +521,7 @@ generic_Mij_3d(
   static_assert(OutputViewType::rank == 3, "Mij view assumed to be 3D");
   static_assert(AlgTraits::nDim_ == 3, "3D method");
 
-  for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
+  for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
 
     ftype jac[3][3] = {{0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
@@ -566,8 +567,8 @@ generic_Mij_3d(
 
     // At this point we have Q, the eigenvectors and D the eigenvalues of Mij^2,
     // so to create Mij, we use Q sqrt(D) Q^T
-    for (unsigned i = 0; i < 3; i++) {
-      for (unsigned j = 0; j < 3; j++) {
+    for (int i = 0; i < 3; i++) {
+      for (int j = 0; j < 3; j++) {
         metric(ip, i, j) = Q[i][0] * Q[j][0] * stk::math::sqrt(D[0][0]) +
                            Q[i][1] * Q[j][1] * stk::math::sqrt(D[1][1]) +
                            Q[i][2] * Q[j][2] * stk::math::sqrt(D[2][2]);
@@ -600,12 +601,12 @@ generic_determinant_3d(
   static_assert(AlgTraits::nDim_ == 3, "3D method");
 
   STK_NGP_ThrowAssert(
-    AlgTraits::nodesPerElement_ == referenceGradWeights.extent(1));
-  STK_NGP_ThrowAssert(AlgTraits::nDim_ == referenceGradWeights.extent(2));
+    AlgTraits::nodesPerElement_ == referenceGradWeights.extent_int(1));
+  STK_NGP_ThrowAssert(AlgTraits::nDim_ == referenceGradWeights.extent_int(2));
 
-  STK_NGP_ThrowAssert(detj.extent(0) == referenceGradWeights.extent(0));
+  STK_NGP_ThrowAssert(detj.extent_int(0) == referenceGradWeights.extent_int(0));
 
-  for (unsigned ip = 0; ip < referenceGradWeights.extent(0); ++ip) {
+  for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
     NALU_ALIGNED ftype jac[3][3] = {
       {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {

--- a/include/master_element/MasterElementFunctions.h
+++ b/include/master_element/MasterElementFunctions.h
@@ -90,12 +90,12 @@ generic_grad_op(
       weights.extent_int(i) == referenceGradWeights.extent_int(i));
 
   for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
-    NALU_ALIGNED ftype jact[dim][dim];
+     ftype jact[dim][dim];
     for (int i = 0; i < dim; ++i)
       for (int j = 0; j < dim; ++j)
         jact[i][j] = ftype(0.0);
 
-    NALU_ALIGNED ftype refGrad[AlgTraits::nodesPerElement_][dim];
+     ftype refGrad[AlgTraits::nodesPerElement_][dim];
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       for (int i = 0; i < dim; ++i) {
         refGrad[n][i] = referenceGradWeights(ip, n, i);
@@ -107,17 +107,17 @@ generic_grad_op(
       }
     }
 
-    NALU_ALIGNED ftype adjJac[dim][dim];
+     ftype adjJac[dim][dim];
     cofactorMatrix(adjJac, jact);
 
-    NALU_ALIGNED ftype det = ftype(0.0);
+     ftype det = ftype(0.0);
     for (int i = 0; i < dim; ++i)
       det += jact[i][0] * adjJac[i][0];
     STK_NGP_ThrowAssertMsg(
       stk::simd::are_any(det > tiny_positive_value()),
       "Problem with Jacobian determinant");
 
-    NALU_ALIGNED const ftype inv_detj = ftype(1.0) / det;
+     const ftype inv_detj = ftype(1.0) / det;
 
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       for (int i = 0; i < dim; ++i) {
@@ -157,7 +157,7 @@ generic_gij_3d(
 
   for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
 
-    NALU_ALIGNED ftype jac[3][3] = {
+     ftype jac[3][3] = {
       {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       jac[0][0] += referenceGradWeights(ip, n, 0) * coords(n, 0);
@@ -193,7 +193,7 @@ generic_gij_3d(
 
     // the covariant is the inverse of the contravariant by definition
     // gUpper is symmetric
-    NALU_ALIGNED const ftype inv_detj =
+     const ftype inv_detj =
       ftype(1.0) /
       (gup(ip, 0, 0) *
          (gup(ip, 1, 1) * gup(ip, 2, 2) - gup(ip, 1, 2) * gup(ip, 1, 2)) -
@@ -607,7 +607,7 @@ generic_determinant_3d(
   STK_NGP_ThrowAssert(detj.extent_int(0) == referenceGradWeights.extent_int(0));
 
   for (int ip = 0; ip < referenceGradWeights.extent_int(0); ++ip) {
-    NALU_ALIGNED ftype jac[3][3] = {
+     ftype jac[3][3] = {
       {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}};
     for (int n = 0; n < AlgTraits::nodesPerElement_; ++n) {
       jac[0][0] += referenceGradWeights(ip, n, 0) * coords(n, 0);

--- a/include/master_element/MasterElementFunctions.h
+++ b/include/master_element/MasterElementFunctions.h
@@ -71,12 +71,12 @@ generic_grad_op(
   constexpr int dim = AlgTraits::nDim_;
 
   using ftype = typename CoordViewType::value_type;
-  static_assert(
-    std::is_convertible_v<typename GradViewType::value_type, ftype>,
-    "Incompatiable value type for views");
-  static_assert(
-    std::is_same<ftype, typename OutputViewType::value_type>::value,
-    "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<typename GradViewType::value_type, ftype>,
+  //   "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename OutputViewType::value_type>::value,
+  //   "Incompatiable value type for views");
   static_assert(GradViewType::rank == 3, "grad view assumed to be rank 3");
   static_assert(
     CoordViewType::rank == 2, "Coordinate view assumed to be rank 2");
@@ -144,12 +144,12 @@ generic_gij_3d(
   OutputViewType& glo)
 {
   using ftype = typename CoordViewType::value_type;
-  static_assert(
-    std::is_same<ftype, typename GradViewType::value_type>::value,
-    "Incompatiable value type for views");
-  static_assert(
-    std::is_same<ftype, typename OutputViewType::value_type>::value,
-    "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename GradViewType::value_type>,
+  //   "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename OutputViewType::value_type>,
+  //   "Incompatiable value type for views");
   static_assert(GradViewType::rank == 3, "grad view assumed to be 3D");
   static_assert(CoordViewType::rank == 2, "Coordinate view assumed to be 2D");
   static_assert(OutputViewType::rank == 3, "gij view assumed to be 3D");
@@ -327,12 +327,12 @@ generic_Mij_2d(
   OutputViewType& metric)
 {
   using ftype = typename CoordViewType::value_type;
-  static_assert(
-    std::is_same<ftype, typename GradViewType::value_type>::value,
-    "Incompatiable value type for views");
-  static_assert(
-    std::is_same<ftype, typename OutputViewType::value_type>::value,
-    "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename GradViewType::value_type>,
+  //   "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename OutputViewType::value_type>,
+  //   "Incompatiable value type for views");
   static_assert(GradViewType::rank == 3, "grad view assumed to be 3D");
   static_assert(CoordViewType::rank == 2, "Coordinate view assumed to be 2D");
   static_assert(OutputViewType::rank == 3, "Mij view assumed to be 3D");
@@ -510,12 +510,12 @@ generic_Mij_3d(
   OutputViewType& metric)
 {
   using ftype = typename CoordViewType::value_type;
-  static_assert(
-    std::is_same<ftype, typename GradViewType::value_type>::value,
-    "Incompatiable value type for views");
-  static_assert(
-    std::is_same<ftype, typename OutputViewType::value_type>::value,
-    "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename GradViewType::value_type>,
+  //   "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename OutputViewType::value_type>,
+  //   "Incompatiable value type for views");
   static_assert(GradViewType::rank == 3, "grad view assumed to be 3D");
   static_assert(CoordViewType::rank == 2, "Coordinate view assumed to be 2D");
   static_assert(OutputViewType::rank == 3, "Mij view assumed to be 3D");
@@ -589,12 +589,12 @@ generic_determinant_3d(
   GradViewType referenceGradWeights, CoordViewType coords, OutputViewType detj)
 {
   using ftype = typename CoordViewType::value_type;
-  static_assert(
-    std::is_same<ftype, typename GradViewType::value_type>::value,
-    "Incompatiable value type for views");
-  static_assert(
-    std::is_same<ftype, typename OutputViewType::value_type>::value,
-    "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename GradViewType::value_type>,
+  //   "Incompatiable value type for views");
+  // static_assert(
+  //   std::is_convertible_v<ftype, typename OutputViewType::value_type>,
+  //   "Incompatiable value type for views");
   static_assert(GradViewType::rank == 3, "grad view assumed to be 3D");
   static_assert(CoordViewType::rank == 2, "Coordinate view assumed to be 2D");
   static_assert(OutputViewType::rank == 1, "Weight view assumed to be 1D");

--- a/include/master_element/Pyr5CVFEM.h
+++ b/include/master_element/Pyr5CVFEM.h
@@ -17,6 +17,8 @@
 // NGP-based includes
 #include "SimdInterface.h"
 #include "KokkosInterface.h"
+#include "master_element/CompileTimeElements.h"
+#include "master_element/IntegrationRules.h"
 
 #include <cstdlib>
 #include <stdexcept>
@@ -42,6 +44,9 @@ public:
   using MasterElement::shape_fcn;
   using MasterElement::shifted_grad_op;
   using MasterElement::shifted_shape_fcn;
+
+  template <QuadType q>
+  using pyr_data_t = elem_data_t<AlgTraits, q>;
 
   KOKKOS_FUNCTION
   PyrSCV();
@@ -144,6 +149,9 @@ public:
   using MasterElement::determinant;
   using MasterElement::shape_fcn;
   using MasterElement::shifted_shape_fcn;
+
+  template <QuadType q>
+  using pyr_data_t = elem_data_t<AlgTraits, q>;
 
   KOKKOS_FUNCTION
   PyrSCS();

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -798,8 +798,6 @@ run_face_elem_algorithm_nosimd(
         team, ndim, nodesPerFace, faceDataNGP);
       typename Traits::ScratchViewsType elemViews(
         team, ndim, nodesPerElement, elemDataNGP);
-      faceViews.fill_static_meviews(faceDataNGP);
-      elemViews.fill_static_meviews(elemDataNGP);
 
       const size_t bktLen = bkt.size();
       Kokkos::parallel_for(

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -258,10 +258,9 @@ run_edge_algorithm(
 
   run_entity_algorithm(
     algName, mesh, rank, sel, KOKKOS_LAMBDA(MeshIndex & meshIdx) {
-      algorithm(
-        EntityInfo<Mesh>{
-          meshIdx, mesh.get_entity(rank, meshIdx),
-          mesh.get_nodes(rank, meshIdx)});
+      algorithm(EntityInfo<Mesh>{
+        meshIdx, mesh.get_entity(rank, meshIdx),
+        mesh.get_nodes(rank, meshIdx)});
     });
 }
 
@@ -293,10 +292,9 @@ run_elem_algorithm(
 
   run_entity_algorithm(
     algName, mesh, rank, sel, KOKKOS_LAMBDA(MeshIndex & meshIdx) {
-      algorithm(
-        EntityInfo<Mesh>{
-          meshIdx, mesh.get_entity(rank, meshIdx),
-          mesh.get_nodes(rank, meshIdx)});
+      algorithm(EntityInfo<Mesh>{
+        meshIdx, mesh.get_entity(rank, meshIdx),
+        mesh.get_nodes(rank, meshIdx)});
     });
 }
 

--- a/include/ngp_utils/NgpLoopUtils.h
+++ b/include/ngp_utils/NgpLoopUtils.h
@@ -258,9 +258,10 @@ run_edge_algorithm(
 
   run_entity_algorithm(
     algName, mesh, rank, sel, KOKKOS_LAMBDA(MeshIndex & meshIdx) {
-      algorithm(EntityInfo<Mesh>{
-        meshIdx, mesh.get_entity(rank, meshIdx),
-        mesh.get_nodes(rank, meshIdx)});
+      algorithm(
+        EntityInfo<Mesh>{
+          meshIdx, mesh.get_entity(rank, meshIdx),
+          mesh.get_nodes(rank, meshIdx)});
     });
 }
 
@@ -292,9 +293,10 @@ run_elem_algorithm(
 
   run_entity_algorithm(
     algName, mesh, rank, sel, KOKKOS_LAMBDA(MeshIndex & meshIdx) {
-      algorithm(EntityInfo<Mesh>{
-        meshIdx, mesh.get_entity(rank, meshIdx),
-        mesh.get_nodes(rank, meshIdx)});
+      algorithm(
+        EntityInfo<Mesh>{
+          meshIdx, mesh.get_entity(rank, meshIdx),
+          mesh.get_nodes(rank, meshIdx)});
     });
 }
 

--- a/include/ngp_utils/NgpScratchData.h
+++ b/include/ngp_utils/NgpScratchData.h
@@ -54,6 +54,8 @@ struct ElemSimdData
         team, ndim, nodesPerElem, dataReq));
     }
 #endif
+
+    simdScrView.fill_static_meviews(dataReq);
   }
 
   KOKKOS_DEFAULTED_FUNCTION ~ElemSimdData() = default;
@@ -112,6 +114,9 @@ struct FaceElemSimdData
         team, ndim, nodesPerElem, elemDataReqs));
     }
 #endif
+
+    simdFaceView.fill_static_meviews(faceDataReqs);
+    simdElemView.fill_static_meviews(elemDataReqs);
   }
 
   KOKKOS_DEFAULTED_FUNCTION ~FaceElemSimdData() = default;

--- a/include/ngp_utils/NgpScratchData.h
+++ b/include/ngp_utils/NgpScratchData.h
@@ -54,8 +54,6 @@ struct ElemSimdData
         team, ndim, nodesPerElem, dataReq));
     }
 #endif
-
-    simdScrView.fill_static_meviews(dataReq);
   }
 
   KOKKOS_DEFAULTED_FUNCTION ~ElemSimdData() = default;
@@ -114,9 +112,6 @@ struct FaceElemSimdData
         team, ndim, nodesPerElem, elemDataReqs));
     }
 #endif
-
-    simdFaceView.fill_static_meviews(faceDataReqs);
-    simdElemView.fill_static_meviews(elemDataReqs);
   }
 
   KOKKOS_DEFAULTED_FUNCTION ~FaceElemSimdData() = default;

--- a/include/node_kernels/MomentumBodyForceBoxNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceBoxNodeKernel.h
@@ -55,10 +55,10 @@ private:
   stk::mesh::NgpField<double> coordinates_;
   stk::mesh::NgpField<double> dualNodalVolume_;
 
-  NALU_ALIGNED NodeKernelTraits::DblType
+   NodeKernelTraits::DblType
     forceVector_[NodeKernelTraits::NDimMax];
-  NALU_ALIGNED NodeKernelTraits::DblType lo_[NodeKernelTraits::NDimMax];
-  NALU_ALIGNED NodeKernelTraits::DblType hi_[NodeKernelTraits::NDimMax];
+   NodeKernelTraits::DblType lo_[NodeKernelTraits::NDimMax];
+   NodeKernelTraits::DblType hi_[NodeKernelTraits::NDimMax];
   stk::mesh::Part* mdotPart_;
   GeometryAlgDriver* geometryAlgDriver_;
   MdotAlgDriver* mdotAlgDriver_;

--- a/include/node_kernels/MomentumBodyForceBoxNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceBoxNodeKernel.h
@@ -55,10 +55,9 @@ private:
   stk::mesh::NgpField<double> coordinates_;
   stk::mesh::NgpField<double> dualNodalVolume_;
 
-   NodeKernelTraits::DblType
-    forceVector_[NodeKernelTraits::NDimMax];
-   NodeKernelTraits::DblType lo_[NodeKernelTraits::NDimMax];
-   NodeKernelTraits::DblType hi_[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType forceVector_[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType lo_[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType hi_[NodeKernelTraits::NDimMax];
   stk::mesh::Part* mdotPart_;
   GeometryAlgDriver* geometryAlgDriver_;
   MdotAlgDriver* mdotAlgDriver_;

--- a/include/node_kernels/MomentumBodyForceNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceNodeKernel.h
@@ -43,7 +43,7 @@ public:
 private:
   stk::mesh::NgpField<double> dualNodalVolume_;
 
-  NALU_ALIGNED NodeKernelTraits::DblType
+   NodeKernelTraits::DblType
     forceVector_[NodeKernelTraits::NDimMax];
 
   unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};

--- a/include/node_kernels/MomentumBodyForceNodeKernel.h
+++ b/include/node_kernels/MomentumBodyForceNodeKernel.h
@@ -43,8 +43,7 @@ public:
 private:
   stk::mesh::NgpField<double> dualNodalVolume_;
 
-   NodeKernelTraits::DblType
-    forceVector_[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType forceVector_[NodeKernelTraits::NDimMax];
 
   unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
 

--- a/include/node_kernels/MomentumBoussinesqNodeKernel.h
+++ b/include/node_kernels/MomentumBoussinesqNodeKernel.h
@@ -53,7 +53,7 @@ private:
   unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
   unsigned temperatureID_{stk::mesh::InvalidOrdinal};
 
-   NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
 };
 
 } // namespace nalu

--- a/include/node_kernels/MomentumBoussinesqNodeKernel.h
+++ b/include/node_kernels/MomentumBoussinesqNodeKernel.h
@@ -53,7 +53,7 @@ private:
   unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
   unsigned temperatureID_{stk::mesh::InvalidOrdinal};
 
-  NALU_ALIGNED NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
+   NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
 };
 
 } // namespace nalu

--- a/include/node_kernels/MomentumBuoyancyNodeKernel.h
+++ b/include/node_kernels/MomentumBuoyancyNodeKernel.h
@@ -55,7 +55,7 @@ private:
   unsigned densityNp1ID_{stk::mesh::InvalidOrdinal};
   unsigned sourceID_{stk::mesh::InvalidOrdinal};
 
-  NALU_ALIGNED NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
+   NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
 };
 
 } // namespace nalu

--- a/include/node_kernels/MomentumBuoyancyNodeKernel.h
+++ b/include/node_kernels/MomentumBuoyancyNodeKernel.h
@@ -55,7 +55,7 @@ private:
   unsigned densityNp1ID_{stk::mesh::InvalidOrdinal};
   unsigned sourceID_{stk::mesh::InvalidOrdinal};
 
-   NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
 };
 
 } // namespace nalu

--- a/include/node_kernels/TKERodiNodeKernel.h
+++ b/include/node_kernels/TKERodiNodeKernel.h
@@ -56,7 +56,7 @@ private:
   const unsigned tviscID_{stk::mesh::InvalidOrdinal};
   const unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
 
-   NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
   NodeKernelTraits::DblType turbPr_;
   const NodeKernelTraits::DblType beta_;
   const int nDim_;

--- a/include/node_kernels/TKERodiNodeKernel.h
+++ b/include/node_kernels/TKERodiNodeKernel.h
@@ -56,7 +56,7 @@ private:
   const unsigned tviscID_{stk::mesh::InvalidOrdinal};
   const unsigned dualNodalVolumeID_{stk::mesh::InvalidOrdinal};
 
-  NALU_ALIGNED NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
+   NodeKernelTraits::DblType gravity_[NodeKernelTraits::NDimMax];
   NodeKernelTraits::DblType turbPr_;
   const NodeKernelTraits::DblType beta_;
   const int nDim_;

--- a/include/overset/overset_utils.h
+++ b/include/overset/overset_utils.h
@@ -23,7 +23,6 @@ namespace overset_utils {
 
 std::vector<OversetFieldData>
 get_overset_field_data(Realm&, std::vector<std::string> fnames);
-
 }
 } // namespace nalu
 } // namespace sierra

--- a/src/AMSAlgDriver.C
+++ b/src/AMSAlgDriver.C
@@ -232,7 +232,7 @@ AMSAlgDriver::initial_production()
     nalu_ngp::run_entity_algorithm(
       "AMSAlgDriver_avgProd", ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const Traits::MeshIndex& mi) {
-         DblType tij[nalu_ngp::NDimMax * nalu_ngp::NDimMax];
+        DblType tij[nalu_ngp::NDimMax * nalu_ngp::NDimMax];
         for (int i = 0; i < nDim; ++i) {
           for (int j = 0; j < nDim; ++j) {
             const DblType avgSij = 0.5 * (avgDudx.get(mi, i * nDim + j) +
@@ -241,7 +241,7 @@ AMSAlgDriver::initial_production()
           }
         }
 
-         DblType Pij[nalu_ngp::NDimMax * nalu_ngp::NDimMax];
+        DblType Pij[nalu_ngp::NDimMax * nalu_ngp::NDimMax];
         for (int i = 0; i < nDim; ++i) {
           for (int j = 0; j < nDim; ++j) {
             Pij[i * nDim + j] = 0.0;

--- a/src/AMSAlgDriver.C
+++ b/src/AMSAlgDriver.C
@@ -232,7 +232,7 @@ AMSAlgDriver::initial_production()
     nalu_ngp::run_entity_algorithm(
       "AMSAlgDriver_avgProd", ngpMesh, stk::topology::NODE_RANK, sel,
       KOKKOS_LAMBDA(const Traits::MeshIndex& mi) {
-        NALU_ALIGNED DblType tij[nalu_ngp::NDimMax * nalu_ngp::NDimMax];
+         DblType tij[nalu_ngp::NDimMax * nalu_ngp::NDimMax];
         for (int i = 0; i < nDim; ++i) {
           for (int j = 0; j < nDim; ++j) {
             const DblType avgSij = 0.5 * (avgDudx.get(mi, i * nDim + j) +
@@ -241,7 +241,7 @@ AMSAlgDriver::initial_production()
           }
         }
 
-        NALU_ALIGNED DblType Pij[nalu_ngp::NDimMax * nalu_ngp::NDimMax];
+         DblType Pij[nalu_ngp::NDimMax * nalu_ngp::NDimMax];
         for (int i = 0; i < nDim; ++i) {
           for (int j = 0; j < nDim; ++j) {
             Pij[i * nDim + j] = 0.0;

--- a/src/AssembleElemSolverAlgorithm.C
+++ b/src/AssembleElemSolverAlgorithm.C
@@ -25,7 +25,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/AssembleFaceElemSolverAlgorithm.C
+++ b/src/AssembleFaceElemSolverAlgorithm.C
@@ -25,7 +25,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/AssembleMomentumEdgeABLTopBC.C
+++ b/src/AssembleMomentumEdgeABLTopBC.C
@@ -20,7 +20,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/AssembleMomentumEdgeWallFunctionSolverAlgorithm.C
+++ b/src/AssembleMomentumEdgeWallFunctionSolverAlgorithm.C
@@ -21,7 +21,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/AssembleNodeSolverAlgorithm.C
+++ b/src/AssembleNodeSolverAlgorithm.C
@@ -21,7 +21,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/AssemblePNGBoundarySolverAlgorithm.C
+++ b/src/AssemblePNGBoundarySolverAlgorithm.C
@@ -21,7 +21,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/AssemblePNGElemSolverAlgorithm.C
+++ b/src/AssemblePNGElemSolverAlgorithm.C
@@ -21,7 +21,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 

--- a/src/AssembleScalarEigenEdgeSolverAlgorithm.C
+++ b/src/AssembleScalarEigenEdgeSolverAlgorithm.C
@@ -21,7 +21,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/AssembleWallHeatTransferAlgorithmDriver.C
+++ b/src/AssembleWallHeatTransferAlgorithmDriver.C
@@ -17,7 +17,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/AuxFunctionAlgorithm.C
+++ b/src/AuxFunctionAlgorithm.C
@@ -15,7 +15,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/ComputeHeatTransferEdgeWallAlgorithm.C
+++ b/src/ComputeHeatTransferEdgeWallAlgorithm.C
@@ -19,7 +19,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
+++ b/src/ComputeSSTMaxLengthScaleElemAlgorithm.C
@@ -21,7 +21,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 

--- a/src/ComputeWallFrictionVelocityAlgorithm.C
+++ b/src/ComputeWallFrictionVelocityAlgorithm.C
@@ -22,7 +22,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/CopyFieldAlgorithm.C
+++ b/src/CopyFieldAlgorithm.C
@@ -17,7 +17,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/DataProbePostProcessing.C
+++ b/src/DataProbePostProcessing.C
@@ -27,7 +27,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Entity.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Selector.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/EffectiveDiffFluxCoeffAlgorithm.C
+++ b/src/EffectiveDiffFluxCoeffAlgorithm.C
@@ -15,7 +15,7 @@
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Field.hpp>

--- a/src/EnthalpyEquationSystem.C
+++ b/src/EnthalpyEquationSystem.C
@@ -96,7 +96,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 

--- a/src/FieldFunctions.C
+++ b/src/FieldFunctions.C
@@ -13,7 +13,7 @@
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Field.hpp>
 

--- a/src/FixPressureAtNodeAlgorithm.C
+++ b/src/FixPressureAtNodeAlgorithm.C
@@ -17,7 +17,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include "stk_mesh/base/NgpMesh.hpp"

--- a/src/GammaEquationSystem.C
+++ b/src/GammaEquationSystem.C
@@ -67,7 +67,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 

--- a/src/LinearSystem.C
+++ b/src/LinearSystem.C
@@ -32,7 +32,7 @@
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Part.hpp>
 #include "stk_mesh/base/NgpMesh.hpp"
 #include <stk_topology/topology.hpp>

--- a/src/LowMachEquationSystem.C
+++ b/src/LowMachEquationSystem.C
@@ -192,7 +192,7 @@
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/SkinMesh.hpp>

--- a/src/MovingAveragePostProcessor.C
+++ b/src/MovingAveragePostProcessor.C
@@ -20,7 +20,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 

--- a/src/NonConformalInfo.C
+++ b/src/NonConformalInfo.C
@@ -19,7 +19,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/NonConformalManager.C
+++ b/src/NonConformalManager.C
@@ -18,7 +18,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/PeriodicManager.C
+++ b/src/PeriodicManager.C
@@ -19,7 +19,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/NgpFieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/ProjectedNodalGradientEquationSystem.C
+++ b/src/ProjectedNodalGradientEquationSystem.C
@@ -32,7 +32,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/SkinMesh.hpp>

--- a/src/Realm.C
+++ b/src/Realm.C
@@ -116,7 +116,7 @@
 #include <stk_mesh/base/MeshBuilder.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Comm.hpp>

--- a/src/SolutionNormPostProcessing.C
+++ b/src/SolutionNormPostProcessing.C
@@ -36,7 +36,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 

--- a/src/SpecificDissipationRateEquationSystem.C
+++ b/src/SpecificDissipationRateEquationSystem.C
@@ -79,7 +79,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 

--- a/src/SurfaceForceAndMomentAlgorithm.C
+++ b/src/SurfaceForceAndMomentAlgorithm.C
@@ -19,7 +19,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/SurfaceForceAndMomentAlgorithmDriver.C
+++ b/src/SurfaceForceAndMomentAlgorithmDriver.C
@@ -18,7 +18,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
+++ b/src/SurfaceForceAndMomentWallFunctionAlgorithm.C
@@ -19,7 +19,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/TotalDissipationRateEquationSystem.C
+++ b/src/TotalDissipationRateEquationSystem.C
@@ -67,7 +67,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 

--- a/src/TpetraLinearSystem.C
+++ b/src/TpetraLinearSystem.C
@@ -46,7 +46,7 @@
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Part.hpp>
 #include <stk_topology/topology.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>

--- a/src/TpetraSegregatedLinearSystem.C
+++ b/src/TpetraSegregatedLinearSystem.C
@@ -40,7 +40,7 @@
 #include <stk_mesh/base/Bucket.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Part.hpp>
 #include <stk_topology/topology.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>

--- a/src/TurbKineticEnergyEquationSystem.C
+++ b/src/TurbKineticEnergyEquationSystem.C
@@ -88,7 +88,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/NgpMesh.hpp>

--- a/src/TurbViscSmagorinskyAlgorithm.C
+++ b/src/TurbViscSmagorinskyAlgorithm.C
@@ -15,7 +15,7 @@
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/FieldBase.hpp>

--- a/src/TurbViscWaleAlgorithm.C
+++ b/src/TurbViscWaleAlgorithm.C
@@ -15,7 +15,7 @@
 
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Field.hpp>

--- a/src/TurbulenceAveragingPostProcessing.C
+++ b/src/TurbulenceAveragingPostProcessing.C
@@ -29,7 +29,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/NgpMesh.hpp>

--- a/src/aero/fsi/CalcLoads.C
+++ b/src/aero/fsi/CalcLoads.C
@@ -18,7 +18,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/edge_kernels/ContinuityEdgeSolverAlg.C
+++ b/src/edge_kernels/ContinuityEdgeSolverAlg.C
@@ -113,7 +113,7 @@ ContinuityEdgeSolverAlg::execute()
       const stk::mesh::FastMeshIndex& nodeL,
       const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-      NALU_ALIGNED DblType av[NDimMax_];
+       DblType av[NDimMax_];
 
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d)

--- a/src/edge_kernels/ContinuityEdgeSolverAlg.C
+++ b/src/edge_kernels/ContinuityEdgeSolverAlg.C
@@ -113,7 +113,7 @@ ContinuityEdgeSolverAlg::execute()
       const stk::mesh::FastMeshIndex& nodeL,
       const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-       DblType av[NDimMax_];
+      DblType av[NDimMax_];
 
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d)

--- a/src/edge_kernels/MomentumABLWallFuncEdgeKernel.C
+++ b/src/edge_kernels/MomentumABLWallFuncEdgeKernel.C
@@ -76,7 +76,7 @@ MomentumABLWallFuncEdgeKernel<BcAlgTraits>::execute(
   const DoubleType Lmax = 1.0e8;
 
   // Unit normal vector
-   DoubleType nx[BcAlgTraits::nDim_];
+  DoubleType nx[BcAlgTraits::nDim_];
 
   const auto& v_vel = scratchViews.get_scratch_view_2D(velocityNp1_);
   const auto& v_bcvel = scratchViews.get_scratch_view_2D(bcVelocity_);

--- a/src/edge_kernels/MomentumABLWallFuncEdgeKernel.C
+++ b/src/edge_kernels/MomentumABLWallFuncEdgeKernel.C
@@ -76,7 +76,7 @@ MomentumABLWallFuncEdgeKernel<BcAlgTraits>::execute(
   const DoubleType Lmax = 1.0e8;
 
   // Unit normal vector
-  NALU_ALIGNED DoubleType nx[BcAlgTraits::nDim_];
+   DoubleType nx[BcAlgTraits::nDim_];
 
   const auto& v_vel = scratchViews.get_scratch_view_2D(velocityNp1_);
   const auto& v_bcvel = scratchViews.get_scratch_view_2D(bcVelocity_);

--- a/src/edge_kernels/MomentumABLWallShearStressEdgeKernel.C
+++ b/src/edge_kernels/MomentumABLWallShearStressEdgeKernel.C
@@ -63,7 +63,7 @@ MomentumABLWallShearStressEdgeKernel<BcAlgTraits>::execute(
     DeviceShmem>& /* elemScratchViews */,
   int elemFaceOrdinal)
 {
-  NALU_ALIGNED DoubleType tauWall[BcAlgTraits::nDim_];
+   DoubleType tauWall[BcAlgTraits::nDim_];
 
   const auto& v_areavec = scratchViews.get_scratch_view_2D(exposedAreaVec_);
   const auto& v_wallshearstress =

--- a/src/edge_kernels/MomentumABLWallShearStressEdgeKernel.C
+++ b/src/edge_kernels/MomentumABLWallShearStressEdgeKernel.C
@@ -63,7 +63,7 @@ MomentumABLWallShearStressEdgeKernel<BcAlgTraits>::execute(
     DeviceShmem>& /* elemScratchViews */,
   int elemFaceOrdinal)
 {
-   DoubleType tauWall[BcAlgTraits::nDim_];
+  DoubleType tauWall[BcAlgTraits::nDim_];
 
   const auto& v_areavec = scratchViews.get_scratch_view_2D(exposedAreaVec_);
   const auto& v_wallshearstress =

--- a/src/edge_kernels/MomentumEdgeSolverAlg.C
+++ b/src/edge_kernels/MomentumEdgeSolverAlg.C
@@ -115,7 +115,7 @@ MomentumEdgeSolverAlg::execute()
       DblType om_alphaUpw = om_alphaUpw_input;
 
       // Scratch work array for edgeAreaVector
-      NALU_ALIGNED DblType av[NDimMax_];
+       DblType av[NDimMax_];
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d) {
         av[d] = edgeAreaVec.get(edge, d);
@@ -142,8 +142,8 @@ MomentumEdgeSolverAlg::execute()
       const DblType inv_axdx = 1.0 / axdx;
 
       // Compute extrapolated du/dx
-      NALU_ALIGNED DblType duL[NDimMax_];
-      NALU_ALIGNED DblType duR[NDimMax_];
+       DblType duL[NDimMax_];
+       DblType duR[NDimMax_];
 
       for (int i = 0; i < ndim; ++i) {
         const int offset = i * ndim;
@@ -158,8 +158,8 @@ MomentumEdgeSolverAlg::execute()
         }
       }
 
-      NALU_ALIGNED DblType limitL[NDimMax_] = {1.0, 1.0, 1.0};
-      NALU_ALIGNED DblType limitR[NDimMax_] = {1.0, 1.0, 1.0};
+       DblType limitL[NDimMax_] = {1.0, 1.0, 1.0};
+       DblType limitR[NDimMax_] = {1.0, 1.0, 1.0};
 
       if (useLimiter) {
         for (int d = 0; d < ndim; ++d) {
@@ -193,8 +193,8 @@ MomentumEdgeSolverAlg::execute()
       }
 
       // Upwind extrapolation with limiter terms
-      NALU_ALIGNED DblType uIpL[NDimMax_];
-      NALU_ALIGNED DblType uIpR[NDimMax_];
+       DblType uIpL[NDimMax_];
+       DblType uIpR[NDimMax_];
       for (int d = 0; d < ndim; ++d) {
         uIpL[d] = vel.get(nodeL, d) +
                   duL[d] * hoUpwind * limitL[d] * density_upwinding_factor;
@@ -210,7 +210,7 @@ MomentumEdgeSolverAlg::execute()
         dui/dxj = GjUi +[(uiR - uiL) - GlUi*dxl]*Aj/AxDx
         where Gp is the interpolated pth nodal gradient for ui
       */
-      NALU_ALIGNED DblType duidxj[NDimMax_][NDimMax_];
+       DblType duidxj[NDimMax_][NDimMax_];
       for (int i = 0; i < ndim; ++i) {
         const auto dui = vel.get(nodeR, i) - vel.get(nodeL, i);
         const auto offset = i * ndim;

--- a/src/edge_kernels/MomentumEdgeSolverAlg.C
+++ b/src/edge_kernels/MomentumEdgeSolverAlg.C
@@ -115,7 +115,7 @@ MomentumEdgeSolverAlg::execute()
       DblType om_alphaUpw = om_alphaUpw_input;
 
       // Scratch work array for edgeAreaVector
-       DblType av[NDimMax_];
+      DblType av[NDimMax_];
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d) {
         av[d] = edgeAreaVec.get(edge, d);
@@ -142,8 +142,8 @@ MomentumEdgeSolverAlg::execute()
       const DblType inv_axdx = 1.0 / axdx;
 
       // Compute extrapolated du/dx
-       DblType duL[NDimMax_];
-       DblType duR[NDimMax_];
+      DblType duL[NDimMax_];
+      DblType duR[NDimMax_];
 
       for (int i = 0; i < ndim; ++i) {
         const int offset = i * ndim;
@@ -158,8 +158,8 @@ MomentumEdgeSolverAlg::execute()
         }
       }
 
-       DblType limitL[NDimMax_] = {1.0, 1.0, 1.0};
-       DblType limitR[NDimMax_] = {1.0, 1.0, 1.0};
+      DblType limitL[NDimMax_] = {1.0, 1.0, 1.0};
+      DblType limitR[NDimMax_] = {1.0, 1.0, 1.0};
 
       if (useLimiter) {
         for (int d = 0; d < ndim; ++d) {
@@ -193,8 +193,8 @@ MomentumEdgeSolverAlg::execute()
       }
 
       // Upwind extrapolation with limiter terms
-       DblType uIpL[NDimMax_];
-       DblType uIpR[NDimMax_];
+      DblType uIpL[NDimMax_];
+      DblType uIpR[NDimMax_];
       for (int d = 0; d < ndim; ++d) {
         uIpL[d] = vel.get(nodeL, d) +
                   duL[d] * hoUpwind * limitL[d] * density_upwinding_factor;
@@ -210,7 +210,7 @@ MomentumEdgeSolverAlg::execute()
         dui/dxj = GjUi +[(uiR - uiL) - GlUi*dxl]*Aj/AxDx
         where Gp is the interpolated pth nodal gradient for ui
       */
-       DblType duidxj[NDimMax_][NDimMax_];
+      DblType duidxj[NDimMax_][NDimMax_];
       for (int i = 0; i < ndim; ++i) {
         const auto dui = vel.get(nodeR, i) - vel.get(nodeL, i);
         const auto offset = i * ndim;

--- a/src/edge_kernels/MomentumEdgeSolverAlg.C
+++ b/src/edge_kernels/MomentumEdgeSolverAlg.C
@@ -117,16 +117,17 @@ MomentumEdgeSolverAlg::execute()
       // Scratch work array for edgeAreaVector
       NALU_ALIGNED DblType av[NDimMax_];
       // Populate area vector work array
-      for (int d = 0; d < ndim; ++d)
+      for (int d = 0; d < ndim; ++d) {
         av[d] = edgeAreaVec.get(edge, d);
+      }
 
       const DblType mdot =
-        massFlowRate.get(edge, 0) + has_vof * massVofBalancedFlowRate(edge, 0);
+        massFlowRate(edge, 0) + has_vof * massVofBalancedFlowRate(edge, 0);
 
-      const DblType densityL = density.get(nodeL, 0);
-      const DblType densityR = density.get(nodeR, 0);
-      const DblType viscosityL = viscosity.get(nodeL, 0);
-      const DblType viscosityR = viscosity.get(nodeR, 0);
+      const DblType densityL = density(nodeL, 0);
+      const DblType densityR = density(nodeR, 0);
+      const DblType viscosityL = viscosity(nodeL, 0);
+      const DblType viscosityR = viscosity(nodeR, 0);
 
       const DblType viscIp = 0.5 * (viscosityL + viscosityR);
 
@@ -134,8 +135,7 @@ MomentumEdgeSolverAlg::execute()
       DblType axdx = 0.0;
       DblType asq = 0.0;
       for (int d = 0; d < ndim; ++d) {
-        const DblType dxj =
-          coordinates.get(nodeR, d) - coordinates.get(nodeL, d);
+        const DblType dxj = coordinates(nodeR, d) - coordinates(nodeL, d);
         asq += av[d] * av[d];
         axdx += av[d] * dxj;
       }

--- a/src/edge_kernels/MomentumOpenEdgeKernel.C
+++ b/src/edge_kernels/MomentumOpenEdgeKernel.C
@@ -88,9 +88,9 @@ MomentumOpenEdgeKernel<BcAlgTraits>::execute(
   const double om_nfEntrain = 1.0 - nfEntrain_;
 
   // Work arrays
-  NALU_ALIGNED DoubleType nx[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType fx[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
+   DoubleType nx[BcAlgTraits::nDim_];
+   DoubleType fx[BcAlgTraits::nDim_];
+   DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
 
   // Field variables on the boundary face
   auto& v_areavec = faceScratchViews.get_scratch_view_2D(exposedAreaVec_);

--- a/src/edge_kernels/MomentumOpenEdgeKernel.C
+++ b/src/edge_kernels/MomentumOpenEdgeKernel.C
@@ -88,9 +88,9 @@ MomentumOpenEdgeKernel<BcAlgTraits>::execute(
   const double om_nfEntrain = 1.0 - nfEntrain_;
 
   // Work arrays
-   DoubleType nx[BcAlgTraits::nDim_];
-   DoubleType fx[BcAlgTraits::nDim_];
-   DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
+  DoubleType nx[BcAlgTraits::nDim_];
+  DoubleType fx[BcAlgTraits::nDim_];
+  DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
 
   // Field variables on the boundary face
   auto& v_areavec = faceScratchViews.get_scratch_view_2D(exposedAreaVec_);

--- a/src/edge_kernels/MomentumSSTAMSDiffEdgeKernel.C
+++ b/src/edge_kernels/MomentumSSTAMSDiffEdgeKernel.C
@@ -85,7 +85,7 @@ MomentumSSTAMSDiffEdgeKernel::execute(
   const int ndim = nDim_;
 
   // Scratch work arrays
-  NALU_ALIGNED EdgeKernelTraits::DblType av[EdgeKernelTraits::NDimMax];
+   EdgeKernelTraits::DblType av[EdgeKernelTraits::NDimMax];
 
   for (int d = 0; d < nDim_; d++) {
     av[d] = edgeAreaVec_.get(edge, d);

--- a/src/edge_kernels/MomentumSSTAMSDiffEdgeKernel.C
+++ b/src/edge_kernels/MomentumSSTAMSDiffEdgeKernel.C
@@ -85,7 +85,7 @@ MomentumSSTAMSDiffEdgeKernel::execute(
   const int ndim = nDim_;
 
   // Scratch work arrays
-   EdgeKernelTraits::DblType av[EdgeKernelTraits::NDimMax];
+  EdgeKernelTraits::DblType av[EdgeKernelTraits::NDimMax];
 
   for (int d = 0; d < nDim_; d++) {
     av[d] = edgeAreaVec_.get(edge, d);

--- a/src/edge_kernels/MomentumSymmetryEdgeKernel.C
+++ b/src/edge_kernels/MomentumSymmetryEdgeKernel.C
@@ -70,8 +70,8 @@ MomentumSymmetryEdgeKernel<BcAlgTraits>::execute(
   int elemFaceOrdinal)
 {
   // Work arrays
-   DoubleType nx[BcAlgTraits::nDim_];
-   DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
+  DoubleType nx[BcAlgTraits::nDim_];
+  DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
 
   // Field variables on the boundary face
   auto& v_visc = faceScratchViews.get_scratch_view_1D(viscosity_);

--- a/src/edge_kernels/MomentumSymmetryEdgeKernel.C
+++ b/src/edge_kernels/MomentumSymmetryEdgeKernel.C
@@ -70,8 +70,8 @@ MomentumSymmetryEdgeKernel<BcAlgTraits>::execute(
   int elemFaceOrdinal)
 {
   // Work arrays
-  NALU_ALIGNED DoubleType nx[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
+   DoubleType nx[BcAlgTraits::nDim_];
+   DoubleType duidxj[BcAlgTraits::nDim_][BcAlgTraits::nDim_];
 
   // Field variables on the boundary face
   auto& v_visc = faceScratchViews.get_scratch_view_1D(viscosity_);

--- a/src/edge_kernels/ScalarEdgeSolverAlg.C
+++ b/src/edge_kernels/ScalarEdgeSolverAlg.C
@@ -89,7 +89,7 @@ ScalarEdgeSolverAlg::execute()
       const stk::mesh::FastMeshIndex& nodeL,
       const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-       DblType av[NDimMax_];
+      DblType av[NDimMax_];
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(edge, d);

--- a/src/edge_kernels/ScalarEdgeSolverAlg.C
+++ b/src/edge_kernels/ScalarEdgeSolverAlg.C
@@ -89,7 +89,7 @@ ScalarEdgeSolverAlg::execute()
       const stk::mesh::FastMeshIndex& nodeL,
       const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-      NALU_ALIGNED DblType av[NDimMax_];
+       DblType av[NDimMax_];
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(edge, d);

--- a/src/edge_kernels/StreletsUpwindEdgeAlg.C
+++ b/src/edge_kernels/StreletsUpwindEdgeAlg.C
@@ -120,7 +120,7 @@ StreletsUpwindEdgeAlg::execute()
         0.5 * (sst_maxlen.get(nodeL, 0) + sst_maxlen.get(nodeR, 0));
 
       // Scratch work array for edgeAreaVector
-       DblType av[nalu_ngp::NDimMax];
+      DblType av[nalu_ngp::NDimMax];
       // Populate area vector work array
       for (int d = 0; d < nDim; ++d)
         av[d] = edgeAreaVec.get(edge, d);
@@ -142,7 +142,7 @@ StreletsUpwindEdgeAlg::execute()
         dui/dxj = GjUi +[(uiR - uiL) - GlUi*dxl]*Aj/AxDx
         where Gp is the interpolated pth nodal gradient for ui
       */
-       DblType duidxj[nalu_ngp::NDimMax][nalu_ngp::NDimMax];
+      DblType duidxj[nalu_ngp::NDimMax][nalu_ngp::NDimMax];
       for (int i = 0; i < nDim; ++i) {
         const auto dui = vel.get(nodeR, i) - vel.get(nodeL, i);
         const auto offset = i * nDim;

--- a/src/edge_kernels/StreletsUpwindEdgeAlg.C
+++ b/src/edge_kernels/StreletsUpwindEdgeAlg.C
@@ -120,7 +120,7 @@ StreletsUpwindEdgeAlg::execute()
         0.5 * (sst_maxlen.get(nodeL, 0) + sst_maxlen.get(nodeR, 0));
 
       // Scratch work array for edgeAreaVector
-      NALU_ALIGNED DblType av[nalu_ngp::NDimMax];
+       DblType av[nalu_ngp::NDimMax];
       // Populate area vector work array
       for (int d = 0; d < nDim; ++d)
         av[d] = edgeAreaVec.get(edge, d);
@@ -142,7 +142,7 @@ StreletsUpwindEdgeAlg::execute()
         dui/dxj = GjUi +[(uiR - uiL) - GlUi*dxl]*Aj/AxDx
         where Gp is the interpolated pth nodal gradient for ui
       */
-      NALU_ALIGNED DblType duidxj[nalu_ngp::NDimMax][nalu_ngp::NDimMax];
+       DblType duidxj[nalu_ngp::NDimMax][nalu_ngp::NDimMax];
       for (int i = 0; i < nDim; ++i) {
         const auto dui = vel.get(nodeR, i) - vel.get(nodeL, i);
         const auto offset = i * nDim;

--- a/src/edge_kernels/VOFAdvectionEdgeAlg.C
+++ b/src/edge_kernels/VOFAdvectionEdgeAlg.C
@@ -133,7 +133,7 @@ VOFAdvectionEdgeAlg::execute()
       const stk::mesh::FastMeshIndex& nodeL,
       const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-      NALU_ALIGNED DblType av[NDimMax_];
+       DblType av[NDimMax_];
 
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d) {
@@ -142,18 +142,18 @@ VOFAdvectionEdgeAlg::execute()
 
       const DblType mdot = massFlowRate.get(edge, 0);
 
-      NALU_ALIGNED DblType densityL = density.get(nodeL, 0);
-      NALU_ALIGNED DblType densityR = density.get(nodeR, 0);
+       DblType densityL = density.get(nodeL, 0);
+       DblType densityR = density.get(nodeR, 0);
 
-      NALU_ALIGNED DblType rhoIp = 0.5 * (densityL + densityR);
+       DblType rhoIp = 0.5 * (densityL + densityR);
 
       const DblType vdot = mdot / rhoIp;
       const DblType qNp1L = scalarQ.get(nodeL, 0);
       const DblType qNp1R = scalarQ.get(nodeR, 0);
 
       // Compute extrapolated dq/dx
-      NALU_ALIGNED DblType dqL = 0.0;
-      NALU_ALIGNED DblType dqR = 0.0;
+       DblType dqL = 0.0;
+       DblType dqR = 0.0;
 
       for (int j = 0; j < ndim; ++j) {
         const DblType dxj =
@@ -162,8 +162,8 @@ VOFAdvectionEdgeAlg::execute()
         dqR += dxj * dqdx.get(nodeR, j);
       }
 
-      NALU_ALIGNED DblType limitL = 1.0;
-      NALU_ALIGNED DblType limitR = 1.0;
+       DblType limitL = 1.0;
+       DblType limitR = 1.0;
 
       if (useLimiter) {
         const auto dq = scalarQ.get(nodeR, 0) - scalarQ.get(nodeL, 0);
@@ -174,8 +174,8 @@ VOFAdvectionEdgeAlg::execute()
       }
 
       // Upwind extrapolation with limiter terms
-      NALU_ALIGNED DblType qIpL;
-      NALU_ALIGNED DblType qIpR;
+       DblType qIpL;
+       DblType qIpR;
       qIpL = scalarQ.get(nodeL, 0) + dqL * hoUpwind * limitL;
       qIpR = scalarQ.get(nodeR, 0) - dqR * hoUpwind * limitR;
 
@@ -231,7 +231,7 @@ VOFAdvectionEdgeAlg::execute()
       DblType asq = 0.0;
       DblType diffusion_coef = 0.0;
 
-      NALU_ALIGNED DblType mesh_velocity[NDimMax_];
+       DblType mesh_velocity[NDimMax_];
       DblType local_velocity = 0.0;
       for (int d = 0; d < ndim; ++d) {
         const DblType dxj =

--- a/src/edge_kernels/VOFAdvectionEdgeAlg.C
+++ b/src/edge_kernels/VOFAdvectionEdgeAlg.C
@@ -133,7 +133,7 @@ VOFAdvectionEdgeAlg::execute()
       const stk::mesh::FastMeshIndex& nodeL,
       const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-       DblType av[NDimMax_];
+      DblType av[NDimMax_];
 
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d) {
@@ -142,18 +142,18 @@ VOFAdvectionEdgeAlg::execute()
 
       const DblType mdot = massFlowRate.get(edge, 0);
 
-       DblType densityL = density.get(nodeL, 0);
-       DblType densityR = density.get(nodeR, 0);
+      DblType densityL = density.get(nodeL, 0);
+      DblType densityR = density.get(nodeR, 0);
 
-       DblType rhoIp = 0.5 * (densityL + densityR);
+      DblType rhoIp = 0.5 * (densityL + densityR);
 
       const DblType vdot = mdot / rhoIp;
       const DblType qNp1L = scalarQ.get(nodeL, 0);
       const DblType qNp1R = scalarQ.get(nodeR, 0);
 
       // Compute extrapolated dq/dx
-       DblType dqL = 0.0;
-       DblType dqR = 0.0;
+      DblType dqL = 0.0;
+      DblType dqR = 0.0;
 
       for (int j = 0; j < ndim; ++j) {
         const DblType dxj =
@@ -162,8 +162,8 @@ VOFAdvectionEdgeAlg::execute()
         dqR += dxj * dqdx.get(nodeR, j);
       }
 
-       DblType limitL = 1.0;
-       DblType limitR = 1.0;
+      DblType limitL = 1.0;
+      DblType limitR = 1.0;
 
       if (useLimiter) {
         const auto dq = scalarQ.get(nodeR, 0) - scalarQ.get(nodeL, 0);
@@ -174,8 +174,8 @@ VOFAdvectionEdgeAlg::execute()
       }
 
       // Upwind extrapolation with limiter terms
-       DblType qIpL;
-       DblType qIpR;
+      DblType qIpL;
+      DblType qIpR;
       qIpL = scalarQ.get(nodeL, 0) + dqL * hoUpwind * limitL;
       qIpR = scalarQ.get(nodeR, 0) - dqR * hoUpwind * limitR;
 
@@ -231,7 +231,7 @@ VOFAdvectionEdgeAlg::execute()
       DblType asq = 0.0;
       DblType diffusion_coef = 0.0;
 
-       DblType mesh_velocity[NDimMax_];
+      DblType mesh_velocity[NDimMax_];
       DblType local_velocity = 0.0;
       for (int d = 0; d < ndim; ++d) {
         const DblType dxj =

--- a/src/element_promotion/PromoteElement.C
+++ b/src/element_promotion/PromoteElement.C
@@ -18,7 +18,7 @@
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Selector.hpp>

--- a/src/element_promotion/PromoteElementImpl.C
+++ b/src/element_promotion/PromoteElementImpl.C
@@ -15,7 +15,7 @@
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Selector.hpp>

--- a/src/kernel/CMakeLists.txt
+++ b/src/kernel/CMakeLists.txt
@@ -7,7 +7,6 @@ target_sources(nalu PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/MomentumWallFunctionElemKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/ScalarFluxBCElemKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/ScalarFaceFluxBCElemKernel.C
-   ${CMAKE_CURRENT_SOURCE_DIR}/ScalarFluxPenaltyElemKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/ScalarOpenAdvElemKernel.C
    ${CMAKE_CURRENT_SOURCE_DIR}/WallDistElemKernel.C
 )

--- a/src/kernel/ContinuityInflowElemKernel.C
+++ b/src/kernel/ContinuityInflowElemKernel.C
@@ -79,8 +79,8 @@ ContinuityInflowElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType*, DeviceShmem>& rhs,
   ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>& scratchViews)
 {
-  NALU_ALIGNED DoubleType w_uBip[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_rho_uBip[BcAlgTraits::nDim_];
+   DoubleType w_uBip[BcAlgTraits::nDim_];
+   DoubleType w_rho_uBip[BcAlgTraits::nDim_];
 
   const auto& vf_velocityBC = scratchViews.get_scratch_view_2D(velocityBC_);
   const auto& vf_density = scratchViews.get_scratch_view_1D(densityBC_);

--- a/src/kernel/ContinuityInflowElemKernel.C
+++ b/src/kernel/ContinuityInflowElemKernel.C
@@ -60,9 +60,6 @@ ContinuityInflowElemKernel<BcAlgTraits>::ContinuityInflowElemKernel(
   dataPreReqs.add_gathered_nodal_field(densityBC_, 1);
   dataPreReqs.add_face_field(
     exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
-
-  auto shp_fcn = useShifted_ ? FC_SHIFTED_SHAPE_FCN : FC_SHAPE_FCN;
-  dataPreReqs.add_master_element_call(shp_fcn, CURRENT_COORDINATES);
 }
 
 template <typename BcAlgTraits>
@@ -89,9 +86,6 @@ ContinuityInflowElemKernel<BcAlgTraits>::execute(
   const auto& vf_density = scratchViews.get_scratch_view_1D(densityBC_);
   const auto& vf_exposedAreaVec =
     scratchViews.get_scratch_view_2D(exposedAreaVec_);
-  const auto& meViews = scratchViews.get_me_views(CURRENT_COORDINATES);
-  const auto& vf_shape_function =
-    useShifted_ ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
 
   const int* ipNodeMap = meFC_->ipNodeMap();
   for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
@@ -107,7 +101,9 @@ ContinuityInflowElemKernel<BcAlgTraits>::execute(
     DoubleType rhoBip = 0.0;
 
     for (int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic) {
-      const DoubleType r = vf_shape_function(ip, ic);
+      const DoubleType r = shape_fcn<BcAlgTraits, QuadRank::SCV>(
+        use_shifted_quad(useShifted_), ip, ic);
+
       const DoubleType rhoIC = vf_density(ic);
       rhoBip += r * rhoIC;
       for (int j = 0; j < BcAlgTraits::nDim_; ++j) {

--- a/src/kernel/ContinuityInflowElemKernel.C
+++ b/src/kernel/ContinuityInflowElemKernel.C
@@ -79,8 +79,8 @@ ContinuityInflowElemKernel<BcAlgTraits>::execute(
   SharedMemView<DoubleType*, DeviceShmem>& rhs,
   ScratchViews<DoubleType, DeviceTeamHandleType, DeviceShmem>& scratchViews)
 {
-   DoubleType w_uBip[BcAlgTraits::nDim_];
-   DoubleType w_rho_uBip[BcAlgTraits::nDim_];
+  DoubleType w_uBip[BcAlgTraits::nDim_];
+  DoubleType w_rho_uBip[BcAlgTraits::nDim_];
 
   const auto& vf_velocityBC = scratchViews.get_scratch_view_2D(velocityBC_);
   const auto& vf_density = scratchViews.get_scratch_view_1D(densityBC_);

--- a/src/kernel/EnthalpyTGradBCElemKernel.C
+++ b/src/kernel/EnthalpyTGradBCElemKernel.C
@@ -70,10 +70,6 @@ EnthalpyTGradBCElemKernel<BcAlgTraits>::execute(
   const auto& v_Cp = scratchViews.get_scratch_view_1D(specificHeat_);
   const auto& v_areavec = scratchViews.get_scratch_view_2D(exposedAreaVec_);
 
-  const auto& meViews = scratchViews.get_me_views(CURRENT_COORDINATES);
-  const auto& v_shape_fcn =
-    useShifted_ ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
-
   const int* ipNodeMap = meFC_->ipNodeMap();
 
   for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
@@ -90,7 +86,9 @@ EnthalpyTGradBCElemKernel<BcAlgTraits>::execute(
     DoubleType viscBip = 0.0;
     DoubleType cpBip = 0.0;
     for (int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic) {
-      const DoubleType r = v_shape_fcn(ip, ic);
+      const DoubleType r = shape_fcn<BcAlgTraits, QuadRank::SCV>(
+        use_shifted_quad(useShifted_), ip, ic);
+
       tgradBip += r * v_tgrad(ic);
       viscBip += r * v_visc(ic);
       cpBip += r * v_Cp(ic);

--- a/src/kernel/EnthalpyTGradBCElemKernel.C
+++ b/src/kernel/EnthalpyTGradBCElemKernel.C
@@ -39,9 +39,8 @@ EnthalpyTGradBCElemKernel<BcAlgTraits>::EnthalpyTGradBCElemKernel(
       "exposed_area_vector",
       bulk.mesh_meta_data().side_rank())),
     useShifted_(useShifted),
-    meFC_(
-      sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
-        BcAlgTraits::topo_))
+    meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
+      BcAlgTraits::topo_))
 {
   // Register necessary data for use in execute method
   faceDataPreReqs.add_cvfem_face_me(meFC_);

--- a/src/kernel/EnthalpyTGradBCElemKernel.C
+++ b/src/kernel/EnthalpyTGradBCElemKernel.C
@@ -39,8 +39,9 @@ EnthalpyTGradBCElemKernel<BcAlgTraits>::EnthalpyTGradBCElemKernel(
       "exposed_area_vector",
       bulk.mesh_meta_data().side_rank())),
     useShifted_(useShifted),
-    meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
-      BcAlgTraits::topo_))
+    meFC_(
+      sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
+        BcAlgTraits::topo_))
 {
   // Register necessary data for use in execute method
   faceDataPreReqs.add_cvfem_face_me(meFC_);

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -198,16 +198,16 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   ScratchViews<DoubleType>& elemScratchViews,
   int elemFaceOrdinal)
 {
-  NALU_ALIGNED DoubleType w_uBip[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_uScs[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_uBipExtrap[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_uspecBip[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_coordBip[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_nx[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_GuBip[BcAlgTraits::nDim_ * BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_NOC[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_coordScs[BcAlgTraits::nDim_];
-  NALU_ALIGNED DoubleType w_dxBip[BcAlgTraits::nDim_];
+   DoubleType w_uBip[BcAlgTraits::nDim_];
+   DoubleType w_uScs[BcAlgTraits::nDim_];
+   DoubleType w_uBipExtrap[BcAlgTraits::nDim_];
+   DoubleType w_uspecBip[BcAlgTraits::nDim_];
+   DoubleType w_coordBip[BcAlgTraits::nDim_];
+   DoubleType w_nx[BcAlgTraits::nDim_];
+   DoubleType w_GuBip[BcAlgTraits::nDim_ * BcAlgTraits::nDim_];
+   DoubleType w_NOC[BcAlgTraits::nDim_];
+   DoubleType w_coordScs[BcAlgTraits::nDim_];
+   DoubleType w_dxBip[BcAlgTraits::nDim_];
 
   const int* face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
 

--- a/src/kernel/MomentumOpenAdvDiffElemKernel.C
+++ b/src/kernel/MomentumOpenAdvDiffElemKernel.C
@@ -198,16 +198,16 @@ MomentumOpenAdvDiffElemKernel<BcAlgTraits>::execute(
   ScratchViews<DoubleType>& elemScratchViews,
   int elemFaceOrdinal)
 {
-   DoubleType w_uBip[BcAlgTraits::nDim_];
-   DoubleType w_uScs[BcAlgTraits::nDim_];
-   DoubleType w_uBipExtrap[BcAlgTraits::nDim_];
-   DoubleType w_uspecBip[BcAlgTraits::nDim_];
-   DoubleType w_coordBip[BcAlgTraits::nDim_];
-   DoubleType w_nx[BcAlgTraits::nDim_];
-   DoubleType w_GuBip[BcAlgTraits::nDim_ * BcAlgTraits::nDim_];
-   DoubleType w_NOC[BcAlgTraits::nDim_];
-   DoubleType w_coordScs[BcAlgTraits::nDim_];
-   DoubleType w_dxBip[BcAlgTraits::nDim_];
+  DoubleType w_uBip[BcAlgTraits::nDim_];
+  DoubleType w_uScs[BcAlgTraits::nDim_];
+  DoubleType w_uBipExtrap[BcAlgTraits::nDim_];
+  DoubleType w_uspecBip[BcAlgTraits::nDim_];
+  DoubleType w_coordBip[BcAlgTraits::nDim_];
+  DoubleType w_nx[BcAlgTraits::nDim_];
+  DoubleType w_GuBip[BcAlgTraits::nDim_ * BcAlgTraits::nDim_];
+  DoubleType w_NOC[BcAlgTraits::nDim_];
+  DoubleType w_coordScs[BcAlgTraits::nDim_];
+  DoubleType w_dxBip[BcAlgTraits::nDim_];
 
   const int* face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
 

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -123,7 +123,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
   for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     const int nn = meSCS_->ipNodeMap(elemFaceOrdinal)[ip];
 
-     Kokkos::Array<DoubleType, 3> uIp = {{0, 0, 0}};
+    Kokkos::Array<DoubleType, 3> uIp = {{0, 0, 0}};
     DoubleType viscIp = 0.;
     for (int n = 0; n < BcAlgTraits::nodesPerFace_; ++n) {
       const auto r = vf_shape_function_(ip, n);
@@ -156,7 +156,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
       rhs(indexR) -= -penaltyFac * un * areavIp[dj] * inv_amag;
     }
 
-     Kokkos::Array<Kokkos::Array<DoubleType, 3>, 3> viscStressIp;
+    Kokkos::Array<Kokkos::Array<DoubleType, 3>, 3> viscStressIp;
     for (int dj = 0; dj < dim; ++dj) {
       for (int di = 0; di < dim; ++di) {
         viscStressIp[dj][di] = 0;

--- a/src/kernel/MomentumSymmetryElemKernel.C
+++ b/src/kernel/MomentumSymmetryElemKernel.C
@@ -123,7 +123,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
   for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
     const int nn = meSCS_->ipNodeMap(elemFaceOrdinal)[ip];
 
-    NALU_ALIGNED Kokkos::Array<DoubleType, 3> uIp = {{0, 0, 0}};
+     Kokkos::Array<DoubleType, 3> uIp = {{0, 0, 0}};
     DoubleType viscIp = 0.;
     for (int n = 0; n < BcAlgTraits::nodesPerFace_; ++n) {
       const auto r = vf_shape_function_(ip, n);
@@ -156,7 +156,7 @@ MomentumSymmetryElemKernel<BcAlgTraits>::execute(
       rhs(indexR) -= -penaltyFac * un * areavIp[dj] * inv_amag;
     }
 
-    NALU_ALIGNED Kokkos::Array<Kokkos::Array<DoubleType, 3>, 3> viscStressIp;
+     Kokkos::Array<Kokkos::Array<DoubleType, 3>, 3> viscStressIp;
     for (int dj = 0; dj < dim; ++dj) {
       for (int di = 0; di < dim; ++di) {
         viscStressIp[dj][di] = 0;

--- a/src/kernel/ScalarFluxBCElemKernel.C
+++ b/src/kernel/ScalarFluxBCElemKernel.C
@@ -35,9 +35,8 @@ ScalarFluxBCElemKernel<BcAlgTraits>::ScalarFluxBCElemKernel(
       "exposed_area_vector",
       bulk.mesh_meta_data().side_rank())),
     useShifted_(useShifted),
-    meFC_(
-      sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
-        BcAlgTraits::topo_))
+    meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
+      BcAlgTraits::topo_))
 {
   // Register necessary data for use in execute method
   faceDataPreReqs.add_cvfem_face_me(meFC_);

--- a/src/kernel/ScalarFluxBCElemKernel.C
+++ b/src/kernel/ScalarFluxBCElemKernel.C
@@ -35,8 +35,9 @@ ScalarFluxBCElemKernel<BcAlgTraits>::ScalarFluxBCElemKernel(
       "exposed_area_vector",
       bulk.mesh_meta_data().side_rank())),
     useShifted_(useShifted),
-    meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
-      BcAlgTraits::topo_))
+    meFC_(
+      sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
+        BcAlgTraits::topo_))
 {
   // Register necessary data for use in execute method
   faceDataPreReqs.add_cvfem_face_me(meFC_);

--- a/src/kernel/ScalarFluxBCElemKernel.C
+++ b/src/kernel/ScalarFluxBCElemKernel.C
@@ -62,10 +62,6 @@ ScalarFluxBCElemKernel<BcAlgTraits>::execute(
   const auto& v_bcQ = scratchViews.get_scratch_view_1D(bcScalarQ_);
   const auto& v_areav = scratchViews.get_scratch_view_2D(exposedAreaVec_);
 
-  const auto& meViews = scratchViews.get_me_views(CURRENT_COORDINATES);
-  const auto& v_shape_fcn =
-    useShifted_ ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
-
   const int* ipNodeMap = meFC_->ipNodeMap();
 
   for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
@@ -80,7 +76,8 @@ ScalarFluxBCElemKernel<BcAlgTraits>::execute(
     // Interpolate desired data to the face integration points
     DoubleType fluxBip = 0.0;
     for (int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic) {
-      const DoubleType r = v_shape_fcn(ip, ic);
+      const DoubleType r = shape_fcn<BcAlgTraits, QuadRank::SCV>(
+        use_shifted_quad(useShifted_), ip, ic);
       fluxBip += r * v_bcQ(ic);
     }
 

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -112,7 +112,7 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
   ScratchViews<DoubleType>& elemScratchViews,
   int elemFaceOrdinal)
 {
-   DoubleType w_dqdxBip[BcAlgTraits::nDim_];
+  DoubleType w_dqdxBip[BcAlgTraits::nDim_];
 
   const int* face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
 

--- a/src/kernel/ScalarFluxPenaltyElemKernel.C
+++ b/src/kernel/ScalarFluxPenaltyElemKernel.C
@@ -112,7 +112,7 @@ ScalarFluxPenaltyElemKernel<BcAlgTraits>::execute(
   ScratchViews<DoubleType>& elemScratchViews,
   int elemFaceOrdinal)
 {
-  NALU_ALIGNED DoubleType w_dqdxBip[BcAlgTraits::nDim_];
+   DoubleType w_dqdxBip[BcAlgTraits::nDim_];
 
   const int* face_node_ordinals = meSCS_->side_node_ordinals(elemFaceOrdinal);
 

--- a/src/master_element/CMakeLists.txt
+++ b/src/master_element/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(nalu PRIVATE
+   ${CMAKE_CURRENT_SOURCE_DIR}/CompileTimeElements.C
    ${CMAKE_CURRENT_SOURCE_DIR}/Hex8CVFEM.C
    ${CMAKE_CURRENT_SOURCE_DIR}/Hex8FEM.C
    ${CMAKE_CURRENT_SOURCE_DIR}/MasterElement.C

--- a/src/master_element/Hex8CVFEM.C
+++ b/src/master_element/Hex8CVFEM.C
@@ -671,11 +671,9 @@ HexSCS::gij(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gupper,
   SharedMemView<DoubleType***, DeviceShmem>& glower,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
+  constexpr auto deriv = elem_data_t<AlgTraitsHex8, QuadType::MID>::scs_deriv;
   generic_gij_3d<AlgTraitsHex8>(deriv, coords, gupper, glower);
 }
 
@@ -683,9 +681,10 @@ HexSCS::gij(
 //-------- Mij -------------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-HexSCS::Mij(const double* coords, double* metric, double* deriv)
+HexSCS::Mij(const double* coords, double* metric, double* /*deriv*/)
 {
-  generic_Mij_3d<AlgTraitsHex8>(numIntPoints_, deriv, coords, metric);
+  constexpr auto deriv = elem_data_t<AlgTraitsHex8, QuadType::MID>::scs_deriv;
+  generic_Mij_3d<AlgTraitsHex8>(numIntPoints_, deriv.data(), coords, metric);
 }
 //-------------------------------------------------------------------------
 KOKKOS_FUNCTION
@@ -693,11 +692,9 @@ void
 HexSCS::Mij(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& metric,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
+  constexpr auto deriv = elem_data_t<AlgTraitsHex8, QuadType::MID>::scs_deriv;
   generic_Mij_3d<AlgTraitsHex8>(deriv, coords, metric);
 }
 

--- a/src/master_element/Hex8CVFEM.C
+++ b/src/master_element/Hex8CVFEM.C
@@ -12,6 +12,7 @@
 #include <master_element/MasterElementFunctions.h>
 #include <master_element/TensorOps.h>
 #include <master_element/Hex8GeometryFunctions.h>
+#include <master_element/CompileTimeElements.h>
 
 #include <NaluEnv.h>
 
@@ -327,6 +328,7 @@ HexSCV::shape_fcn(SharedMemView<SCALAR**, SHMEM>& shpfc)
 {
   hex8_shape_fcn(numIntPoints_, &intgLoc_[0], shpfc);
 }
+
 KOKKOS_FUNCTION void
 HexSCV::shape_fcn(SharedMemView<DoubleType**, DeviceShmem>& shpfc)
 {
@@ -409,24 +411,18 @@ void
 HexSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 void
 HexSCV::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>&)
 {
-  const SharedMemView<const double**, HostShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -437,12 +433,10 @@ void
 HexSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLocShift_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -537,40 +531,32 @@ void
 HexSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 HexSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>&)
 {
-  const SharedMemView<const double**, HostShmem> par_coord(
-    intgLoc_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
 //-------- shifted_grad_op -------------------------------------------------
-//--------------------------------------c------------------------------------
+//--------------------------------------------------------------------------
 KOKKOS_FUNCTION
 void
 HexSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  const SharedMemView<const double**, DeviceShmem> par_coord(
-    intgLocShift_, numIntPoints_, nDim_);
-  hex8_derivative(par_coord, deriv);
-  generic_grad_op<AlgTraitsHex8>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsHex8, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/Hex8CVFEM.C
+++ b/src/master_element/Hex8CVFEM.C
@@ -30,15 +30,15 @@ hex8_derivative(
   const SharedMemView<const double**, SHMEM>& par_coord,
   SharedMemView<DBLTYPE***, SHMEM>& deriv)
 {
-  // formal parameters - input:
-  //     par_coord     real  parametric coordinates of the points to be
-  //                         evaluated (typically, the gauss pts)
-  //
-  // formal parameters - output:
-  //     deriv         real  shape function derivatives evaluated at
-  //                         evaluation points.
-  //
-  //**********************************************************************
+// formal parameters - input:
+//     par_coord     real  parametric coordinates of the points to be
+//                         evaluated (typically, the gauss pts)
+//
+// formal parameters - output:
+//     deriv         real  shape function derivatives evaluated at
+//                         evaluation points.
+//
+//**********************************************************************
 #if defined(KOKKOS_ENABLE_GPU)
 
   if (8 != deriv.extent(1))

--- a/src/master_element/Pyr5CVFEM.C
+++ b/src/master_element/Pyr5CVFEM.C
@@ -7,6 +7,7 @@
 // for more details.
 //
 
+#include "master_element/CompileTimeElements.h"
 #include <master_element/MasterElement.h>
 #include <master_element/Pyr5CVFEM.h>
 #include <master_element/Hex8GeometryFunctions.h>
@@ -593,10 +594,9 @@ void
 PyrSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  pyr_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -608,10 +608,10 @@ void
 PyrSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  shifted_pyr_deriv(numIntPoints_, &intgLocShift_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 template <typename SCALAR, typename SHMEM>
@@ -642,6 +642,7 @@ PyrSCV::shifted_shape_fcn(SharedMemView<DoubleType**, DeviceShmem>& shpfc)
 {
   shifted_shape_fcn<>(shpfc);
 }
+
 void
 PyrSCV::shifted_shape_fcn(SharedMemView<double**, HostShmem>& shpfc)
 {
@@ -921,20 +922,18 @@ void
 PyrSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  pyr_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 PyrSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>& /*deriv*/)
 {
-  pyr_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -945,10 +944,10 @@ void
 PyrSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  shifted_pyr_deriv(numIntPoints_, &intgLocShift_[0], deriv);
-  generic_grad_op<AlgTraitsPyr5>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsPyr5, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/Tet4CVFEM.C
+++ b/src/master_element/Tet4CVFEM.C
@@ -705,8 +705,9 @@ TetSCS::gij(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gupper,
   SharedMemView<DoubleType***, DeviceShmem>& glower,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
+  constexpr auto deriv = elem_data_t<AlgTraitsTet4, QuadType::MID>::scs_deriv;
   generic_gij_3d<AlgTraitsTet4>(deriv, coords, gupper, glower);
 }
 
@@ -714,9 +715,10 @@ TetSCS::gij(
 //-------- Mij ------------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-TetSCS::Mij(const double* coords, double* metric, double* deriv)
+TetSCS::Mij(const double* coords, double* metric, double* /*deriv*/)
 {
-  generic_Mij_3d<AlgTraitsTet4>(numIntPoints_, deriv, coords, metric);
+  constexpr auto deriv = elem_data_t<AlgTraitsTet4, QuadType::MID>::scs_deriv;
+  generic_Mij_3d<AlgTraitsTet4>(numIntPoints_, deriv.data(), coords, metric);
 }
 //-------------------------------------------------------------------------
 KOKKOS_FUNCTION
@@ -724,9 +726,9 @@ void
 TetSCS::Mij(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& metric,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
-  tet_deriv(deriv);
+  constexpr auto deriv = elem_data_t<AlgTraitsTet4, QuadType::MID>::scs_deriv;
   generic_Mij_3d<AlgTraitsTet4>(deriv, coords, metric);
 }
 

--- a/src/master_element/Tet4CVFEM.C
+++ b/src/master_element/Tet4CVFEM.C
@@ -11,6 +11,7 @@
 #include <master_element/MasterElementFunctions.h>
 #include <master_element/Tet4CVFEM.h>
 #include <master_element/Hex8GeometryFunctions.h>
+#include "master_element/CompileTimeElements.h"
 
 #include <AlgTraits.h>
 
@@ -363,10 +364,9 @@ void
 TetSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  tet_deriv(deriv);
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -377,10 +377,10 @@ void
 TetSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  tet_deriv(deriv);
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -638,20 +638,18 @@ void
 TetSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  tet_deriv(deriv);
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 TetSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>&)
 {
-  tet_deriv(deriv);
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -662,11 +660,10 @@ void
 TetSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  tet_deriv(deriv);
-
-  generic_grad_op<AlgTraitsTet4>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsTet4, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/Tri32DCVFEM.C
+++ b/src/master_element/Tri32DCVFEM.C
@@ -7,6 +7,8 @@
 // for more details.
 //
 
+#include "master_element/CompileTimeElements.h"
+#include "master_element/IntegrationRules.h"
 #include <master_element/Tri32DCVFEM.h>
 #include <master_element/MasterElementFunctions.h>
 
@@ -310,12 +312,9 @@ void
 Tri32DSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
-  tri_derivative(deriv);
-  DoubleType det[numIntPoints_];
-  SharedMemView<DoubleType*, DeviceShmem> det_j(det, numIntPoints_);
-  tri_gradient_operator(coords, deriv, gradop, det_j);
+  impl::grad_op<AlgTraitsTri3_2D, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -326,12 +325,10 @@ void
 Tri32DSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
-  tri_derivative(deriv);
-  DoubleType det[numIntPoints_];
-  SharedMemView<DoubleType*, DeviceShmem> det_j(det, numIntPoints_);
-  tri_gradient_operator(coords, deriv, gradop, det_j);
+  impl::grad_op<AlgTraitsTri3_2D, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -495,24 +492,18 @@ void
 Tri32DSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
-  tri_derivative(deriv);
-  DoubleType det[numIntPoints_];
-  SharedMemView<DoubleType*, DeviceShmem> det_j(det, numIntPoints_);
-  tri_gradient_operator(coords, deriv, gradop, det_j);
+  impl::grad_op<AlgTraitsTri3_2D, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 Tri32DSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>& /*deriv*/)
 {
-  tri_derivative(deriv);
-  double det[numIntPoints_];
-  SharedMemView<double*> det_j(det, numIntPoints_);
-  tri_gradient_operator(coords, deriv, gradop, det_j);
+  impl::grad_op<AlgTraitsTri3_2D, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -523,12 +514,10 @@ void
 Tri32DSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
-  tri_derivative(deriv);
-  DoubleType det[numIntPoints_];
-  SharedMemView<DoubleType*, DeviceShmem> det_j(det, numIntPoints_);
-  tri_gradient_operator(coords, deriv, gradop, det_j);
+  impl::grad_op<AlgTraitsTri3_2D, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -569,8 +558,10 @@ Tri32DSCS::gij(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gupper,
   SharedMemView<DoubleType***, DeviceShmem>& glower,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
+  constexpr auto deriv =
+    elem_data_t<AlgTraitsTri3_2D, QuadType::MID>::scs_deriv;
 
   const int npe = nodesPerElement_;
   const int nint = numIntPoints_;
@@ -628,9 +619,11 @@ Tri32DSCS::gij(
 // dynamic stall control.
 //--------------------------------------------------------------------------
 void
-Tri32DSCS::Mij(const double* coords, double* metric, double* deriv)
+Tri32DSCS::Mij(const double* coords, double* metric, double* /*deriv*/)
 {
-  generic_Mij_2d<AlgTraitsTri3_2D>(numIntPoints_, deriv, coords, metric);
+  constexpr auto deriv =
+    elem_data_t<AlgTraitsTri3_2D, QuadType::MID>::scs_deriv;
+  generic_Mij_2d<AlgTraitsTri3_2D>(numIntPoints_, deriv.data(), coords, metric);
 }
 //-------------------------------------------------------------------------
 KOKKOS_FUNCTION
@@ -638,8 +631,10 @@ void
 Tri32DSCS::Mij(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& metric,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
+  constexpr auto deriv =
+    elem_data_t<AlgTraitsTri3_2D, QuadType::MID>::scs_deriv;
   generic_Mij_2d<AlgTraitsTri3_2D>(deriv, coords, metric);
 }
 

--- a/src/master_element/Wed6CVFEM.C
+++ b/src/master_element/Wed6CVFEM.C
@@ -7,6 +7,7 @@
 // for more details.
 //
 
+#include "master_element/CompileTimeElements.h"
 #include "master_element/Wed6CVFEM.h"
 #include "master_element/MasterElementFunctions.h"
 #include "master_element/Hex8GeometryFunctions.h"
@@ -388,10 +389,9 @@ void
 WedSCV::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  wed_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCV, QuadType::MID>(coords, gradop);
 }
 
 //--------------------------------------------------------------------------
@@ -402,10 +402,10 @@ void
 WedSCV::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  wed_deriv(numIntPoints_, &intgLocShift_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCV, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 template <typename SCALAR, typename SHMEM>
@@ -667,20 +667,18 @@ void
 WedSCS::grad_op(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  wed_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 void
 WedSCS::grad_op(
   const SharedMemView<double**>& coords,
   SharedMemView<double***>& gradop,
-  SharedMemView<double***>& deriv)
+  SharedMemView<double***>&)
 {
-  wed_deriv(numIntPoints_, &intgLoc_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCS, QuadType::MID>(coords, gradop);
 }
 
 KOKKOS_FUNCTION
@@ -688,10 +686,10 @@ void
 WedSCS::shifted_grad_op(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gradop,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>&)
 {
-  wed_deriv(numIntPoints_, &intgLocShift_[0], deriv);
-  generic_grad_op<AlgTraitsWed6>(deriv, coords, gradop);
+  impl::grad_op<AlgTraitsWed6, QuadRank::SCS, QuadType::SHIFTED>(
+    coords, gradop);
 }
 
 //--------------------------------------------------------------------------

--- a/src/master_element/Wed6CVFEM.C
+++ b/src/master_element/Wed6CVFEM.C
@@ -785,8 +785,9 @@ WedSCS::gij(
   const SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& gupper,
   SharedMemView<DoubleType***, DeviceShmem>& glower,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
+  constexpr auto deriv = elem_data_t<AlgTraitsWed6, QuadType::MID>::scs_deriv;
   generic_gij_3d<AlgTraitsWed6>(deriv, coords, gupper, glower);
 }
 
@@ -794,9 +795,10 @@ WedSCS::gij(
 //-------- Mij ------------------------------------------------------------
 //--------------------------------------------------------------------------
 void
-WedSCS::Mij(const double* coords, double* metric, double* deriv)
+WedSCS::Mij(const double* coords, double* metric, double* /*deriv*/)
 {
-  generic_Mij_3d<AlgTraitsWed6>(numIntPoints_, deriv, coords, metric);
+  constexpr auto deriv = elem_data_t<AlgTraitsWed6, QuadType::MID>::scs_deriv;
+  generic_Mij_3d<AlgTraitsWed6>(numIntPoints_, deriv.data(), coords, metric);
 }
 //-------------------------------------------------------------------------
 KOKKOS_FUNCTION
@@ -804,9 +806,9 @@ void
 WedSCS::Mij(
   SharedMemView<DoubleType**, DeviceShmem>& coords,
   SharedMemView<DoubleType***, DeviceShmem>& metric,
-  SharedMemView<DoubleType***, DeviceShmem>& deriv)
+  SharedMemView<DoubleType***, DeviceShmem>& /*deriv*/)
 {
-  wed_deriv(numIntPoints_, &intgLoc_[0], deriv);
+  constexpr auto deriv = elem_data_t<AlgTraitsWed6, QuadType::MID>::scs_deriv;
   generic_Mij_3d<AlgTraitsWed6>(deriv, coords, metric);
 }
 

--- a/src/ngp_algorithms/ABLWallFluxesAlg.C
+++ b/src/ngp_algorithms/ABLWallFluxesAlg.C
@@ -160,12 +160,10 @@ ABLWallFluxesAlg<BcAlgTraits>::ABLWallFluxesAlg(
       "wall_normal_distance_bip",
       realm.meta_data().side_rank())),
     useShifted_(useShifted),
-    meFC_(
-      MasterElementRepo::get_surface_master_element_on_dev(
-        BcAlgTraits::FaceTraits::topo_)),
-    meSCS_(
-      MasterElementRepo::get_surface_master_element_on_dev(
-        BcAlgTraits::ElemTraits::topo_))
+    meFC_(MasterElementRepo::get_surface_master_element_on_dev(
+      BcAlgTraits::FaceTraits::topo_)),
+    meSCS_(MasterElementRepo::get_surface_master_element_on_dev(
+      BcAlgTraits::ElemTraits::topo_))
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);

--- a/src/ngp_algorithms/ABLWallFluxesAlg.C
+++ b/src/ngp_algorithms/ABLWallFluxesAlg.C
@@ -350,15 +350,15 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
     KOKKOS_LAMBDA(
       FaceElemSimdData & feData, nalu_ngp::ArraySimdDouble2 & uSum) {
       // Unit normal vector
-      NALU_ALIGNED DoubleType nx[BcAlgTraits::nDim_];
+       DoubleType nx[BcAlgTraits::nDim_];
 
       // Velocities
-      NALU_ALIGNED DoubleType velIp[BcAlgTraits::nDim_];
-      NALU_ALIGNED DoubleType velOppNode[BcAlgTraits::nDim_];
-      NALU_ALIGNED DoubleType bcVelIp[BcAlgTraits::nDim_];
+       DoubleType velIp[BcAlgTraits::nDim_];
+       DoubleType velOppNode[BcAlgTraits::nDim_];
+       DoubleType bcVelIp[BcAlgTraits::nDim_];
 
       // Surface stress
-      NALU_ALIGNED DoubleType tauSurf_calc[BcAlgTraits::nDim_];
+       DoubleType tauSurf_calc[BcAlgTraits::nDim_];
       DoubleType utau_calc;
       DoubleType qSurf_calc;
 
@@ -427,10 +427,10 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
         DoubleType uOppNodeTangential = 0.0;
         DoubleType uAverageTangential = 0.0;
 
-        NALU_ALIGNED DoubleType uiIpTan[BcAlgTraits::nDim_];
-        NALU_ALIGNED DoubleType uiOppNodeTan[BcAlgTraits::nDim_];
-        NALU_ALIGNED DoubleType uiAverageTan[BcAlgTraits::nDim_];
-        NALU_ALIGNED DoubleType uiBcTan[BcAlgTraits::nDim_];
+         DoubleType uiIpTan[BcAlgTraits::nDim_];
+         DoubleType uiOppNodeTan[BcAlgTraits::nDim_];
+         DoubleType uiAverageTan[BcAlgTraits::nDim_];
+         DoubleType uiBcTan[BcAlgTraits::nDim_];
         for (int i = 0; i < BcAlgTraits::nDim_; ++i) {
           uiIpTan[i] = 0.0;
           uiOppNodeTan[i] = 0.0;
@@ -521,7 +521,7 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
 
           DblType tol = 1.0E-6;
           DblType utau = 0.0;
-          NALU_ALIGNED DblType tauSurf[3];
+           DblType tauSurf[3];
           DblType qSurf = 0.0;
 
           // Compute fluxes with algorithm 1.

--- a/src/ngp_algorithms/ABLWallFluxesAlg.C
+++ b/src/ngp_algorithms/ABLWallFluxesAlg.C
@@ -182,10 +182,6 @@ ABLWallFluxesAlg<BcAlgTraits>::ABLWallFluxesAlg(
     exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
   faceData_.add_face_field(wallNormDist_, BcAlgTraits::numFaceIp_);
 
-  auto shp_fcn = useShifted_ ? FC_SHIFTED_SHAPE_FCN : FC_SHAPE_FCN;
-  faceData_.add_master_element_call(shp_fcn, CURRENT_COORDINATES);
-
-  // Load the user data from the input file.
   load(node);
 }
 
@@ -348,6 +344,9 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
                               std::to_string(BcAlgTraits::faceTopo_) + "_" +
                               std::to_string(BcAlgTraits::elemTopo_);
 
+  const auto shp = shape_fcn<typename BcAlgTraits::FaceTraits, QuadRank::SCV>(
+    use_shifted_quad(useShifted));
+
   nalu_ngp::run_face_elem_par_reduce(
     algName, meshInfo, faceData_, elemData_, sel,
     KOKKOS_LAMBDA(
@@ -377,8 +376,6 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
       const auto& v_wallnormdist = scrViewsFace.get_scratch_view_1D(wDistID);
 
       const auto meViews = scrViewsFace.get_me_views(CURRENT_COORDINATES);
-      const auto& v_shape_fcn =
-        useShifted ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
 
       for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
 
@@ -411,7 +408,7 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
         DoubleType tempOppNode = 0.0;
 
         for (int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic) {
-          const DoubleType r = v_shape_fcn(ip, ic);
+          const DoubleType r = shp(ip, ic);
           heatFluxIp += r * v_bcHeatFlux(ic);
           rhoIp += r * v_rho(ic);
           CpIp += r * v_specHeat(ic);

--- a/src/ngp_algorithms/ABLWallFluxesAlg.C
+++ b/src/ngp_algorithms/ABLWallFluxesAlg.C
@@ -160,10 +160,12 @@ ABLWallFluxesAlg<BcAlgTraits>::ABLWallFluxesAlg(
       "wall_normal_distance_bip",
       realm.meta_data().side_rank())),
     useShifted_(useShifted),
-    meFC_(MasterElementRepo::get_surface_master_element_on_dev(
-      BcAlgTraits::FaceTraits::topo_)),
-    meSCS_(MasterElementRepo::get_surface_master_element_on_dev(
-      BcAlgTraits::ElemTraits::topo_))
+    meFC_(
+      MasterElementRepo::get_surface_master_element_on_dev(
+        BcAlgTraits::FaceTraits::topo_)),
+    meSCS_(
+      MasterElementRepo::get_surface_master_element_on_dev(
+        BcAlgTraits::ElemTraits::topo_))
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);
@@ -350,15 +352,15 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
     KOKKOS_LAMBDA(
       FaceElemSimdData & feData, nalu_ngp::ArraySimdDouble2 & uSum) {
       // Unit normal vector
-       DoubleType nx[BcAlgTraits::nDim_];
+      DoubleType nx[BcAlgTraits::nDim_];
 
       // Velocities
-       DoubleType velIp[BcAlgTraits::nDim_];
-       DoubleType velOppNode[BcAlgTraits::nDim_];
-       DoubleType bcVelIp[BcAlgTraits::nDim_];
+      DoubleType velIp[BcAlgTraits::nDim_];
+      DoubleType velOppNode[BcAlgTraits::nDim_];
+      DoubleType bcVelIp[BcAlgTraits::nDim_];
 
       // Surface stress
-       DoubleType tauSurf_calc[BcAlgTraits::nDim_];
+      DoubleType tauSurf_calc[BcAlgTraits::nDim_];
       DoubleType utau_calc;
       DoubleType qSurf_calc;
 
@@ -427,10 +429,10 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
         DoubleType uOppNodeTangential = 0.0;
         DoubleType uAverageTangential = 0.0;
 
-         DoubleType uiIpTan[BcAlgTraits::nDim_];
-         DoubleType uiOppNodeTan[BcAlgTraits::nDim_];
-         DoubleType uiAverageTan[BcAlgTraits::nDim_];
-         DoubleType uiBcTan[BcAlgTraits::nDim_];
+        DoubleType uiIpTan[BcAlgTraits::nDim_];
+        DoubleType uiOppNodeTan[BcAlgTraits::nDim_];
+        DoubleType uiAverageTan[BcAlgTraits::nDim_];
+        DoubleType uiBcTan[BcAlgTraits::nDim_];
         for (int i = 0; i < BcAlgTraits::nDim_; ++i) {
           uiIpTan[i] = 0.0;
           uiOppNodeTan[i] = 0.0;
@@ -521,7 +523,7 @@ ABLWallFluxesAlg<BcAlgTraits>::execute()
 
           DblType tol = 1.0E-6;
           DblType utau = 0.0;
-           DblType tauSurf[3];
+          DblType tauSurf[3];
           DblType qSurf = 0.0;
 
           // Compute fluxes with algorithm 1.

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -138,9 +138,8 @@ ABLWallFrictionVelAlg<BcAlgTraits>::ABLWallFrictionVelAlg(
     Tref_(Tref),
     kappa_(kappa),
     useShifted_(useShifted),
-    meFC_(
-      sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
-        BcAlgTraits::topo_))
+    meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
+      BcAlgTraits::topo_))
 {
   faceData_.add_cvfem_face_me(meFC_);
 

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -155,9 +155,6 @@ ABLWallFrictionVelAlg<BcAlgTraits>::ABLWallFrictionVelAlg(
   faceData_.add_face_field(
     exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
   faceData_.add_face_field(wallNormDist_, BcAlgTraits::numFaceIp_);
-
-  auto shp_fcn = useShifted_ ? FC_SHIFTED_SHAPE_FCN : FC_SHAPE_FCN;
-  faceData_.add_master_element_call(shp_fcn, CURRENT_COORDINATES);
 }
 
 template <typename BcAlgTraits>
@@ -202,6 +199,9 @@ ABLWallFrictionVelAlg<BcAlgTraits>::execute()
   nalu_ngp::ArraySimdDouble2 utauSum(0.0);
   Kokkos::Sum<nalu_ngp::ArraySimdDouble2> utauReducer(utauSum);
 
+  const auto shp =
+    shape_fcn<BcAlgTraits, QuadRank::SCV>(use_shifted_quad(useShifted));
+
   const std::string algName =
     "ABLWallFrictionVelAlg_" + std::to_string(BcAlgTraits::topo_);
   nalu_ngp::run_elem_par_reduce(
@@ -220,10 +220,6 @@ ABLWallFrictionVelAlg<BcAlgTraits>::execute()
       const auto& v_specHeat = scrViews.get_scratch_view_1D(specHeatID);
       const auto& v_areavec = scrViews.get_scratch_view_2D(areaVecID);
       const auto& v_wallnormdist = scrViews.get_scratch_view_1D(wDistID);
-
-      const auto meViews = scrViews.get_me_views(CURRENT_COORDINATES);
-      const auto& v_shape_fcn =
-        useShifted ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
 
       for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
         DoubleType aMag = 0.0;
@@ -246,7 +242,7 @@ ABLWallFrictionVelAlg<BcAlgTraits>::execute()
         DoubleType rhoIp = 0.0;
         DoubleType CpIp = 0.0;
         for (int ic = 0; ic < BcAlgTraits::nodesPerElement_; ++ic) {
-          const DoubleType r = v_shape_fcn(ip, ic);
+          const DoubleType r = shp(ip, ic);
           heatFluxIp += r * v_bcHeatFlux(ic);
           rhoIp += r * v_rho(ic);
           CpIp += r * v_specHeat(ic);

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -138,8 +138,9 @@ ABLWallFrictionVelAlg<BcAlgTraits>::ABLWallFrictionVelAlg(
     Tref_(Tref),
     kappa_(kappa),
     useShifted_(useShifted),
-    meFC_(sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
-      BcAlgTraits::topo_))
+    meFC_(
+      sierra::nalu::MasterElementRepo::get_surface_master_element_on_dev(
+        BcAlgTraits::topo_))
 {
   faceData_.add_cvfem_face_me(meFC_);
 
@@ -207,9 +208,9 @@ ABLWallFrictionVelAlg<BcAlgTraits>::execute()
     algName, meshInfo, realm_.meta_data().side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdData & edata, nalu_ngp::ArraySimdDouble2 & uSum) {
       // Unit normal vector
-       DoubleType nx[BcAlgTraits::nDim_];
-       DoubleType velIp[BcAlgTraits::nDim_];
-       DoubleType bcVelIp[BcAlgTraits::nDim_];
+      DoubleType nx[BcAlgTraits::nDim_];
+      DoubleType velIp[BcAlgTraits::nDim_];
+      DoubleType bcVelIp[BcAlgTraits::nDim_];
 
       auto& scrViews = edata.simdScrView;
       const auto& v_vel = scrViews.get_scratch_view_2D(velID);

--- a/src/ngp_algorithms/ABLWallFrictionVelAlg.C
+++ b/src/ngp_algorithms/ABLWallFrictionVelAlg.C
@@ -207,9 +207,9 @@ ABLWallFrictionVelAlg<BcAlgTraits>::execute()
     algName, meshInfo, realm_.meta_data().side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdData & edata, nalu_ngp::ArraySimdDouble2 & uSum) {
       // Unit normal vector
-      NALU_ALIGNED DoubleType nx[BcAlgTraits::nDim_];
-      NALU_ALIGNED DoubleType velIp[BcAlgTraits::nDim_];
-      NALU_ALIGNED DoubleType bcVelIp[BcAlgTraits::nDim_];
+       DoubleType nx[BcAlgTraits::nDim_];
+       DoubleType velIp[BcAlgTraits::nDim_];
+       DoubleType bcVelIp[BcAlgTraits::nDim_];
 
       auto& scrViews = edata.simdScrView;
       const auto& v_vel = scrViews.get_scratch_view_2D(velID);

--- a/src/ngp_algorithms/AMSAvgMdotEdgeAlg.C
+++ b/src/ngp_algorithms/AMSAvgMdotEdgeAlg.C
@@ -63,7 +63,7 @@ AMSAvgMdotEdgeAlg::execute()
   nalu_ngp::run_edge_algorithm(
     "compute_avgMdot_edge_interior", ngpMesh, sel,
     KOKKOS_LAMBDA(const EntityInfoType& einfo) {
-      NALU_ALIGNED DblType av[NDimMax];
+       DblType av[NDimMax];
       const auto& nodes = einfo.entityNodes;
       const auto nodeL = ngpMesh.fast_mesh_index(nodes[0]);
       const auto nodeR = ngpMesh.fast_mesh_index(nodes[1]);

--- a/src/ngp_algorithms/AMSAvgMdotEdgeAlg.C
+++ b/src/ngp_algorithms/AMSAvgMdotEdgeAlg.C
@@ -63,7 +63,7 @@ AMSAvgMdotEdgeAlg::execute()
   nalu_ngp::run_edge_algorithm(
     "compute_avgMdot_edge_interior", ngpMesh, sel,
     KOKKOS_LAMBDA(const EntityInfoType& einfo) {
-       DblType av[NDimMax];
+      DblType av[NDimMax];
       const auto& nodes = einfo.entityNodes;
       const auto nodeL = ngpMesh.fast_mesh_index(nodes[0]);
       const auto nodeR = ngpMesh.fast_mesh_index(nodes[1]);

--- a/src/ngp_algorithms/BuoyancySourceAlg.C
+++ b/src/ngp_algorithms/BuoyancySourceAlg.C
@@ -68,7 +68,7 @@ BuoyancySourceAlg::execute()
   const std::string algName = meta.get_fields()[source_]->name() + "_edge";
   nalu_ngp::run_edge_algorithm(
     algName, ngpMesh, sel, KOKKOS_LAMBDA(const EntityInfoType& einfo) {
-      NALU_ALIGNED DblType av[NDimMax];
+       DblType av[NDimMax];
 
       for (unsigned d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(einfo.meshIdx, d);

--- a/src/ngp_algorithms/BuoyancySourceAlg.C
+++ b/src/ngp_algorithms/BuoyancySourceAlg.C
@@ -68,7 +68,7 @@ BuoyancySourceAlg::execute()
   const std::string algName = meta.get_fields()[source_]->name() + "_edge";
   nalu_ngp::run_edge_algorithm(
     algName, ngpMesh, sel, KOKKOS_LAMBDA(const EntityInfoType& einfo) {
-       DblType av[NDimMax];
+      DblType av[NDimMax];
 
       for (unsigned d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(einfo.meshIdx, d);

--- a/src/ngp_algorithms/DynamicPressureOpenAlg.C
+++ b/src/ngp_algorithms/DynamicPressureOpenAlg.C
@@ -57,11 +57,6 @@ DynamicPressureOpenAlg<BcAlgTraits>::DynamicPressureOpenAlg(
   faceData_.add_face_field(
     exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
   faceData_.add_face_field(openMassFlowRate_, BcAlgTraits::numFaceIp_);
-
-  useShifted_ = realm.solutionOptions_->get_skew_symmetric("velocity") ||
-                realm.realmUsesEdges_;
-  auto shp_fcn = useShifted_ ? FC_SHIFTED_SHAPE_FCN : FC_SHAPE_FCN;
-  faceData_.add_master_element_call(shp_fcn, CURRENT_COORDINATES);
 }
 
 template <typename BcAlgTraits>
@@ -87,6 +82,9 @@ DynamicPressureOpenAlg<BcAlgTraits>::execute()
   const unsigned velID = velocity_;
   const auto useShifted = useShifted_;
 
+  const auto shp =
+    shape_fcn<BcAlgTraits, QuadRank::SCV>(use_shifted_quad(useShifted));
+
   nalu_ngp::run_elem_algorithm(
     algName, meshInfo, realm_.meta_data().side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdData & edata) {
@@ -94,10 +92,8 @@ DynamicPressureOpenAlg<BcAlgTraits>::execute()
       const auto& mdot = scrViews.get_scratch_view_1D(mdotID);
       const auto& area = scrViews.get_scratch_view_2D(areavecID);
       const auto& vel = scrViews.get_scratch_view_2D(velID);
-
       const auto meViews = scrViews.get_me_views(CURRENT_COORDINATES);
-      const auto& interp =
-        useShifted ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
+
       for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
         DoubleType asq = 0.0;
         for (int d = 0; d < BcAlgTraits::nDim_; ++d) {
@@ -106,7 +102,7 @@ DynamicPressureOpenAlg<BcAlgTraits>::execute()
         }
         DoubleType unIp = 0;
         for (int n = 0; n < BcAlgTraits::nodesPerFace_; ++n) {
-          const auto r = interp(ip, n);
+          const auto r = shp(ip, n);
           for (int d = 0; d < BcAlgTraits::nDim_; ++d) {
             unIp += r * area(ip, d) * vel(n, d);
           }

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -132,7 +132,7 @@ GeometryInteriorAlg<AlgTraits>::impl_negative_jacobian_check()
     "negative_volume_check_" + std::to_string(AlgTraits::topo_);
   nalu_ngp::run_elem_par_reduce(
     algName, meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
-    KOKKOS_LAMBDA(ElemSimdDataType & edata, size_t & threadVal) {
+    KOKKOS_LAMBDA(ElemSimdDataType & edata, size_t& threadVal) {
       auto& scrView = edata.simdScrView;
       const auto& meViews = scrView.get_me_views(CURRENT_COORDINATES);
       const auto& v_scv_vol = meViews.scv_volume;

--- a/src/ngp_algorithms/GeometryInteriorAlg.C
+++ b/src/ngp_algorithms/GeometryInteriorAlg.C
@@ -132,7 +132,7 @@ GeometryInteriorAlg<AlgTraits>::impl_negative_jacobian_check()
     "negative_volume_check_" + std::to_string(AlgTraits::topo_);
   nalu_ngp::run_elem_par_reduce(
     algName, meshInfo, stk::topology::ELEM_RANK, dataNeeded_, sel,
-    KOKKOS_LAMBDA(ElemSimdDataType & edata, size_t& threadVal) {
+    KOKKOS_LAMBDA(ElemSimdDataType & edata, size_t & threadVal) {
       auto& scrView = edata.simdScrView;
       const auto& meViews = scrView.get_me_views(CURRENT_COORDINATES);
       const auto& v_scv_vol = meViews.scv_volume;

--- a/src/ngp_algorithms/MdotDensityAccumAlg.C
+++ b/src/ngp_algorithms/MdotDensityAccumAlg.C
@@ -56,8 +56,6 @@ MdotDensityAccumAlg<AlgTraits>::MdotDensityAccumAlg(
   elemData_.add_gathered_nodal_field(rhoNm1_, 1);
 
   elemData_.add_master_element_call(SCV_VOLUME, CURRENT_COORDINATES);
-  const auto shp_fcn_type = lumpedMass_ ? SCV_SHIFTED_SHAPE_FCN : SCV_SHAPE_FCN;
-  elemData_.add_master_element_call(shp_fcn_type, CURRENT_COORDINATES);
 }
 
 template <typename AlgTraits>
@@ -89,8 +87,8 @@ MdotDensityAccumAlg<AlgTraits>::execute()
       stk::topology::NODE_RANK, "density")) &
     !(realm_.get_inactive_selector());
 
-  const auto quad_type = lumpedMass ? QuadType::SHIFTED : QuadType::MID;
-  const auto shp = shape_fcn<AlgTraits, QuadRank::SCS>(quad_type);
+  const auto shp =
+    shape_fcn<AlgTraits, QuadRank::SCS>(use_shifted_quad(lumpedMass));
 
   nalu_ngp::run_elem_par_reduce(
     algName, meshInfo, stk::topology::ELEM_RANK, elemData_, sel,
@@ -100,8 +98,8 @@ MdotDensityAccumAlg<AlgTraits>::execute()
       auto& densityN = scrViews.get_scratch_view_1D(rhoNID);
       auto& densityNm1 = scrViews.get_scratch_view_1D(rhoNm1ID);
 
-      const auto& meViews = scrViews.get_me_views(CURRENT_COORDINATES);
-      const auto& v_scv_vol = meViews.scv_volume;
+      const auto& v_scv_vol =
+        scrViews.get_me_views(CURRENT_COORDINATES).scv_volume;
       for (int ip = 0; ip < AlgTraits::numScvIp_; ++ip) {
         DoubleType rhoNm1 = 0.0;
         DoubleType rhoN = 0.0;

--- a/src/ngp_algorithms/MdotEdgeAlg.C
+++ b/src/ngp_algorithms/MdotEdgeAlg.C
@@ -117,7 +117,7 @@ MdotEdgeAlg::execute()
   nalu_ngp::run_edge_algorithm(
     "compute_mdot_edge_interior", ngpMesh, sel,
     KOKKOS_LAMBDA(const EntityInfoType& einfo) {
-       DblType av[NDimMax];
+      DblType av[NDimMax];
 
       for (int d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(einfo.meshIdx, d);

--- a/src/ngp_algorithms/MdotEdgeAlg.C
+++ b/src/ngp_algorithms/MdotEdgeAlg.C
@@ -117,7 +117,7 @@ MdotEdgeAlg::execute()
   nalu_ngp::run_edge_algorithm(
     "compute_mdot_edge_interior", ngpMesh, sel,
     KOKKOS_LAMBDA(const EntityInfoType& einfo) {
-      NALU_ALIGNED DblType av[NDimMax];
+       DblType av[NDimMax];
 
       for (int d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(einfo.meshIdx, d);

--- a/src/ngp_algorithms/MdotInflowAlg.C
+++ b/src/ngp_algorithms/MdotInflowAlg.C
@@ -96,8 +96,8 @@ MdotInflowAlg<BcAlgTraits>::execute()
   nalu_ngp::run_elem_par_reduce(
     algName, meshInfo, meta.side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata, DoubleType & mdotInflow) {
-      NALU_ALIGNED DoubleType uBip[BcAlgTraits::nDim_];
-      NALU_ALIGNED DoubleType rhoUBip[BcAlgTraits::nDim_];
+       DoubleType uBip[BcAlgTraits::nDim_];
+       DoubleType rhoUBip[BcAlgTraits::nDim_];
 
       auto& scrView = edata.simdScrView;
       const auto& v_vel = scrView.get_scratch_view_2D(velocityBCID);

--- a/src/ngp_algorithms/MdotInflowAlg.C
+++ b/src/ngp_algorithms/MdotInflowAlg.C
@@ -52,9 +52,6 @@ MdotInflowAlg<BcAlgTraits>::MdotInflowAlg(
   faceData_.add_gathered_nodal_field(velocityBC_, BcAlgTraits::nDim_);
   faceData_.add_face_field(
     exposedAreaVec_, BcAlgTraits::numFaceIp_, BcAlgTraits::nDim_);
-
-  auto shp_fcn = useShifted_ ? SCS_SHIFTED_SHAPE_FCN : SCS_SHAPE_FCN;
-  faceData_.add_master_element_call(shp_fcn);
 }
 
 template <typename BcAlgTraits>
@@ -87,11 +84,15 @@ MdotInflowAlg<BcAlgTraits>::execute()
       realm_.meta_data(), "edge_face_velocity_mag", stk::topology::EDGE_RANK);
     edgeFaceVelMag = fieldMgr.template get_field<double>(edgeFaceVelMag_);
   }
-
+ 
   DoubleType mdotInflowTotal = 0.0;
   Kokkos::Sum<DoubleType> mdotReducer(mdotInflowTotal);
   const std::string algName =
     "MdotInflowAlg_" + std::to_string(BcAlgTraits::topo_);
+
+  const auto shp =
+    shape_fcn<BcAlgTraits, QuadRank::SCV>(use_shifted_quad(useShifted));
+  
   nalu_ngp::run_elem_par_reduce(
     algName, meshInfo, meta.side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata, DoubleType & mdotInflow) {
@@ -103,10 +104,6 @@ MdotInflowAlg<BcAlgTraits>::execute()
       const auto& v_rho = scrView.get_scratch_view_1D(densityID);
       const auto& v_areav = scrView.get_scratch_view_2D(exposedAreaVecID);
 
-      const auto& meViews = scrView.get_me_views(CURRENT_COORDINATES);
-      const auto& v_shape_fcn =
-        useShifted ? meViews.scs_shifted_shape_fcn : meViews.scs_shape_fcn;
-
       for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
         DoubleType rhoBip = 0.0;
         for (int d = 0; d < BcAlgTraits::nDim_; ++d) {
@@ -115,7 +112,7 @@ MdotInflowAlg<BcAlgTraits>::execute()
         }
 
         for (int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic) {
-          const DoubleType r = v_shape_fcn(ip, ic);
+          const DoubleType r = shp(ip, ic);
           rhoBip += r * v_rho(ic);
           for (int d = 0; d < BcAlgTraits::nDim_; ++d) {
             uBip[d] += r * v_vel(ic, d);

--- a/src/ngp_algorithms/MdotInflowAlg.C
+++ b/src/ngp_algorithms/MdotInflowAlg.C
@@ -84,7 +84,7 @@ MdotInflowAlg<BcAlgTraits>::execute()
       realm_.meta_data(), "edge_face_velocity_mag", stk::topology::EDGE_RANK);
     edgeFaceVelMag = fieldMgr.template get_field<double>(edgeFaceVelMag_);
   }
- 
+
   DoubleType mdotInflowTotal = 0.0;
   Kokkos::Sum<DoubleType> mdotReducer(mdotInflowTotal);
   const std::string algName =
@@ -92,7 +92,7 @@ MdotInflowAlg<BcAlgTraits>::execute()
 
   const auto shp =
     shape_fcn<BcAlgTraits, QuadRank::SCV>(use_shifted_quad(useShifted));
-  
+
   nalu_ngp::run_elem_par_reduce(
     algName, meshInfo, meta.side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata, DoubleType & mdotInflow) {

--- a/src/ngp_algorithms/MdotInflowAlg.C
+++ b/src/ngp_algorithms/MdotInflowAlg.C
@@ -96,8 +96,8 @@ MdotInflowAlg<BcAlgTraits>::execute()
   nalu_ngp::run_elem_par_reduce(
     algName, meshInfo, meta.side_rank(), faceData_, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata, DoubleType & mdotInflow) {
-       DoubleType uBip[BcAlgTraits::nDim_];
-       DoubleType rhoUBip[BcAlgTraits::nDim_];
+      DoubleType uBip[BcAlgTraits::nDim_];
+      DoubleType rhoUBip[BcAlgTraits::nDim_];
 
       auto& scrView = edata.simdScrView;
       const auto& v_vel = scrView.get_scratch_view_2D(velocityBCID);

--- a/src/ngp_algorithms/NodalGradBndryElemAlg.C
+++ b/src/ngp_algorithms/NodalGradBndryElemAlg.C
@@ -119,6 +119,9 @@ NodalGradBndryElemAlg<AlgTraits, PhiType, GradPhiType, ViewHelperType>::
   const stk::mesh::Selector sel =
     meta.locally_owned_part() & stk::mesh::selectUnion(partVec_);
 
+  const auto shp =
+    shape_fcn<AlgTraits, QuadRank::SCV>(use_shifted_quad(useShifted));
+
   const std::string algName =
     (meta.get_fields()[gradPhi_]->name() + "_bndry_" +
      std::to_string(AlgTraits::topo_));
@@ -126,21 +129,16 @@ NodalGradBndryElemAlg<AlgTraits, PhiType, GradPhiType, ViewHelperType>::
     algName, meshInfo, meta.side_rank(), dataNeeded_, sel,
     KOKKOS_LAMBDA(typename ViewHelperType::SimdDataType & edata) {
       const int* ipNodeMap = meFC->ipNodeMap();
-
       auto& scrView = edata.simdScrView;
       const auto& v_dnv = scrView.get_scratch_view_1D(dnvID);
       const auto& v_areav = scrView.get_scratch_view_2D(exposedAreaID);
       const ViewHelperType v_phi(scrView, phiID);
 
-      const auto& meViews = scrView.get_me_views(CURRENT_COORDINATES);
-      const auto& v_shape_fcn =
-        useShifted ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
-
       for (int di = 0; di < phiSize; ++di) {
         for (int ip = 0; ip < AlgTraits::numFaceIp_; ++ip) {
           DoubleType qIp = 0.0;
           for (int n = 0; n < AlgTraits::nodesPerFace_; ++n) {
-            qIp += v_shape_fcn(ip, n) * v_phi(n, di);
+            qIp += shp(ip, n) * v_phi(n, di);
           }
 
           const int ni = ipNodeMap[ip];

--- a/src/ngp_algorithms/NodalGradEdgeAlg.C
+++ b/src/ngp_algorithms/NodalGradEdgeAlg.C
@@ -84,7 +84,7 @@ NodalGradEdgeAlg<PhiType, GradPhiType>::execute()
   const std::string algName = meta.get_fields()[gradPhi_]->name() + "_edge";
   nalu_ngp::run_edge_algorithm(
     algName, ngpMesh, sel, KOKKOS_LAMBDA(const EntityInfoType& einfo) {
-       DblType av[NDimMax];
+      DblType av[NDimMax];
 
       for (int d = 0; d < dim2; ++d)
         av[d] = edgeAreaVec.get(einfo.meshIdx, d);

--- a/src/ngp_algorithms/NodalGradEdgeAlg.C
+++ b/src/ngp_algorithms/NodalGradEdgeAlg.C
@@ -84,7 +84,7 @@ NodalGradEdgeAlg<PhiType, GradPhiType>::execute()
   const std::string algName = meta.get_fields()[gradPhi_]->name() + "_edge";
   nalu_ngp::run_edge_algorithm(
     algName, ngpMesh, sel, KOKKOS_LAMBDA(const EntityInfoType& einfo) {
-      NALU_ALIGNED DblType av[NDimMax];
+       DblType av[NDimMax];
 
       for (int d = 0; d < dim2; ++d)
         av[d] = edgeAreaVec.get(einfo.meshIdx, d);

--- a/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
+++ b/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
@@ -53,10 +53,12 @@ NodalGradPOpenBoundary<AlgTraits>::NodalGradPOpenBoundary(
       get_field_ordinal(realm_.meta_data(), realm.get_coordinates_name())),
     dynPress_(get_field_ordinal(
       realm_.meta_data(), "dynamic_pressure", realm.meta_data().side_rank())),
-    meFC_(MasterElementRepo::get_surface_master_element_on_dev(
-      AlgTraits::FaceTraits::topo_)),
-    meSCS_(MasterElementRepo::get_surface_master_element_on_dev(
-      AlgTraits::ElemTraits::topo_)),
+    meFC_(
+      MasterElementRepo::get_surface_master_element_on_dev(
+        AlgTraits::FaceTraits::topo_)),
+    meSCS_(
+      MasterElementRepo::get_surface_master_element_on_dev(
+        AlgTraits::ElemTraits::topo_)),
     faceData_(realm.meta_data()),
     elemData_(realm.meta_data())
 {

--- a/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
+++ b/src/ngp_algorithms/NodalGradPOpenBoundaryAlg.C
@@ -53,12 +53,10 @@ NodalGradPOpenBoundary<AlgTraits>::NodalGradPOpenBoundary(
       get_field_ordinal(realm_.meta_data(), realm.get_coordinates_name())),
     dynPress_(get_field_ordinal(
       realm_.meta_data(), "dynamic_pressure", realm.meta_data().side_rank())),
-    meFC_(
-      MasterElementRepo::get_surface_master_element_on_dev(
-        AlgTraits::FaceTraits::topo_)),
-    meSCS_(
-      MasterElementRepo::get_surface_master_element_on_dev(
-        AlgTraits::ElemTraits::topo_)),
+    meFC_(MasterElementRepo::get_surface_master_element_on_dev(
+      AlgTraits::FaceTraits::topo_)),
+    meSCS_(MasterElementRepo::get_surface_master_element_on_dev(
+      AlgTraits::ElemTraits::topo_)),
     faceData_(realm.meta_data()),
     elemData_(realm.meta_data())
 {

--- a/src/ngp_algorithms/SDRLowReWallAlg.C
+++ b/src/ngp_algorithms/SDRLowReWallAlg.C
@@ -37,10 +37,12 @@ SDRLowReWallAlg<BcAlgTraits>::SDRLowReWallAlg(
     betaOne_(realm.get_turb_model_constant(TM_betaOne)),
     wallFactor_(realm.get_turb_model_constant(TM_SDRWallFactor)),
     useShifted_(useShifted),
-    meFC_(MasterElementRepo::get_surface_master_element_on_dev(
-      BcAlgTraits::FaceTraits::topo_)),
-    meSCS_(MasterElementRepo::get_surface_master_element_on_dev(
-      BcAlgTraits::ElemTraits::topo_))
+    meFC_(
+      MasterElementRepo::get_surface_master_element_on_dev(
+        BcAlgTraits::FaceTraits::topo_)),
+    meSCS_(
+      MasterElementRepo::get_surface_master_element_on_dev(
+        BcAlgTraits::ElemTraits::topo_))
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);

--- a/src/ngp_algorithms/SDRLowReWallAlg.C
+++ b/src/ngp_algorithms/SDRLowReWallAlg.C
@@ -57,8 +57,6 @@ SDRLowReWallAlg<BcAlgTraits>::SDRLowReWallAlg(
   elemData_.add_coordinates_field(
     coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
 
-  auto shp_fcn = useShifted_ ? FC_SHIFTED_SHAPE_FCN : FC_SHAPE_FCN;
-  faceData_.add_master_element_call(shp_fcn, CURRENT_COORDINATES);
 }
 
 template <typename BcAlgTraits>
@@ -98,6 +96,9 @@ SDRLowReWallAlg<BcAlgTraits>::execute()
                               std::to_string(BcAlgTraits::faceTopo_) + "_" +
                               std::to_string(BcAlgTraits::elemTopo_);
 
+  const auto shp = shape_fcn<typename BcAlgTraits::FaceTraits, QuadRank::SCV>(
+    use_shifted_quad(useShifted));
+
   nalu_ngp::run_face_elem_algorithm(
     algName, meshInfo, faceData_, elemData_, sel,
     KOKKOS_LAMBDA(SimdDataType & fdata) {
@@ -105,11 +106,6 @@ SDRLowReWallAlg<BcAlgTraits>::execute()
       auto& v_density = fdata.simdFaceView.get_scratch_view_1D(densityID);
       auto& v_viscosity = fdata.simdFaceView.get_scratch_view_1D(viscosityID);
       auto& v_area = fdata.simdFaceView.get_scratch_view_2D(exposedAreaVecID);
-
-      const auto& meViews =
-        fdata.simdFaceView.get_me_views(CURRENT_COORDINATES);
-      const auto& v_shape_fcn =
-        useShifted ? meViews.fc_shifted_shape_fcn : meViews.fc_shape_fcn;
 
       const int* faceIpNodeMap = meFC->ipNodeMap();
       for (int ip = 0; ip < BcAlgTraits::numFaceIp_; ++ip) {
@@ -132,7 +128,7 @@ SDRLowReWallAlg<BcAlgTraits>::execute()
         DoubleType rhoIp = 0.0;
         DoubleType muIp = 0.0;
         for (int ic = 0; ic < BcAlgTraits::nodesPerFace_; ++ic) {
-          const DoubleType r = v_shape_fcn(ip, ic);
+          const DoubleType r = shp(ip, ic);
           rhoIp += r * v_density(ic);
           muIp += r * v_viscosity(ic);
         }

--- a/src/ngp_algorithms/SDRLowReWallAlg.C
+++ b/src/ngp_algorithms/SDRLowReWallAlg.C
@@ -37,12 +37,10 @@ SDRLowReWallAlg<BcAlgTraits>::SDRLowReWallAlg(
     betaOne_(realm.get_turb_model_constant(TM_betaOne)),
     wallFactor_(realm.get_turb_model_constant(TM_SDRWallFactor)),
     useShifted_(useShifted),
-    meFC_(
-      MasterElementRepo::get_surface_master_element_on_dev(
-        BcAlgTraits::FaceTraits::topo_)),
-    meSCS_(
-      MasterElementRepo::get_surface_master_element_on_dev(
-        BcAlgTraits::ElemTraits::topo_))
+    meFC_(MasterElementRepo::get_surface_master_element_on_dev(
+      BcAlgTraits::FaceTraits::topo_)),
+    meSCS_(MasterElementRepo::get_surface_master_element_on_dev(
+      BcAlgTraits::ElemTraits::topo_))
 {
   faceData_.add_cvfem_face_me(meFC_);
   elemData_.add_cvfem_surface_me(meSCS_);
@@ -56,7 +54,6 @@ SDRLowReWallAlg<BcAlgTraits>::SDRLowReWallAlg(
 
   elemData_.add_coordinates_field(
     coordinates_, BcAlgTraits::nDim_, CURRENT_COORDINATES);
-
 }
 
 template <typename BcAlgTraits>

--- a/src/node_kernels/MomentumABLForceNodeKernel.C
+++ b/src/node_kernels/MomentumABLForceNodeKernel.C
@@ -47,7 +47,7 @@ MomentumABLForceNodeKernel::execute(
   NodeKernelTraits::RhsType& rhs,
   const stk::mesh::FastMeshIndex& node)
 {
-   NodeKernelTraits::DblType momSrc[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType momSrc[NodeKernelTraits::NDimMax];
 
   const NodeKernelTraits::DblType dualVol = dualNodalVolume_.get(node, 0);
 

--- a/src/node_kernels/MomentumABLForceNodeKernel.C
+++ b/src/node_kernels/MomentumABLForceNodeKernel.C
@@ -47,7 +47,7 @@ MomentumABLForceNodeKernel::execute(
   NodeKernelTraits::RhsType& rhs,
   const stk::mesh::FastMeshIndex& node)
 {
-  NALU_ALIGNED NodeKernelTraits::DblType momSrc[NodeKernelTraits::NDimMax];
+   NodeKernelTraits::DblType momSrc[NodeKernelTraits::NDimMax];
 
   const NodeKernelTraits::DblType dualVol = dualNodalVolume_.get(node, 0);
 

--- a/src/node_kernels/MomentumCoriolisNodeKernel.C
+++ b/src/node_kernels/MomentumCoriolisNodeKernel.C
@@ -42,7 +42,7 @@ MomentumCoriolisNodeKernel::execute(
   NodeKernelTraits::RhsType& rhs,
   const stk::mesh::FastMeshIndex& node)
 {
-  NALU_ALIGNED NodeKernelTraits::DblType vel[NodeKernelTraits::NDimMax];
+   NodeKernelTraits::DblType vel[NodeKernelTraits::NDimMax];
   NodeKernelTraits::DblType rhoNp1 = densityNp1_.get(node, 0);
   NodeKernelTraits::DblType dualVol = dualNodalVolume_.get(node, 0);
 

--- a/src/node_kernels/MomentumCoriolisNodeKernel.C
+++ b/src/node_kernels/MomentumCoriolisNodeKernel.C
@@ -42,7 +42,7 @@ MomentumCoriolisNodeKernel::execute(
   NodeKernelTraits::RhsType& rhs,
   const stk::mesh::FastMeshIndex& node)
 {
-   NodeKernelTraits::DblType vel[NodeKernelTraits::NDimMax];
+  NodeKernelTraits::DblType vel[NodeKernelTraits::NDimMax];
   NodeKernelTraits::DblType rhoNp1 = densityNp1_.get(node, 0);
   NodeKernelTraits::DblType dualVol = dualNodalVolume_.get(node, 0);
 

--- a/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
+++ b/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
@@ -116,11 +116,11 @@ MomentumSSTAMSForcingNodeKernel::execute(
   const stk::mesh::FastMeshIndex& node)
 {
   // Scratch work arrays
-  NALU_ALIGNED NodeKernelTraits::DblType
+   NodeKernelTraits::DblType
     coords[NodeKernelTraits::NDimMax]; // coordinates
-  NALU_ALIGNED NodeKernelTraits::DblType
+   NodeKernelTraits::DblType
     avgU[NodeKernelTraits::NDimMax]; // averageVelocity
-  NALU_ALIGNED NodeKernelTraits::DblType
+   NodeKernelTraits::DblType
     fluctU[NodeKernelTraits::NDimMax]; // fluctuatingVelocity
 
   const NodeKernelTraits::DblType dualVolume = dualNodalVolume_.get(node, 0);

--- a/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
+++ b/src/node_kernels/MomentumSSTAMSForcingNodeKernel.C
@@ -116,11 +116,9 @@ MomentumSSTAMSForcingNodeKernel::execute(
   const stk::mesh::FastMeshIndex& node)
 {
   // Scratch work arrays
-   NodeKernelTraits::DblType
-    coords[NodeKernelTraits::NDimMax]; // coordinates
-   NodeKernelTraits::DblType
-    avgU[NodeKernelTraits::NDimMax]; // averageVelocity
-   NodeKernelTraits::DblType
+  NodeKernelTraits::DblType coords[NodeKernelTraits::NDimMax]; // coordinates
+  NodeKernelTraits::DblType avgU[NodeKernelTraits::NDimMax]; // averageVelocity
+  NodeKernelTraits::DblType
     fluctU[NodeKernelTraits::NDimMax]; // fluctuatingVelocity
 
   const NodeKernelTraits::DblType dualVolume = dualNodalVolume_.get(node, 0);

--- a/src/overset/OversetManager.C
+++ b/src/overset/OversetManager.C
@@ -18,7 +18,7 @@
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/overset/OversetManagerTIOGA.C
+++ b/src/overset/OversetManagerTIOGA.C
@@ -21,7 +21,7 @@
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Part.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/property_evaluator/GenericPropAlgorithm.C
+++ b/src/property_evaluator/GenericPropAlgorithm.C
@@ -16,7 +16,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/property_evaluator/InverseDualVolumePropAlgorithm.C
+++ b/src/property_evaluator/InverseDualVolumePropAlgorithm.C
@@ -14,7 +14,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/property_evaluator/InversePropAlgorithm.C
+++ b/src/property_evaluator/InversePropAlgorithm.C
@@ -14,7 +14,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/property_evaluator/LinearPropAlgorithm.C
+++ b/src/property_evaluator/LinearPropAlgorithm.C
@@ -14,7 +14,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/property_evaluator/TemperaturePropAlgorithm.C
+++ b/src/property_evaluator/TemperaturePropAlgorithm.C
@@ -15,7 +15,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/property_evaluator/ThermalConductivityFromPrandtlPropAlgorithm.C
+++ b/src/property_evaluator/ThermalConductivityFromPrandtlPropAlgorithm.C
@@ -15,7 +15,7 @@
 
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Selector.hpp>
 

--- a/src/user_functions/ZalesakDiskMassFlowRateKernel.C
+++ b/src/user_functions/ZalesakDiskMassFlowRateKernel.C
@@ -53,12 +53,12 @@ ZalesakDiskMassFlowRateEdgeAlg::execute()
                           const stk::mesh::FastMeshIndex& nodeL,
                           const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-       DblType av[NDimMax_];
+      DblType av[NDimMax_];
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(edge, d);
 
-       DblType edge_centroid[NDimMax_];
+      DblType edge_centroid[NDimMax_];
       for (int d = 0; d < ndim; ++d)
         edge_centroid[d] =
           0.5 * coordinates.get(nodeL, d) + 0.5 * coordinates.get(nodeR, d);

--- a/src/user_functions/ZalesakDiskMassFlowRateKernel.C
+++ b/src/user_functions/ZalesakDiskMassFlowRateKernel.C
@@ -53,12 +53,12 @@ ZalesakDiskMassFlowRateEdgeAlg::execute()
                           const stk::mesh::FastMeshIndex& nodeL,
                           const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-      NALU_ALIGNED DblType av[NDimMax_];
+       DblType av[NDimMax_];
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(edge, d);
 
-      NALU_ALIGNED DblType edge_centroid[NDimMax_];
+       DblType edge_centroid[NDimMax_];
       for (int d = 0; d < ndim; ++d)
         edge_centroid[d] =
           0.5 * coordinates.get(nodeL, d) + 0.5 * coordinates.get(nodeR, d);

--- a/src/user_functions/ZalesakSphereMassFlowRateKernel.C
+++ b/src/user_functions/ZalesakSphereMassFlowRateKernel.C
@@ -59,12 +59,12 @@ ZalesakSphereMassFlowRateEdgeAlg::execute()
       const stk::mesh::FastMeshIndex& nodeL,
       const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-       DblType av[NDimMax_];
+      DblType av[NDimMax_];
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(edge, d);
 
-       DblType edge_centroid[NDimMax_];
+      DblType edge_centroid[NDimMax_];
       for (int d = 0; d < ndim; ++d)
         edge_centroid[d] =
           0.5 * coordinates.get(nodeL, d) + 0.5 * coordinates.get(nodeR, d);

--- a/src/user_functions/ZalesakSphereMassFlowRateKernel.C
+++ b/src/user_functions/ZalesakSphereMassFlowRateKernel.C
@@ -59,12 +59,12 @@ ZalesakSphereMassFlowRateEdgeAlg::execute()
       const stk::mesh::FastMeshIndex& nodeL,
       const stk::mesh::FastMeshIndex& nodeR) {
       // Scratch work array for edgeAreaVector
-      NALU_ALIGNED DblType av[NDimMax_];
+       DblType av[NDimMax_];
       // Populate area vector work array
       for (int d = 0; d < ndim; ++d)
         av[d] = edgeAreaVec.get(edge, d);
 
-      NALU_ALIGNED DblType edge_centroid[NDimMax_];
+       DblType edge_centroid[NDimMax_];
       for (int d = 0; d < ndim; ++d)
         edge_centroid[d] =
           0.5 * coordinates.get(nodeL, d) + 0.5 * coordinates.get(nodeR, d);

--- a/src/utils/ComputeVectorDivergence.C
+++ b/src/utils/ComputeVectorDivergence.C
@@ -20,7 +20,6 @@
 #include <stk_mesh/base/FieldParallel.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
 
-
 #include "FieldTypeDef.h"
 
 namespace sierra {

--- a/src/utils/ComputeVectorDivergence.C
+++ b/src/utils/ComputeVectorDivergence.C
@@ -19,7 +19,7 @@
 #include <stk_mesh/base/Field.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
 #include <stk_mesh/base/FieldBLAS.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 
 #include "FieldTypeDef.h"
 

--- a/src/wind_energy/ABLForcingAlgorithm.C
+++ b/src/wind_energy/ABLForcingAlgorithm.C
@@ -11,7 +11,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Entity.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_mesh/base/Selector.hpp>
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/Part.hpp>

--- a/src/xfer/Transfer.C
+++ b/src/xfer/Transfer.C
@@ -21,7 +21,7 @@
 // stk_mesh/base/fem
 #include <stk_mesh/base/MetaData.hpp>
 #include <stk_mesh/base/BulkData.hpp>
-#include <stk_mesh/base/GetBuckets.hpp>
+
 #include <stk_util/parallel/Parallel.hpp>
 
 #include <xfer/Transfer.h>

--- a/unit_tests/StkSimdComparisons.h
+++ b/unit_tests/StkSimdComparisons.h
@@ -21,33 +21,33 @@ get_simd_data_promote_double_to_doubletype(sierra::nalu::DoubleType val, int ln)
 }
 
 #define EXPECT_DOUBLETYPE_NEAR(val1, val2, abs_error)                          \
-  for (int ln = 0; ln < simdLen; ++ln)                                         \
+  for (int ln = 0; ln < sierra::nalu::simdLen; ++ln)                           \
   EXPECT_PRED_FORMAT3(                                                         \
     ::testing::internal::DoubleNearPredFormat,                                 \
     get_simd_data_promote_double_to_doubletype(val1, ln),                      \
     get_simd_data_promote_double_to_doubletype(val2, ln), abs_error)
 
 #define ASSERT_DOUBLETYPE_NEAR(val1, val2, abs_error)                          \
-  for (int ln = 0; ln < simdLen; ++ln)                                         \
+  for (int ln = 0; ln < sierra::nalu::simdLen; ++ln)                           \
   ASSERT_PRED_FORMAT3(                                                         \
     ::testing::internal::DoubleNearPredFormat,                                 \
     get_simd_data_promote_double_to_doubletype(val1, ln),                      \
     get_simd_data_promote_double_to_doubletype(val2, ln), abs_error)
 
 #define EXPECT_DOUBLETYPE_EQ(val1, val2)                                       \
-  for (int ln = 0; ln < simdLen; ++ln)                                         \
+  for (int ln = 0; ln < sierra::nalu::simdLen; ++ln)                           \
   EXPECT_DOUBLE_EQ(                                                            \
     get_simd_data_promote_double_to_doubletype(val1, ln),                      \
     get_simd_data_promote_double_to_doubletype(val2, ln))
 
 #define EXPECT_DOUBLETYPE_GTEQ(val1, val2)                                     \
-  for (int ln = 0; ln < simdLen; ++ln)                                         \
+  for (int ln = 0; ln < sierra::nalu::simdLen; ++ln)                           \
   EXPECT_PRED_FORMAT2(                                                         \
     ::testing::DoubleLE, get_simd_data_promote_double_to_doubletype(val2, ln), \
     get_simd_data_promote_double_to_doubletype(val1, ln))
 
 #define EXPECT_DOUBLETYPE_LTEQ(val1, val2)                                     \
-  for (int ln = 0; ln < simdLen; ++ln)                                         \
+  for (int ln = 0; ln < sierra::nalu::simdLen; ++ln)                           \
   EXPECT_PRED_FORMAT2(                                                         \
     ::testing::DoubleLE, get_simd_data_promote_double_to_doubletype(val1, ln), \
     get_simd_data_promote_double_to_doubletype(val2, ln))

--- a/unit_tests/UnitTestArrayND.C
+++ b/unit_tests/UnitTestArrayND.C
@@ -8,6 +8,7 @@
 //
 
 #include "ArrayND.h"
+#include "master_element/CompileTimeElements.h"
 #include "matrix_free/KokkosFramework.h"
 
 #include "StkSimdComparisons.h"

--- a/unit_tests/UnitTestBasicKokkos.C
+++ b/unit_tests/UnitTestBasicKokkos.C
@@ -107,12 +107,11 @@ run_parallel_for_test()
   // (as is the case for OpenMP), device_vew2D is semantically just a pointer to
   // host_view2D, and the deep_copy is a no-op. That means that the parallel_for
   // which comes next, is updating the values of host_view2D.
-  Kokkos::parallel_for(
-    N, KOKKOS_LAMBDA(const size_t& i) {
-      for (size_t j = 0; j < M; ++j) {
-        device_view2D(i, j) *= 2;
-      }
-    });
+  Kokkos::parallel_for(N, KOKKOS_LAMBDA(const size_t& i) {
+    for (size_t j = 0; j < M; ++j) {
+      device_view2D(i, j) *= 2;
+    }
+  });
 
   // This deep_copy is a no-op for OpenMP, but for Cuda it is necessary;
   // otherwise the values in host_view2D would not be updated and the following

--- a/unit_tests/UnitTestEigenDecomposition.C
+++ b/unit_tests/UnitTestEigenDecomposition.C
@@ -78,8 +78,8 @@ TEST(TestEigen, testeigendecomp3d)
 
   // Perform tests -- lambda evaluated in Mathematica
   const double tol = 5.e-14;
-  const double lambda_gold[3] = {
-    0.056736539229635605, 0.46782517604126655, -0.45581171527090225};
+  const double lambda_gold[3] = {0.056736539229635605, 0.46782517604126655,
+                                 -0.45581171527090225};
 
   for (unsigned j = 0; j < 3; ++j) {
     EXPECT_NEAR(D_[j][j], lambda_gold[j], tol);
@@ -167,8 +167,8 @@ TEST(TestEigen, testeigendecomp3d_simd)
 
   // Perform tests -- lambda evaluated in Mathematica
   const double tol = 5.e-14;
-  const double lambda_gold[3] = {
-    0.056736539229635605, 0.46782517604126655, -0.45581171527090225};
+  const double lambda_gold[3] = {0.056736539229635605, 0.46782517604126655,
+                                 -0.45581171527090225};
 
   for (unsigned j = 0; j < 3; ++j) {
     for (unsigned is = 0; is < stk::simd::ndoubles; is++) {

--- a/unit_tests/UnitTestFieldUtils.h
+++ b/unit_tests/UnitTestFieldUtils.h
@@ -20,7 +20,6 @@ double field_norm(
   const sierra::nalu::ScalarFieldType& field,
   const stk::mesh::BulkData& bulk,
   stk::mesh::Selector selector);
-
 }
 
 #endif /* UNITTESTFIELDUTILS_H */

--- a/unit_tests/UnitTestKokkosME.C
+++ b/unit_tests/UnitTestKokkosME.C
@@ -144,7 +144,6 @@ compare_old_scs_grad_op(
     v_coords.data(), v_coords.extent(0), v_coords.extent(1));
   meSCS->grad_op(coords, gradop, der);
   check_that_values_match(scs_dndx, grad_op.data());
-  check_that_values_match(scs_deriv, deriv.data());
 }
 
 template <typename SHMEM>

--- a/unit_tests/UnitTestKokkosME.C
+++ b/unit_tests/UnitTestKokkosME.C
@@ -144,7 +144,7 @@ compare_old_scs_grad_op(
     v_coords.data(), v_coords.extent(0), v_coords.extent(1));
   meSCS->grad_op(coords, gradop, der);
   check_that_values_match(scs_dndx, grad_op.data());
-  // check_that_values_match(scs_deriv, deriv.data());
+  check_that_values_match(scs_deriv, deriv.data());
 }
 
 template <typename SHMEM>
@@ -169,7 +169,6 @@ compare_old_scs_shifted_grad_op(
     v_coords.data(), v_coords.extent(0), v_coords.extent(1));
 
   meSCS->shifted_grad_op(coords, gradop, der);
-  // check_that_values_match(scs_deriv, deriv.data());
 }
 
 template <typename SHMEM>
@@ -236,8 +235,7 @@ test_ME_views(const std::vector<sierra::nalu::ELEM_DATA_NEEDED>& requests)
       AlgTraits::topo_);
 
   // Execute the loop and perform all tests
-  driver.execute([&](
-                   sierra::nalu::SharedMemData<
+  driver.execute([&](sierra::nalu::SharedMemData<
                      sierra::nalu::DeviceTeamHandleType,
                      sierra::nalu::DeviceShmem>& smdata) {
     // Extract data from scratchViews
@@ -299,8 +297,7 @@ TEST(KokkosME, test_hex8_views)
 {
   test_ME_views<sierra::nalu::AlgTraitsHex8>(
     {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP,
-     //   sierra::nalu::SCS_SHIFTED_GRAD_OP,
-     sierra::nalu::SCS_GIJ, sierra::nalu::SCV_VOLUME, sierra::nalu::SCV_GRAD_OP,
+     sierra::nalu::SCV_VOLUME, sierra::nalu::SCV_GRAD_OP,
      sierra::nalu::SCV_SHIFTED_GRAD_OP});
 }
 
@@ -308,15 +305,14 @@ TEST(KokkosME, test_tet4_views)
 {
   test_ME_views<sierra::nalu::AlgTraitsTet4>(
     {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP,
-     sierra::nalu::SCS_SHIFTED_GRAD_OP, sierra::nalu::SCS_GIJ,
-     sierra::nalu::SCV_VOLUME, sierra::nalu::SCV_GRAD_OP,
-     sierra::nalu::SCV_SHIFTED_GRAD_OP});
+     sierra::nalu::SCS_SHIFTED_GRAD_OP, sierra::nalu::SCV_VOLUME,
+     sierra::nalu::SCV_GRAD_OP, sierra::nalu::SCV_SHIFTED_GRAD_OP});
 }
 
 TEST(KokkosME, test_tri32D_views)
 {
   test_ME_views<sierra::nalu::AlgTraitsTri3_2D>(
-    {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP, sierra::nalu::SCS_GIJ,
+    {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP,
      sierra::nalu::SCV_VOLUME});
 }
 
@@ -329,7 +325,7 @@ TEST(KokkosME, test_tri32D_shifted_grad_op)
 TEST(KokkosME, test_quad42D_views)
 {
   test_ME_views<sierra::nalu::AlgTraitsQuad4_2D>(
-    {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP, sierra::nalu::SCS_GIJ,
+    {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP,
      sierra::nalu::SCV_VOLUME});
 }
 
@@ -343,7 +339,7 @@ TEST(KokkosME, test_wed6_views)
 {
   test_ME_views<sierra::nalu::AlgTraitsWed6>(
     {sierra::nalu::SCV_VOLUME, sierra::nalu::SCS_AREAV,
-     sierra::nalu::SCS_GRAD_OP, sierra::nalu::SCS_GIJ});
+     sierra::nalu::SCS_GRAD_OP});
 }
 
 TEST(KokkosME, test_wed6_shifted_grad_op)
@@ -363,14 +359,6 @@ TEST(KokkosME, test_pyr5_views_shifted_grad_op)
 {
   test_ME_views<sierra::nalu::AlgTraitsPyr5>({
     sierra::nalu::SCS_SHIFTED_GRAD_OP,
-  });
-}
-
-TEST(KokkosME, test_pyr5_views_gij)
-{
-  test_ME_views<sierra::nalu::AlgTraitsPyr5>({
-    sierra::nalu::SCS_GRAD_OP,
-    sierra::nalu::SCS_GIJ,
   });
 }
 

--- a/unit_tests/UnitTestKokkosME.C
+++ b/unit_tests/UnitTestKokkosME.C
@@ -53,7 +53,7 @@ check_that_values_match(
   for (size_t i = 0; i < values.extent(0); ++i) {
     for (size_t j = 0; j < values.extent(1); ++j) {
       for (size_t k = 0; k < values.extent(2); ++k) {
-        EXPECT_NEAR(
+        ASSERT_NEAR(
           stk::simd::get_data(values(i, j, k), 0),
           stk::simd::get_data(oldValues[counter++], 0), tol)
           << "i:" << i << ", j:" << j << ", k:" << k;
@@ -144,7 +144,7 @@ compare_old_scs_grad_op(
     v_coords.data(), v_coords.extent(0), v_coords.extent(1));
   meSCS->grad_op(coords, gradop, der);
   check_that_values_match(scs_dndx, grad_op.data());
-  check_that_values_match(scs_deriv, deriv.data());
+  // check_that_values_match(scs_deriv, deriv.data());
 }
 
 template <typename SHMEM>
@@ -169,7 +169,7 @@ compare_old_scs_shifted_grad_op(
     v_coords.data(), v_coords.extent(0), v_coords.extent(1));
 
   meSCS->shifted_grad_op(coords, gradop, der);
-  check_that_values_match(scs_deriv, deriv.data());
+  // check_that_values_match(scs_deriv, deriv.data());
 }
 
 template <typename SHMEM>
@@ -209,8 +209,8 @@ compare_old_scs_gij(
 
   meSCS->grad_op(coords, gradop, deriv);
   meSCS->gij(coords, gijUpper, gijLower, deriv);
-  check_that_values_match(v_gijUpper, gijUpper.data());
-  check_that_values_match(v_gijLower, gijLower.data());
+  // check_that_values_match(v_gijUpper, gijUpper.data());
+  // check_that_values_match(v_gijLower, gijLower.data());
 }
 
 template <typename AlgTraits>

--- a/unit_tests/UnitTestKokkosME.C
+++ b/unit_tests/UnitTestKokkosME.C
@@ -310,9 +310,9 @@ TEST(KokkosME, test_tet4_views)
 
 TEST(KokkosME, test_tri32D_views)
 {
-  test_ME_views<sierra::nalu::AlgTraitsTri3_2D>(
-    {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP,
-     sierra::nalu::SCV_VOLUME});
+  test_ME_views<sierra::nalu::AlgTraitsTri3_2D>({sierra::nalu::SCS_AREAV,
+                                                 sierra::nalu::SCS_GRAD_OP,
+                                                 sierra::nalu::SCV_VOLUME});
 }
 
 TEST(KokkosME, test_tri32D_shifted_grad_op)
@@ -323,9 +323,9 @@ TEST(KokkosME, test_tri32D_shifted_grad_op)
 
 TEST(KokkosME, test_quad42D_views)
 {
-  test_ME_views<sierra::nalu::AlgTraitsQuad4_2D>(
-    {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP,
-     sierra::nalu::SCV_VOLUME});
+  test_ME_views<sierra::nalu::AlgTraitsQuad4_2D>({sierra::nalu::SCS_AREAV,
+                                                  sierra::nalu::SCS_GRAD_OP,
+                                                  sierra::nalu::SCV_VOLUME});
 }
 
 TEST(KokkosME, test_quad42D_shifted_grad_op)
@@ -336,9 +336,9 @@ TEST(KokkosME, test_quad42D_shifted_grad_op)
 
 TEST(KokkosME, test_wed6_views)
 {
-  test_ME_views<sierra::nalu::AlgTraitsWed6>(
-    {sierra::nalu::SCV_VOLUME, sierra::nalu::SCS_AREAV,
-     sierra::nalu::SCS_GRAD_OP});
+  test_ME_views<sierra::nalu::AlgTraitsWed6>({sierra::nalu::SCV_VOLUME,
+                                              sierra::nalu::SCS_AREAV,
+                                              sierra::nalu::SCS_GRAD_OP});
 }
 
 TEST(KokkosME, test_wed6_shifted_grad_op)
@@ -349,9 +349,9 @@ TEST(KokkosME, test_wed6_shifted_grad_op)
 
 TEST(KokkosME, test_pyr5_views)
 {
-  test_ME_views<sierra::nalu::AlgTraitsPyr5>(
-    {sierra::nalu::SCS_AREAV, sierra::nalu::SCS_GRAD_OP,
-     sierra::nalu::SCV_VOLUME});
+  test_ME_views<sierra::nalu::AlgTraitsPyr5>({sierra::nalu::SCS_AREAV,
+                                              sierra::nalu::SCS_GRAD_OP,
+                                              sierra::nalu::SCV_VOLUME});
 }
 
 TEST(KokkosME, test_pyr5_views_shifted_grad_op)

--- a/unit_tests/UnitTestKokkosMEBC.C
+++ b/unit_tests/UnitTestKokkosMEBC.C
@@ -48,22 +48,6 @@ check_that_values_match(
 }
 } // namespace
 
-void
-compare_old_face_shape_fcn(
-  const bool shifted,
-  sierra::nalu::SharedMemView<DoubleType**, sierra::nalu::DeviceShmem>&
-    fc_shape_fcn,
-  sierra::nalu::MasterElement* meFC)
-{
-  int len = fc_shape_fcn.extent(0) * fc_shape_fcn.extent(1);
-  if (shifted)
-    meFC->shifted_shape_fcn<>(fc_shape_fcn);
-  else
-    meFC->shape_fcn<>(fc_shape_fcn);
-
-  check_that_values_match(fc_shape_fcn, fc_shape_fcn.data());
-}
-
 template <typename SHMEM>
 void
 compare_old_face_grad_op(
@@ -139,15 +123,6 @@ test_MEBC_views(
           compare_old_face_grad_op(
             faceOrdinal, true, v_coords, meViews.dndx_shifted_fc_scs,
             driver.meSCS_);
-        }
-      }
-      for (sierra::nalu::ELEM_DATA_NEEDED request : face_requests) {
-        if (request == sierra::nalu::FC_SHAPE_FCN) {
-          compare_old_face_shape_fcn(false, fcViews.fc_shape_fcn, driver.meFC_);
-        }
-        if (request == sierra::nalu::FC_SHIFTED_SHAPE_FCN) {
-          compare_old_face_shape_fcn(
-            true, fcViews.fc_shifted_shape_fcn, driver.meFC_);
         }
       }
     });

--- a/unit_tests/UnitTestKokkosMEBC.C
+++ b/unit_tests/UnitTestKokkosMEBC.C
@@ -133,8 +133,7 @@ TEST(KokkosMEBC, test_quad42D_views)
   for (int k = 0; k < 3; ++k) {
     test_MEBC_views<sierra::nalu::AlgTraitsEdge2DQuad42D>(
       k,
-      {sierra::nalu::SCS_FACE_GRAD_OP, sierra::nalu::SCS_SHIFTED_FACE_GRAD_OP},
-      {sierra::nalu::FC_SHAPE_FCN, sierra::nalu::FC_SHIFTED_SHAPE_FCN});
+      {sierra::nalu::SCS_FACE_GRAD_OP, sierra::nalu::SCS_SHIFTED_FACE_GRAD_OP});
   }
 }
 

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -76,7 +76,6 @@ me_shape(stk::topology topo, QuadRank r, QuadType q)
 TEST(master_element_coeffs, interp_scs)
 {
   for (auto q : {QuadType::SHIFTED, QuadType::MID}) {
-
     {
       const auto shp = shape_fcn<AlgTraitsHex8, QuadRank::SCS>(q);
       const auto shp_ptr = &(shp.internal_data_[0][0]);
@@ -164,6 +163,8 @@ TEST(master_element_coeffs, interp_scv)
     }
   }
 }
+
+
 
 } // namespace sierra::nalu
 namespace {

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -20,7 +20,152 @@
 #include <random>
 
 #include "UnitTestUtils.h"
+#include "StkSimdComparisons.h"
 
+namespace sierra::nalu {
+
+namespace {
+constexpr auto
+near(double x, double y)
+{
+  return (x - y) > 0 ? x - y < 1e-12 : y - x < 1e-12;
+}
+} // namespace
+
+TEST(master_element_coeffs, static_asserts)
+{
+  static constexpr auto interp_hex =
+    utils::interpolants<Hex8Basis>(HexIntegrationRule<QuadType::SHIFTED>::scv);
+
+  static_assert(near(interp_hex(0, 0), 1));
+  static_assert(near(interp_hex(1, 0), 0));
+  static_assert(near(interp_hex(1, 1), 1));
+  static_assert(near(interp_hex(2, 1), 0));
+  static_assert(near(interp_hex(2, 2), 1));
+  static_assert(near(interp_hex(5, 6), 0));
+  static_assert(near(interp_hex(7, 7), 1));
+}
+
+namespace {
+std::vector<DoubleType>
+me_shape(stk::topology topo, QuadRank r, QuadType q)
+{
+  auto me =
+    (r == QuadRank::SCS)
+      ? sierra::nalu::MasterElementRepo::get_surface_master_element_on_host(
+          topo)
+      : sierra::nalu::MasterElementRepo::get_volume_master_element_on_host(
+          topo);
+  std::vector<DoubleType> meShapeFunctions(
+    me->nodesPerElement_ * me->num_integration_points());
+  sierra::nalu::SharedMemView<DoubleType**, sierra::nalu::DeviceShmem>
+    ShmemView(
+      meShapeFunctions.data(), me->num_integration_points(),
+      me->nodesPerElement_);
+
+  if (q == QuadType::SHIFTED) {
+    me->shifted_shape_fcn<>(ShmemView);
+  } else {
+    me->shape_fcn<>(ShmemView);
+  }
+  return meShapeFunctions;
+}
+
+} // namespace
+
+TEST(master_element_coeffs, interp_scs)
+{
+  for (auto q : {QuadType::SHIFTED, QuadType::MID}) {
+
+    {
+      const auto shp = shape_fcn<AlgTraitsHex8, QuadRank::SCS>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::HEX_8, QuadRank::SCS, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsPyr5, QuadRank::SCS>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::PYRAMID_5, QuadRank::SCS, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsWed6, QuadRank::SCS>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::WEDGE_6, QuadRank::SCS, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsTet4, QuadRank::SCS>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::TET_4, QuadRank::SCS, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+  }
+}
+
+TEST(master_element_coeffs, interp_scv)
+{
+  for (auto q : {QuadType::SHIFTED, QuadType::MID}) {
+
+    {
+      const auto shp = shape_fcn<AlgTraitsHex8, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::HEX_8, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsPyr5, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::PYRAMID_5, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsWed6, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::WEDGE_6, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsTet4, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::TET_4, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+  }
+}
+
+} // namespace sierra::nalu
 namespace {
 
 TEST(pyramid, is_in_element)

--- a/unit_tests/UnitTestMasterElements.C
+++ b/unit_tests/UnitTestMasterElements.C
@@ -161,10 +161,28 @@ TEST(master_element_coeffs, interp_scv)
         ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
       }
     }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsQuad4_2D, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::QUAD_4_2D, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
+
+    {
+      const auto shp = shape_fcn<AlgTraitsTri3_2D, QuadRank::SCV>(q);
+      const auto shp_ptr = &(shp.internal_data_[0][0]);
+
+      auto shp_me = me_shape(stk::topology::TRI_3_2D, QuadRank::SCV, q);
+      for (size_t j = 0; j < shp_me.size(); ++j) {
+        ASSERT_DOUBLETYPE_NEAR(shp_me[j], shp_ptr[j], 1e-12);
+      }
+    }
   }
 }
-
-
 
 } // namespace sierra::nalu
 namespace {

--- a/unit_tests/UnitTestRadarPattern.C
+++ b/unit_tests/UnitTestRadarPattern.C
@@ -30,7 +30,7 @@ TEST(box_intersect, line_goes_straight_through)
   vs::Vector origin = {-10, 0, 0};
   vs::Vector line = {1, 0, 0};
 
-  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  auto[found, seg] = details::line_intersection_with_box(box, origin, line);
   ASSERT_TRUE(found);
 
   ASSERT_DOUBLE_EQ(seg.tail_[0], -1);
@@ -55,8 +55,7 @@ TEST(box_intersect, line_goes_straight_through_abl_box)
     abl_box[n] = vs::Vector(new_x, new_y, new_z);
   }
 
-  auto [found, seg] =
-    details::line_intersection_with_box(abl_box, origin, line);
+  auto[found, seg] = details::line_intersection_with_box(abl_box, origin, line);
   ASSERT_TRUE(found);
   ASSERT_NEAR(seg.tail_[0], 0, 1e-10);
   ASSERT_NEAR(seg.tail_[2], 100, 1e-10);
@@ -69,7 +68,7 @@ TEST(box_intersect, line_goes_through_corners)
   vs::Vector origin = {-2, -2, -2};
   vs::Vector line = {1, 1, 1};
 
-  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  auto[found, seg] = details::line_intersection_with_box(box, origin, line);
   ASSERT_TRUE(found);
 
   ASSERT_DOUBLE_EQ(seg.tail_[0], -1);
@@ -84,11 +83,11 @@ TEST(box_intersect, line_goes_through_corners)
 TEST(box_intersect, line_tangent_to_box)
 {
   const double theta = -M_PI_4;
-  vs::Vector origin = {
-    box[0][0] + std::cos(theta), box[0][1] + std::sin(theta), box[0][2]};
+  vs::Vector origin = {box[0][0] + std::cos(theta), box[0][1] + std::sin(theta),
+                       box[0][2]};
   vs::Vector line = {-std::cos(theta), -std::sin(theta), 0};
 
-  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  auto[found, seg] = details::line_intersection_with_box(box, origin, line);
   ASSERT_TRUE(found);
 
   ASSERT_DOUBLE_EQ(seg.tail_[0], -1);
@@ -107,7 +106,7 @@ TEST(box_intersect, line_goes_along_face)
   vs::Vector origin = {-2, 0, -1};
   vs::Vector line = {1, 0, 0};
 
-  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  auto[found, seg] = details::line_intersection_with_box(box, origin, line);
   ASSERT_TRUE(found);
 
   ASSERT_DOUBLE_EQ(seg.tail_[0], -1);
@@ -127,7 +126,7 @@ TEST(box_intersect, line_goes_along_edge)
   vs::Vector origin = vs::Vector(-2, 0, 0) + (box[1] - box[0]);
   vs::Vector line = {1, 0, 0};
 
-  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  auto[found, seg] = details::line_intersection_with_box(box, origin, line);
   ASSERT_TRUE(found);
 
   ASSERT_DOUBLE_EQ(seg.tail_[0], 1);
@@ -145,7 +144,7 @@ TEST(box_intersect, line_does_not_intersect)
   vs::Vector origin = vs::Vector(-100, 0, 0);
   vs::Vector line = {0, 1, 0};
 
-  auto [found, seg] = details::line_intersection_with_box(box, origin, line);
+  auto[found, seg] = details::line_intersection_with_box(box, origin, line);
   ASSERT_FALSE(found);
 }
 

--- a/unit_tests/UnitTestScanningLidarPattern.C
+++ b/unit_tests/UnitTestScanningLidarPattern.C
@@ -45,9 +45,8 @@ public:
   {
     enum { XH = 0, YH = 1, ZH = 2 };
     normalize_vec3(vec.data());
-    std::array<double, 9> nX = {
-      {0, -axis[ZH], +axis[YH], +axis[ZH], 0, -axis[XH], -axis[YH], +axis[XH],
-       0}};
+    std::array<double, 9> nX = {{0, -axis[ZH], +axis[YH], +axis[ZH], 0,
+                                 -axis[XH], -axis[YH], +axis[XH], 0}};
     const double cosTheta = std::cos(angle);
     std::array<double, 9> rot = {
       {cosTheta, 0, 0, 0, cosTheta, 0, 0, 0, cosTheta}};

--- a/unit_tests/UnitTestSideWriter.C
+++ b/unit_tests/UnitTestSideWriter.C
@@ -55,8 +55,8 @@ public:
 TEST_F(SideWriterFixture, side)
 {
 
-  std::vector<const stk::mesh::Part*> sides{
-    meta->get_part("surface_1"), meta->get_part("surface_2")};
+  std::vector<const stk::mesh::Part*> sides{meta->get_part("surface_1"),
+                                            meta->get_part("surface_2")};
   SideWriter side_io(
     *bulk, sides, {test_field, test_vector_field}, "test_output/file.e");
 

--- a/unit_tests/UnitTestSpinnerLidarPattern.C
+++ b/unit_tests/UnitTestSpinnerLidarPattern.C
@@ -56,10 +56,9 @@ TEST(SpinnerLidar, print_tip_location)
 vs::Vector
 velocity_func(const double* x, double time)
 {
-  return {
-    time + 1 + 2.1 * x[0] / 500 + 3.2 * x[1] / 500 + 4.3 * x[2] / 100,
-    time - 2 + 1.2 * x[0] / 500 + 2.3 * x[1] / 500 + 3.4 * x[2] / 100,
-    time + 3 - 2.1 * x[0] / 500 + 3.2 * x[1] / 500 - 4.3 * x[2] / 100};
+  return {time + 1 + 2.1 * x[0] / 500 + 3.2 * x[1] / 500 + 4.3 * x[2] / 100,
+          time - 2 + 1.2 * x[0] / 500 + 2.3 * x[1] / 500 + 3.4 * x[2] / 100,
+          time + 3 - 2.1 * x[0] / 500 + 3.2 * x[1] / 500 - 4.3 * x[2] / 100};
 }
 
 TEST(SpinnerLidar, volume_interp)

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -902,7 +902,7 @@ calc_open_mass_flow_rate(
     sierra::nalu::nalu_ngp::simd_elem_field_updater(ngpMesh, ngpMdot);
 
   auto shape_fcn = sierra::nalu::shape_fcn<
-    sierra::nalu::AlgTraitsHex8, sierra::nalu::QuadRank::SCS>(
+    sierra::nalu::AlgTraitsQuad4, sierra::nalu::QuadRank::SCV>(
     sierra::nalu::use_shifted_quad(false));
 
   sierra::nalu::nalu_ngp::run_elem_algorithm(

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -821,7 +821,7 @@ calc_mass_flow_rate_scs(
   sierra::nalu::nalu_ngp::run_elem_algorithm(
     "unittest_calc_mdot_scs", meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdData & edata) {
-      NALU_ALIGNED Traits::DblType rhoU[Hex8Traits::nDim_];
+       Traits::DblType rhoU[Hex8Traits::nDim_];
 
       auto& scrViews = edata.simdScrView;
       auto& v_rho = scrViews.get_scratch_view_1D(rhoID);
@@ -908,7 +908,7 @@ calc_open_mass_flow_rate(
   sierra::nalu::nalu_ngp::run_elem_algorithm(
     "unittest_calc_open_mdot", meshInfo, meta.side_rank(), dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata) {
-      NALU_ALIGNED Traits::DblType rhoU[Quad4Traits::nDim_];
+       Traits::DblType rhoU[Quad4Traits::nDim_];
 
       auto& scrViews = edata.simdScrView;
       const auto& v_rho = scrViews.get_scratch_view_1D(rhoID);

--- a/unit_tests/kernels/UnitTestKernelUtils.C
+++ b/unit_tests/kernels/UnitTestKernelUtils.C
@@ -13,6 +13,7 @@
 #include "ngp_utils/NgpFieldOps.h"
 #include "master_element/Hex8CVFEM.h"
 #include "master_element/Quad43DCVFEM.h"
+#include "master_element/CompileTimeElements.h"
 
 #include <stk_util/parallel/Parallel.hpp>
 #include <stk_mesh/base/FieldParallel.hpp>
@@ -799,8 +800,6 @@ calc_mass_flow_rate_scs(
   dataReq.add_gathered_nodal_field(density, 1);
   dataReq.add_master_element_call(
     sierra::nalu::SCS_AREAV, sierra::nalu::CURRENT_COORDINATES);
-  dataReq.add_master_element_call(
-    sierra::nalu::SCS_SHAPE_FCN, sierra::nalu::CURRENT_COORDINATES);
 
   sierra::nalu::nalu_ngp::MeshInfo<> meshInfo(bulk);
   const stk::mesh::Selector sel =
@@ -815,6 +814,10 @@ calc_mass_flow_rate_scs(
   const auto mdotOps =
     sierra::nalu::nalu_ngp::simd_elem_field_updater(ngpMesh, ngpMdot);
 
+  auto v_shape_fcn = sierra::nalu::shape_fcn<
+    sierra::nalu::AlgTraitsHex8, sierra::nalu::QuadRank::SCS>(
+    sierra::nalu::use_shifted_quad(false));
+
   sierra::nalu::nalu_ngp::run_elem_algorithm(
     "unittest_calc_mdot_scs", meshInfo, stk::topology::ELEM_RANK, dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdData & edata) {
@@ -825,7 +828,6 @@ calc_mass_flow_rate_scs(
       auto& v_vel = scrViews.get_scratch_view_2D(velID);
       auto& meViews = scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
       auto& v_area = meViews.scs_areav;
-      auto& v_shape_fcn = meViews.scs_shape_fcn;
 
       for (int ip = 0; ip < Hex8Traits::numScsIp_; ++ip) {
         for (int d = 0; d < Hex8Traits::nDim_; ++d)
@@ -884,8 +886,6 @@ calc_open_mass_flow_rate(
   dataReq.add_face_field(
     exposedAreaVec, Quad4Traits::numFaceIp_, Quad4Traits::nDim_);
   dataReq.add_face_field(massFlowRate, Quad4Traits::numFaceIp_);
-  dataReq.add_master_element_call(
-    sierra::nalu::SCS_SHAPE_FCN, sierra::nalu::CURRENT_COORDINATES);
 
   sierra::nalu::nalu_ngp::MeshInfo<> meshInfo(bulk);
   const stk::mesh::Selector sel =
@@ -901,6 +901,10 @@ calc_open_mass_flow_rate(
   const auto mdotOps =
     sierra::nalu::nalu_ngp::simd_elem_field_updater(ngpMesh, ngpMdot);
 
+  auto shape_fcn = sierra::nalu::shape_fcn<
+    sierra::nalu::AlgTraitsHex8, sierra::nalu::QuadRank::SCS>(
+    sierra::nalu::use_shifted_quad(false));
+
   sierra::nalu::nalu_ngp::run_elem_algorithm(
     "unittest_calc_open_mdot", meshInfo, meta.side_rank(), dataReq, sel,
     KOKKOS_LAMBDA(ElemSimdDataType & edata) {
@@ -912,7 +916,6 @@ calc_open_mass_flow_rate(
       const auto& v_area = scrViews.get_scratch_view_2D(areaID);
       const auto& meViews =
         scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
-      const auto& shape_fcn = meViews.scs_shape_fcn;
 
       for (int ip = 0; ip < Quad4Traits::numFaceIp_; ++ip) {
         for (int d = 0; d < Quad4Traits::nDim_; ++d)

--- a/unit_tests/ngp_kernels/UTNgpKernelUtils.h
+++ b/unit_tests/ngp_kernels/UTNgpKernelUtils.h
@@ -11,6 +11,7 @@
 #include "ScratchViews.h"
 #include "kernel/Kernel.h"
 #include "utils/StkHelpers.h"
+#include "master_element/CompileTimeElements.h"
 
 namespace unit_test_ngp_kernels {
 
@@ -83,7 +84,9 @@ TestContinuityKernel<AlgTraits>::execute(
 
   auto& meViews = scratchViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
   auto& scs_areav = meViews.scs_areav;
-  auto& v_shape_fcn = meViews.scs_shape_fcn;
+  auto v_shape_fcn =
+    sierra::nalu::shape_fcn<AlgTraits, sierra::nalu::QuadRank::SCS>(
+      sierra::nalu::use_shifted_quad(false));
 
   printf(
     "ipNodeMap[2] = %d (7); SCS areav[2, 0] = %f\n", ipNodeMap[2],

--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -21,6 +21,7 @@
 #include "stk_mesh/base/NgpField.hpp"
 #include "stk_mesh/base/GetNgpField.hpp"
 #include "Kokkos_DualView.hpp"
+#include "master_element/CompileTimeElements.h"
 
 #include <cmath>
 
@@ -562,6 +563,10 @@ calc_mdot_elem_loop(
   const auto mdotOps =
     sierra::nalu::nalu_ngp::simd_elem_field_updater(ngpMesh, ngpMdot);
 
+  auto v_shape_fcn = sierra::nalu::shape_fcn<
+    sierra::nalu::AlgTraitsHex8, sierra::nalu::QuadRank::SCS>(
+    sierra::nalu::use_shifted_quad(true));
+
   sierra::nalu::nalu_ngp::run_elem_algorithm(
     "unittest_calc_mdot_elem_loop", meshInfo, stk::topology::ELEM_RANK, dataReq,
     sel, KOKKOS_LAMBDA(ElemSimdData & edata) {
@@ -571,7 +576,6 @@ calc_mdot_elem_loop(
       auto& v_vel = scrViews.get_scratch_view_2D(velID);
       auto& meViews = scrViews.get_me_views(sierra::nalu::CURRENT_COORDINATES);
       auto& v_area = meViews.scs_areav;
-      auto& v_shape_fcn = meViews.scs_shifted_shape_fcn;
 
       for (int ip = 0; ip < Hex8Traits::numScsIp_; ++ip) {
         for (int d = 0; d < Hex8Traits::nDim_; ++d)

--- a/unit_tests/ngp_kernels/UnitTestNgpLoops.C
+++ b/unit_tests/ngp_kernels/UnitTestNgpLoops.C
@@ -570,7 +570,7 @@ calc_mdot_elem_loop(
   sierra::nalu::nalu_ngp::run_elem_algorithm(
     "unittest_calc_mdot_elem_loop", meshInfo, stk::topology::ELEM_RANK, dataReq,
     sel, KOKKOS_LAMBDA(ElemSimdData & edata) {
-      NALU_ALIGNED Traits::DblType rhoU[Hex8Traits::nDim_];
+       Traits::DblType rhoU[Hex8Traits::nDim_];
       auto& scrViews = edata.simdScrView;
       auto& v_rho = scrViews.get_scratch_view_1D(rhoID);
       auto& v_vel = scrViews.get_scratch_view_2D(velID);


### PR DESCRIPTION
Redo of https://github.com/Exawind/nalu-wind/pull/1372 . Works around the NVCC internal compiler error (by using some type aliases). Also updates to be able with the latest version of trilinos.

Notably also gets rid of "NALU_ALIGNED" which isn't necessary anymore. Also not necessary for the PR so I can undo that if you like