### PR TITLE
Match kynema-fmb's conventions for rotation

### DIFF
--- a/src/mesh_motion/MotionPrescribedKernel.C
+++ b/src/mesh_motion/MotionPrescribedKernel.C
@@ -222,20 +222,21 @@ MotionPrescribedKernel::build_transformation(
   transMat[1 * mm::matSize + 3] = -origin_[1];
   transMat[2 * mm::matSize + 3] = -origin_[2];
 
-  const double rollX = current_displacement[3];
-  const double pitchY = current_displacement[4];
-  const double yawZ = current_displacement[5];
+  const double vector_angle_0 = current_displacement[3];
+  const double vector_angle_1 = current_displacement[4];
+  const double vector_angle_2 = current_displacement[5];
 
-  const double angle =
-    Kokkos::sqrt((rollX * rollX) + (pitchY * pitchY) + (yawZ * yawZ));
+  const double angle = Kokkos::sqrt(
+    (vector_angle_0 * vector_angle_0) + (vector_angle_1 * vector_angle_1) +
+    (vector_angle_2 * vector_angle_2));
   const double cos_angle = Kokkos::cos(angle / 2.);
   const double factor =
     (Kokkos::abs(angle) < 1.e-12) ? 0.0 : Kokkos::sin(angle / 2.) / angle;
 
   double q0 = cos_angle;
-  double q1 = factor * rollX;
-  double q2 = factor * pitchY;
-  double q3 = factor * yawZ;
+  double q1 = factor * vector_angle_0;
+  double q2 = factor * vector_angle_1;
+  double q3 = factor * vector_angle_2;
 
   const double n = Kokkos::sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
   q0 /= n;

--- a/src/mesh_motion/MotionPrescribedKernel.C
+++ b/src/mesh_motion/MotionPrescribedKernel.C
@@ -230,8 +230,9 @@ MotionPrescribedKernel::build_transformation(
     (vector_angle_0 * vector_angle_0) + (vector_angle_1 * vector_angle_1) +
     (vector_angle_2 * vector_angle_2));
   const double cos_angle = Kokkos::cos(angle / 2.);
-  const double factor =
-    (Kokkos::abs(angle) < 1.e-12) ? 0.0 : Kokkos::sin(angle / 2.) / angle;
+  const double factor = (Kokkos::abs(angle) < 1.e-12)
+                          ? (0.5 - (angle * angle) / 48.0)
+                          : Kokkos::sin(angle / 2.) / angle;
 
   double q0 = cos_angle;
   double q1 = factor * vector_angle_0;

--- a/src/mesh_motion/MotionPrescribedKernel.C
+++ b/src/mesh_motion/MotionPrescribedKernel.C
@@ -237,7 +237,7 @@ MotionPrescribedKernel::build_transformation(
   double q2 = factor * pitchY;
   double q3 = factor * yawZ;
 
-  const double n = std::sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
+  const double n = Kokkos::sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
   q0 /= n;
   q1 /= n;
   q2 /= n;

--- a/src/mesh_motion/MotionPrescribedKernel.C
+++ b/src/mesh_motion/MotionPrescribedKernel.C
@@ -226,17 +226,16 @@ MotionPrescribedKernel::build_transformation(
   const double pitchY = current_displacement[4];
   const double yawZ = current_displacement[5];
 
-  const double cy = std::cos(0.5 * yawZ);
-  const double sy = std::sin(0.5 * yawZ);
-  const double cp = std::cos(0.5 * pitchY);
-  const double sp = std::sin(0.5 * pitchY);
-  const double cr = std::cos(0.5 * rollX);
-  const double sr = std::sin(0.5 * rollX);
+  const double angle =
+    Kokkos::sqrt((rollX * rollX) + (pitchY * pitchY) + (yawZ * yawZ));
+  const double cos_angle = Kokkos::cos(angle / 2.);
+  const double factor =
+    (Kokkos::abs(angle) < 1.e-12) ? 0.0 : Kokkos::sin(angle / 2.) / angle;
 
-  double q0 = cr * cp * cy + sr * sp * sy;
-  double q3 = sr * cp * cy - cr * sp * sy;
-  double q1 = cr * sp * cy + sr * cp * sy;
-  double q2 = cr * cp * sy - sr * sp * cy;
+  double q0 = cos_angle;
+  double q1 = factor * rollX;
+  double q2 = factor * pitchY;
+  double q3 = factor * yawZ;
 
   const double n = std::sqrt(q0 * q0 + q1 * q1 + q2 * q2 + q3 * q3);
   q0 /= n;


### PR DESCRIPTION
## Summary

<!--- Please provide a one sentence summary of your changes  -->

This changes over the new prescribed motion routines to match the rotation conventions for kynema-fmb. This makes things far less confusing when comparing between the two codes. It will also make it much easier for users to switch between rigid body and prescribed motion. 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix?
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [x ] on CPU <!-- note the OS and compiler -->

## Additional background

I didn't see a difference in the gold files for the prescribed motion test with this change but things are a bit wonky since we changed over to kynema-ugf. To verify this I cloned the new kynema-ugf-meshes repo and dropped it in the reg_tests/mesh folder.

Issue Number: <!-- Note related issues -->
