### PR TITLE
Remove unnecessary assert

### DIFF
--- a/src/property_evaluator/ThermalConductivityFromPrandtlPropAlgorithm.C
+++ b/src/property_evaluator/ThermalConductivityFromPrandtlPropAlgorithm.C
@@ -46,9 +46,6 @@ ThermalConductivityFromPrandtlPropAlgorithm::
 void
 ThermalConductivityFromPrandtlPropAlgorithm::execute()
 {
-  // make sure that partVec_ is size one
-  STK_ThrowAssert(partVec_.size() == 1);
-
   stk::mesh::Selector selector = stk::mesh::selectUnion(partVec_);
 
   stk::mesh::BucketVector const& node_buckets =


### PR DESCRIPTION
## Summary

This causes the `hybridMeshDeformation` test to fail when the assert is on.

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change introduced:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## Checklist

The following is included:

- [ ] new unit-test(s)
- [ ] new regression test(s)
- [ ] documentation for new capability

This PR was tested by running:

- the unit tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->
- the regression tests
  - [ ] on GPU <!-- note the OS and compiler -->
  - [ ] on CPU <!-- note the OS and compiler -->

## Additional background

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Issue Number: <!-- Note related issues -->
