### PR TITLE
Annotate compile-time shape_fcn overloads for device use

### DIFF
--- a/include/master_element/CompileTimeElements.h
+++ b/include/master_element/CompileTimeElements.h
@@ -105,7 +105,7 @@ enum class QuadRank { SCS, SCV };
 
 namespace sierra::kynema_ugf {
 template <typename AlgTraits, QuadRank rank>
-std::enable_if_t<rank == QuadRank::SCS, double>
+KOKKOS_FUNCTION std::enable_if_t<rank == QuadRank::SCS, double>
 shape_fcn(QuadType quad, int ip, int n)
 {
   if (quad == QuadType::SHIFTED) {
@@ -120,7 +120,7 @@ shape_fcn(QuadType quad, int ip, int n)
 }
 
 template <typename AlgTraits, QuadRank rank>
-std::enable_if_t<rank == QuadRank::SCV, double>
+KOKKOS_FUNCTION std::enable_if_t<rank == QuadRank::SCV, double>
 shape_fcn(QuadType quad, int ip, int n)
 {
   if (quad == QuadType::SHIFTED) {


### PR DESCRIPTION
## Summary

Annotate the compile-time `shape_fcn` overloads with `KOKKOS_FUNCTION` so they can be called from Kokkos/HIP device code.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

The affected `shape_fcn` overloads are used from device paths, but without `KOKKOS_FUNCTION` HIP treats them as host-only functions. This fixes compile errors like calling a `__host__` function from `__host__ __device__` code.

Issue Number: <!-- Note related issues -->
